### PR TITLE
refactor(Table): added the ability to specify custom options for qty …

### DIFF
--- a/demo/pages/table/TableDemo.js
+++ b/demo/pages/table/TableDemo.js
@@ -73,6 +73,13 @@ export class TableDemo {
         this.DetailsTableDemoTpl = DetailsTableDemoTpl;
         this.SelectAllTableDemoTpl = SelectAllTableDemoTpl;
 
+        this.customPageOptions = [
+            { label: '10', value: 10 },
+            { label: '20', value: 20 },
+            { label: '30', value: 30 },
+            { label: '40', value: 40 }
+        ];
+
         let columns = [
             { title: 'Name', name: 'name', ordering: true, type: 'link', filtering: true },
             { title: 'Position', name: 'position', ordering: true, filtering: true },

--- a/demo/pages/table/templates/TableDemo.html
+++ b/demo/pages/table/templates/TableDemo.html
@@ -8,6 +8,7 @@
     </div>
     <novo-pagination *ngIf="basic.config.paging"
                      [page]="basic.config.paging.current"
+                     [pageOptions]="customPageOptions"
                      [totalItems]="basic.rows.length"
                      [itemsPerPage]="basic.config.paging.itemsPerPage"
                      (onPageChange)="basic.config.paging.onPageChange($event)">

--- a/src/elements/table/extras/pagination/Pagination.js
+++ b/src/elements/table/extras/pagination/Pagination.js
@@ -7,7 +7,8 @@ import { NOVO_SELECT_ELEMENTS } from '../../../select';
     inputs: [
         'page',
         'totalItems',
-        'itemsPerPage'
+        'itemsPerPage',
+        'pageOptions'
     ],
     outputs: ['onPageChange'],
     directives: [
@@ -29,12 +30,16 @@ export class Pagination {
     constructor() {
         this.maxPagesDisplayed = 5;
         this.itemsPerPage = 10;
-        this.pageOptions = [
+        this.onPageChange = new EventEmitter();
+    }
+
+    ngOnInit() {
+        this.pageOptions = this.pageOptions || [
             { value: 10, label: '10' },
+            { value: 25, label: '25' },
             { value: 50, label: '50' },
             { value: 500, label: '500' }
         ];
-        this.onPageChange = new EventEmitter();
     }
 
     ngOnChanges() {


### PR DESCRIPTION
Added the ability to specify custom row quantities to be displayed in the table. Instead of just 10, 50, and 100 rows per page, a user can specify their own quantities.

##### **What did you change?**

Added `pageOptions` as an `input`

##### **Reviewers**
* @bvkimball 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices
…of rows being shown