### PR TITLE
feat(multipicker): Make 'All [type]' indeterminate state function like Table

### DIFF
--- a/src/elements/multi-picker/MultiPicker.js
+++ b/src/elements/multi-picker/MultiPicker.js
@@ -159,8 +159,20 @@ export class NovoMultiPickerElement extends OutsideClick {
         } else {
             this.updateItems(event, 'add');
             this.value[event.type].push(event.value);
+            let allOfType = this.getAllOfType(event.type);
+            let allOfTypeSelected = this.allItemsSelected(allOfType, event.type);
+            this.updateIndeterminateState(event.type, !allOfTypeSelected);
+            if (allOfTypeSelected) {
+                this.selectAll(allOfType, event.type);
+            }
         }
         this.select(null, event);
+    }
+
+    updateIndeterminateState(type, status) {
+        let allOfType = this.getAllOfType(type);
+        let allItem = allOfType[0];
+        allItem.indeterminate = status;
     }
 
     updateItems(item, action) {
@@ -182,7 +194,7 @@ export class NovoMultiPickerElement extends OutsideClick {
                 let count;
                 let selectedOfType = notShown.filter(x => x.type === type);
                 if (selectedOfType.length === 1 && selectedOfType[0].value === 'ALL') {
-                    count = this._options.filter(x => x.type === type)[0].data.length - 1;
+                    count = this.getAllOfType(type).length - 1;
                 } else {
                     count = selectedOfType.length;
                 }
@@ -213,6 +225,7 @@ export class NovoMultiPickerElement extends OutsideClick {
         this.value[item.type] = updatedValues;
         this.onModelChange(this.value);
         this.updateItems(item, 'remove');
+        if (this.value[item.type].length === 0) { this.updateIndeterminateState(item.type, false); }
     }
 
     onKeyDown(event) {
@@ -237,7 +250,7 @@ export class NovoMultiPickerElement extends OutsideClick {
 
     modifyAllOfType(type, action) {
         let selecting = action === 'select';
-        let allOfType = this._options.filter(x => x.type === type)[0].data;
+        let allOfType = this.getAllOfType(type);
         allOfType.forEach(item => item.checked = selecting);
         if (selecting) {
             this.selectAll(allOfType, type);
@@ -250,6 +263,7 @@ export class NovoMultiPickerElement extends OutsideClick {
     }
 
     selectAll(allOfType, type) {
+        allOfType[0].checked = true;
         let values = allOfType.map(i => { return i.value; });
         //remove 'ALL' value
         values.splice(0, 1);
@@ -261,9 +275,10 @@ export class NovoMultiPickerElement extends OutsideClick {
 
     handleRemoveItemIfAllSelected(item) {
         let type = item.type;
-        let allOfType = this._options.filter(x => x.type === type)[0].data;
+        let allOfType = this.getAllOfType(type);
         let allItem = allOfType[0];
         this.removeItem(allItem);
+
         allItem.indeterminate = true;
         let selectedItems = allOfType.filter(i => i.checked === true);
         this.items = [...this.items, ...selectedItems];
@@ -277,6 +292,10 @@ export class NovoMultiPickerElement extends OutsideClick {
             this.blur.emit(event);
             this.deselectAll(event, false);
         }
+    }
+
+    getAllOfType(type) {
+        return this._options.filter(x => x.type === type)[0].data;
     }
 
     //get accessor
@@ -302,14 +321,17 @@ export class NovoMultiPickerElement extends OutsideClick {
         if (this.types) {
             this.types.forEach(type => {
                 if (this.value[type]) {
-                    let allSelected = false;
-                    let optionsByType = this._options.filter(x => x.type === type)[0].data;
-                    if (this.value[type].length === optionsByType.length - 1) {
-                        allSelected = true;
-                        optionsByType[0].checked = true;
-                        this.updateItems(optionsByType[0], 'add');
+                    let indeterminateIsSet = false;
+                    let optionsByType = this.getAllOfType(type);
+                    let allSelected = this.allItemsSelected(optionsByType, type);
+                    if (allSelected) {
+                        this.selectAll(optionsByType, type);
                     }
                     this.value[type].forEach(item => {
+                        if (!allSelected && !indeterminateIsSet) {
+                            indeterminateIsSet = true;
+                            this.updateIndeterminateState(type, true);
+                        }
                         let value = optionsByType.filter(x => x.value === item)[0];
                         value.checked = true;
                         if (!allSelected) { this.updateItems(value, 'add'); }
@@ -319,6 +341,10 @@ export class NovoMultiPickerElement extends OutsideClick {
                 }
             });
         }
+    }
+
+    allItemsSelected(optionsByType, type) {
+        return this.value[type].length === optionsByType.length - 1;
     }
 
     // Set touched on blur

--- a/src/elements/multi-picker/Multipicker.spec.js
+++ b/src/elements/multi-picker/Multipicker.spec.js
@@ -135,6 +135,30 @@ describe('Element: NovoMultiPickerElement', () => {
         });
     });
 
+    describe('Function: add(event)', () => {
+        it('should add ALL item correctly', () => {
+            let item = { value: 'ALL' };
+            spyOn(component, 'modifyAllOfType');
+            spyOn(component, 'select');
+            component.add(item);
+            expect(component.modifyAllOfType).toHaveBeenCalled();
+            expect(component.select).toHaveBeenCalled();
+        });
+
+        it('should correctly add individual item', () => {
+            component.types = ['cats'];
+            component.value = { cats: [] };
+            component._options = [{ type: 'cats', data: [{ value: 'ALL', indeterminate: undefined }, { value: 'Kitty' }, { value: 'Tiger' }] }];
+            let itemToAdd = { value: 'Cat', label: 'Cat', type: 'cats' };
+            spyOn(component, 'updateItems');
+            spyOn(component, 'updateIndeterminateState');
+            component.add(itemToAdd);
+            expect(component.updateItems).toHaveBeenCalled();
+            expect(component.updateIndeterminateState).toHaveBeenCalled();
+            expect(component.value.cats.length).toBe(1);
+        });
+    });
+
     describe('Function: remove(item)', () => {
         it('should handle removing item correctly from value and items and update checked state', () => {
             let item = { value: 'Cat', checked: true, type: 'cats' };
@@ -251,6 +275,44 @@ describe('Element: NovoMultiPickerElement', () => {
             component.setInitialValue(null);
             expect(component.items).toEqual([]);
             expect(component.value.cats).toEqual([]);
+        });
+    });
+
+    describe('Function: updateIndeterminateState(type, status)', () => {
+        it('should correctly set "ALL [type" to true', () => {
+            component.types = ['cats'];
+            component._options = [{ type: 'cats', data: [{ value: 'ALL', checked: false, type: 'cats', indeterminate: undefined }] }];
+            component.updateIndeterminateState('cats', true);
+            expect(component._options[0].data[0].indeterminate).toBeTruthy();
+        });
+        it('should correctly set "ALL [type" to false', () => {
+            component.types = ['cats'];
+            component._options = [{ type: 'cats', data: [{ value: 'ALL', checked: false, type: 'cats', indeterminate: undefined }] }];
+            component.updateIndeterminateState('cats', false);
+            expect(component._options[0].data[0].indeterminate).toBeFalsy();
+        });
+    });
+
+    describe('Function: getAllOfType(type)', () => {
+        it('should get all of type', () => {
+            component.types = ['cats'];
+            component._options = [{ type: 'cats', data: [1, 2, 3, 4] }];
+            let result = component.getAllOfType('cats');
+            expect(result.length).toBe(4);
+        });
+    });
+    describe('Function: allItemsSelected(optionsByType, type)', () => {
+        it('should return true if all individual items are selected', () => {
+            component.types = ['cats'];
+            let options = ['All', 'Kitty', 'Tiger'];
+            component.value = { cats: ['Kitty', 'Tiger'] };
+            expect(component.allItemsSelected(options, 'cats')).toBeTruthy();
+        });
+        it('should return false if all individual items are not selected', () => {
+            component.types = ['cats'];
+            let options = ['All', 'Kitty', 'Tiger'];
+            component.value = { cats: ['Kitty'] };
+            expect(component.allItemsSelected(options, 'cats')).toBeFalsy();
         });
     });
 });

--- a/src/elements/picker/extras/checklist-picker-results/ChecklistPickerResults.js
+++ b/src/elements/picker/extras/checklist-picker-results/ChecklistPickerResults.js
@@ -100,8 +100,12 @@ export class ChecklistPickerResults extends PickerResults {
      */
     selectMatch(event, item) {
         Helpers.swallowEvent(event);
-        item.checked = !item.checked;
-        if (item.indeterminate) { item.indeterminate = false; }
+        if (item.indeterminate) {
+            item.indeterminate = false;
+            item.checked = true;
+        } else {
+            item.checked = !item.checked;
+        }
 
         let selected = this.activeMatch;
         if (selected) {


### PR DESCRIPTION
This PR makes the indeterminate state of 'All [type]' function the same as the 'All Selected' checkbox in Table. That is - when any item of a type is checked, the state of 'All [type]' should be indeterminate. This PR also makes it so when all items of a type are selected individually/manually, 'ALL [type]' will become checked and 'ALL [type]' will be displayed as a chip (instead of all individual items). Also includes some clean up and additional specs.

##### **What did you change?**
- Improvements to Multipicker to make it behave like Table


##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices
…e table