### PR TITLE
Adds max-width to paragraph tags

### DIFF
--- a/src/assets/styles/content/_typography.scss
+++ b/src/assets/styles/content/_typography.scss
@@ -6,7 +6,6 @@ html {
     font-size: $base-font-size;
     color: $base-font-color;
 }
-
 // Headers
 // --------------------------------------------------
 
@@ -53,7 +52,6 @@ h6 {
     margin: 0;
     padding: 0.75em 0 0.25em;
 }
-
 // Body And Paragraph
 // --------------------------------------------------
 
@@ -62,8 +60,8 @@ p {
     line-height: 1.7rem;
     margin: 0;
     padding: 0.25rem 0 0.55rem;
+    max-width: 33em;
 }
-
 // Special Classes
 // --------------------------------------------------
 
@@ -74,7 +72,6 @@ p {
     opacity: 0.55;
     letter-spacing: 0.1px;
 }
-
 // Iconography
 // --------------------------------------------------
 $icon-height: 1.7em; // 24px Base background size
@@ -97,17 +94,13 @@ i {
                 vertical-align: baseline;
                 line-height: 1.8;
             }
-
-            @each $entity,
-            $color in $entity-colors {
+            @each $entity, $color in $entity-colors {
                 &.#{$entity} {
                     color: $white;
                     background: $color;
                 }
             }
-
-            @each $key,
-            $color in $analytics-colors {
+            @each $key, $color in $analytics-colors {
                 &.#{$key} {
                     color: $white;
                     background: $color;
@@ -116,8 +109,7 @@ i {
         }
 
         &[theme="entity"] {
-            @each $entity,
-            $color in $entity-colors {
+            @each $entity, $color in $entity-colors {
                 &.#{$entity} {
                     color: $color;
                     background: transparent;
@@ -126,8 +118,8 @@ i {
         }
     }
 }
-
 // Nested icons
+figcaption,
 h1,
 h2,
 h3,
@@ -135,8 +127,7 @@ h4,
 h5,
 h6,
 p,
-span,
-figcaption {
+span {
     i {
         margin: 0 0.45em 0 0;
         padding: 0;
@@ -159,7 +150,6 @@ figcaption {
         }
     }
 }
-
 // Hyperlinks
 // --------------------------------------------------
 
@@ -174,12 +164,11 @@ a {
         color: $positive;
     }
 
-    &:hover,
-    &:active {
+    &:active,
+    &:hover {
         color: darken($positive, 10%);
     }
 }
-
 // Code
 // --------------------------------------------------
 


### PR DESCRIPTION
`<p>` tags are used for block paragraph text and should have a max-width. (See [typography](http://bullhorn.github.io/novo-elements/#/typography) section of style guide)

##### **What did you change?**
* Adds `max-width: 33em;` to `p` tags in global typographic styles.

##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices
