### PR TITLE
fix(forms): Adds support for placeholders in vertical layout

### DIFF
--- a/src/elements/form/Control.html
+++ b/src/elements/form/Control.html
@@ -28,8 +28,8 @@
             <novo-tiles *ngSwitchCase="'tiles'" [options]="control.options" [formControlName]="control.key" (onChange)="modelChange($event)"></novo-tiles>
             <!--Picker-->
             <div class="novo-control-input-container" *ngSwitchCase="'picker'">
-                <novo-picker [config]="control.config" [formControlName]="control.key" [placeholder]="control.placeholder" *ngIf="!control.multiple" (select)="toggleState()" (focus)="toggleState()" (blur)="toggleState()"></novo-picker>
-                <chips [source]="control.config" [type]="control.config.type" [formControlName]="control.key" [placeholder]="control.placeholder" *ngIf="control.multiple" (focus)="toggleState()" (blur)="toggleState()"></chips>
+                <novo-picker [config]="control.config" [formControlName]="control.key" [placeholder]="control.placeholder" *ngIf="!control.multiple" (select)="checkState()" (focus)="toggleState()" (blur)="checkState()"></novo-picker>
+                <chips [source]="control.config" [type]="control.config.type" [formControlName]="control.key" [placeholder]="control.placeholder" *ngIf="control.multiple" (focus)="toggleState()" (blur)="checkState()"></chips>
             </div>
             <!--Novo Select-->
             <novo-select *ngSwitchCase="'select'" [options]="control.options" [headerConfig]="control.headerConfig" [placeholder]="control.placeholder" [formControlName]="control.key"></novo-select>

--- a/src/elements/form/Control.js
+++ b/src/elements/form/Control.js
@@ -11,10 +11,10 @@ import { NovoLabelService } from './../../services/novo-label-service';
     animations: [
         trigger('heroState', [
             state('inactive', style({
-                transform: 'translate(0px, 25px) scale(1)'
+                transform: 'translate(0px, 25px) scale(1.1)'
             })),
             state('active', style({
-                transform: 'translate(-5px, 0px) scale(.8)'
+                transform: 'translate(-5px, 0px) scale(1)'
             })),
             state('horizontal', style({
                 transform: 'translateY(0px. 0px) scale(1)'

--- a/src/elements/form/Control.js
+++ b/src/elements/form/Control.js
@@ -14,7 +14,7 @@ import { NovoLabelService } from './../../services/novo-label-service';
                 transform: 'translate(0px, 25px) scale(1.1)'
             })),
             state('active', style({
-                transform: 'translate(-5px, 0px) scale(1)'
+                transform: 'translate(-1px, 0px) scale(1)'
             })),
             state('horizontal', style({
                 transform: 'translateY(0px. 0px) scale(1)'
@@ -144,7 +144,7 @@ export class NovoControlElement extends OutsideClick {
                 if (this.alwaysActive.indexOf(this.control.controlType) !== -1) {
                     this.state = 'active';
                 } else {
-                    this.state = (this.form.value[this.control.key]) ? 'active' : 'inactive';
+                    this.state = (this.form.value[this.control.key] || this.control.placeholder) ? 'active' : 'inactive';
                 }
             } else {
                 this.state = 'horizontal';
@@ -158,7 +158,7 @@ export class NovoControlElement extends OutsideClick {
                 if (this.alwaysActive.indexOf(this.control.controlType) !== -1) {
                     this.state = 'active';
                 } else {
-                    if (!this.form.value[this.control.key]) {
+                    if (!this.form.value[this.control.key] && !this.control.placeholder) {
                         this.state = (this.state === 'active' ? 'inactive' : 'active');
                     }
                 }


### PR DESCRIPTION
Fixes vertical layout forms with placeholders... 
![image](https://cloud.githubusercontent.com/assets/5579814/18754829/a3f40b58-80af-11e6-8ca4-8e1326d4da58.png)


##### **What did you change?**
* checks `control.placeholder`
* fixes active field label alignment

##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices