### PR TITLE
Updates for required fields & toast

### DIFF
--- a/src/elements/form/Form.js
+++ b/src/elements/form/Form.js
@@ -1,4 +1,4 @@
-import { Component, ViewContainerRef, ComponentResolver, ViewChild, ElementRef, EventEmitter } from '@angular/core';
+import { Component, ViewContainerRef, ComponentResolver, ViewChild, EventEmitter } from '@angular/core';
 import { COMMON_DIRECTIVES } from '@angular/common';
 import { isBlank } from '@angular/core/src/facade/lang';
 
@@ -29,9 +29,8 @@ import { FormField, FormFieldMeta, FormLabel, FormInput } from './extras/FormExt
 export class Form {
     @ViewChild('form', { read: ViewContainerRef }) form:ViewContainerRef;
 
-    constructor(componentResolver:ComponentResolver, el:ElementRef) {
+    constructor(componentResolver:ComponentResolver) {
         this.componentResolver = componentResolver;
-        this.element = el;
         this.data = {};
         this.fields = [];
         this.changed = new EventEmitter();
@@ -43,7 +42,7 @@ export class Form {
             let required = field.data.required;
             let data = this.data[name];
 
-            if ((data && required) || !required) {
+            if ((data !== undefined && data !== null && required) || !required) {
                 field.hidden = true;
             }
         }

--- a/src/elements/form/Form.spec.js
+++ b/src/elements/form/Form.spec.js
@@ -12,6 +12,11 @@ class TestCmp {
 }
 
 describe('Element: Form', () => {
+    let comp;
+    beforeEachProviders(() => [
+        Form
+    ]);
+
     it('should initialize correctly', testComponent(TestCmp, (fixture) => {
         const { instance, element, testComponentInstance, testComponentElement } = grabComponent(fixture, Form);
         expect(instance).toBeTruthy();
@@ -19,4 +24,37 @@ describe('Element: Form', () => {
         expect(testComponentInstance).toBeTruthy();
         expect(testComponentElement).toBeTruthy();
     }));
+
+    beforeEach(inject([Form], _comp => {
+        comp = _comp;
+    }));
+
+    describe('Function: hideCompletedFields', () => {
+        it('should not hide required fields with no data', () => {
+            comp.fields = [{
+                data: {
+                    name: 'stuff',
+                    required: true
+                },
+                hidden: false
+            }];
+            comp.data = {};
+            comp.hideCompletedFields();
+            expect(comp.fields[0].hidden).toBeFalsy();
+        });
+        it('should hide required fields with data', () => {
+            comp.fields = [{
+                data: {
+                    name: 'stuff',
+                    required: true
+                },
+                hidden: false
+            }];
+            comp.data = {
+                stuff: 'stuff'
+            };
+            comp.hideCompletedFields();
+            expect(comp.fields[0].hidden).toBeTruthy();
+        });
+    });
 });

--- a/src/elements/toast/_Toast.scss
+++ b/src/elements/toast/_Toast.scss
@@ -3,7 +3,7 @@ novo-toast {
     position: relative;
     background: $navy;
     color: $white;
-    padding: 15px;
+    padding: 15px 15px 15px 25px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, .15);
 
     &.show {
@@ -37,6 +37,7 @@ novo-toast.toast-container > .toast-icon {
     margin-right: 15px;
 
     i {
+        display: flex;
         position: relative;
         top: 0;
         font-size: 16px;
@@ -47,6 +48,8 @@ novo-toast.toast-container > .toast-icon {
 novo-toast.toast-container .toast-content {
     float: left;
     width: calc(100% - 47px);
+    flex-direction: column;
+    display: flex;
 
     h5 + p {
         top: 0;
@@ -77,8 +80,9 @@ novo-toast .toast-content > p {
 
     &.message-only {
         top: 0;
-        font-size: 18px;
+        font-size: 16px;
         line-height: 22px;
+        padding: 0;
     }
 }
 


### PR DESCRIPTION
- style(toast): updates to toast styles
- fix(form): fixes hiding of boolean required fields

##### **What did you change?**
- Form: checks explicitly for null & undefined to account for boolean fields
- Form: removed unused import
- Toast: message only version font-size
- Toast: more padding-left

##### **Reviewers**
* @krsween @bvkimball 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices