### PR TITLE
feat(form): allowing setting of maxlength on input

### DIFF
--- a/src/elements/form/Control.html
+++ b/src/elements/form/Control.html
@@ -9,7 +9,7 @@
             <!--Text-based Inputs-->
             <!--TODO prefix/suffix on the control-->
             <div class="novo-control-input-container novo-control-input-with-label" *ngSwitchCase="'textbox'">
-                <input [formControlName]="control.key" [id]="control.key" [type]="control.type" [placeholder]="control.placeholder" (focus)="toggleState()" (blur)="toggleState()" (input)="emitChange($event)">
+                <input [formControlName]="control.key" [id]="control.key" [type]="control.type" [placeholder]="control.placeholder" (focus)="toggleState()" (blur)="toggleState()" (input)="emitChange($event)" [maxlength]="control.maxlength">
                 <label class="input-label" *ngIf="control.subType === 'currency'">{{control.currencyFormat}}</label>
                 <label class="input-label" *ngIf="control.subType === 'percentage'">%</label>
             </div>

--- a/src/elements/form/Control.html
+++ b/src/elements/form/Control.html
@@ -14,7 +14,7 @@
                 <label class="input-label" *ngIf="control.subType === 'percentage'">%</label>
             </div>
             <!--TextArea-->
-            <textarea *ngSwitchCase="'text-area'" [name]="control.key" [attr.id]="control.key" [placeholder]="control.placeholder" [formControlName]="control.key" (input)="resizeTextArea($event)"></textarea>
+            <textarea *ngSwitchCase="'text-area'" [name]="control.key" [attr.id]="control.key" [placeholder]="control.placeholder" [formControlName]="control.key" (input)="resizeTextArea($event)" [maxlength]="control.maxlength"></textarea>
             <!--Editor-->
             <novo-editor *ngSwitchCase="'editor'" [name]="control.key" [formControlName]="control.key"></novo-editor>
             <!--HTML5 Select-->

--- a/src/elements/form/Control.js
+++ b/src/elements/form/Control.js
@@ -40,7 +40,6 @@ export class NovoControlElement extends OutsideClick {
     constructor(element:ElementRef, labels:NovoLabelService) {
         super(element);
         this.labels = labels;
-
         this.onActiveChange.subscribe(active => {
             if (!active) {
                 setTimeout(() => {

--- a/src/elements/form/README.md
+++ b/src/elements/form/README.md
@@ -20,3 +20,6 @@ import {NOVO_FORM_ELEMENTS} from 'novo-elements';
     * Adds placeholder text to form field in empty state    
 - `'multiple' : Bool`
     * Determines whether **pickers** can have multiple values.
+- `'maxlength' : Number`
+    * The maximum number of characters (Unicode code points) that the user can enter. If it is not specified, the user can enter an unlimited number of characters.
+    * Works for textarea and textbox

--- a/src/elements/form/controls/BaseControl.js
+++ b/src/elements/form/controls/BaseControl.js
@@ -21,9 +21,11 @@ export class BaseControl {
         this.associatedEntity = config.associatedEntity || null;
         this.optionsType = config.optionsType || null;
         this.forceClear = new EventEmitter();
-
         if (this.required) {
             this.validators.push(Validators.required);
+        }
+        if (config.maxlength) {
+            this.maxlength = config.maxlength;
         }
     }
 }

--- a/src/elements/form/controls/BaseControl.spec.js
+++ b/src/elements/form/controls/BaseControl.spec.js
@@ -69,7 +69,8 @@ describe('Control: BaseControl', () => {
                 headerConfig: { test: 'TEST_HEADER_CONFIG' },
                 currencyFormat: 'TEST_CURRENCY_FORMAT',
                 associatedEntity: 'ENTITY',
-                optionsType: 'TYPE'
+                optionsType: 'TYPE',
+                maxlength: 100
             });
         });
 
@@ -114,6 +115,9 @@ describe('Control: BaseControl', () => {
         });
         it('should set the optionsType', () => {
             expect(control.optionsType).toEqual('TYPE');
+        });
+        it('should set maxlength', () => {
+            expect(control.maxlength).toEqual(100);
         });
     });
 });


### PR DESCRIPTION
allowing setting of maxlength
##### **What did you change?**
- setting maxlength on the control will set it on the input & textarea


##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices
