### PR TITLE
bug(Form): DateInput value does not bind to ngModel

### DIFF
--- a/src/elements/form/extras/date-input/DateInput.js
+++ b/src/elements/form/extras/date-input/DateInput.js
@@ -16,7 +16,7 @@ import { NovoLabelService } from './../../../../novo-elements';
         <i *ngIf="required" class="required-indicator" [ngClass]="{'bhi-circle': !control.valid, 'bhi-check': control.valid}"></i>
         <input [name]="name" type="text" [attr.id]="name" [placeholder]="placeholder" (focus)="toggleInactive($event)" (blur)="toggleInactive($event)" (click)="toggleActive($event)" [ngModel]="value" [ngFormControl]="control" readonly/>
         <i (click)="toggleActive($event)" class="bhi-calendar"></i>
-        <novo-date-picker [inline]="inline" [hidden]="!active" (onSelect)="onSelect($event); toggleInactive($event)"></novo-date-picker>
+        <novo-date-picker [inline]="inline" [hidden]="!active" (onSelect)="onSelect($event); toggleInactive($event)" [ngModel]="value"></novo-date-picker>
         <span class="error-message" *ngIf="required && control.touched && control?.errors?.required">{{labels.required}}</span>
     `
 })


### PR DESCRIPTION
DateInput sets the input to ngModel.value but does not pass it to the date picker component

##### **What did you change?**
DateInput.js


##### **Reviewers**
* @bvkimball @jgodi @krsween 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices
