### PR TITLE
fix(Chips): Preventing null values from being passed on double-click

### DIFF
--- a/src/elements/chips/Chips.js
+++ b/src/elements/chips/Chips.js
@@ -134,7 +134,7 @@ export class NovoChipsElement extends OutsideClick {
     }
 
     add(event) {
-        if (event) {
+        if (event && !(event instanceof Event)) {
             this.items.push(event);
             this.value = this.items.map(i => i.value);
         }


### PR DESCRIPTION
Fixed a bug on chips that allowed events to be passed in as values.

##### **What did you change?**

I added a condition to check if the data being passed in was an event.

Resolves #165 

##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices
