### PR TITLE
fix(chips): change extra margin/padding on bottom

### DIFF
--- a/src/elements/picker/_Picker.scss
+++ b/src/elements/picker/_Picker.scss
@@ -95,7 +95,7 @@ picker-null-recent-results {
     &.active {
         max-height: 200px;
         overflow: auto;
-        padding: 8px 0 16px;
+        padding: 0 0 16px;
         z-index: 2;
     }
     &:focus {
@@ -116,4 +116,3 @@ picker-loader {
     align-items: center;
     flex-direction: column;
 }
-


### PR DESCRIPTION
Extra padding was added to the top of picker results

##### **What did you change?**

Removed padding-top

##### **Reviewers**
* @jgodi @bvkimball @krsween 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices
