### PR TITLE
refactor(Picker): Added the ability to filter out events

### DIFF
--- a/src/elements/form/extras/picker-input/PickerInput.js
+++ b/src/elements/form/extras/picker-input/PickerInput.js
@@ -44,9 +44,15 @@ export class PickerInput extends BaseInput {
     }
 
     onSelect(value) {
-        this.update.emit(value);
-        this.control.updateValue(value);
-        this.toggleInactive(value);
+        if (value instanceof Event) {
+            this.update.emit(null);
+            this.control.updateValue(null);
+            this.toggleInactive(null);
+        } else {
+            this.update.emit(value);
+            this.control.updateValue(value);
+            this.toggleInactive(value);
+        }
     }
 
     toggleInactive(ev) {


### PR DESCRIPTION
In forms with the picker, if you press CMD+A or CTRL+A it registers in the DOM as a `select` event and passes that as a value into the picker, which throws off validation.

##### **What did you change?**

This checks if the value being passed in is an event and if it is an event it sets the value of picker to null.

##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices
