### PR TITLE
BH-38530 Novo: Incorporate Schedule Next Action within Notes

### DIFF
--- a/demo/pages/form/FormDemo.js
+++ b/demo/pages/form/FormDemo.js
@@ -62,7 +62,7 @@ const template = `
     <p>This allows the user to select multiple items from a list, or returned via search.</p>
     <div class="example form-demo">${MultiselectDemoTpl}</div>
     <code-snippet [code]="MultiselectDemoTpl"></code-snippet>
-    
+
     <h5>Note</h5>
     <p>This allows the user to add a note with references/tags.</p>
     <div class="example form-demo">${QuickNoteInputDemoTpl}</div>
@@ -271,7 +271,29 @@ export class FormDemo {
                             label: 'TRIGGER'
                         }
                     ]
-                }, {
+                },
+                {
+                    name: 'nextAction',
+                    type: 'tiles',
+                    dataType: 'String',
+                    label: 'Next Action',
+                    required: true,
+                    options: [
+                        {
+                            value: 'none',
+                            label: 'None'
+                        },
+                        {
+                            value: 'task',
+                            label: 'Task'
+                        },
+                        {
+                            value: 'appointment',
+                            label: 'Appointment'
+                        }
+                    ]
+                },
+                {
                     name: 'state',
                     type: 'picker',
                     dataType: 'String',

--- a/src/elements/form/_Form.scss
+++ b/src/elements/form/_Form.scss
@@ -94,6 +94,7 @@ novo-form {
                     select-input,
                     text-area,
                     text-input,
+                    tiles-input,
                     time-input {
                         font-size: 1rem;
                         flex: 1;

--- a/src/elements/form/extras/FormExtras.js
+++ b/src/elements/form/extras/FormExtras.js
@@ -19,6 +19,7 @@ import { CurrencyInput } from './currency-input/CurrencyInput';
 import { PercentInput } from './percent-input/PercentInput';
 import { FloatInput } from './float-input/FloatInput';
 import { QuickNoteInput } from './quick-note-input/QuickNoteInput';
+import { TilesInput } from './tiles-input/TilesInput';
 
 import { FormInput } from './form-input/FormInput';
 import { FormLabel, FormLabelMeta } from './form-label/FormLabel';
@@ -46,6 +47,7 @@ export * from './currency-input/CurrencyInput';
 export * from './percent-input/PercentInput';
 export * from './float-input/FloatInput';
 export * from './quick-note-input/QuickNoteInput';
+export * from './tiles-input/TilesInput';
 export * from './FormValidators';
 
 export * from './form-input/FormInput';
@@ -74,7 +76,8 @@ export const NOVO_FORM_EXTRAS = [
     PercentInput,
     FloatInput,
     FormValidators,
-    QuickNoteInput
+    QuickNoteInput,
+    TilesInput
 ];
 
 export const NOVO_FORM_CORE = [

--- a/src/elements/form/extras/form-input/FormInput.js
+++ b/src/elements/form/extras/form-input/FormInput.js
@@ -21,7 +21,8 @@ import {
     CurrencyInput,
     PercentInput,
     FloatInput,
-    QuickNoteInput
+    QuickNoteInput,
+    TilesInput
 } from '../FormExtras';
 
 @Component({
@@ -89,7 +90,8 @@ export class FormInput {
             percentage: PercentInput,
             money: CurrencyInput,
             float: FloatInput,
-            note: QuickNoteInput
+            note: QuickNoteInput,
+            tiles: TilesInput
         };
 
         if (this.type === 'checkbox' && this.options) {

--- a/src/elements/form/extras/tiles-input/TilesInput.js
+++ b/src/elements/form/extras/tiles-input/TilesInput.js
@@ -1,0 +1,40 @@
+import { Component } from '@angular/core';
+import { COMMON_DIRECTIVES, NgModel } from '@angular/common';
+
+import { BaseInput } from './../FormExtras';
+import { NOVO_TILES_ELEMENTS } from './../../../tiles';
+import { NOVO_PICKER_ELEMENTS } from './../../../picker';
+import { NovoLabelService } from './../../../../novo-elements';
+
+@Component({
+    selector: 'tiles-input',
+    inputs: [
+        'name',
+        'placeholder',
+        'options',
+        'placeholder',
+        'required'
+    ],
+    directives: [
+        COMMON_DIRECTIVES,
+        NOVO_TILES_ELEMENTS,
+        NOVO_PICKER_ELEMENTS,
+        NgModel
+    ],
+    template: `
+        <i *ngIf="required" class="required-indicator" [ngClass]="{'bhi-circle': !control.valid, 'bhi-check': control.valid}"></i>
+        <novo-tiles [options]="options" (changed)="onChanged($event)"></novo-tiles>
+        <span class="error-message" *ngIf="required && control.touched && control?.errors?.required">{{labels.required}}</span>
+    `
+})
+export class TilesInput extends BaseInput {
+    constructor(labels:NovoLabelService) {
+        super();
+        this.labels = labels;
+    }
+
+    onChanged(e) {
+        this.value = e.value ? e.value : null;
+        this.update.emit(this.value);
+    }
+}

--- a/src/elements/form/extras/tiles-input/TilesInput.spec.js
+++ b/src/elements/form/extras/tiles-input/TilesInput.spec.js
@@ -1,0 +1,50 @@
+// // import {DOM} from 'angular2/src/platform/dom/dom_adapter';
+// import { Component } from '@angular/core';
+// import { By } from 'angular2/platform/common_dom';
+// import { beforeEach, expect, describe, it } from 'angular2/testing';
+// import { createTestContext } from '../../../../testing/TestContext';
+// import { FormInput, TilesInput } from '../FormExtras';
+//
+// @Component({
+//     selector: 'test-cmp',
+//     directives: [FormInput, TilesInput],
+//     template: `
+//     <form-input type="picker" multiple="true"></form-input>
+// `
+// })
+// class TestCmp {
+//     constructor() {
+//     }
+// }
+//
+// describe('Element: TilesInput', () => {
+//     let ctx;
+//     let instance;
+//     let cmpElement;
+//     let cmpInstance;
+//
+//     beforeEach(createTestContext(_ctx => ctx = _ctx));
+//
+//     beforeEach(done => {
+//         ctx.init(TestCmp)
+//             .finally(done)
+//             .subscribe(() => {
+//                 instance = ctx.fixture.componentInstance;
+//             });
+//     });
+//
+//     beforeEach(done => {
+//         setTimeout(() => {
+//             const cmpDebugElement = ctx.fixture.debugElement.query(By.directive(TilesInput));
+//             cmpElement = cmpDebugElement.nativeElement;
+//             cmpInstance = cmpDebugElement.componentInstance;
+//             done();
+//         }, 50);
+//     });
+//
+//     it('should have the instance and cmpElement defined', () => {
+//         expect(instance).toBeDefined();
+//         expect(cmpInstance).toBeDefined();
+//         expect(cmpElement).toBeDefined();
+//     });
+// });

--- a/src/elements/tiles/_Tiles.scss
+++ b/src/elements/tiles/_Tiles.scss
@@ -1,32 +1,7 @@
 novo-tiles {
-    display: flex;
     border-radius: .5em;
     color: $grey;
-    font-weight: 500;
-    width: 100%;
-    margin-left: 2px;
-
-    i.required-indicator {
-        position: absolute;
-        left: -25px;
-        height: 15px;
-        width: 15px;
-        font-size: 15px;
-        top: 13px;
-        transform: translateY(-50%);
-
-        &.bhi-circle {
-            color: $grapefruit;
-            height: 10px;
-            width: 10px;
-            text-align: center;
-            font-size: 7px;
-        }
-
-        &.bhi-check {
-            color: $grass;
-        }
-    }
+    margin-left:3px;
 
     $border-properties: solid 2px lighten($grey, 20%);
 
@@ -40,19 +15,11 @@ novo-tiles {
         border-top-right-radius: .5em;
         border-right: $border-properties;
         border-bottom-right-radius: .5em;
-
-        &.active {
-            label {
-                left: 2px;
-            }
-        }
     }
 
     > div {
         cursor: pointer;
-        flex: 1;
-        min-width: 40px;
-        min-height: 40px;
+        display: inline-block;
         padding: 1em;
         text-align: center;
         background-color: $off-white;
@@ -60,6 +27,16 @@ novo-tiles {
         border-bottom: $border-properties;
         position: relative;
         transition: border-color 250ms, background-color 250ms, color 250ms;
+        margin-left:-3px;
+
+        &.active{
+            display: inline-block;
+            z-index: 1;
+            padding: 1em calc(1em - 2px);
+        }
+        &:nth-of-type(1).active{
+            padding: 1em calc(1em - 2px) 1em 1em;
+        }
 
         label {
             transition: border-color 250ms, background-color 250ms, color 250ms;
@@ -71,16 +48,10 @@ novo-tiles {
         }
 
         &.active {
+            border: solid 2px $positive!important;
+            border-radius: .5em;
+            background-color: white;
             label {
-                left: -2px;
-                top: -2px;
-                width: 100%;
-                position: absolute;
-                display: block;
-                padding: 1em;
-                border: solid 2px $positive;
-                border-radius: .5em;
-                background-color: white;
                 span {
                     color: $positive;
                 }


### PR DESCRIPTION
Updated the Styling for tiles so it is more flexible to various content, removed any absolute labels.

Added tiles to the form component

##### **What did you change?**
form component
tiles component


##### **Reviewers**
* @bvkimball @jgodi @krsween 

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices
Changes to styling for Tiles component and adding form support for it