### PR TITLE
fix(Toast): Theme and Icon are now bound properly

### DIFF
--- a/demo/pages/elements/toast/ToastDemo.js
+++ b/demo/pages/elements/toast/ToastDemo.js
@@ -65,9 +65,27 @@ export class ToastDemoComponent {
             'warning',
             'danger'
         ];
+        this.icons = [
+            'add',
+            'check',
+            'clock',
+            'lock',
+            'caution'
+        ];
         this.options = {
             'title': 'Title',
             'message': 'Some Message...'
+        };
+        this.toast = {
+            theme: 'danger',
+            icon: 'caution'
+        };
+    }
+
+    changeToast() {
+        this.toast = {
+            theme: this.themes[(this.themes.indexOf(this.toast.theme) + 1) % (this.themes.length)],
+            icon: this.icons[(this.icons.indexOf(this.toast.icon) + 1) % (this.icons.length)]
         };
     }
 

--- a/demo/pages/elements/toast/templates/ToastDemo.html
+++ b/demo/pages/elements/toast/templates/ToastDemo.html
@@ -6,8 +6,7 @@
             <util-action icon="times"></util-action>
         </utils>
     </header>
-    <novo-toast theme="danger" title="Save Failed" message="Oops! Looks like you're missing some required fields"
-                icon="caution" position="growlTopRight"></novo-toast>
+    <novo-toast [theme]="toast.theme" [icon]="toast.icon" title="Save Failed" message="Oops! Looks like you're missing some required fields"></novo-toast>
     <div class="content">
         <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
@@ -20,5 +19,6 @@
             sunt in culpa qui officia deserunt mollit anim id
             est laborum.
         </p>
+        <button (click)="changeToast()">Change toast!</button>
     </div>
 </div>

--- a/src/elements/toast/Toast.js
+++ b/src/elements/toast/Toast.js
@@ -1,9 +1,8 @@
 // NG2
-import { Component, ElementRef } from '@angular/core';
+import { Component, ElementRef, Input } from '@angular/core';
 
 @Component({
     selector: 'novo-toast',
-    inputs: ['theme', 'icon', 'title', 'message'],
     host: {
         '[class]': 'alertTheme',
         '[class.show]': 'show',
@@ -22,6 +21,11 @@ import { Component, ElementRef } from '@angular/core';
     `
 })
 export class NovoToastElement {
+    @Input() theme:string = 'danger';
+    @Input() icon:string = 'caution';
+    @Input() title:string;
+    @Input() message:string;
+
     constructor(element:ElementRef) {
         this.show = false;
         this.animate = false;
@@ -39,6 +43,12 @@ export class NovoToastElement {
             this.iconClass = `bhi-${this.icon}`;
             this.alertTheme = `${this.theme} toast-container embedded`;
         }
+    }
+
+    ngOnChanges() {
+        // set icon and styling
+        this.iconClass = `bhi-${this.icon}`;
+        this.alertTheme = `${this.theme} toast-container embedded`;
     }
 
     clickHandler(event) {


### PR DESCRIPTION
Toast: Theme and Icon are now bound properly and will update when you are using a static toast component.

##### **What did you change?**

added `ngOnChanges`


##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices
