### PR TITLE
Fix logic to respect when column sorting is false

### DIFF
--- a/src/elements/table/Table.js
+++ b/src/elements/table/Table.js
@@ -51,9 +51,9 @@ export class NovoTableHeaderElement {
                     <th *ngFor="let column of columns" [novoThOrderable]="column" (onOrderChange)="onOrderChange($event)">
                         <div class="th-group" [attr.data-automation-id]="column.id || column.name" *ngIf="!column.hideHeader">
                             <!-- LABEL & SORT ARROWS -->
-                            <div class="th-title" [novoThSortable]="config" [column]="column" (onSortChange)="onSortChange($event)">
+                            <div class="th-title" [ngClass]="(config.sorting !== false && column.sorting !== false) ? 'sortable' : ''" [novoThSortable]="config" [column]="column" (onSortChange)="onSortChange($event)">
                                 <label>{{ column.title }}</label>
-                                <div class="table-sort-icons" [ngClass]="column.sort || ''" *ngIf="config.sorting || column.sorting">
+                                <div class="table-sort-icons" [ngClass]="column.sort || ''" *ngIf="config.sorting !== false && column.sorting !== false">
                                     <i class="bhi-arrow-down"></i>
                                     <i class="bhi-arrow-up"></i>
                                 </div>

--- a/src/elements/table/_Table.scss
+++ b/src/elements/table/_Table.scss
@@ -249,8 +249,16 @@ $table-border-color: #f5f5f5; // Tables
                 align-items: center;
                 padding: 10px;
                 border-radius: 3px;
-                cursor: pointer;
                 font-weight: $table-header-font-weight;
+
+                &.sortable {
+                    cursor: pointer;
+
+                    label {
+                        cursor: pointer; // chrome user agent style will override this unless explicitly set on the element
+                        margin-right: 10px;
+                    }
+                }
 
                 &:hover {
                     .table-sort-icons {
@@ -266,10 +274,6 @@ $table-border-color: #f5f5f5; // Tables
                             }
                         }
                     }
-                }
-
-                label {
-                    margin-right: 10px;
                 }
 
                 .table-sort-icons {

--- a/src/elements/table/extras/th-sortable/ThSortable.js
+++ b/src/elements/table/extras/th-sortable/ThSortable.js
@@ -21,7 +21,7 @@ export class ThSortable {
             event.preventDefault();
         }
 
-        if (this.config && this.column && this.config.sorting !== false && this.column.sort !== false) {
+        if (this.config && this.column && this.config.sorting !== false && this.column.sorting !== false) {
             switch (this.column.sort) {
                 case 'asc':
                     this.column.sort = 'desc';


### PR DESCRIPTION
Fix table and sorting logic so that columns marked sorting: false do not display sorting features.

##### **What did you change?**
Table.js
_Table.scss
ThSortable.js


##### **Reviewers**
* @user

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices
