### PR TITLE
fix(loading): Cross browser fixes for Loading element animations

### DIFF
--- a/src/assets/styles/global/_functions.scss
+++ b/src/assets/styles/global/_functions.scss
@@ -1,12 +1,9 @@
 // Function to loop through a SCSS map ($map) and set the map's key values to a
 // specific CSS attribute ($target) each time creating a new :nth-of-type rule at
 // the key's index.
-
 // For example see "loading" element. (BhLoading.scss)
-
 @mixin enumerate($map, $target, $prop, $val) {
     $keys: map-keys($map);
-
     @each $item in $keys {
         $idx: index($keys, $item);
         //@debug $idx;
@@ -24,16 +21,33 @@
         }
     }
 }
-
 // Animation Delay Function - multiplies $base-speed by key index;
 @mixin delay($map, $base-speed) {
     $keys: map-keys($map);
-
     @each $item in $keys {
         $idx: index($keys, $item);
 
         &:nth-of-type(#{$idx}) {
             animation-delay: $base-speed * $idx;
+        }
+    }
+}
+// FULL Animation Delay Function - multiplies $base-speed by key index;
+@mixin animationMapDelay($map, $animation-name, $animation-duration, $animation-timing-function, $delay-base-speed, $animation-direction, $animation-iterate-count, $animation-fill-mode, $animation-play-state) {
+    $keys: map-keys($map);
+    @each $item in $keys {
+        $idx: index($keys, $item);
+
+        &:nth-of-type(#{$idx}) {
+            animation: $animation-name $animation-duration $animation-timing-function ($delay-base-speed * $idx) $animation-direction $animation-iterate-count $animation-fill-mode $animation-play-state;
+            animation-name: $animation-name;
+            animation-duration: $animation-duration;
+            animation-timing-function: $animation-timing-function;
+            animation-delay: $delay-base-speed * $idx;
+            animation-direction: $animation-direction;
+            animation-iteration-count: $animation-iterate-count;
+            animation-fill-mode: $animation-fill-mode;
+            animation-play-state: $animation-play-state;
         }
     }
 }

--- a/src/elements/loading/Loading.js
+++ b/src/elements/loading/Loading.js
@@ -33,6 +33,22 @@ export class Loading {}
                     -webkit-filter: url("{{baseHref || ''}}#gooEffect");
                     filter: url("{{baseHref || ''}}#gooEffect");
                 }
+                _:-webkit-full-screen:not(:root:root), .bullhornSpinner g.circleGroup {
+                    -webkit-filter: none;
+                    filter: none;
+                }
+                @supports (-webkit-text-size-adjust:none) and (not (-ms-accelerator:true)) and (not (-moz-appearance:none)) {
+                    .bullhornSpinner g.circleGroup {
+                        -webkit-filter: none;
+                        filter: none;
+                    }
+                }
+                @supports (-webkit-text-size-adjust:none) and (not (-ms-accelerator:true)) and (not (-moz-appearance:none)) {
+                    .bullhornSpinner g.circleGroup {
+                        -webkit-filter: none;
+                        filter: none;
+                    }
+                }
             </style>
             <filter id="gooEffect">
                 <feGaussianBlur in="SourceGraphic" stdDeviation="5" result="blur" />
@@ -44,12 +60,53 @@ export class Loading {}
                 <feComposite in="SourceGraphic" in2="gooEffect" operator="atop" />
             </filter>
         </defs>
+
+        <path d="M 43 43 L 54 45 L 80 40 L 43 43"
+            stroke="none" fill="none" id="firstLinePath"/>
+
+        <path d="M 43 43 L 48 41 L 48 18 L 43 43"
+            stroke="none" fill="none" id="secondLinePath"/>
+
+        <path d="M 43 43 L 42 45 L 15 40 L 43 43"
+            stroke="none" fill="none" id="thirdLinePath"/>
+
+        <path d="M 43 43 L 44 52 L 29 78 L 43 43"
+            stroke="none" fill="none" id="fourthLinePath"/>
+
+        <path d="M 43 43 L 52 52 L 68 78 L 43 43"
+            stroke="none" fill="none" id="fifthLinePath"/>
+
         <g class="circleGroup" transform="translate(7, 7)">
-            <circle />
-            <circle />
-            <circle />
-            <circle />
-            <circle />
+            <circle r="6" cx="0" cy="0">
+                <!-- Define the motion path animation -->
+                <animateMotion dur="3.4" repeatCount="indefinite">
+                    <mpath xlink:href="#firstLinePath"/>
+                </animateMotion>
+            </circle>
+            <circle r="6" cx="0" cy="0">
+                <!-- Define the motion path animation -->
+                <animateMotion dur="3.4" repeatCount="indefinite">
+                    <mpath xlink:href="#secondLinePath"/>
+                </animateMotion>
+            </circle>
+            <circle r="6" cx="0" cy="0">
+                <!-- Define the motion path animation -->
+                <animateMotion dur="3.4" repeatCount="indefinite">
+                    <mpath xlink:href="#thirdLinePath"/>
+                </animateMotion>
+            </circle>
+            <circle r="6" cx="0" cy="0">
+                <!-- Define the motion path animation -->
+                <animateMotion dur="3.4" repeatCount="indefinite">
+                    <mpath xlink:href="#fourthLinePath"/>
+                </animateMotion>
+            </circle>
+            <circle r="6" cx="0" cy="0">
+                <!-- Define the motion path animation -->
+                <animateMotion dur="3.4" repeatCount="indefinite">
+                    <mpath xlink:href="#fifthLinePath"/>
+                </animateMotion>
+            </circle>
         </g>
     </svg>
     `

--- a/src/elements/loading/_Loading.scss
+++ b/src/elements/loading/_Loading.scss
@@ -1,20 +1,3 @@
-@mixin enum-delay-child($map) {
-    $keys: map-keys($map);
-    @each $item in $keys {
-        $idx: index($keys, $item);
-
-        &:nth-of-type(#{$idx}) {
-            dot {
-                background-color: map-get($map, $item);
-
-                &.cycle {
-                    animation-delay: 100ms * $idx;
-                }
-            }
-        }
-    }
-}
-
 novo-loading {
     padding: 20px;
     display: flex;
@@ -25,11 +8,10 @@ novo-loading {
         display: block;
         border-radius: 50%;
         margin: 3px;
-        animation: jump 1600ms infinite;
         height: 13px;
         width: 13px;
         @include enumerate($dot-colors, 'background-color', 'map-val', '');
-        @include delay($dot-colors, 70ms);
+        @include animationMapDelay($dot-colors, jump, 1600ms, ease-in-out, 70ms, forward, infinite, '', '');
     }
     @each $analytics, $color in $analytics-colors {
         &.#{$analytics} {

--- a/src/elements/loading/_NovoSpinner.scss
+++ b/src/elements/loading/_NovoSpinner.scss
@@ -17,9 +17,9 @@ novo-spinner {
         }
 
         .circleGroup circle {
-            cx: 47;
-            cy: 47;
-            r: 6;
+            //cx: 47;
+            //cy: 47;
+            //r: 6;
             fill: $dark;
 
             &:nth-of-type(odd) {
@@ -28,7 +28,7 @@ novo-spinner {
             transform-origin: center center;
             @for $i from 1 through 5 {
                 &:nth-of-type(#{$i}) {
-                    animation: circle#{$i} 3400ms infinite;
+                    //animation: circle#{$i} 3400ms infinite;
                     animation-delay: $i * 70ms;
                 }
             }
@@ -169,5 +169,4 @@ novo-spinner {
             cy: 43;
         }
     }
-
 }


### PR DESCRIPTION
Cross-browser fixes for loading animations: chrome, firefox, safari, iOS

##### **What did you change?**
* Adds animation path to spinner animation for firefox
* Removes filter effect on Safari / iOS Safari (Safari bug)

##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices
