### PR TITLE
feat(select) implement optional select footer component

### DIFF
--- a/demo/pages/select/SelectDemo.js
+++ b/demo/pages/select/SelectDemo.js
@@ -16,7 +16,7 @@ const template = `
     <p>The select element (<code>novo-select</code>) represents a control that presents a menu of options. The options
     within are set by the <code>items</code> attribute. Options can be pre-selected for the user using the <code>value</code>
     attribute.</p>
-
+    
     <br/>
 
     <h5>Basic Examples</h5>
@@ -52,5 +52,14 @@ export class SelectDemo {
         this.states = ['Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California', 'Colorado', 'Connecticut', 'Delaware', 'Florida', 'Georgia', 'Hawaii', 'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky', 'Louisiana', 'Maine', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi', 'Missouri', 'Montana', 'Nebraska', 'Nevada', 'New Hampshire', 'New Jersey', 'New Mexico', 'New York', 'North Dakota', 'North Carolina', 'Ohio', 'Oklahoma', 'Oregon', 'Pennsylvania', 'Rhode Island', 'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont', 'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'];
         this.value = 'Bravo';
         this.state = null;
+        this.footerConfig = {
+            label: 'Add New Item',
+            placeholder: 'Enter item here',
+            onSave: this.create.bind(this)
+        };
+    }
+
+    create(opt) {
+        this.options = [...this.options, opt];
     }
 }

--- a/demo/pages/select/templates/BasicSelectDemo.html
+++ b/demo/pages/select/templates/BasicSelectDemo.html
@@ -13,7 +13,7 @@
 </div>
 <div>
     <label>
-        <span class="caption">No Model</span>
+        <span class="caption">No Model With Footer</span>
     </label>
-    <novo-select [options]="options" [placeholder]="placeholder"></novo-select>
+    <novo-select [options]="options" [placeholder]="placeholder" [footerConfig]="footerConfig"></novo-select>
 </div>

--- a/src/elements/form/extras/form-input/FormInput.js
+++ b/src/elements/form/extras/form-input/FormInput.js
@@ -37,7 +37,8 @@ import {
         'value',
         'label',
         'currencyFormat',
-        'references'
+        'references',
+        'footerConfig'
     ],
     outputs: [
         'broadcast',
@@ -119,6 +120,9 @@ export class FormInput {
                     }
                     if (this.inline) {
                         this.componentRef.instance.inline = this.inline;
+                    }
+                    if (this.footerConfig) {
+                        this.componentRef.instance.footerConfig = this.footerConfig;
                     }
                     if (this.broadcast) {
                         this.componentRef.instance.broadcast = this.broadcast;

--- a/src/elements/form/extras/select-input/SelectInput.js
+++ b/src/elements/form/extras/select-input/SelectInput.js
@@ -7,11 +7,11 @@ import { NovoLabelService } from './../../../../novo-elements';
 
 @Component({
     selector: 'select-input',
-    inputs: ['name', 'options', 'required'],
+    inputs: ['name', 'options', 'required', 'footerConfig'],
     directives: [COMMON_DIRECTIVES, NOVO_SELECT_ELEMENTS],
     template: `
         <i *ngIf="required" class="required-indicator" [ngClass]="{'bhi-circle': !control.valid, 'bhi-check': control.valid}"></i>
-        <novo-select [options]="options" [placeholder]="placeholder" [(ngModel)]="value" (onSelect)="select($event)" [class.error]="control.touched && !control.valid"></novo-select>
+        <novo-select [(options)]="options" [footerConfig]="footerConfig" [placeholder]="placeholder" [(ngModel)]="value" (onSelect)="select($event)" [class.error]="control.touched && !control.valid"></novo-select>
         <span class="error-message" *ngIf="required && control.touched && control?.errors?.required">{{labels.required}}</span>
     `
 })

--- a/src/elements/select/_Select.scss
+++ b/src/elements/select/_Select.scss
@@ -123,6 +123,12 @@ novo-select {
         &:focus {
             outline: none;
         }
+
+        &.footer {
+            max-height: 240px;
+            min-width: 200px;
+            padding: 8px 0 0 0;
+        }
     }
 
     &[disabled] {
@@ -130,6 +136,105 @@ novo-select {
 
         button {
             color: $grey;
+        }
+    }
+
+    .select-footer {
+        button.footer  {
+            text-transform: uppercase;
+            color: $positive;
+            position: relative;
+            text-align: left;
+            cursor: pointer;
+            height: 48px;
+            margin: 0;
+            padding: 10px 16px 0px 10px;
+            box-sizing: border-box;
+            border: none;
+            display: block;
+            align-items: center;
+            justify-content: space-between;
+            font-size: 1rem;
+
+            &:focus,
+            &:hover {
+                background: lighten($light, 10%);
+                color: darken($light, 55%);
+            }
+
+            i {
+                color: $positive;
+                padding-right: 10px;
+            }
+
+            span {
+                text-align: left;
+            }
+        }
+
+        div.active {
+            background: #F4F4F4;
+            width: 100%;
+            float: right;
+            padding: 5px;
+
+            footer {
+                float: right;
+            }
+
+            button {
+                display: inline-block;
+                border: none;
+                float: left;
+                width: auto;
+                font-weight: 500;
+                font-size: .9rem;
+                color: #ACACAC;
+
+                &:hover {
+                    color: darken(#ACACAC, 15%);
+                }
+            }
+
+            button.primary {
+                color: $positive;
+                &:hover {
+                    color: darken($positive, 15%);
+                }
+            }
+
+            input {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                background-color: transparent;
+                border: none;
+                border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+                color: rgba(0, 0, 0, 0.73);
+                height: 2.05rem;
+                position: relative;
+                text-align: left;
+                text-shadow: none;
+                width: 100%;
+                z-index: 1;
+                cursor: pointer;
+                text-transform: none;
+                padding-top: 10px;
+                font-size: 1rem;
+                &.empty {
+                    color: #A9A9A9;
+                }
+                &:focus {
+                    outline: none;
+                }
+                &:hover {
+                    border-bottom: 1px solid $positive;
+                }
+
+                &.invalid {
+                    border-bottom: 1px solid #DA4453;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This branch adds an optional footer to the novo-select element that adds a new item to the list. The footer will be displayed if a footerConfig object is passed in; that footerConfig should contain the label for the footer (the default display), the placeholder for the input (displayed when footer is open), and the onSave function. 

##### **What did you change?**
Primarily the Select element. Passed the footerConfig down through the FormInput --> SelectInput. Updated the SelectDemo to show an example.


##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices