### PR TITLE
refactor(QuickNote): Added emitter for model changes on QuickNote

### DIFF
--- a/demo/novo-elements-demo.module.js
+++ b/demo/novo-elements-demo.module.js
@@ -7,6 +7,38 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DemoComponent } from './app/App';
 import { routing } from './app/App.routes';
 import { CodeSnippet } from './elements/codesnippet/CodeSnippet';
+import { Home } from './pages/home/Home';
+import { ColorComponent, CompositionComponent, TypographyComponent, IconographyComponent } from './pages/design/all';
+import {
+    ButtonDemoComponent,
+    RadioDemoComponent,
+    QuickNoteDemoComponent,
+    ModalDemoComponent,
+    FormDemoComponent,
+    ToastDemoComponent,
+    TooltipDemoComponent,
+    CardDemoComponent,
+    LoadingDemoComponent,
+    DropdownDemoComponent,
+    PickerDemoComponent,
+    ChipsDemoComponent,
+    SelectDemoComponent,
+    TabsDemoComponent,
+    TableDemoComponent,
+    ListDemoComponent,
+    HeaderDemoComponent,
+    SwitchDemoComponent,
+    DrawerDemoComponent,
+    CalendarDemoComponent,
+    DragulaDemoComponent,
+    TilesDemoComponent,
+    SlidesDemoComponent,
+    EditorDemoComponent,
+    TipWellDemoComponent
+} from './pages/elements/all';
+import { UtilsDemoComponent } from './pages/utils/utils/UtilsDemo';
+import { PipesDemoComponent } from './pages/utils/pipes/PipesDemo';
+
 import './demo.scss';
 // Vendor
 import { NovoElementsModule, FormUtils } from './../src/novo-elements';
@@ -14,7 +46,39 @@ import { NovoElementsModule, FormUtils } from './../src/novo-elements';
 @NgModule({
     declarations: [
         DemoComponent,
-        CodeSnippet
+        CodeSnippet,
+        Home,
+        ColorComponent,
+        CompositionComponent,
+        TypographyComponent,
+        IconographyComponent,
+        ButtonDemoComponent,
+        RadioDemoComponent,
+        QuickNoteDemoComponent,
+        ModalDemoComponent,
+        FormDemoComponent,
+        ToastDemoComponent,
+        TooltipDemoComponent,
+        CardDemoComponent,
+        LoadingDemoComponent,
+        DropdownDemoComponent,
+        PickerDemoComponent,
+        ChipsDemoComponent,
+        SelectDemoComponent,
+        TabsDemoComponent,
+        TableDemoComponent,
+        ListDemoComponent,
+        HeaderDemoComponent,
+        SwitchDemoComponent,
+        DrawerDemoComponent,
+        CalendarDemoComponent,
+        DragulaDemoComponent,
+        TilesDemoComponent,
+        SlidesDemoComponent,
+        EditorDemoComponent,
+        TipWellDemoComponent,
+        UtilsDemoComponent,
+        PipesDemoComponent
     ],
     imports: [
         BrowserModule,
@@ -27,8 +91,11 @@ import { NovoElementsModule, FormUtils } from './../src/novo-elements';
     providers: [
         FormUtils
     ],
-    entryComponents: [DemoComponent],
+    entryComponents: [
+        DemoComponent
+    ],
     bootstrap: [DemoComponent]
 })
 export class NovoElementsDemoModule {
 }
+

--- a/demo/pages/elements/form/FormDemo.js
+++ b/demo/pages/elements/form/FormDemo.js
@@ -7,7 +7,7 @@ import TextBasedControlsDemoTpl from './templates/TextBasedControls.html';
 import CheckBoxControlsDemoTpl from './templates/CheckBoxControls.html';
 import MockMeta from './MockMeta';
 // Vendor
-import { FormUtils, TextBoxControl, CheckboxControl, CheckListControl } from './../../../../src/novo-elements';
+import { FormUtils, TextBoxControl, CheckboxControl, CheckListControl, QuickNoteControl } from './../../../../src/novo-elements';
 
 const template = `
 <div class="container">
@@ -47,7 +47,30 @@ export class FormDemoComponent {
         this.VerticalDynamicFormDemoTpl = VerticalDynamicFormDemoTpl;
         this.TextBasedControlsDemoTpl = TextBasedControlsDemoTpl;
         this.CheckBoxControlsDemoTpl = CheckBoxControlsDemoTpl;
-
+        // Quick note config
+        this.quickNoteConfig = {
+            triggers: {
+                tags: '@',
+                references: '#',
+                boos: '^'
+            },
+            options: {
+                tags: ['First', 'Second'],
+                references: ['Third', 'Forth'],
+                boos: ['Test']
+            },
+            renderer: {
+                tags: (symbol, item) => {
+                    return `<a class="tag">${symbol}${item.label}</a>`;
+                },
+                references: (symbol, item) => {
+                    return `<a class="tag">${symbol}${item.label}</a>`;
+                },
+                boos: (symbol, item) => {
+                    return `<strong>${symbol}${item.label}</strong>`;
+                }
+            }
+        };
         // Text-based Controls
         this.textControl = new TextBoxControl({ key: 'text', label: 'Text Box' });
         this.emailControl = new TextBoxControl({ type: 'email', key: 'email', label: 'Email' });
@@ -55,7 +78,8 @@ export class FormDemoComponent {
         this.currencyControl = new TextBoxControl({ type: 'currency', key: 'currency', label: 'Currency', currencyFormat: '$ USD' });
         this.floatControl = new TextBoxControl({ type: 'float', key: 'float', label: 'Float' });
         this.percentageControl = new TextBoxControl({ type: 'percentage', key: 'percentage', label: 'Percent' });
-        this.textForm = formUtils.toFormGroup([this.textControl, this.emailControl, this.numberControl, this.currencyControl, this.floatControl, this.percentageControl]);
+        this.quickNoteControl = new QuickNoteControl({ key: 'note', label: 'Note', config: this.quickNoteConfig });
+        this.textForm = formUtils.toFormGroup([this.textControl, this.emailControl, this.numberControl, this.currencyControl, this.floatControl, this.percentageControl, this.quickNoteControl]);
 
         // Check box controls
         this.checkControl = new CheckboxControl({ key: 'check', label: 'Checkbox' });

--- a/demo/pages/elements/form/templates/TextBasedControls.html
+++ b/demo/pages/elements/form/templates/TextBasedControls.html
@@ -18,5 +18,8 @@
     <div class="novo-form-row">
         <novo-control [form]="textForm" [control]="percentageControl"></novo-control>
     </div>
+    <div class="novo-form-row">
+        <novo-control [form]="textForm" [control]="quickNoteControl"></novo-control>
+    </div>
 </novo-form>
 <div class="final-value">Value: {{textForm.value | json}}</div>

--- a/demo/pages/elements/quick-note/QuickNoteDemo.js
+++ b/demo/pages/elements/quick-note/QuickNoteDemo.js
@@ -61,7 +61,7 @@ export class QuickNoteDemoComponent {
         this.CustomQuickNoteDemoTpl = CustomQuickNoteDemoTpl;
         this.CustomQuickNoteResultsDemoTpl = CustomQuickNoteResultsDemoTpl;
 
-        this.placeholder = 'Enter your note text here. Reference people and distrubution lists using @ (eg. @John Smith). Reference other records using # (e.g. #Project Manager)';
+        this.placeholder = 'Enter your note text here. Reference people and distribution lists using @ (eg. @John Smith). Reference other records using # (e.g. #Project Manager)';
 
         let customData = {
             tags: [{ id: 1, name: 'OH YA!', test: 'TWO' }, { id: 2, name: 'TAGGING!', test: 'ONE' }],

--- a/src/elements/form/Control.html
+++ b/src/elements/form/Control.html
@@ -64,7 +64,7 @@
             <!--Checklist-->
             <novo-check-list *ngSwitchCase="'checklist'" [formControlName]="control.key" [name]="control.key" [options]="control.options"></novo-check-list>
             <!--QuickNote-->
-            <novo-quick-note *ngSwitchCase="'quick-note'" [formControlName]="control.key" [placeholder]="control.placeholder" [config]="control.config"></novo-quick-note>
+            <novo-quick-note *ngSwitchCase="'quick-note'" [formControlName]="control.key" [placeholder]="control.placeholder" [config]="control.config" (changed)="modelChange($event)"></novo-quick-note>
         </div>
     </div>
     <!--Error Message-->

--- a/src/elements/form/Control.html
+++ b/src/elements/form/Control.html
@@ -64,7 +64,7 @@
             <!--Checklist-->
             <novo-check-list *ngSwitchCase="'checklist'" [formControlName]="control.key" [name]="control.key" [options]="control.options"></novo-check-list>
             <!--QuickNote-->
-            <novo-quick-note *ngSwitchCase="'quick-note'" [formControlName]="control.key" [placeholder]="control.placeholder" [config]="control.config" (changed)="modelChange($event)"></novo-quick-note>
+            <novo-quick-note *ngSwitchCase="'quick-note'" [formControlName]="control.key" [placeholder]="control.placeholder" [config]="control.config" (change)="modelChange($event)"></novo-quick-note>
         </div>
     </div>
     <!--Error Message-->

--- a/src/elements/form/Control.js
+++ b/src/elements/form/Control.js
@@ -1,5 +1,5 @@
 // NG2
-import { Component, Input, ElementRef } from '@angular/core';
+import { Component, Input, ElementRef, EventEmitter } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 // APP
 import { OutsideClick } from './../../utils/outside-click/OutsideClick';
@@ -11,12 +11,15 @@ import moment from 'moment/moment';
     template: require('./Control.html'),
     host: {
         '[hidden]': 'control.hidden || control.type === \'hidden\''
-    }
+    },
+    outputs: [
+        'changed'
+    ]
 })
 export class NovoControlElement extends OutsideClick {
     @Input() control;
     @Input() form:FormGroup;
-
+    changed:EventEmitter = new EventEmitter;
     formattedValue:String = '';
 
     constructor(element:ElementRef) {
@@ -74,5 +77,9 @@ export class NovoControlElement extends OutsideClick {
         let height = event.target.value.length > 0 ? `${event.target.scrollHeight}px` : '2rem';
         event.target.style.height = '';
         event.target.style.height = height;
+    }
+
+    modelChange(value) {
+        this.changed.emit(value);
     }
 }

--- a/src/elements/form/Control.js
+++ b/src/elements/form/Control.js
@@ -13,13 +13,13 @@ import moment from 'moment/moment';
         '[hidden]': 'control.hidden || control.type === \'hidden\''
     },
     outputs: [
-        'changed'
+        'change'
     ]
 })
 export class NovoControlElement extends OutsideClick {
     @Input() control;
     @Input() form:FormGroup;
-    changed:EventEmitter = new EventEmitter;
+    change:EventEmitter = new EventEmitter;
     formattedValue:String = '';
 
     constructor(element:ElementRef) {
@@ -80,6 +80,6 @@ export class NovoControlElement extends OutsideClick {
     }
 
     modelChange(value) {
-        this.changed.emit(value);
+        this.change.emit(value);
     }
 }

--- a/src/elements/quick-note/QuickNote.js
+++ b/src/elements/quick-note/QuickNote.js
@@ -21,7 +21,7 @@ const QUICK_NOTE_VALUE_ACCESSOR = new Provider(NG_VALUE_ACCESSOR, {
     outputs: [
         'focus',
         'blur',
-        'changed'
+        'change'
     ],
     providers: [QUICK_NOTE_VALUE_ACCESSOR],
     template: `
@@ -45,7 +45,7 @@ export class QuickNoteElement extends OutsideClick {
     // Emitter for selects
     focus:EventEmitter = new EventEmitter();
     blur:EventEmitter = new EventEmitter();
-    changed:EventEmitter = new EventEmitter();
+    change:EventEmitter = new EventEmitter();
     // Internal search string
     searchTerm:string = '';
 
@@ -193,7 +193,7 @@ export class QuickNoteElement extends OutsideClick {
         // Propagate change to ngModel
         let newModel = { note: (this.formattedNote || ''), references: this.model.references };
         this.onModelChange(newModel);
-        this.changed.emit(newModel);
+        this.change.emit(newModel);
     }
 
     renderLink(symbol, item) {

--- a/src/elements/quick-note/QuickNote.js
+++ b/src/elements/quick-note/QuickNote.js
@@ -14,8 +14,15 @@ const QUICK_NOTE_VALUE_ACCESSOR = new Provider(NG_VALUE_ACCESSOR, {
 
 @Component({
     selector: 'novo-quick-note',
-    inputs: ['config', 'placeholder'],
-    outputs: ['focus', 'blur'],
+    inputs: [
+        'config',
+        'placeholder'
+    ],
+    outputs: [
+        'focus',
+        'blur',
+        'changed'
+    ],
     providers: [QUICK_NOTE_VALUE_ACCESSOR],
     template: `
         <div class="quick-note-wrapper">
@@ -38,15 +45,13 @@ export class QuickNoteElement extends OutsideClick {
     // Emitter for selects
     focus:EventEmitter = new EventEmitter();
     blur:EventEmitter = new EventEmitter();
-
+    changed:EventEmitter = new EventEmitter();
     // Internal search string
     searchTerm:string = '';
 
     model:any;
-    onModelChange:Function = () => {
-    };
-    onModelTouched:Function = () => {
-    };
+    onModelChange:Function = () => {};
+    onModelTouched:Function = () => {};
 
     // Results container
     @ViewChild('results', { read: ViewContainerRef }) results:ViewContainerRef;
@@ -186,11 +191,9 @@ export class QuickNoteElement extends OutsideClick {
         // Update basic note
         this.basicNote = tempBasicValue;
         // Propagate change to ngModel
-        if (this.formattedNote) {
-            this.onModelChange({ note: this.formattedNote, references: this.model.references });
-        } else {
-            this.onModelChange({ note: '', references: {} });
-        }
+        let newModel = { note: (this.formattedNote || ''), references: this.model.references };
+        this.onModelChange(newModel);
+        this.changed.emit(newModel);
     }
 
     renderLink(symbol, item) {


### PR DESCRIPTION
Need to listen to changes on model passed into QuickNote CMP

##### **What did you change?**

Added eventEmitter that broadcasts changes on the QuickNote CMP and the form Control that injects it.

##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices
