### PR TITLE
Bug (Button): Fixes buttons so that they apply disabled attribute whe…

### DIFF
--- a/src/elements/button/Button.js
+++ b/src/elements/button/Button.js
@@ -8,7 +8,6 @@ import { Component } from '@angular/core';
         '[attr.theme]': 'theme',
         '[attr.color]': 'color',
         '[attr.icon]': 'icon',
-        '[disabled]': 'loading',
         '[attr.loading]': 'loading'
     },
     template: `

--- a/src/elements/button/_Button.scss
+++ b/src/elements/button/_Button.scss
@@ -39,6 +39,9 @@ button {
         }
 
         &[loading="true"] {
+            opacity: 0.5;
+            cursor: not-allowed;
+            pointer-events: none;
             i.loading {
                 display: flex;
                 align-items: center;


### PR DESCRIPTION
This PR unties the disabled attribute from a component's loading input so that buttons will apply as disabled when intended. (See issue #232)

It applies the disabled css within the loading attribute.  

##### **What did you change?**

- Untied disabled attribute from loading input
- Added disabled css to loading

##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices
…n disabled - issue #232

Applies disabled styles as part of the loading attribute, rather than using the host to set the disabled attribute when loading.