### PR TITLE
Styling for Underline Required Note fields

### DIFF
--- a/src/elements/form/Form.scss
+++ b/src/elements/form/Form.scss
@@ -165,6 +165,10 @@ novo-form {
                                     &:focus {
                                         border-bottom: 1px solid $positive;
                                     }
+
+                                    &:invalid {
+                                        border-bottom: 1px solid #DA4453;
+                                    }
                                 }
 
                                 textarea {


### PR DESCRIPTION
_REPLACE ME WITH A SHORT DESCRIPTION_

##### **What did you change?**

Added styling to change gray bottom border to display red when Note is saved and required field is not populated.

##### **Reviewers**
* @user

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices
