### PR TITLE
feat(TipWell): adding new TipWell feature

### DIFF
--- a/demo/pages/app/App.js
+++ b/demo/pages/app/App.js
@@ -47,6 +47,7 @@ import { TOAST_PROVIDERS, ToastService, MODAL_PROVIDERS, ModalService } from './
     { path: '/dragula', name: 'Dragula', loader: () => require('es6-promise!./../dragula/DragulaDemo')('DragulaDemo') },
     { path: '/tiles', name: 'Tiles', loader: () => require('es6-promise!./../tiles/TilesDemo')('TilesDemo') },
     { path: '/slides', name: 'Slides', loader: () => require('es6-promise!./../slides/SlidesDemo')('SlidesDemo') },
+    { path: '/tipwell', name: 'TipWell', loader: () => require('es6-promise!./../tip-well/TipWellDemo')('TipWellDemo') },
 
     // Utils
     { path: '/utils', name: 'Utils', loader: () => require('es6-promise!./../utils/UtilsDemo')('UtilsDemo') },
@@ -95,7 +96,8 @@ export class DemoApp {
             { name: 'Calendar', path: '/calendar' },
             { name: 'Dragula', path: '/dragula' },
             { name: 'Tiles', path: '/tiles' },
-            { name: 'Slides', path: '/slides' }
+            { name: 'Slides', path: '/slides' },
+            { name: 'TipWell', path: '/tipwell' }
         ].sort((a, b) => {
             if (a.name < b.name) return -1;
             if (a.name > b.name) return 1;

--- a/demo/pages/tip-well/TipWellDemo.js
+++ b/demo/pages/tip-well/TipWellDemo.js
@@ -1,0 +1,46 @@
+// NG2
+import { Component } from '@angular/core';
+import { CORE_DIRECTIVES } from '@angular/common';
+// App
+import { NOVO_TIPWELL_ELEMENTS, NOVO_BUTTON_ELEMENTS } from './../../../src/novo-elements';
+import { CodeSnippet } from '../../elements/codesnippet/CodeSnippet';
+import TipWellDemoTpl from './templates/TipWellDemo.html';
+
+const template = `
+<div class="container">
+    <h1>TipWell <small><a target="_blank" href="https://github.com/bullhorn/novo-elements/tree/master/src/elements/tip-well">(source)</a></small></h1>
+    <p>
+        This component is meant to be akin to Bootstrap's 'well'. It's a small container for help text.
+    </p>
+    <h4>Demo</h4>
+    <div>${TipWellDemoTpl}</div>
+    <br />
+    <p>Did you hide the TipWell?</p>
+    <button theme="primary" color="success" icon="refresh" (click)="clearLocalStorage()">Reset localStorage and Reload</button>
+    <br />
+    <h4>Code</h4>
+    <code-snippet [code]="TipWellDemoTpl"></code-snippet>
+</div>
+`;
+
+@Component({
+    selector: 'tip-well-demo',
+    template: template,
+    directives: [
+        NOVO_TIPWELL_ELEMENTS,
+        NOVO_BUTTON_ELEMENTS,
+        CodeSnippet,
+        CORE_DIRECTIVES
+    ]
+})
+export class TipWellDemo {
+    constructor() {
+        this.TipWellDemoTpl = TipWellDemoTpl;
+        this.demoTip = 'Sed sodales ligula et fermentum bibendum. Aliquam tincidunt sagittis leo eget auctor. Fusce eu sagittis metus, ut viverra magna. Mauris mollis nisl nec libero tincidunt posuere.';
+    }
+
+    clearLocalStorage() {
+        localStorage.removeItem('novo-tw_Demo');
+        location.reload();
+    }
+}

--- a/demo/pages/tip-well/templates/TipWellDemo.html
+++ b/demo/pages/tip-well/templates/TipWellDemo.html
@@ -1,0 +1,1 @@
+<novo-tip-well name="Demo" [tip]="demoTip"></novo-tip-well>

--- a/src/elements/tip-well.js
+++ b/src/elements/tip-well.js
@@ -1,0 +1,1 @@
+export { NOVO_TIPWELL_ELEMENTS } from './tip-well/TipWell';

--- a/src/elements/tip-well/README.md
+++ b/src/elements/tip-well/README.md
@@ -1,0 +1,12 @@
+# TipWells
+
+## Usage
+    import { NOVO_TIPWELL_ELEMENTS } from 'novo-elements';
+
+##### Properties
+- `'name' : String`
+    * Defines the name of the TipWell that will be used by localStorage for state management.
+- `'tip' : String`
+    * The contents of the TipWell.
+- `'buttonText' : String`
+    * An override of the default 'Ok, Got it' button text.

--- a/src/elements/tip-well/TipWell.js
+++ b/src/elements/tip-well/TipWell.js
@@ -1,0 +1,66 @@
+// NG2
+import { Component } from '@angular/core';
+// App
+import { NOVO_BUTTON_ELEMENTS } from '../button';
+
+@Component({
+    selector: 'novo-tip-well',
+    inputs: [
+        'name',
+        'tip',
+        'buttonText'
+    ],
+    directives: [
+        NOVO_BUTTON_ELEMENTS
+    ],
+    template: `
+        <div *ngIf="isActive">
+            <p>{{ tip }}</p>
+            <button theme="dialogue" (click)="hideTip()">{{ buttonText }}</button>
+        </div>
+    `
+})
+export class TipWell {
+    constructor() {
+        this.isActive = true;
+        // Check if localStorage is enabled
+        this.isLocalStorageEnabled = (() => {
+            let isEnabled = false;
+            if (typeof localStorage === 'object') {
+                try {
+                    localStorage.setItem('lsTest', 1);
+                    localStorage.removeItem('lsTest');
+                    isEnabled = true;
+                } catch (e) {
+                    console.warn('This web browser does not support storing settings locally. In Safari, the most common cause of this is using "Private Browsing Mode". Some settings may not save or some features may not work properly for you.'); // eslint-disable-line
+                }
+            }
+            return isEnabled;
+        })();
+    }
+
+    ngOnInit() {
+        this.tip = this.tip || '';
+        this.buttonText = this.buttonText || 'Ok, Got it';
+        // Set a (semi) unique name for the tip-well
+        this.name = this.name || Math.round(Math.round() * 100);
+        this.localStorageKey = `novo-tw_${this.name}`;
+        // Check localStorage for state
+        if (this.isLocalStorageEnabled) {
+            let storedValue = JSON.parse(localStorage.getItem(this.localStorageKey));
+            this.isActive = storedValue !== false;
+        }
+    }
+
+	/**
+     * @name hideTip
+     */
+    hideTip() {
+        if (this.isLocalStorageEnabled) {
+            localStorage.setItem(this.localStorageKey, JSON.stringify(false));
+        }
+        this.isActive = false;
+    }
+}
+
+export const NOVO_TIPWELL_ELEMENTS = [TipWell];

--- a/src/elements/tip-well/TipWell.spec.js
+++ b/src/elements/tip-well/TipWell.spec.js
@@ -1,0 +1,54 @@
+// NG2
+import { Component } from '@angular/core';
+// App
+import { TipWell } from './TipWell';
+import { testComponent, grabComponent } from './../../testing/TestHelpers';
+
+@Component({
+    selector: 'test-cmp',
+    directives: [
+        TipWell
+    ],
+    template: '<novo-tip-well></novo-tip-well>'
+})
+class TestCmp {
+}
+
+describe('Component: TipWell', () => {
+    let comp;
+
+    beforeEachProviders(() => [
+        TipWell
+    ]);
+
+    describe('Element: TipWell', () => {
+        it('should initialize correctly', testComponent(TestCmp, (fixture) => {
+            const { instance, element, testComponentInstance, testComponentElement } = grabComponent(fixture, TipWell);
+            expect(instance).toBeTruthy();
+            expect(element).toBeTruthy();
+            expect(element.innerHTML).toContain('template bindings');
+            expect(testComponentInstance).toBeTruthy();
+            expect(testComponentElement).toBeTruthy();
+        }));
+    });
+
+    beforeEach(inject([TipWell], _comp => {
+        comp = _comp;
+        localStorage.clear();
+    }));
+
+    it('should initialize with defaults.', () => {
+        expect(comp).toBeDefined();
+        expect(comp.isActive).toBeTruthy();
+        expect(comp.isLocalStorageEnabled).toBeTruthy();
+    });
+
+    describe('Method: hideTip()', () => {
+        it('should hide the tip and add a value to localStorage', () => {
+            expect(comp.hideTip).toBeDefined();
+            expect(localStorage.getItem(comp.localStorageKey)).toBe(null);
+            comp.hideTip();
+            expect(JSON.parse(localStorage.getItem(comp.localStorageKey))).toBeFalsy();
+        });
+    });
+});

--- a/src/elements/tip-well/_TipWell.scss
+++ b/src/elements/tip-well/_TipWell.scss
@@ -1,0 +1,17 @@
+novo-tip-well {
+    width: 100%;
+    min-height: 3em;
+    margin: 1em 0 1em;
+    > div {
+        border-radius: .25em;
+        background-color: $off-white;
+        color: $dark;
+        padding: 1em;
+        text-align: right;
+        
+        > p {
+            width: 100%;
+            text-align: left;
+        }
+    }
+}

--- a/src/novo-elements.js
+++ b/src/novo-elements.js
@@ -28,6 +28,7 @@ import { NOVO_DRAGULA_ELEMENTS } from './elements/dragula';
 import { NOVO_FORM_ELEMENTS, NOVO_FORM_CORE, NOVO_FORM_EXTRAS } from './elements/form';
 import { NOVO_TILES_ELEMENTS } from './elements/tiles';
 import { NOVO_SLIDER_ELEMENTS } from './elements/slider';
+import { NOVO_TIPWELL_ELEMENTS } from './elements/tip-well';
 
 // Elements
 export * from './elements/button';
@@ -57,6 +58,7 @@ export * from './elements/dragula';
 export * from './elements/form';
 export * from './elements/tiles';
 export * from './elements/slider';
+export * from './elements/tip-well';
 
 // Pipes
 export * from './pipes/plural/Plural';
@@ -99,7 +101,8 @@ export const NOVO_ELEMENTS = [
     ...NOVO_FORM_CORE,
     ...NOVO_FORM_EXTRAS,
     ...NOVO_TILES_ELEMENTS,
-    ...NOVO_SLIDER_ELEMENTS
+    ...NOVO_SLIDER_ELEMENTS,
+    ...NOVO_TIPWELL_ELEMENTS
 ];
 
 export const NOVO_SERVICES = [

--- a/src/novo-elements.scss
+++ b/src/novo-elements.scss
@@ -43,3 +43,4 @@
 @import "./elements/quick-note/QuickNote";
 @import "./elements/tiles/Tiles";
 @import "./elements/slider/Slider";
+@import "./elements/tip-well/TipWell";


### PR DESCRIPTION
A TipWell can be used to display an in-line contextual help window for features that may confuse average users.

##### **What did you change?**

Added a new component, it's demo, and associated readme to novo-elements

##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices