### PR TITLE
fix(tiles): fix for no defaults

### DIFF
--- a/src/elements/tiles/Tiles.js
+++ b/src/elements/tiles/Tiles.js
@@ -22,7 +22,7 @@ import { CORE_DIRECTIVES, NgControl, NgModel } from '@angular/common';
                 </label>
                 <input [hidden]="true" [name]="name" type="radio" [value]="option.checked || option" [attr.id]="name + i">
             </div>
-            <span class="active-indicator" *ngIf="activeTile"></span>
+            <span class="active-indicator" [hidden]="(activeTile === undefined || activeTile === null)"></span>
         </div>
     `
 })

--- a/src/elements/tiles/Tiles.js
+++ b/src/elements/tiles/Tiles.js
@@ -45,7 +45,7 @@ export class Tiles {
         if (this.control) {
             this.control.updateValue(this.value);
         }
-        if (this.options && this.options.length && !this.options[0].value) {
+        if (this.options && this.options.length && (this.options[0].value === undefined || this.options[0].value === null)) {
             this._options = this.options.map((x) => {
                 let item = { value: x, label: x, checked: this.value === x };
                 return item;


### PR DESCRIPTION
fix for bug when element span.active-indicator did not exist (when there was no default value)

##### **What did you change?**

ngIf -> hidden

##### **Reviewers**
* @bvkimball 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices
- switched ngIf to hidden so that element always exists