### PR TITLE
feat(list): Added themes support to Novo List

### DIFF
--- a/demo/pages/elements/button/ButtonDemo.js
+++ b/demo/pages/elements/button/ButtonDemo.js
@@ -7,13 +7,14 @@ import HeaderButtonDemoTpl from './templates/HeaderButtonDemo.html';
 import IconButtonDemoTpl from './templates/IconButtonDemo.html';
 import StandardButtonDemoTpl from './templates/StandardButtonDemo.html';
 import SecondaryButtonDemoTpl from './templates/SecondaryButtonDemo.html';
+import DynamicButtonDemoTpl from './templates/DynamicButtonDemo.html';
 
 const template = `
 <div class="container">
     <h1>Button <small><a target="_blank" href="https://github.com/bullhorn/novo-elements/tree/master/src/elements/button">(source)</a></small></h1>
     <p>A button clearly indicates a point of action for the user. Bullhorn buttons
      come in a variety of themes, custom tailored to fit your use-case.</p>
-    
+
     <h2>Themes</h2>
     <p>
         Bullhorn button themes were hand crafted to make your life easier.
@@ -26,15 +27,15 @@ const template = `
          There are also three other button types that are independent of function:
          Dialogue, Icon, and Header.
     </p>
-    
+
     <h5>Colors</h5>
     <p>
         Acceptable colors include <code>Primary</code>, <code>Success</code>, <code>Warning</code>, <code>Negative</code>,
          and <strong>all analytics colors</strong> which can be found in the color section of the style guide.
     </p>
-    
+
     <br/>
-    
+
     <h5>Primary</h5>
     <p>
         Primary buttons are used to as primary calls-to-action. They should <strong>always</strong>
@@ -45,7 +46,7 @@ const template = `
     </p>
     <div class="example buttons-demo">${PrimaryButtonDemoTpl}</div>
     <code-snippet [code]="PrimaryButtonDemoTpl"></code-snippet>
-    
+
     <h5>Secondary</h5>
     <p>
         Secondary buttons are used as an alternative Primary button or when there
@@ -60,7 +61,7 @@ const template = `
     </p>
     <div class="example header buttons-demo" [ngClass]="color" (click)="changeColor()" tooltip="Click Me!" tooltipPlacement="top">${HeaderButtonDemoTpl}</div>
     <code-snippet [code]="HeaderButtonDemoTpl"></code-snippet>
-    
+
     <h5>Dialogue</h5>
     <p>
         Similar to icon buttons, dialogue buttons require less visual dominance but often need additional helper text. Dialogue buttons
@@ -70,7 +71,7 @@ const template = `
     </p>
     <div class="example buttons-demo">${DialogueButtonDemoTpl}</div>
     <code-snippet [code]="DialogueButtonDemoTpl"></code-snippet>
-    
+
     <h5>Standard</h5>
     <p>
         Standard buttons are the most generic button style. Standard buttons by default are
@@ -83,7 +84,7 @@ const template = `
     </p>
     <div class="example buttons-demo">${StandardButtonDemoTpl}</div>
     <code-snippet [code]="NeutralButtonDemoTpl"></code-snippet>
-    
+
     <h5>Icon</h5>
     <p>
         The <code>icon</code> theme is used to create
@@ -94,6 +95,14 @@ const template = `
     </p>
     <div class="example buttons-demo icons" [ngClass]="color" (click)="changeColor()" tooltip="Click Me!" tooltipPlacement="top">${IconButtonDemoTpl}</div>
     <code-snippet [code]="IconButtonDemoTpl"></code-snippet>
+
+    <h5>Dynamic</h5>
+    <p>
+        Button parameters can be dynamically set and change at runtime.  The styles should
+        change and be applied when the values change.
+    </p>
+    <div class="example buttons-demo">${DynamicButtonDemoTpl}</div>
+    <code-snippet [code]="DynamicButtonDemoTpl"></code-snippet>
 </div>
 `;
 
@@ -111,6 +120,10 @@ export class ButtonDemoComponent {
         this.NeutralButtonDemoTpl = StandardButtonDemoTpl;
         this.HeaderButtonDemoTpl = HeaderButtonDemoTpl;
         this.IconButtonDemoTpl = IconButtonDemoTpl;
+        this.DynamicButtonDemoTpl = DynamicButtonDemoTpl;
+
+        this.theme = 'primary';
+        this.isChecked = false;
     }
 
     ngOnInit() {
@@ -121,5 +134,10 @@ export class ButtonDemoComponent {
     changeColor() {
         let idx = HEADER_COLORS.indexOf(this.color);
         this.color = HEADER_COLORS[idx + 1];
+    }
+
+    changeTheme() {
+        let i = Math.floor(Math.random() * 4);
+        this.theme = ['primary', 'secondary', 'dialogue', 'standard', 'icon'][i];
     }
 }

--- a/demo/pages/elements/button/templates/DynamicButtonDemo.html
+++ b/demo/pages/elements/button/templates/DynamicButtonDemo.html
@@ -1,0 +1,2 @@
+<button [theme]="theme" [icon]="isChecked ? 'check' : 'times'" (click)="changeTheme()">Change Theme</button>
+<novo-checkbox label="Checked?" [(ngModel)]="isChecked"></novo-checkbox>

--- a/demo/pages/elements/list/ListDemo.js
+++ b/demo/pages/elements/list/ListDemo.js
@@ -2,6 +2,7 @@
 import { Component } from '@angular/core';
 // APP
 import ListDemoTpl from './templates/ListDemo.html';
+import ThemedListDemoTpl from './templates/ThemedListDemo.html';
 
 const template = `
 <div class="container">
@@ -15,6 +16,11 @@ const template = `
     <p>This is an example of a standard list.</p>
     <div class="example standard-list-demo">${ListDemoTpl}</div>
     <code-snippet [code]="ListDemoTpl"></code-snippet>
+
+    <h5>Themed List</h5>
+    <p>This is an example of a themed list.</p>
+    <div class="example themed-list-demo">${ThemedListDemoTpl}</div>
+    <code-snippet [code]="ThemedListDemoTpl"></code-snippet>
 </div>
 `;
 
@@ -25,6 +31,7 @@ const template = `
 export class ListDemoComponent {
     constructor() {
         this.ListDemoTpl = ListDemoTpl;
+        this.ThemedListDemoTpl = ThemedListDemoTpl;
 
         let ONE_HOUR = 60 * 60 * 1000;
         /* ms */

--- a/demo/pages/elements/list/templates/ThemedListDemo.html
+++ b/demo/pages/elements/list/templates/ThemedListDemo.html
@@ -1,0 +1,21 @@
+<header>
+    <novo-list theme="navigation" direction="vertical">
+        <novo-list-item *ngFor="let item of pulseItems">
+            <item-avatar [icon]="item.type"></item-avatar>
+            <item-title>{{item.name}}</item-title>
+            <item-content direction="vertical">
+                <p>
+                    <i *ngIf="item.icon.name" class="{{item.icon.name}} {{item.icon.sentiment}}"></i>
+                    {{item.comment}}
+                </p>
+                <span>
+                    <i class="bhi-clock"></i>
+                    {{item.timeAgo | date: 'shortTime'}}
+                </span>
+            </item-content>
+            <item-end>
+                <i class="bhi-next"></i>
+            </item-end>
+        </novo-list-item>
+    </novo-list>
+</header>

--- a/src/elements/button/Button.js
+++ b/src/elements/button/Button.js
@@ -24,8 +24,9 @@ import { Component } from '@angular/core';
 export class NovoButtonElement {
     leftSide:boolean = false;
     rightSide:boolean = true;
+    icon:string
 
-    ngOnInit() {
+    ngOnChanges() {
         this.iconClass = this.icon ? `bhi-${this.icon}` : '';
         this.flex = this.theme ? 'flex-wrapper' : '';
         if (this.side !== null && this.theme !== 'primary') {

--- a/src/elements/button/Button.spec.js
+++ b/src/elements/button/Button.spec.js
@@ -15,42 +15,42 @@ describe('Element: NovoButtonElement', () => {
         component = _component;
     }));
 
-    describe('Function: ngOnInit()', () => {
+    describe('Function: ngOnChanges()', () => {
         it('should initialize correctly', () => {
             expect(component).toBeTruthy();
         });
     });
 
-    describe('Function: ngOnInit()', () => {
+    describe('Function: ngOnChanges()', () => {
         it('should initialize correctly', () => {
             expect(component).toBeTruthy();
-            expect(component.ngOnInit).toBeDefined();
+            expect(component.ngOnChanges).toBeDefined();
         });
 
         it('should setup the iconClass if icon is passed', () => {
             component.icon = 'test';
-            component.ngOnInit();
+            component.ngOnChanges();
             expect(component.iconClass).toBe('bhi-test');
         });
 
         it('should NOT set the iconClass if icon is NOT present', () => {
-            component.ngOnInit();
+            component.ngOnChanges();
             expect(component.iconClass).toBe('');
         });
 
         it('should set flex based on theme', () => {
             component.theme = 'primary';
-            component.ngOnInit();
+            component.ngOnChanges();
             expect(component.flex).toBe('flex-wrapper');
             component.theme = null;
-            component.ngOnInit();
+            component.ngOnChanges();
             expect(component.flex).toBe('');
         });
 
         it('should force icon to right if theme is primary', () => {
             component.theme = 'primary';
             component.side = 'left';
-            component.ngOnInit();
+            component.ngOnChanges();
             expect(component.leftSide).toBeFalsy();
             expect(component.rightSide).toBeTruthy();
         });
@@ -58,7 +58,7 @@ describe('Element: NovoButtonElement', () => {
         it('should set icon to left as long as theme is NOT primary', () => {
             component.theme = 'secondary';
             component.side = 'left';
-            component.ngOnInit();
+            component.ngOnChanges();
             expect(component.leftSide).toBeTruthy();
             expect(component.rightSide).toBeFalsy();
         });

--- a/src/elements/list/List.js
+++ b/src/elements/list/List.js
@@ -3,10 +3,11 @@ import { Component } from '@angular/core';
 
 @Component({
     selector: 'novo-list',
-    inputs: ['direction'],
+    inputs: ['theme', 'direction'],
     host: {
         '[class.vertical-list]': 'direction === "vertical"',
-        '[class.horizontal-list]': 'direction === "horizontal"'
+        '[class.horizontal-list]': 'direction === "horizontal"',
+        '[attr.theme]': 'theme'
     },
     template: `
         <ng-content></ng-content>

--- a/src/elements/list/README.md
+++ b/src/elements/list/README.md
@@ -4,6 +4,12 @@
     import { NOVO_LIST_ELEMENTS } from 'novo-elements';
 
 ##### NovoList Properties
+- `'theme' : String`
+    * Defines the theme of the button
+    * Available Values:
+        * Entity Colors: `['company', 'candidate', 'lead', 'contact', 'opportunity', ...]`
+        * App Colors: `['navigation', 'positive', 'success', 'negative', 'pulse', ...]`
+
 - `'direction' : String`
     * Defines the direction of the List
     * Available Values: `['horizontal', 'vertical']`

--- a/src/elements/list/_List.scss
+++ b/src/elements/list/_List.scss
@@ -8,6 +8,47 @@ novo-list {
     &.horizontal-list {
         flex-direction: row;
     }
+
+    @each $entity, $color in $entity-colors {
+        &[theme="#{$entity}"] {
+            novo-list-item {
+                background: $color;
+                color: #fff;
+                border-bottom: 1px solid rgba(#fff, .1);
+                i {
+                    color: #fff;
+                }
+                item-title h3 {
+                    color: #fff;
+                }
+                item-content {
+                    > * {
+                        color: rgba(#fff, .65);
+                    }
+                }
+            }
+        }
+    }
+    @each $basic, $color in $colors {
+        &[theme="#{$basic}"] {
+            novo-list-item {
+                background: $color;
+                color: #fff;
+                border-bottom: 1px solid rgba(#fff, .1);
+                i {
+                    color: #fff;
+                }
+                item-title h3 {
+                    color: #fff;
+                }
+                item-content {
+                    > * {
+                        color: rgba(#fff, .65);
+                    }
+                }
+            }
+        }
+    }
 }
 
 novo-list-item {


### PR DESCRIPTION
Novo Lists not can be themed with the [theme] attribute

```
<novo-list theme="navigation"></novo-list>
```

demo included!

What did you change?

Lists
also had a bug fix for button to update when Inputs changed

Reviewers: @jgodi 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices