### PR TITLE
fix: remove min-height from novo-control

### DIFF
--- a/src/elements/form/_Form.scss
+++ b/src/elements/form/_Form.scss
@@ -35,7 +35,6 @@ novo-form {
                     align-items: center;
                     width: 100%;
                     height: auto;
-                    min-height: 44px;
                     opacity: 1;
 
                     .ng-touched.ng-invalid:not(.ng-pristine):not(.novo-control-container) {


### PR DESCRIPTION
_Remove min-height from novo-control_

##### **What did you change?**

I removed the `min-height` property from `novo-control`

##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices
The min-height is causing a ton of white space to happen when the
control is hidden