### PR TITLE
F/multipicker parent children

### DIFF
--- a/demo/pages/elements/multi-picker/MultiPickerDemo.js
+++ b/demo/pages/elements/multi-picker/MultiPickerDemo.js
@@ -62,55 +62,43 @@ export class MultiPickerDemoComponent {
             firstName: 'Kameron',
             lastName: 'Sween'
         }];
-        let statesWithIds = [{
+        let departments = [{
             id: 1,
-            name: 'Massachusetts'
+            name: 'Sales'
         }, {
             id: 2,
-            name: 'Missouri'
+            name: 'Engineering'
         }, {
             id: 3,
-            name: 'New York'
+            name: 'Marketing'
         }, {
             id: 4,
-            name: 'Virginia'
+            name: 'Finance'
         }];
-        let cities = [{
+        let users = [{
             id: 1,
-            states: [{
-                id: 1
-            }],
-            name: 'Boston'
+            departments: [1, 3, 4],
+            name: 'Bob Sales/Engineering/Fin'
         }, {
             id: 2,
-            states: [{
-                id: 4
-            }],
-            name: 'Richmond'
+            departments: [4],
+            name: 'Beth Fin'
         }, {
             id: 3,
-            states: [{
-                id: 4
-            }],
-            name: 'Charlottesville'
+            departments: [2],
+            name: 'Artemis Eng'
         }, {
             id: 4,
-            states: [{
-                id: 2
-            }],
-            name: 'St. Louis'
+            departments: [1],
+            name: 'Andy Sales'
         }, {
             id: 5,
-            states: [{
-                id: 3
-            }],
-            name: 'New York City'
+            departments: [3],
+            name: 'Zoe Marketing'
         }, {
             id: 6,
-            states: [{
-                id: 4
-            }],
-            name: 'Roanoke'
+            departments: [4, 2],
+            name: 'Ziva Eng Fin'
         }];
         this.static = {
             options: [
@@ -121,17 +109,17 @@ export class MultiPickerDemoComponent {
         };
         this.parentChild = {
             options: [
-                { type: 'states', data: statesWithIds, format: '$name', field: 'id', isParent: { childType: 'cities' } },
-                { type: 'cities', data: cities, format: '$name', field: 'id', isChild: { parentType: 'states' } }
+                { type: 'departments', data: departments, format: '$name', field: 'id', isParent: { childType: 'users' } },
+                { type: 'users', data: users, format: '$name', field: 'id', isChild: { parentType: 'departments' } }
             ],
             resultsTemplate: ChecklistPickerResults
         };
-        this.parentChildTypes = [{ value: 'states', isParent: true, singular: 'state' }, { value: 'cities', isChild: true, singular: 'city' }];
+        this.parentChildTypes = [{ value: 'departments', isParent: true, singular: 'department' }, { value: 'users', isChild: true, singular: 'user' }];
         this.formatted = {
             format: '$firstName $lastName',
             options: collaborators
         };
-        this.parentChildValue = { states: [], cities: [] };
+        this.parentChildValue = { departments: [4], users: [2, 5] };
     }
     onChanged() {
     }

--- a/demo/pages/elements/multi-picker/MultiPickerDemo.js
+++ b/demo/pages/elements/multi-picker/MultiPickerDemo.js
@@ -77,7 +77,7 @@ export class MultiPickerDemoComponent {
         }];
         let users = [{
             id: 1,
-            departments: [1, 3, 4],
+            departments: [1, 2, 4],
             name: 'Bob Sales/Engineering/Fin'
         }, {
             id: 2,
@@ -109,12 +109,12 @@ export class MultiPickerDemoComponent {
         };
         this.parentChild = {
             options: [
-                { type: 'departments', data: departments, format: '$name', field: 'id', isParent: { childType: 'users' } },
-                { type: 'users', data: users, format: '$name', field: 'id', isChild: { parentType: 'departments' } }
+                { type: 'departments', data: departments, format: '$name', field: 'id', isParentOf: 'users' },
+                { type: 'users', data: users, format: '$name', field: 'id', isChildOf: 'departments' }
             ],
             resultsTemplate: ChecklistPickerResults
         };
-        this.parentChildTypes = [{ value: 'departments', isParent: true, singular: 'department' }, { value: 'users', isChild: true, singular: 'user' }];
+        this.parentChildTypes = [{ value: 'departments', isParentOf: true, singular: 'department' }, { value: 'users', isChildOf: true, singular: 'user' }];
         this.formatted = {
             format: '$firstName $lastName',
             options: collaborators

--- a/demo/pages/elements/multi-picker/MultiPickerDemo.js
+++ b/demo/pages/elements/multi-picker/MultiPickerDemo.js
@@ -24,8 +24,7 @@ const template = `
     
     <h5>Nested Example</h5>
     <p>
-        By clicking on the <code>multi-picker</code> element, the options list will be displayed.  Select any of the options
-        by clicking on the item in the list.  The value selected will be added to the list of selected values.
+        The multipicker can also support a parent-child relationship between the types, such as the relationship between a state with many cities or a department with users.
     </p>
     <div class="example chips-demo">${NestedMultiPicker}</div>
     <code-snippet [code]="NestedMultiPicker"></code-snippet>

--- a/demo/pages/elements/multi-picker/MultiPickerDemo.js
+++ b/demo/pages/elements/multi-picker/MultiPickerDemo.js
@@ -2,6 +2,7 @@
 import { Component } from '@angular/core';
 // APP
 import BasicMultiPicker from './templates/BasicMultiPickerDemo.html';
+import NestedMultiPicker from './templates/NestedMultiPickerDemo.html';
 import { ChecklistPickerResults } from './../../../../src/novo-elements';
 
 const template = `
@@ -13,13 +14,21 @@ const template = `
 
     <br/>
 
-    <h5>Basic Examples</h5>
+    <h5>Basic Example</h5>
     <p>
         By clicking on the <code>multi-picker</code> element, the options list will be displayed.  Select any of the options
         by clicking on the item in the list.  The value selected will be added to the list of selected values.
     </p>
     <div class="example chips-demo">${BasicMultiPicker}</div>
     <code-snippet [code]="BasicMultiPicker"></code-snippet>
+    
+    <h5>Nested Example</h5>
+    <p>
+        By clicking on the <code>multi-picker</code> element, the options list will be displayed.  Select any of the options
+        by clicking on the item in the list.  The value selected will be added to the list of selected values.
+    </p>
+    <div class="example chips-demo">${NestedMultiPicker}</div>
+    <code-snippet [code]="NestedMultiPicker"></code-snippet>
 </div>
 `;
 
@@ -30,10 +39,11 @@ const template = `
 export class MultiPickerDemoComponent {
     constructor() {
         this.BasicMultiPicker = BasicMultiPicker;
+        this.NestedMultiPicker = NestedMultiPicker;
 
         this.placeholder = 'Select...';
         this.value = { states: ['Alabama'], collaborators: [1, 2, 3, 4] };
-        this.types = ['states', 'collaborators'];
+        this.types = [{ value: 'states', singular: 'state' }, { value: 'collaborators', singular: 'collaborator' }];
 
         let states = ['Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California', 'Colorado', 'Connecticut', 'Delaware', 'Florida', 'Georgia', 'Hawaii', 'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky', 'Louisiana', 'Maine', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi', 'Missouri', 'Montana', 'Nebraska', 'Nevada', 'New Hampshire', 'New Jersey', 'New Mexico', 'New York', 'North Dakota', 'North Carolina', 'Ohio', 'Oklahoma', 'Oregon', 'Pennsylvania', 'Rhode Island', 'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont', 'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'];
         let collaborators = [{
@@ -53,6 +63,56 @@ export class MultiPickerDemoComponent {
             firstName: 'Kameron',
             lastName: 'Sween'
         }];
+        let statesWithIds = [{
+            id: 1,
+            name: 'Massachusetts'
+        }, {
+            id: 2,
+            name: 'Missouri'
+        }, {
+            id: 3,
+            name: 'New York'
+        }, {
+            id: 4,
+            name: 'Virginia'
+        }];
+        let cities = [{
+            id: 1,
+            states: [{
+                id: 1
+            }],
+            name: 'Boston'
+        }, {
+            id: 2,
+            states: [{
+                id: 4
+            }],
+            name: 'Richmond'
+        }, {
+            id: 3,
+            states: [{
+                id: 4
+            }],
+            name: 'Charlottesville'
+        }, {
+            id: 4,
+            states: [{
+                id: 2
+            }],
+            name: 'St. Louis'
+        }, {
+            id: 5,
+            states: [{
+                id: 3
+            }],
+            name: 'New York City'
+        }, {
+            id: 6,
+            states: [{
+                id: 4
+            }],
+            name: 'Roanoke'
+        }];
         this.static = {
             options: [
                 { type: 'collaborators', data: collaborators, format: '$firstName $lastName', field: 'id' },
@@ -60,10 +120,19 @@ export class MultiPickerDemoComponent {
             ],
             resultsTemplate: ChecklistPickerResults
         };
+        this.parentChild = {
+            options: [
+                { type: 'states', data: statesWithIds, format: '$name', field: 'id', isParent: { childType: 'cities' } },
+                { type: 'cities', data: cities, format: '$name', field: 'id', isChild: { parentType: 'states' } }
+            ],
+            resultsTemplate: ChecklistPickerResults
+        };
+        this.parentChildTypes = [{ value: 'states', isParent: true, singular: 'state' }, { value: 'cities', isChild: true, singular: 'city' }];
         this.formatted = {
             format: '$firstName $lastName',
             options: collaborators
         };
+        this.parentChildValue = { states: [], cities: [] };
     }
     onChanged() {
     }

--- a/demo/pages/elements/multi-picker/templates/NestedMultiPickerDemo.html
+++ b/demo/pages/elements/multi-picker/templates/NestedMultiPickerDemo.html
@@ -1,5 +1,5 @@
-<div class="selected-value">Selected States: <span *ngFor="let item of parentChildValue.states">{{item}} </span>
-    Selected Cities: <span *ngFor="let item of parentChildValue.cities">{{item}} </span></div>
+<div class="selected-value">Selected Departments: <span *ngFor="let item of parentChildValue.departments">{{item}} </span>
+    Selected Users: <span *ngFor="let item of parentChildValue.users">{{item}} </span></div>
 <multi-picker
     [source]="parentChild"
     [placeholder]="placeholder"

--- a/demo/pages/elements/multi-picker/templates/NestedMultiPickerDemo.html
+++ b/demo/pages/elements/multi-picker/templates/NestedMultiPickerDemo.html
@@ -1,0 +1,9 @@
+<div class="selected-value">Selected States: <span *ngFor="let item of parentChildValue.states">{{item}} </span>
+    Selected Cities: <span *ngFor="let item of parentChildValue.cities">{{item}} </span></div>
+<multi-picker
+    [source]="parentChild"
+    [placeholder]="placeholder"
+    [types]="parentChildTypes"
+    [(ngModel)]="parentChildValue"
+    (changed)="onChanged($event)">
+</multi-picker>

--- a/src/elements/chips/Chips.js
+++ b/src/elements/chips/Chips.js
@@ -37,7 +37,7 @@ export class NovoChipElement {
             e.stopPropagation();
             e.preventDefault();
         }
-        this.remove.emit();
+        this.remove.emit(e);
         return false;
     }
 
@@ -46,7 +46,7 @@ export class NovoChipElement {
             e.stopPropagation();
             e.preventDefault();
         }
-        this.select.emit();
+        this.select.emit(e);
         return false;
     }
 }

--- a/src/elements/multi-picker/MultiPicker.js
+++ b/src/elements/multi-picker/MultiPicker.js
@@ -183,6 +183,7 @@ export class NovoMultiPickerElement extends OutsideClick {
             this.updateDisplayItems(event, 'add');
             this.value[event.type].push(event.value);
             this.updateAllItemState(event.type, true);
+            this.triggerValueUpdate();
         }
         this.updateParentOrChildren(event, 'select');
         this.select(null, event);
@@ -259,7 +260,7 @@ export class NovoMultiPickerElement extends OutsideClick {
     removeValue(item) {
         let updatedValues = this.value[item.type].filter(x => x !== item.value);
         this.value[item.type] = updatedValues;
-        this.onModelChange(this.value);
+        this.triggerValueUpdate();
         this.updateDisplayItems(item, 'remove');
         if (this.value[item.type].length === 0) { this.updateIndeterminateState(item.type, false); }
     }
@@ -297,6 +298,10 @@ export class NovoMultiPickerElement extends OutsideClick {
         } else {
             this.value[type] = [];
         }
+        this.triggerValueUpdate();
+    }
+
+    triggerValueUpdate() {
         let updatedObject = {};
         this.types.forEach(x => updatedObject[x.value] = this.value[x.value]);
         this.value = updatedObject;

--- a/src/elements/multi-picker/Multipicker.spec.js
+++ b/src/elements/multi-picker/Multipicker.spec.js
@@ -25,7 +25,7 @@ describe('Element: NovoMultiPickerElement', () => {
 
     describe('Function: clearValue()', () => {
         it('should clear items, uncheck options, and reset value', () => {
-            component.types = ['numbers'];
+            component.types = [{ value: 'numbers' }];
             component.items = [1, 2];
             component.value = [1, 2];
             component._options = [{ type: 'numbers', data: [{ value: 1, checked: true }, { value: 2, checked: false, indeterminate: true }] }];
@@ -41,23 +41,102 @@ describe('Element: NovoMultiPickerElement', () => {
         it('should correctly setup options', () => {
             component.source = { options: [{ type: 'numbers', data: [1] }] };
             component.setupOptions();
-            let data = [{ value: 'ALL', label: 'All numbers', type: 'numbers', checked: undefined }, { value: 1, label: '1', type: 'numbers', checked: undefined }];
+            let data = [{ value: 'ALL', label: 'All numbers', type: 'numbers', checked: undefined, isParent: undefined, isChild: undefined }, { value: 1, label: '1', type: 'numbers', checked: undefined, isParent: undefined, isChild: undefined }];
             let originalData = data;
             expect(component._options).toEqual([{ type: 'numbers', data: data, originalData: originalData }]);
             expect(component.source.options).toBe(component._options);
         });
     });
 
+    describe('Function: formatOption(section)', () => {
+        it('should correctly format a parent option', () => {
+            let section = { type: 'cats', isParent: { childType: 'kittens' } };
+            let item = { value: 1 };
+            let expectedObj = {
+                value: 1,
+                label: '1',
+                type: 'cats',
+                checked: undefined,
+                isParent: {
+                    childType: 'kittens'
+                },
+                isChild: undefined
+            };
+            let actual = component.formatOption(section, item);
+            expect(actual).toEqual(expectedObj);
+        });
+        it('should correctly format a child option', () => {
+            let section = { type: 'kittens', isChild: { parentType: 'cats' } };
+            let item = { value: 1, cats: [{ id: 1 }] };
+            let expectedObj = {
+                value: 1,
+                label: '1',
+                type: 'kittens',
+                checked: undefined,
+                isChild: {
+                    parentType: 'cats'
+                },
+                isParent: undefined,
+                cats: [{ id: 1 }]
+            };
+            let actual = component.formatOption(section, item);
+            expect(actual).toEqual(expectedObj);
+        });
+        it('should correctly format a non parent/child option', () => {
+            let section = { type: 'kittens' };
+            let item = { value: 1 };
+            let expectedObj = {
+                value: 1,
+                label: '1',
+                type: 'kittens',
+                checked: undefined,
+                isChild: undefined,
+                isParent: undefined
+            };
+            let actual = component.formatOption(section, item);
+            expect(actual).toEqual(expectedObj);
+        });
+    });
+
+    describe('Function: createSelectAllOption(section, item)', () => {
+        it('should correctly create a select all option for a child type', () => {
+            let section = { type: 'kittens', isChild: { parentType: 'cats' }, data: [{ cats: [{ id: 1 }, { id: 2 }] }] };
+            let expected = {
+                value: 'ALL',
+                label: 'All kittens',
+                type: 'kittens',
+                checked: undefined,
+                isParent: undefined,
+                isChild: { parentType: 'cats' },
+                cats: [{ id: 1 }, { id: 2 }]
+            };
+            let actualResult = component.createSelectAllOption(section);
+            expect(actualResult).toEqual(expected);
+        });
+        it('should correctly create a select all option for a parent type', () => {
+            let section = { type: 'cats', isParent: { childType: 'kittens' }, data: [{ cats: [{ id: 1 }, { id: 2 }] }] };
+            let expected = {
+                value: 'ALL',
+                label: 'All cats',
+                type: 'cats',
+                checked: undefined,
+                isParent: { childType: 'kittens' },
+                isChild: undefined
+            };
+            let actualResult = component.createSelectAllOption(section);
+            expect(actualResult).toEqual(expected);
+        });
+    });
+
     describe('Function: setupOptionByType(section)', () => {
         it('should correctly format a section of options', () => {
             let section = { type: 'cats', data: ['Kitty'] };
-            let data = [{ value: 'ALL', label: 'All cats', type: 'cats', checked: undefined }, { value: 'Kitty', label: 'Kitty', type: 'cats', checked: undefined }];
+            let data = [{ value: 'ALL', label: 'All cats', type: 'cats', checked: undefined, isParent: undefined, isChild: undefined }, { value: 'Kitty', label: 'Kitty', type: 'cats', checked: undefined, isParent: undefined, isChild: undefined }];
             let expected = { type: 'cats', data: data, originalData: data };
             let actualResult = component.setupOptionsByType(section);
             expect(actualResult).toEqual(expected);
         });
     });
-
 
     describe('Function: deselectAll()', () => {
         it('should remove selection', () => {
@@ -91,18 +170,18 @@ describe('Element: NovoMultiPickerElement', () => {
         });
     });
 
-    describe('Function: updateItems(item, action)', () => {
+    describe('Function: updateDisplayItems(item, action)', () => {
         it('should update items if adding', () => {
             component.items = [];
             let item = { value: 'Cat', label: 'Cat' };
-            component.updateItems(item, 'add');
+            component.updateDisplayItems(item, 'add');
             expect(component.items.length).toBe(1);
         });
 
         it('should update items if removing', () => {
             let item = { value: 'Cat', label: 'Cat' };
             component.items = [item];
-            component.updateItems(item, 'remove');
+            component.updateDisplayItems(item, 'remove');
             expect(component.items.length).toBe(0);
         });
     });
@@ -147,52 +226,68 @@ describe('Element: NovoMultiPickerElement', () => {
         });
 
         it('should correctly add individual item', () => {
-            component.types = ['cats'];
+            component.types = [{ value: 'cats' }];
             component.value = { cats: [] };
             component._options = [{ type: 'cats', data: [{ value: 'ALL', indeterminate: undefined }, { value: 'Kitty' }, { value: 'Tiger' }] }];
             let itemToAdd = { value: 'Cat', label: 'Cat', type: 'cats' };
-            spyOn(component, 'updateItems');
+            spyOn(component, 'updateDisplayItems');
             spyOn(component, 'updateIndeterminateState');
             component.add(itemToAdd);
-            expect(component.updateItems).toHaveBeenCalled();
+            expect(component.updateDisplayItems).toHaveBeenCalled();
             expect(component.updateIndeterminateState).toHaveBeenCalled();
             expect(component.value.cats.length).toBe(1);
         });
     });
 
-    describe('Function: remove(item)', () => {
+    describe('Function: removeItem(item)', () => {
         it('should handle removing item correctly from value and items and update checked state', () => {
             let item = { value: 'Cat', checked: true, type: 'cats' };
-            component.types = ['cats'];
-            component.items = [item, { value: 'Tiger' }];
-            component.value = { cats: ['Tiger', 'Cat'] };
+            spyOn(component, 'removeValue');
+            spyOn(component, 'updateParentOrChildren');
             component.removeItem(item);
             expect(item.checked).toBeFalsy();
-            expect(component.items.length).toBe(1);
-            expect(component.value.cats).toEqual(['Tiger']);
+            expect(component.removeValue).toHaveBeenCalled();
+            expect(component.updateParentOrChildren).toHaveBeenCalled();
         });
     });
 
-    describe('Function: updateMoreItemsText(items)', () => {
+    describe('Function: removeValue(item)', () => {
+        it('should handle removing item correctly from value', () => {
+            let item = { value: 'Cat', type: 'cats' };
+            component.types = [{ value: 'cats' }];
+            component.value = { cats: ['Tiger', 'Cat'] };
+            spyOn(component, 'updateDisplayItems');
+            spyOn(component, 'updateIndeterminateState');
+            component.removeValue(item);
+            expect(component.updateDisplayItems).toHaveBeenCalled();
+            expect(component.value.cats).toEqual(['Tiger']);
+            component.removeValue({ value: 'Tiger', type: 'cats' });
+            expect(component.value.cats).toEqual([]);
+            expect(component.updateIndeterminateState).toHaveBeenCalled();
+            expect(component.updateDisplayItems).toHaveBeenCalled();
+        });
+    });
+
+    describe('Function: updateDisplayText(items)', () => {
         it('should create an object with correct type and count when count is above 2', () => {
             let items = [{ value: 1, type: 'numbers' }, { value: 2, type: 'numbers' }, { value: 3, type: 'numbers' }, { value: 4, type: 'numbers' }, { value: 5, type: 'numbers' }, { value: 6, type: 'numbers' }];
-            component.types = ['numbers'];
-            component.updateMoreItemsText(items);
+            component.types = [{ value: 'numbers' }];
+            component.updateDisplayText(items);
             expect(component.notShown.length).toBe(1);
             expect(component.notShown[0].type).toBe('numbers');
             expect(component.notShown[0].count).toBe(2);
         });
         it('not add type and count to object if count is 0', () => {
             let items = [{ value: 1, type: 'numbers' }, { value: 2, type: 'numbers' }, { value: 3, type: 'numbers' }, { value: 4, type: 'numbers' }];
-            component.types = ['numbers'];
-            component.updateMoreItemsText(items);
+            component.types = [{ value: 'numbers' }];
+            component.updateDisplayText(items);
             expect(component.notShown.length).toBe(0);
         });
         it('add all items to count if all of type is selected', () => {
             let items = [{ value: 1, type: 'numbers' }, { value: 2, type: 'numbers' }, { value: 3, type: 'numbers' }, { value: 4, type: 'numbers' }, { value: 'ALL', type: 'cats' }];
-            component.types = ['numbers', 'cats'];
+            component.types = [{ value: 'numbers' }, { value: 'cats' }];
             component._options = [{ type: 'numbers', data: [1, 2, 3, 4] }, { type: 'cats', data: ['ALL', 2, 3, 4, 5, 6, 7, 8] }];
-            component.updateMoreItemsText(items);
+            component.updateDisplayText(items);
             expect(component.notShown.length).toBe(1);
             expect(component.notShown[0].type).toBe('cats');
             expect(component.notShown[0].count).toBe(7);
@@ -215,7 +310,7 @@ describe('Element: NovoMultiPickerElement', () => {
 
     describe('Function: modifyAllOfType(type, action)', () => {
         it('should select all if selecting', () => {
-            component.types = ['cats'];
+            component.types = [{ value: 'cats' }];
             component._options = [{ type: 'cats', data: [{ value: 'ALL', checked: false, type: 'cats' }, { value: 'Kitty', checked: false, type: 'cats' }] }];
             component.value = { cats: [] };
             component.modifyAllOfType('cats', 'select');
@@ -225,7 +320,7 @@ describe('Element: NovoMultiPickerElement', () => {
         });
 
         it('should unselect all if unselecting', () => {
-            component.types = ['cats'];
+            component.types = [{ value: 'cats' }];
             component._options = [{ type: 'cats', data: [{ value: 'ALL', checked: false, type: 'cats' }, { value: 'Kitty', checked: true, type: 'cats' }] }];
             component.value = { cats: [{ value: 'Kitty', checked: true, type: 'cats' }] };
             component.modifyAllOfType('cats', 'unselect');
@@ -236,7 +331,7 @@ describe('Element: NovoMultiPickerElement', () => {
 
     describe('Function: selectAll(type,)', () => {
         it('should correctly update value and items when selecting all', () => {
-            component.types = ['cats'];
+            component.types = [{ value: 'cats' }];
             component._options = [{ type: 'cats', data: [{ value: 'ALL', checked: false, type: 'cats' }, { value: 'Kitty', checked: false, type: 'cats' }, { value: 'Tiger', checked: false, type: 'cats' }] }];
             component.value = { cats: [{ value: 'Kitty', checked: false, type: 'cats' }] };
             component.selectAll(component._options[0].data, 'cats');
@@ -248,7 +343,7 @@ describe('Element: NovoMultiPickerElement', () => {
 
     describe('Function: handleRemoveItemIfAllSelected(item)', () => {
         it('should correctly update value and items when removing an item AND ALL is currently selected', () => {
-            component.types = ['cats'];
+            component.types = [{ value: 'cats' }];
             let allItem = { value: 'ALL', checked: true, type: 'cats' };
             component._options = [{ type: 'cats', data: [allItem, { value: 'Kitty', checked: true, type: 'cats' }, { value: 'Tiger', checked: true, type: 'cats' }] }];
             component.value = { cats: [{ value: 'ALL', checked: false, type: 'cats' }] };
@@ -263,7 +358,7 @@ describe('Element: NovoMultiPickerElement', () => {
     describe('Function: setInitialValue(model)', () => {
         it('should correctly set intial value and items if a model is passed in to start', () => {
             let model = { cats: ['Kitty'] };
-            component.types = ['cats'];
+            component.types = [{ value: 'cats' }];
             component._options = [{ type: 'cats', data: [{ value: 'ALL', checked: false, type: 'cats' }, { value: 'Kitty', checked: true, type: 'cats' }, { value: 'Tiger', checked: true, type: 'cats' }] }];
             component.setInitialValue(model);
             expect(component._options[0].data[1].checked).toBeTruthy();
@@ -271,7 +366,7 @@ describe('Element: NovoMultiPickerElement', () => {
             expect(component.value.cats).toEqual(['Kitty']);
         });
         it('should correctly set intial value and items if no model is passed in to start', () => {
-            component.types = ['cats'];
+            component.types = [{ value: 'cats' }];
             component._options = [{ type: 'cats', data: [{ value: 'ALL', checked: false, type: 'cats' }, { value: 'Kitty', checked: true, type: 'cats' }, { value: 'Tiger', checked: true, type: 'cats' }] }];
             component.setInitialValue(null);
             expect(component.items).toEqual([]);
@@ -281,13 +376,13 @@ describe('Element: NovoMultiPickerElement', () => {
 
     describe('Function: updateIndeterminateState(type, status)', () => {
         it('should correctly set "ALL [type" to true', () => {
-            component.types = ['cats'];
+            component.types = [{ value: 'cats' }];
             component._options = [{ type: 'cats', data: [{ value: 'ALL', checked: false, type: 'cats', indeterminate: undefined }] }];
             component.updateIndeterminateState('cats', true);
             expect(component._options[0].data[0].indeterminate).toBeTruthy();
         });
         it('should correctly set "ALL [type" to false', () => {
-            component.types = ['cats'];
+            component.types = [{ value: 'cats' }];
             component._options = [{ type: 'cats', data: [{ value: 'ALL', checked: false, type: 'cats', indeterminate: undefined }] }];
             component.updateIndeterminateState('cats', false);
             expect(component._options[0].data[0].indeterminate).toBeFalsy();
@@ -296,7 +391,7 @@ describe('Element: NovoMultiPickerElement', () => {
 
     describe('Function: getAllOfType(type)', () => {
         it('should get all of type', () => {
-            component.types = ['cats'];
+            component.types = [{ value: 'cats' }];
             component._options = [{ type: 'cats', data: [1, 2, 3, 4] }];
             let result = component.getAllOfType('cats');
             expect(result.length).toBe(4);
@@ -304,16 +399,79 @@ describe('Element: NovoMultiPickerElement', () => {
     });
     describe('Function: allItemsSelected(optionsByType, type)', () => {
         it('should return true if all individual items are selected', () => {
-            component.types = ['cats'];
+            component.types = [{ value: 'cats' }];
             let options = ['All', 'Kitty', 'Tiger'];
             component.value = { cats: ['Kitty', 'Tiger'] };
             expect(component.allItemsSelected(options, 'cats')).toBeTruthy();
         });
         it('should return false if all individual items are not selected', () => {
-            component.types = ['cats'];
+            component.types = [{ value: 'cats' }];
             let options = ['All', 'Kitty', 'Tiger'];
             component.value = { cats: ['Kitty'] };
             expect(component.allItemsSelected(options, 'cats')).toBeFalsy();
+        });
+    });
+    describe('Function: addIndividualChildren(parent, checked)', () => {
+        it('should add an item', () => {
+            component.types = [{ value: 'cats' }];
+            component.value = { cats: [1] };
+            let item = { type: 'cats', value: 2 };
+            spyOn(component, 'add');
+            component.addIndividualChildren([item]);
+            expect(component.add).toHaveBeenCalled();
+        });
+        it('should not add a duplicate item', () => {
+            component.types = [{ value: 'cats' }];
+            component.value = { cats: [1] };
+            let item = { type: 'cats', value: 1 };
+            spyOn(component, 'add');
+            component.addIndividualChildren([item]);
+            expect(component.add).not.toHaveBeenCalled();
+        });
+    });
+    describe('Function: determineIndeterminateState(parent, selecting)', () => {
+        it('should set parent to indeterminate and parent type ALL item to indeterminate if selecting', () => {
+            let parent = { indeterminate: false, type: 'cats' };
+            spyOn(component, 'updateIndeterminateState');
+            component.determineIndeterminateState(parent, true);
+            expect(component.updateIndeterminateState).toHaveBeenCalled();
+            expect(parent.indeterminate).toBeTruthy();
+        });
+        it('should set remove parent if no other children are selected if removing', () => {
+            let parent = { indeterminate: false, type: 'cats', isParent: { childType: 'kittens' } };
+            spyOn(component, 'getAllOfType').and.returnValue([{ checked: false }]);
+            spyOn(component, 'remove');
+            component.determineIndeterminateState(parent, false);
+            expect(component.remove).toHaveBeenCalled();
+            expect(parent.indeterminate).toBeFalsy();
+        });
+        it('should add individual children and remove parent value if other children are selected if removing', () => {
+            let parent = { value: 1, indeterminate: false, type: 'cats', isParent: { childType: 'kittens' } };
+            spyOn(component, 'getAllOfType').and.returnValue([{ cats: [{ id: 1 }], checked: true }]);
+            spyOn(component, 'addIndividualChildren');
+            spyOn(component, 'removeValue');
+            component.determineIndeterminateState(parent, false);
+            expect(component.addIndividualChildren).toHaveBeenCalled();
+            expect(component.removeValue).toHaveBeenCalled();
+            expect(parent.indeterminate).toBeTruthy();
+        });
+    });
+    describe('Function: updateParentOrChildren(item, action)', () => {
+        it('should call updateChildrenValue if item isParent', () => {
+            let item = { isParent: true };
+            spyOn(component, 'updateChildrenValue');
+            spyOn(component, 'updateParentValue');
+            component.updateParentOrChildren(item);
+            expect(component.updateChildrenValue).toHaveBeenCalled();
+            expect(component.updateParentValue).not.toHaveBeenCalled();
+        });
+        it('should call updateParentValue if item isChild', () => {
+            let item = { isChild: true };
+            spyOn(component, 'updateChildrenValue');
+            spyOn(component, 'updateParentValue');
+            component.updateParentOrChildren(item);
+            expect(component.updateParentValue).toHaveBeenCalled();
+            expect(component.updateChildrenValue).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/elements/multi-picker/Multipicker.spec.js
+++ b/src/elements/multi-picker/Multipicker.spec.js
@@ -14,9 +14,9 @@ describe('Element: NovoMultiPickerElement', () => {
 
     beforeEach(inject([NovoMultiPickerElement], _component => {
         component = _component;
-        component.types = [{ value: 'cats', isParent: { childType: 'kittens' } }, { value: 'kittens', isChild: { parentType: 'cats' } }];
+        component.types = [{ value: 'cats', isParentOf: 'kittens' }, { value: 'kittens', isChildOf: 'cats' }];
         // let kittens = [{ value: 'ALL', checked: true, type: 'kittens' }, { value: 'Kitty', checked: true, type: 'kittens' }, { value: 'Tiger', checked: true, type: 'kittens' }];
-        let cats = [{ value: 'ALL', checked: true, type: 'cats', isParent: { childType: 'kittens' } }, { value: 'Kitty', checked: true, type: 'cats', isParent: { childType: 'kittens' } }, { value: 'Tiger', checked: true, type: 'cats' }];
+        let cats = [{ value: 'ALL', checked: true, type: 'cats', isParentOf: 'kittens' }, { value: 'Kitty', checked: true, type: 'cats', isParentOf: 'kittens' }, { value: 'Tiger', checked: true, type: 'cats' }];
         component._options = [{ type: 'cats', data: cats, originalData: cats }];
     }));
 
@@ -48,7 +48,7 @@ describe('Element: NovoMultiPickerElement', () => {
         it('should correctly setup options', () => {
             component.source = { options: [{ type: 'numbers', data: [1] }] };
             component.setupOptions();
-            let data = [{ value: 'ALL', label: 'All numbers', type: 'numbers', checked: undefined, isParent: undefined, isChild: undefined }, { value: 1, label: '1', type: 'numbers', checked: undefined, isParent: undefined, isChild: undefined }];
+            let data = [{ value: 'ALL', label: 'All numbers', type: 'numbers', checked: undefined, isParentOf: undefined, isChildOf: undefined }, { value: 1, label: '1', type: 'numbers', checked: undefined, isParentOf: undefined, isChildOf: undefined }];
             let originalData = data;
             expect(component._options).toEqual([{ type: 'numbers', data: data, originalData: originalData }]);
             expect(component.source.options).toBe(component._options);
@@ -57,33 +57,29 @@ describe('Element: NovoMultiPickerElement', () => {
 
     describe('Function: formatOption(section)', () => {
         it('should correctly format a parent option', () => {
-            let section = { type: 'cats', isParent: { childType: 'kittens' } };
+            let section = { type: 'cats', isParentOf: 'kittens' };
             let item = { value: 1 };
             let expectedObj = {
                 value: 1,
                 label: '1',
                 type: 'cats',
                 checked: undefined,
-                isParent: {
-                    childType: 'kittens'
-                },
-                isChild: undefined
+                isParentOf: 'kittens',
+                isChildOf: undefined
             };
             let actual = component.formatOption(section, item);
             expect(actual).toEqual(expectedObj);
         });
         it('should correctly format a child option', () => {
-            let section = { type: 'kittens', isChild: { parentType: 'cats' } };
+            let section = { type: 'kittens', isChildOf: 'cats' };
             let item = { value: 1, cats: [{ id: 1 }] };
             let expectedObj = {
                 value: 1,
                 label: '1',
                 type: 'kittens',
                 checked: undefined,
-                isChild: {
-                    parentType: 'cats'
-                },
-                isParent: undefined,
+                isChildOf: 'cats',
+                isParentOf: undefined,
                 cats: [{ id: 1 }]
             };
             let actual = component.formatOption(section, item);
@@ -97,8 +93,8 @@ describe('Element: NovoMultiPickerElement', () => {
                 label: '1',
                 type: 'kittens',
                 checked: undefined,
-                isChild: undefined,
-                isParent: undefined
+                isChildOf: undefined,
+                isParentOf: undefined
             };
             let actual = component.formatOption(section, item);
             expect(actual).toEqual(expectedObj);
@@ -107,28 +103,28 @@ describe('Element: NovoMultiPickerElement', () => {
 
     describe('Function: createSelectAllOption(section, item)', () => {
         it('should correctly create a select all option for a child type', () => {
-            let section = { type: 'kittens', isChild: { parentType: 'cats' }, data: [{ cats: [{ id: 1 }, { id: 2 }] }] };
+            let section = { type: 'kittens', isChildOf: 'cats', data: [{ cats: [{ id: 1 }, { id: 2 }] }] };
             let expected = {
                 value: 'ALL',
                 label: 'All kittens',
                 type: 'kittens',
                 checked: undefined,
-                isParent: undefined,
-                isChild: { parentType: 'cats' },
+                isParentOf: undefined,
+                isChildOf: 'cats',
                 cats: [{ id: 1 }, { id: 2 }]
             };
             let actualResult = component.createSelectAllOption(section);
             expect(actualResult).toEqual(expected);
         });
         it('should correctly create a select all option for a parent type', () => {
-            let section = { type: 'cats', isParent: { childType: 'kittens' }, data: [{ cats: [{ id: 1 }, { id: 2 }] }] };
+            let section = { type: 'cats', isParentOf: 'kittens', data: [{ cats: [{ id: 1 }, { id: 2 }] }] };
             let expected = {
                 value: 'ALL',
                 label: 'All cats',
                 type: 'cats',
                 checked: undefined,
-                isParent: { childType: 'kittens' },
-                isChild: undefined
+                isParentOf: 'kittens',
+                isChildOf: undefined
             };
             let actualResult = component.createSelectAllOption(section);
             expect(actualResult).toEqual(expected);
@@ -138,7 +134,7 @@ describe('Element: NovoMultiPickerElement', () => {
     describe('Function: setupOptionByType(section)', () => {
         it('should correctly format a section of options', () => {
             let section = { type: 'cats', data: ['Kitty'] };
-            let data = [{ value: 'ALL', label: 'All cats', type: 'cats', checked: undefined, isParent: undefined, isChild: undefined }, { value: 'Kitty', label: 'Kitty', type: 'cats', checked: undefined, isParent: undefined, isChild: undefined }];
+            let data = [{ value: 'ALL', label: 'All cats', type: 'cats', checked: undefined, isParentOf: undefined, isChildOf: undefined }, { value: 'Kitty', label: 'Kitty', type: 'cats', checked: undefined, isParentOf: undefined, isChildOf: undefined }];
             let expected = { type: 'cats', data: data, originalData: data };
             let actualResult = component.setupOptionsByType(section);
             expect(actualResult).toEqual(expected);
@@ -449,16 +445,16 @@ describe('Element: NovoMultiPickerElement', () => {
         });
     });
     describe('Function: updateParentOrChildren(item, action)', () => {
-        it('should call updateChildrenValue if item isParent', () => {
-            let item = { isParent: true };
+        it('should call updateChildrenValue if item isParentOf', () => {
+            let item = { isParentOf: true };
             spyOn(component, 'updateChildrenValue');
             spyOn(component, 'updateParentValue');
             component.updateParentOrChildren(item);
             expect(component.updateChildrenValue).toHaveBeenCalled();
             expect(component.updateParentValue).not.toHaveBeenCalled();
         });
-        it('should call updateParentValue if item isChild', () => {
-            let item = { isChild: true };
+        it('should call updateParentValue if item isChildOf', () => {
+            let item = { isChildOf: true };
             spyOn(component, 'updateChildrenValue');
             spyOn(component, 'updateParentValue');
             component.updateParentOrChildren(item);
@@ -467,16 +463,16 @@ describe('Element: NovoMultiPickerElement', () => {
         });
     });
     describe('Function: updateParentOrChildren(item, action)', () => {
-        it('should call updateChildrenValue if item isParent', () => {
-            let item = { isParent: true };
+        it('should call updateChildrenValue if item isParentOf', () => {
+            let item = { isParentOf: true };
             spyOn(component, 'updateChildrenValue');
             spyOn(component, 'updateParentValue');
             component.updateParentOrChildren(item);
             expect(component.updateChildrenValue).toHaveBeenCalled();
             expect(component.updateParentValue).not.toHaveBeenCalled();
         });
-        it('should call updateParentValue if item isChild', () => {
-            let item = { isChild: true };
+        it('should call updateParentValue if item isChildOf', () => {
+            let item = { isChildOf: true };
             spyOn(component, 'updateChildrenValue');
             spyOn(component, 'updateParentValue');
             component.updateParentOrChildren(item);
@@ -485,16 +481,16 @@ describe('Element: NovoMultiPickerElement', () => {
         });
     });
     describe('Function: updateAllParentsOrChildren(item, action)', () => {
-        it('should call updateChildrenValue if item isParent', () => {
-            let item = { isParent: true };
+        it('should call updateChildrenValue if item isParentOf', () => {
+            let item = { isParentOf: true };
             spyOn(component, 'updateAllChildrenValue');
             spyOn(component, 'updateAllParentValue');
             component.updateAllParentsOrChildren(item);
             expect(component.updateAllChildrenValue).toHaveBeenCalled();
             expect(component.updateAllParentValue).not.toHaveBeenCalled();
         });
-        it('should call updateParentValue if item isChild', () => {
-            let item = { isChild: true };
+        it('should call updateParentValue if item isChildOf', () => {
+            let item = { isChildOf: true };
             spyOn(component, 'updateAllChildrenValue');
             spyOn(component, 'updateAllParentValue');
             component.updateAllParentsOrChildren(item);
@@ -506,7 +502,7 @@ describe('Element: NovoMultiPickerElement', () => {
         it('should handle removing item while all parents selected', () => {
             component._options = [{ type: 'cats', data: [{ checked: true, type: 'cats' }], originalData: [{ checked: true, type: 'cats' }] }];
             spyOn(component, 'handleRemoveItemIfAllSelected');
-            component.updateParentValue({ isChild: { parentType: 'cats' } }, 'remove');
+            component.updateParentValue({ isChildOf: 'cats' }, 'remove');
             expect(component.handleRemoveItemIfAllSelected).toHaveBeenCalled();
         });
     });
@@ -514,7 +510,7 @@ describe('Element: NovoMultiPickerElement', () => {
         it('should set all parents to indeterminate if not already checked', () => {
             let cat = { checked: false, type: 'cats', indeterminate: false };
             component._options = [{ type: 'cats', data: [cat], originalData: [cat] }];
-            component.updateAllParentValue({ isChild: { parentType: 'cats' } }, 'select');
+            component.updateAllParentValue({ isChildOf: 'cats' }, 'select');
             expect(component._options[0].data[0].indeterminate).toBeTruthy();
         });
     });
@@ -522,7 +518,7 @@ describe('Element: NovoMultiPickerElement', () => {
         it('should set children to checked if selecting', () => {
             let cat = { checked: false, type: 'cats', indeterminate: false, cats: [1] };
             component._options = [{ type: 'kittens', data: [cat], originalData: [cat] }];
-            component.updateChildrenValue({ type: 'cats', value: 1, isParent: { childType: 'kittens' } }, 'select');
+            component.updateChildrenValue({ type: 'cats', value: 1, isParentOf: 'kittens' }, 'select');
             expect(component._options[0].data[0].checked).toBeTruthy();
         });
     });
@@ -546,16 +542,16 @@ describe('Element: NovoMultiPickerElement', () => {
     });
     describe('Function: modifyAffectedParentsOrChildren(selecting, itemChanged)', () => {
         it('should update indeterminate states for parent and child type', () => {
-            let kitty = { value: 'Kitty', checked: false, type: 'cats', isParent: { childType: 'kittens' } };
-            let allCat = { value: 'ALL', checked: true, type: 'cats', isParent: { childType: 'kittens' } };
-            let allKitten = { value: 'ALL', checked: true, type: 'kittens', isChild: { parentType: 'cats' } };
-            let cat = { value: 'Cat', checked: true, type: 'kittens', isChild: { parentType: 'cats' } };
+            let kitty = { value: 'Kitty', checked: false, type: 'cats', isParentOf: 'kittens' };
+            let allCat = { value: 'ALL', checked: true, type: 'cats', isParentOf: 'kittens' };
+            let allKitten = { value: 'ALL', checked: true, type: 'kittens', isChildOf: 'cats', cats: [1] };
+            let cat = { value: 'Cat', checked: true, type: 'kittens', isChildOf: 'cats', cats: [1] };
             component._options = [
                 { type: 'cats', data: [allCat, kitty], originalData: [allCat, kitty] },
                 { type: 'kittens', data: [allKitten, cat], originalData: [allKitten, cat] }
             ];
             spyOn(component, 'setIndeterminateState');
-            component.modifyAffectedParentsOrChildren(true, { isParent: true, type: 'cats' });
+            component.modifyAffectedParentsOrChildren(true, { isParentOf: true, type: 'cats' });
             expect(component._options[0].data[0].checked).toBeTruthy();
             expect(component.setIndeterminateState).toHaveBeenCalled();
         });

--- a/src/elements/multi-picker/Multipicker.spec.js
+++ b/src/elements/multi-picker/Multipicker.spec.js
@@ -437,8 +437,10 @@ describe('Element: NovoMultiPickerElement', () => {
             expect(component.updateIndeterminateState).toHaveBeenCalled();
             expect(parent.indeterminate).toBeTruthy();
         });
-        it('should set remove parent if no other children are selected if removing', () => {
+        it('should remove parent if no other children are selected if removing', () => {
             let parent = { indeterminate: false, type: 'cats', isParent: { childType: 'kittens' } };
+            component.types = [{ value: 'cats' }, { value: 'kittens' }];
+            component.value = { cats: [1], kittens: [] };
             spyOn(component, 'getAllOfType').and.returnValue([{ checked: false }]);
             spyOn(component, 'remove');
             component.determineIndeterminateState(parent, false);


### PR DESCRIPTION
This PR adds the ability for multipicker types to have a parent-child relationship such as between a department with many users.

##### **What did you change?**
- Added parent/child functionality (un/check all children with a parent is un/checked, handle indeterminate states for parent items when a child is checked, etc)
- Updated specs
- Updated demo


##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices