### PR TITLE
chore(Table): Refactored automation IDs

### DIFF
--- a/src/elements/table/Table.js
+++ b/src/elements/table/Table.js
@@ -121,7 +121,7 @@ export class NovoTableHeader {
                                             <button theme="dialogue" color="negative" icon="times" (click)="onFilterClear(column)" *ngIf="column.filter">{{ labels.clear }}</button>
                                         </div>
                                     </item>
-                                    <item [ngClass]="{ active: isFilterActive(column, option) }" *ngFor="let option of column.options" (click)="onFilterClick(column, option)" [showAfterSelect]="option.range" [attr.data-automation-id]="option">
+                                    <item [ngClass]="{ active: isFilterActive(column, option) }" *ngFor="let option of column.options" (click)="onFilterClick(column, option)" [showAfterSelect]="option.range" [attr.data-automation-id]="(option?.label || option)">
                                         {{ option?.label || option }} <i class="bhi-check" *ngIf="isFilterActive(column, option)"></i>
                                     </item>
                                     <div class="calender-container" [class.active]="column.calenderShow">


### PR DESCRIPTION
Date filters are objects in the new date-filter drop-down, but the data automation IDs still treat them as though they're strings.

##### **What did you change?**

Date-filter automation IDs now pass a date object's `label` property or the date object itself.

##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices
