### PR TITLE
bug(multipicker): fix for clearAll

### DIFF
--- a/src/elements/multi-picker/MultiPicker.js
+++ b/src/elements/multi-picker/MultiPicker.js
@@ -251,7 +251,10 @@ export class NovoMultiPickerElement extends OutsideClick {
     modifyAllOfType(type, action) {
         let selecting = action === 'select';
         let allOfType = this.getAllOfType(type);
-        allOfType.forEach(item => item.checked = selecting);
+        allOfType.forEach(item => {
+            item.checked = selecting;
+            item.indeterminate = false;
+        });
         if (selecting) {
             this.selectAll(allOfType, type);
         } else {

--- a/src/elements/multi-picker/Multipicker.spec.js
+++ b/src/elements/multi-picker/Multipicker.spec.js
@@ -28,11 +28,12 @@ describe('Element: NovoMultiPickerElement', () => {
             component.types = ['numbers'];
             component.items = [1, 2];
             component.value = [1, 2];
-            component._options = [{ type: 'numbers', data: [{ value: 1, checked: true }, { value: 2, checked: false }] }];
+            component._options = [{ type: 'numbers', data: [{ value: 1, checked: true }, { value: 2, checked: false, indeterminate: true }] }];
             component.clearValue();
             expect(component.items.length).toBe(0);
             expect(component.value).toEqual({ numbers: [] });
             expect(component._options[0].data[0].checked).toBeFalsy();
+            expect(component._options[0].data[1].indeterminate).toBeFalsy();
         });
     });
 


### PR DESCRIPTION
This PR fixes a bug where clearAll failed to reset indeterminate checkboxes.

##### **What did you change?**
- clearAll now sets indeterminate to false
- added to spec


##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices
