### PR TITLE
fix(Select) : Clean up select footer, convert to header for UX/ease-o…

### DIFF
--- a/demo/pages/select/SelectDemo.js
+++ b/demo/pages/select/SelectDemo.js
@@ -52,7 +52,7 @@ export class SelectDemo {
         this.states = ['Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California', 'Colorado', 'Connecticut', 'Delaware', 'Florida', 'Georgia', 'Hawaii', 'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky', 'Louisiana', 'Maine', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi', 'Missouri', 'Montana', 'Nebraska', 'Nevada', 'New Hampshire', 'New Jersey', 'New Mexico', 'New York', 'North Dakota', 'North Carolina', 'Ohio', 'Oklahoma', 'Oregon', 'Pennsylvania', 'Rhode Island', 'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont', 'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'];
         this.value = 'Bravo';
         this.state = null;
-        this.footerConfig = {
+        this.headerConfig = {
             label: 'Add New Item',
             placeholder: 'Enter item here',
             onSave: this.create.bind(this)

--- a/demo/pages/select/templates/BasicSelectDemo.html
+++ b/demo/pages/select/templates/BasicSelectDemo.html
@@ -13,7 +13,7 @@
 </div>
 <div>
     <label>
-        <span class="caption">No Model With Footer</span>
+        <span class="caption">No Model With Header</span>
     </label>
-    <novo-select [options]="options" [placeholder]="placeholder" [footerConfig]="footerConfig"></novo-select>
+    <novo-select [options]="options" [placeholder]="placeholder" [headerConfig]="headerConfig"></novo-select>
 </div>

--- a/src/elements/form/extras/form-input/FormInput.js
+++ b/src/elements/form/extras/form-input/FormInput.js
@@ -38,8 +38,8 @@ import {
         'label',
         'currencyFormat',
         'references',
-        'footerConfig',
-        'disabled'
+        'disabled',
+        'headerConfig'
     ],
     outputs: [
         'broadcast',
@@ -123,8 +123,8 @@ export class FormInput {
                     if (this.inline) {
                         this.componentRef.instance.inline = this.inline;
                     }
-                    if (this.footerConfig) {
-                        this.componentRef.instance.footerConfig = this.footerConfig;
+                    if (this.headerConfig) {
+                        this.componentRef.instance.headerConfig = this.headerConfig;
                     }
                     if (this.broadcast) {
                         this.componentRef.instance.broadcast = this.broadcast;

--- a/src/elements/form/extras/select-input/SelectInput.js
+++ b/src/elements/form/extras/select-input/SelectInput.js
@@ -7,11 +7,11 @@ import { NovoLabelService } from './../../../../novo-elements';
 
 @Component({
     selector: 'select-input',
-    inputs: ['name', 'options', 'required', 'footerConfig'],
+    inputs: ['name', 'options', 'required', 'headerConfig'],
     directives: [COMMON_DIRECTIVES, NOVO_SELECT_ELEMENTS],
     template: `
         <i *ngIf="required" class="required-indicator" [ngClass]="{'bhi-circle': !control.valid, 'bhi-check': control.valid}"></i>
-        <novo-select [(options)]="options" [footerConfig]="footerConfig" [placeholder]="placeholder" [(ngModel)]="value" (onSelect)="select($event)" [class.error]="control.touched && !control.valid"></novo-select>
+        <novo-select [(options)]="options" [headerConfig]="headerConfig" [placeholder]="placeholder" [(ngModel)]="value" (onSelect)="select($event)" [class.error]="control.touched && !control.valid"></novo-select>
         <span class="error-message" *ngIf="required && control.touched && control?.errors?.required">{{labels.required}}</span>
     `
 })

--- a/src/elements/select/Select.spec.js
+++ b/src/elements/select/Select.spec.js
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 
 import { Select } from './Select';
 import { testComponent, grabComponent } from './../../testing/TestHelpers';
+import { NOVO_ELEMENTS_LABELS_PROVIDERS } from './../../novo-elements';
 
 @Component({
     selector: 'test-cmp',
@@ -17,6 +18,7 @@ class TestCmp {
 }
 
 describe('Element: Select', () => {
+    beforeEachProviders(() => [NOVO_ELEMENTS_LABELS_PROVIDERS]);
     it('should initialize correctly', testComponent(TestCmp, (fixture) => {
         const { instance, element, testComponentInstance, testComponentElement } = grabComponent(fixture, Select);
         expect(instance).toBeTruthy();

--- a/src/elements/select/_Select.scss
+++ b/src/elements/select/_Select.scss
@@ -118,16 +118,25 @@ novo-select {
                 color: darken($light, 55%);
                 font-weight: 500;
             }
+
+            &.open.select-header {
+                background: lighten($light, 10%);
+                padding: 10px 0 0 0;
+                line-height: 28px;
+                height: 60px;
+                border-bottom: 1px solid #e9e9e9;
+            }
+
         }
 
         &:focus {
             outline: none;
         }
 
-        &.footer {
+        &.header {
             max-height: 240px;
             min-width: 200px;
-            padding: 8px 0 0 0;
+            padding: 0;
         }
     }
 
@@ -139,41 +148,42 @@ novo-select {
         }
     }
 
-    .select-footer {
-        button.footer  {
+    .select-header {
+        button {
             text-transform: uppercase;
-            color: $positive;
-            position: relative;
-            text-align: left;
-            cursor: pointer;
-            height: 48px;
-            margin: 0;
-            padding: 10px 16px 0px 10px;
-            box-sizing: border-box;
-            border: none;
-            display: block;
-            align-items: center;
-            justify-content: space-between;
-            font-size: 1rem;
 
-            &:focus,
-            &:hover {
-                background: lighten($light, 10%);
-                color: darken($light, 55%);
-            }
-
-            i {
+            &.header  {
                 color: $positive;
-                padding-right: 10px;
-            }
-
-            span {
+                position: relative;
                 text-align: left;
+                cursor: pointer;
+                height: 48px;
+                margin: 0;
+                padding: 10px 16px 0 0;
+                box-sizing: border-box;
+                border: none;
+                display: block;
+                align-items: center;
+                justify-content: space-between;
+                font-size: 1rem;
+
+                &:focus,
+                &:hover {
+                    color: darken($light, 55%);
+                }
+
+                i {
+                    color: $positive;
+                    padding-right: 10px;
+                }
+
+                span {
+                    text-align: left;
+                }
             }
         }
 
         div.active {
-            background: #F4F4F4;
             width: 100%;
             float: right;
             padding: 5px;
@@ -188,7 +198,7 @@ novo-select {
                 float: left;
                 width: auto;
                 font-weight: 500;
-                font-size: .9rem;
+                font-size: .8rem;
                 color: #ACACAC;
 
                 &:hover {

--- a/src/elements/table/extras/pagination/Pagination.spec.js
+++ b/src/elements/table/extras/pagination/Pagination.spec.js
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 
 import { Pagination } from './Pagination';
 import { testComponent, grabComponent } from './../../../../testing/TestHelpers';
+import { NOVO_ELEMENTS_LABELS_PROVIDERS } from './../../../../novo-elements';
 
 @Component({
     selector: 'test-cmp',
@@ -26,6 +27,8 @@ class TestCmp {
 }
 
 describe('Element: Pagination', () => {
+    beforeEachProviders(() => [NOVO_ELEMENTS_LABELS_PROVIDERS]);
+
     it('should initialize correctly', testComponent(TestCmp, (fixture) => {
         const { instance, element, testComponentInstance, testComponentElement } = grabComponent(fixture, Pagination);
         expect(instance).toBeTruthy();

--- a/src/services/novo-label-service.js
+++ b/src/services/novo-label-service.js
@@ -11,6 +11,8 @@ export class NovoLabelService {
     quickNoteEmpty = 'No results to display...';
     required = 'Required';
     numberTooLarge = 'Number is too large';
+    save = 'Save';
+    cancel = 'Cancel';
 }
 
 export const NOVO_ELEMENTS_LABELS_PROVIDERS = [


### PR DESCRIPTION
This PR makes changes requested in Issue #72 . It also moves the footer from the base of the select list to the top - with the possibility of a long list, a user might not scroll to the bottom or be aware of the 'Add New Item' capability. 

##### **What did you change?**
- footerConfig has been renamed to headerConfig
- header is an li not a div
- left aligns '+ Add New Item' with other li items
- repositions as a header to solve other UX issues

##### **Reviewers**
@jgodi 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices
…f-use

Fix issue #72.

Breaking Changes: Renames Select footerConfig to Select headerConfig