### PR TITLE
feat(tipwell): Add icon and optional button

### DIFF
--- a/demo/pages/tip-well/TipWellDemo.js
+++ b/demo/pages/tip-well/TipWellDemo.js
@@ -5,6 +5,8 @@ import { CORE_DIRECTIVES } from '@angular/common';
 import { NOVO_TIPWELL_ELEMENTS, NOVO_BUTTON_ELEMENTS } from './../../../src/novo-elements';
 import { CodeSnippet } from '../../elements/codesnippet/CodeSnippet';
 import TipWellDemoTpl from './templates/TipWellDemo.html';
+import TipWellNoButtonDemoTpl from './templates/TipWellNoButtonDemo.html';
+import TipWellIconDemoTpl from './templates/TipWellIconDemo.html';
 
 const template = `
 <div class="container">
@@ -20,6 +22,19 @@ const template = `
     <br />
     <h4>Code</h4>
     <code-snippet [code]="TipWellDemoTpl"></code-snippet>
+    <h4>No Button Demo</h4>
+    <div>${TipWellNoButtonDemoTpl}</div>
+    <br />
+    <h4>Code</h4>
+    <code-snippet [code]="TipWellNoButtonDemoTpl"></code-snippet>
+    <h4>Icon Demo</h4>
+    <div>${TipWellIconDemoTpl}</div>
+    <br />
+    <p>Did you hide the TipWell?</p>
+    <button theme="primary" color="success" icon="refresh" (click)="clearLocalStorage()">Reset localStorage and Reload</button>
+    <br />
+    <h4>Code</h4>
+    <code-snippet [code]="TipWellIconDemoTpl"></code-snippet>
 </div>
 `;
 
@@ -36,6 +51,8 @@ const template = `
 export class TipWellDemo {
     constructor() {
         this.TipWellDemoTpl = TipWellDemoTpl;
+        this.TipWellNoButtonDemoTpl = TipWellNoButtonDemoTpl;
+        this.TipWellIconDemoTpl = TipWellIconDemoTpl;
         this.demoTip = 'Sed sodales ligula et fermentum bibendum. Aliquam tincidunt sagittis leo eget auctor. Fusce eu sagittis metus, ut viverra magna. Mauris mollis nisl nec libero tincidunt posuere.';
     }
 

--- a/demo/pages/tip-well/templates/TipWellDemo.html
+++ b/demo/pages/tip-well/templates/TipWellDemo.html
@@ -1,5 +1,1 @@
 <novo-tip-well name="Demo" [tip]="demoTip"></novo-tip-well>
-
-<novo-tip-well name="Demo" [tip]="demoTip" icon="info"></novo-tip-well>
-
-<novo-tip-well name="Demo" [tip]="demoTip" hasButton="false"></novo-tip-well>

--- a/demo/pages/tip-well/templates/TipWellDemo.html
+++ b/demo/pages/tip-well/templates/TipWellDemo.html
@@ -1,1 +1,5 @@
 <novo-tip-well name="Demo" [tip]="demoTip"></novo-tip-well>
+
+<novo-tip-well name="Demo" [tip]="demoTip" icon="info"></novo-tip-well>
+
+<novo-tip-well name="Demo" [tip]="demoTip" hasButton="false"></novo-tip-well>

--- a/demo/pages/tip-well/templates/TipWellIconDemo.html
+++ b/demo/pages/tip-well/templates/TipWellIconDemo.html
@@ -1,0 +1,1 @@
+<novo-tip-well name="Demo" [tip]="demoTip" icon="info" button="false"></novo-tip-well>

--- a/demo/pages/tip-well/templates/TipWellNoButtonDemo.html
+++ b/demo/pages/tip-well/templates/TipWellNoButtonDemo.html
@@ -1,0 +1,1 @@
+<novo-tip-well name="Demo" [tip]="demoTip" button="false"></novo-tip-well>

--- a/src/elements/tip-well/README.md
+++ b/src/elements/tip-well/README.md
@@ -10,3 +10,7 @@
     * The contents of the TipWell.
 - `'buttonText' : String`
     * An override of the default 'Ok, Got it' button text.
+- `'hasButton' : String`
+   * A flag that when set to 'false' makes the button optional (defaults to 'true')
+- `'icon' : String`
+   * Adds an icon at the start of the tipwell (more about icons [here](http://bullhorn.github.io/novo-elements/#/icons))

--- a/src/elements/tip-well/README.md
+++ b/src/elements/tip-well/README.md
@@ -10,7 +10,7 @@
     * The contents of the TipWell.
 - `'buttonText' : String`
     * An override of the default 'Ok, Got it' button text.
-- `'hasButton' : String`
-   * A flag that when set to 'false' makes the button optional (defaults to 'true')
+- `'button' : String`
+    * A flag that when set to 'false' makes the button optional (defaults to 'true')
 - `'icon' : String`
-   * Adds an icon at the start of the tipwell (more about icons [here](http://bullhorn.github.io/novo-elements/#/icons))
+    * Adds an icon at the start of the tipwell (more about icons [here](http://bullhorn.github.io/novo-elements/#/icons))

--- a/src/elements/tip-well/TipWell.js
+++ b/src/elements/tip-well/TipWell.js
@@ -9,7 +9,7 @@ import { NOVO_BUTTON_ELEMENTS } from '../button';
         'name',
         'tip',
         'buttonText',
-        'hasButton',
+        'button',
         'icon'
     ],
     directives: [
@@ -21,7 +21,7 @@ import { NOVO_BUTTON_ELEMENTS } from '../button';
                 <i class="bhi-{{ icon }}" *ngIf="icon"></i>
                 <p>{{ tip }}</p>
             </div>
-            <button theme="dialogue" (click)="hideTip()" *ngIf="hasButton!=='false'">{{ buttonText }}</button>
+            <button theme="dialogue" (click)="hideTip()" *ngIf="button==='true'">{{ buttonText }}</button>
         </div>
     `
 })
@@ -47,7 +47,7 @@ export class TipWell {
     ngOnInit() {
         this.tip = this.tip || '';
         this.buttonText = this.buttonText || 'Ok, Got it';
-        this.hasButton = this.hasButton || 'true';
+        this.button = this.button || 'true';
         this.icon = this.icon || null;
         // Set a (semi) unique name for the tip-well
         this.name = this.name || Math.round(Math.random() * 100);

--- a/src/elements/tip-well/TipWell.js
+++ b/src/elements/tip-well/TipWell.js
@@ -8,15 +8,20 @@ import { NOVO_BUTTON_ELEMENTS } from '../button';
     inputs: [
         'name',
         'tip',
-        'buttonText'
+        'buttonText',
+        'hasButton',
+        'icon'
     ],
     directives: [
         NOVO_BUTTON_ELEMENTS
     ],
     template: `
         <div *ngIf="isActive">
-            <p>{{ tip }}</p>
-            <button theme="dialogue" (click)="hideTip()">{{ buttonText }}</button>
+            <div>
+                <i class="bhi-{{ icon }}" *ngIf="icon"></i>
+                <p>{{ tip }}</p>
+            </div>
+            <button theme="dialogue" (click)="hideTip()" *ngIf="hasButton!=='false'">{{ buttonText }}</button>
         </div>
     `
 })
@@ -42,6 +47,8 @@ export class TipWell {
     ngOnInit() {
         this.tip = this.tip || '';
         this.buttonText = this.buttonText || 'Ok, Got it';
+        this.hasButton = this.hasButton || 'true';
+        this.icon = this.icon || null;
         // Set a (semi) unique name for the tip-well
         this.name = this.name || Math.round(Math.random() * 100);
         this.localStorageKey = `novo-tw_${this.name}`;

--- a/src/elements/tip-well/TipWell.spec.js
+++ b/src/elements/tip-well/TipWell.spec.js
@@ -35,15 +35,12 @@ describe('Component: TipWell', () => {
     beforeEach(inject([TipWell], _comp => {
         comp = _comp;
         localStorage.clear();
-        comp.ngOnInit();
     }));
 
     it('should initialize with defaults.', () => {
         expect(comp).toBeDefined();
         expect(comp.isActive).toBeTruthy();
         expect(comp.isLocalStorageEnabled).toBeTruthy();
-        expect(comp.hasButton).toBeTruthy();
-        expect(comp.icon).toBeNull();
     });
 
     describe('Method: hideTip()', () => {
@@ -52,6 +49,16 @@ describe('Component: TipWell', () => {
             expect(localStorage.getItem(comp.localStorageKey)).toBe(null);
             comp.hideTip();
             expect(JSON.parse(localStorage.getItem(comp.localStorageKey))).toBeFalsy();
+        });
+    });
+
+    describe('Method: ngOnInit()', () => {
+        it('should initialize tipwell variables to defaults', () => {
+            comp.ngOnInit();
+            expect(comp.tip).toEqual('');
+            expect(comp.buttonText).toEqual('Ok, Got it');
+            expect(comp.button).toBeTruthy();
+            expect(comp.icon).toBeNull();
         });
     });
 });

--- a/src/elements/tip-well/TipWell.spec.js
+++ b/src/elements/tip-well/TipWell.spec.js
@@ -35,12 +35,15 @@ describe('Component: TipWell', () => {
     beforeEach(inject([TipWell], _comp => {
         comp = _comp;
         localStorage.clear();
+        comp.ngOnInit();
     }));
 
     it('should initialize with defaults.', () => {
         expect(comp).toBeDefined();
         expect(comp.isActive).toBeTruthy();
         expect(comp.isLocalStorageEnabled).toBeTruthy();
+        expect(comp.hasButton).toBeTruthy();
+        expect(comp.icon).toBeNull();
     });
 
     describe('Method: hideTip()', () => {

--- a/src/elements/tip-well/_TipWell.scss
+++ b/src/elements/tip-well/_TipWell.scss
@@ -1,8 +1,8 @@
 novo-tip-well {
-    width: 100%;
-    min-height: 3em;
+    display: inline-block;
     margin: 1em 0 1em;
     > div {
+        display: inline-block;
         border-radius: .25em;
         background-color: $off-white;
         color: $dark;
@@ -12,12 +12,14 @@ novo-tip-well {
         > div {
             display: flex;
             > i {
-                flex: 1;
+                flex-shrink: 0;
                 text-align: center;
-                margin-top: .5em;
+                margin-top: .3em;
+                margin-right: 10px;
             }
             > p {
-                flex: 12;
+                width: 100%;
+                max-width: 33em; 
                 text-align: left;
             }
         }

--- a/src/elements/tip-well/_TipWell.scss
+++ b/src/elements/tip-well/_TipWell.scss
@@ -8,10 +8,18 @@ novo-tip-well {
         color: $dark;
         padding: 1em;
         text-align: right;
-        
-        > p {
-            width: 100%;
-            text-align: left;
+
+        > div {
+            display: flex;
+            > i {
+                flex: 1;
+                text-align: center;
+                margin-top: .5em;
+            }
+            > p {
+                flex: 12;
+                text-align: left;
+            }
         }
     }
 }


### PR DESCRIPTION
Add icon to tipwell and make button optional

##### **What did you change?**
I added two variables icon and hasButton. Icon is used to display an icon at the front of the tipwell. Icon defaults to not showing. hasButton decides whether or not the button will be shown. It defaults to true. 


##### **Reviewers**
* @user

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices
