### PR TITLE
BH-45115 - Show Select All text correctly

### DIFF
--- a/src/elements/table/_Table.scss
+++ b/src/elements/table/_Table.scss
@@ -407,7 +407,7 @@ $table-border-color: #f5f5f5; // Tables
 // Default zebra-stripe styles (alternating gray and transparent backgrounds)
 
 .table-striped:not(.table-details) {
-    > tbody tr:nth-of-type(odd) {
+    > tbody tr:nth-of-type(odd):not(.table-selection-row) {
         background-color: $table-bg-accent;
 
         td {


### PR DESCRIPTION
Show background correctly for select all results

##### **What did you change?**

Update the zibra table to not display for the selection line

##### **Reviewers**
* @user

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices
