### PR TITLE
feat(table): make clearing filtering/sorting optional when setting rows

### DIFF
--- a/src/elements/table/Table.js
+++ b/src/elements/table/Table.js
@@ -160,6 +160,7 @@ export class NovoTableElement {
     @Input() config:any;
     @Input() columns:[any];
     @Input() theme:string;
+    @Input() skipSortAndFilterClear:boolean = false;
 
     @Input()
     set rows(rows) {
@@ -169,7 +170,10 @@ export class NovoTableElement {
         if (rows && rows.length > 0) {
             this.setupColumnDefaults();
         }
-        this.clearAllSortAndFilters();
+        //this is a temporary/hacky fix until async dataloading is handled within the table
+        if (!this.skipSortAndFilterClear) {
+            this.clearAllSortAndFilters();
+        }
     }
 
     get rows() {


### PR DESCRIPTION
This PR adds an additional input to the novo-table element. When skipSortAndFilterClear is true, the sorts and filters will persist after resetting the table rows. This will allow outside handling of async dataloading with persistent filters (needed for canvas-ui), until that's handled inside novo-table.

##### **What did you change?**
-Added a boolean input (skipSortAndFilterClear) to novo-table that defaults to false.
-Wrapped the clearSortFilters function in an if statement


##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices
