### PR TITLE
fix(address field): state matching and country name matching

### DIFF
--- a/src/elements/form/extras/address/Address.js
+++ b/src/elements/form/extras/address/Address.js
@@ -86,6 +86,10 @@ export class NovoAddressElement implements ControlValueAccessor {
             if (!countryName) {
                 countryName = findByCountryId(model.countryID).name;
             }
+            if (countryName) {
+                countryName = countryName.trim();
+            }
+            model.state = model.state || '';
             let stateObj = getStateObjects(countryName).find(state => {
                 return state.code === model.state.replace(/\W+/g, '').toUpperCase() || state.name === model.state;
             }) || {};

--- a/src/elements/form/extras/address/Address.js
+++ b/src/elements/form/extras/address/Address.js
@@ -87,8 +87,8 @@ export class NovoAddressElement implements ControlValueAccessor {
                 countryName = findByCountryId(model.countryID).name;
             }
             let stateObj = getStateObjects(countryName).find(state => {
-                return state.code === model.state || state.name === model.state;
-            });
+                return state.code === model.state.replace(/\W+/g, '').toUpperCase() || state.name === model.state;
+            }) || {};
             this.model = Object.assign(model, { countryName: countryName, state: stateObj.name });
         }
     }


### PR DESCRIPTION
Some state data is stored as `Ca.`, so we need to replace all odd characters and toUpperCase the state code. Also, fixed country name matching.

##### **What did you change?**

I added a `.replace` to remove odd characters when matching state codes, and added `.trim` for the countryName to ensure matching is correct.

##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices