### PR TITLE
refactor(Pagination): changed property names to be more intuitive

### DIFF
--- a/demo/pages/table/TableDemo.js
+++ b/demo/pages/table/TableDemo.js
@@ -73,7 +73,7 @@ export class TableDemo {
         this.DetailsTableDemoTpl = DetailsTableDemoTpl;
         this.SelectAllTableDemoTpl = SelectAllTableDemoTpl;
 
-        this.customPageOptions = [
+        this.customRowOptions = [
             { label: '10', value: 10 },
             { label: '20', value: 20 },
             { label: '30', value: 30 },

--- a/demo/pages/table/templates/TableDemo.html
+++ b/demo/pages/table/templates/TableDemo.html
@@ -8,7 +8,7 @@
     </div>
     <novo-pagination *ngIf="basic.config.paging"
                      [page]="basic.config.paging.current"
-                     [pageOptions]="customPageOptions"
+                     [rowOptions]="customRowOptions"
                      [totalItems]="basic.rows.length"
                      [itemsPerPage]="basic.config.paging.itemsPerPage"
                      (onPageChange)="basic.config.paging.onPageChange($event)">

--- a/src/elements/table/extras/pagination/Pagination.js
+++ b/src/elements/table/extras/pagination/Pagination.js
@@ -8,7 +8,7 @@ import { NOVO_SELECT_ELEMENTS } from '../../../select';
         'page',
         'totalItems',
         'itemsPerPage',
-        'pageOptions'
+        'rowOptions'
     ],
     outputs: ['onPageChange'],
     directives: [
@@ -17,7 +17,7 @@ import { NOVO_SELECT_ELEMENTS } from '../../../select';
     ],
     template: `
         <h5 class="rows">Rows Per Page: </h5>
-        <novo-select [options]="pageOptions" placeholder="Select..." [(ngModel)]="itemsPerPage" (onSelect)="onPageSizeChanged($event)" data-automation-id="pager-select"></novo-select>
+        <novo-select [options]="rowOptions" placeholder="Select..." [(ngModel)]="itemsPerPage" (onSelect)="onPageSizeChanged($event)" data-automation-id="pager-select"></novo-select>
         <spacer></spacer>
         <ul class="pager" data-automation-id="pager">
             <li class="page" (click)="selectPage(page-1)"><i class="bhi-previous" [hidden]="noPrevious()" data-automation-id="pager-previous"></i></li>
@@ -34,11 +34,11 @@ export class Pagination {
     }
 
     ngOnInit() {
-        this.pageOptions = this.pageOptions || [
+        this.rowOptions = this.rowOptions || [
             { value: 10, label: '10' },
             { value: 25, label: '25' },
             { value: 50, label: '50' },
-            { value: 500, label: '500' }
+            { value: 100, label: '100' }
         ];
     }
 


### PR DESCRIPTION
Changed property names to be more intuitive.

##### **What did you change?**

`tableOptions` is now `rowOptions`

##### **Reviewers**
* @bvkimball 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices
