### PR TITLE
fix:(address fields): Show and populate address fields

### DIFF
--- a/src/elements/form/Control.html
+++ b/src/elements/form/Control.html
@@ -62,7 +62,7 @@
                 </div>
             </div>
             <!--Address-->
-            <novo-address *ngSwitchCase="'address'" [formControlName]="control.key" [model]="control.value"></novo-address>
+            <novo-address *ngSwitchCase="'address'" [formControlName]="control.key"></novo-address>
             <!--Checkbox-->
             <novo-checkbox *ngSwitchCase="'checkbox'" [formControlName]="control.key" [name]="control.key"></novo-checkbox>
             <!--Checklist-->

--- a/src/elements/form/Control.html
+++ b/src/elements/form/Control.html
@@ -62,7 +62,7 @@
                 </div>
             </div>
             <!--Address-->
-            <novo-address *ngSwitchCase="'address'" [formControlName]="control.key"></novo-address>
+            <novo-address *ngSwitchCase="'address'" [formControlName]="control.key" [model]="control.value"></novo-address>
             <!--Checkbox-->
             <novo-checkbox *ngSwitchCase="'checkbox'" [formControlName]="control.key" [name]="control.key"></novo-checkbox>
             <!--Checklist-->

--- a/src/elements/form/FormUtils.js
+++ b/src/elements/form/FormUtils.js
@@ -208,7 +208,7 @@ export class FormUtils {
         if (meta && meta.fields) {
             let fields = meta.fields;
             fields.forEach(field => {
-                if (field.name !== 'id' && (field.dataSpecialization !== 'SYSTEM') && !field.readOnly) {
+                if (field.name !== 'id' && (field.dataSpecialization !== 'SYSTEM' || field.name === 'address') && !field.readOnly) {
                     let control = this.getControlForField(field, http, config);
                     // Set currency format
                     if (control.subType === 'currency') {

--- a/src/elements/form/extras/address/Address.js
+++ b/src/elements/form/extras/address/Address.js
@@ -1,8 +1,8 @@
 // NG2
-import { Component, forwardRef } from '@angular/core';
+import { Component, forwardRef, Input } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 // APP
-import { getCountries, getStates, findByCountryName } from '../../../../utils/countries/Countries';
+import { getCountries, getStates, findByCountryName, findByCountryId } from '../../../../utils/countries/Countries';
 
 // Value accessor for the component (supports ngModel)
 const ADDRESS_VALUE_ACCESSOR = {
@@ -15,19 +15,19 @@ const ADDRESS_VALUE_ACCESSOR = {
     selector: 'novo-address',
     providers: [ADDRESS_VALUE_ACCESSOR],
     template: `
-        <input type="text" class="street-address" id="address1" name="address1" placeholder="Address" [(ngModel)]="model.address1" (ngModelChange)="updateControl()"/>
-        <input type="text" class="apt suite" id="address2" name="address2" placeholder="Apt" [(ngModel)]="model.address2" (ngModelChange)="updateControl()"/>
-        <input type="text" class="city locality" id="city" name="city" placeholder="City / Locality" [(ngModel)]="model.city" (ngModelChange)="updateControl()"/>
-        <novo-select class="state region" id="state" [options]="states" placeholder="State / Region" [(ngModel)]="model.state" (ngModelChange)="onStateChange($event)"></novo-select>
-        <input type="text" class="zip postal-code" id="zip" name="zip" placeholder="Postal Code" [(ngModel)]="model.zip" (ngModelChange)="updateControl()"/>
-        <novo-select class="country-name" id="country" [options]="countries" placeholder="Country" [(ngModel)]="model.countryName" (ngModelChange)="onCountryChange($event)"></novo-select>
+        <input type="text" class="street-address" id="address1" name="address1" placeholder="Address" [(ngModel)]="address1" (ngModelChange)="updateControl()"/>
+        <input type="text" class="apt suite" id="address2" name="address2" placeholder="Apt" [(ngModel)]="address2" (ngModelChange)="updateControl()"/>
+        <input type="text" class="city locality" id="city" name="city" placeholder="City / Locality" [(ngModel)]="city" (ngModelChange)="updateControl()"/>
+        <novo-select class="state region" id="state" [options]="states" placeholder="State / Region" [(ngModel)]="state" (ngModelChange)="onStateChange($event)"></novo-select>
+        <input type="text" class="zip postal-code" id="zip" name="zip" placeholder="Postal Code" [(ngModel)]="zip" (ngModelChange)="updateControl()"/>
+        <novo-select class="country-name" id="country" [options]="countries" placeholder="Country" [(ngModel)]="countryName" (ngModelChange)="onCountryChange($event)"></novo-select>
     `
 })
 export class NovoAddressElement implements ControlValueAccessor {
     states:Array = [];
     countries:Array = getCountries();
 
-    model;
+    @Input() model;
     onModelChange:Function = () => {
     };
     onModelTouched:Function = () => {
@@ -41,20 +41,32 @@ export class NovoAddressElement implements ControlValueAccessor {
             };
         } else if (this.model.countryName) {
             this.model.countryName = this.model.countryName.trim();
+        } else {
+            this.address1 = this.model.address1;
+            this.address2 = this.model.address2;
+            this.city = this.model.city;
+            this.state = this.model.state;
+            this.zip = this.model.zip;
+            this.countryID = this.model.countryID;
         }
         this.updateControl();
         this.updateStates();
     }
 
     onCountryChange(evt) {
-        this.model.countryName = evt;
-        let country = findByCountryName(this.model.countryName);
+        let country;
+        if (typeof evt === 'number') {
+            country = findByCountryId(this.model.countryID);
+        } else {
+            country = findByCountryName(evt);
+        }
+        this.model.countryName = country.name;
         this.model.countryCode = country.code;
         this.model.countryID = country.id;
         this.updateStates();
 
         // Update state
-        this.model.state = null;
+        // this.model.state = null;
         this.updateControl();
     }
 

--- a/src/elements/form/extras/address/Address.js
+++ b/src/elements/form/extras/address/Address.js
@@ -93,12 +93,12 @@ export class NovoAddressElement implements ControlValueAccessor {
                     countryName: 'United States'
                 };
             } else {
-                model.countryName = findByCountryId(model.countryID);
-                model.state = this.states.find(state => {
+                model.countryName = findByCountryId(model.countryID).name;
+                this.model = model;
+                let modelState = this.states.find(state => {
                     return state === model.state;
                 });
-                this.model = model;
-                this.updateControl();
+                this.onStateChange(modelState);
             }
         });
     }

--- a/src/utils/countries/Countries.js
+++ b/src/utils/countries/Countries.js
@@ -6975,3 +6975,11 @@ export function getStates(name) {
     let country = COUNTRIES.find(c => c.name === name.trim());
     return country ? country.states.map(s => s.name) : [];
 }
+
+/**
+ * Get states by country name
+ */
+export function getStateObjects(name) {
+    let country = COUNTRIES.find(c => c.name === name.trim());
+    return country ? country.states : [];
+}

--- a/src/utils/countries/Countries.spec.js
+++ b/src/utils/countries/Countries.spec.js
@@ -1,5 +1,5 @@
 // APP
-import { getCountries, getStates } from './Countries';
+import { getCountries, getStates, getStateObjects } from './Countries';
 
 describe('Util: Countries', () => {
     describe('Function: getCountries()', () => {
@@ -19,6 +19,16 @@ describe('Util: Countries', () => {
 
         it('should get states for US', () => {
             expect(getStates('United States')[0]).toBe('Alabama');
+        });
+    });
+
+    describe('Function: getStateObjects(countryName)', () => {
+        it('should be defined', () => {
+            expect(getStateObjects).toBeDefined();
+        });
+
+        it('should get states for US', () => {
+            expect(getStateObjects('United States')[0]).toEqual({ code: 'AL', name: 'Alabama' });
         });
     });
 });


### PR DESCRIPTION
Show and populate address fields

##### **What did you change?**

I changed the Address `writeValue` function to actually populate the address field, and changed formUtils to show the address field

##### **Reviewers**
* @jgodi 
* @bvkimball 

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices