### PR TITLE
feat(entitycolor): adding notes entity color

### DIFF
--- a/src/assets/styles/global/_variables.scss
+++ b/src/assets/styles/global/_variables.scss
@@ -30,6 +30,7 @@ $opportunity: #662255;
 $job: #BB5566;
 $submission: #778899;
 $placement: #0B344F;
+$note: #778899;
 
 // Color Applications
 $positive: $ocean;
@@ -68,7 +69,8 @@ $entity-colors: (
     opportunity: $opportunity,
     job: $job,
     submission: $submission,
-    placement: $placement
+    placement: $placement,
+    note: $note
 );
 
 // Generic Color Map


### PR DESCRIPTION
adding Notes entity color to _variables.scss

##### **What did you change?**
`+$note: #778899;
+note: $note`


##### **Reviewers**
* @bvkimball @jgodi @krsween 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices
