### PR TITLE
bug(multipicker): Fix bugs surrounding  parents without children

### DIFF
--- a/demo/pages/elements/multi-picker/MultiPickerDemo.ts
+++ b/demo/pages/elements/multi-picker/MultiPickerDemo.ts
@@ -79,6 +79,9 @@ export class MultiPickerDemoComponent {
         }, {
             id: 4,
             name: 'Finance'
+        }, {
+            id: 5,
+            name: 'Nobody Works Here'
         }];
         let users = [{
             id: 1,
@@ -124,7 +127,7 @@ export class MultiPickerDemoComponent {
             format: '$firstName $lastName',
             options: collaborators
         };
-        this.parentChildValue = { departments: [4], users: [2, 5] };
+        this.parentChildValue = { departments: [1, 2, 3, 4, 5], users: [] };
     }
 
     onChanged() {


### PR DESCRIPTION
Fix bugs to handle parents who don't have children. Added an example to demo. Make sure to reset display items when unselecting all of a type.

##### **What did you change?**
Multipicker


##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices
