### PR TITLE
feat(form) added fieldsets with headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
+bundles
+lib
 /dist
 /tmp
 /demo/**/*.js

--- a/demo/pages/elements/form/FormDemo.ts
+++ b/demo/pages/elements/form/FormDemo.ts
@@ -7,7 +7,8 @@ let TextBasedControlsDemoTpl = require('./templates/TextBasedControls.html');
 let CheckBoxControlsDemoTpl = require('./templates/CheckBoxControls.html');
 let FileInputControlsDemoTpl = require('./templates/FileInputControls.html');
 let CalendarControlsDemoTpl = require('./templates/CalendarInputControls.html');
-import MockMeta from './MockMeta';
+let FieldsetsFormDemoTpl = require('./templates/DynamicFormFieldSets.html');
+import { MockMeta, MockMetaHeaders } from './MockMeta';
 // Vendor
 import {
     FormUtils, TextBoxControl, CheckboxControl, CheckListControl, FileControl,
@@ -47,6 +48,10 @@ const template = `
     <h5>Vertical</h5>
     <div class="example form-demo dynamic">${VerticalDynamicFormDemoTpl}</div>
     <code-snippet [code]="VerticalDynamicFormDemoTpl"></code-snippet>
+
+    <h5>Fieldsets</h5>
+    <div class="example form-demo fieldsets">${FieldsetsFormDemoTpl}</div>
+    <code-snippet [code]="FieldsetsFormDemoTpl"></code-snippet>
 </div>
 `;
 
@@ -61,6 +66,7 @@ export class FormDemoComponent {
     private CheckBoxControlsDemoTpl: string = CheckBoxControlsDemoTpl;
     private FileInputControlsDemoTpl: string = FileInputControlsDemoTpl;
     private CalendarControlsDemoTpl: string = CalendarControlsDemoTpl;
+    private FieldsetsFormDemoTpl: string = FieldsetsFormDemoTpl;
     private quickNoteConfig: any;
     private textControl: any;
     private emailControl: any;
@@ -85,7 +91,8 @@ export class FormDemoComponent {
     private dynamicVertical: any;
     private dynamicVerticalForm: any;
     private calendarForm: any;
-
+    private fieldsets: Array<any>;
+    private fieldsetsForm:any;
     constructor(private formUtils: FormUtils) {
         // Quick note config
         this.quickNoteConfig = {
@@ -139,13 +146,19 @@ export class FormDemoComponent {
         this.calendarForm = formUtils.toFormGroup([this.dateControl, this.timeControl, this.dateTimeControl]);
 
         // Dynamic
-        this.dynamic = formUtils.toControls(MockMeta, '$ USD', {}, 'TOKEN');
-        formUtils.setInitialValues(this.dynamic, { firstName: 'Initial F Name', number: 12 });
-        this.dynamicForm = formUtils.toFormGroup(this.dynamic);
+        this.dynamic = formUtils.toFieldSets(MockMeta, '$ USD', {}, 'TOKEN');
+        formUtils.setInitialValuesFieldsets(this.dynamic, { firstName: 'Initial F Name', number: 12 });
+        this.dynamicForm = formUtils.toFormGroupFromFieldset(this.dynamic);
 
         this.dynamicVertical = formUtils.toControls(MockMeta, '$ USD', {}, 'TOKEN');
         formUtils.setInitialValues(this.dynamicVertical, { number: 0 });
         this.dynamicVerticalForm = formUtils.toFormGroup(this.dynamicVertical);
+
+        // Dynamic + Fieldsets
+        this.fieldsets = formUtils.toFieldSets(MockMetaHeaders, '$ USD', {}, 'TOKEN');
+        formUtils.setInitialValuesFieldsets(this.fieldsets, { firstName: 'Initial F Name', number: 12 });
+        this.fieldsetsForm = formUtils.toFormGroupFromFieldset(this.fieldsets);
+
     }
 
     save(form) {

--- a/demo/pages/elements/form/MockMeta.ts
+++ b/demo/pages/elements/form/MockMeta.ts
@@ -1,4 +1,4 @@
-export default {
+export const MockMeta = {
     entity: 'Opportunity',
     entityMetaUrl: 'http://develop-backend.bh-bos2.bullhorn.com:8181/rest-services/1yg8p/meta/Opportunity?fields=*',
     label: 'Opportunity',
@@ -7,56 +7,65 @@ export default {
             name: 'firstName',
             type: 'text',
             label: 'First Name',
-            required: true
+            required: true,
+            sortOrder: 10
         },
         {
             name: 'lastName',
             type: 'text',
-            label: 'Last Name'
+            label: 'Last Name',
+            sortOrder: 20
         },
         {
             name: 'number',
             type: 'number',
             label: 'Number',
             required: true,
-            disabled: true
+            disabled: true,
+            sortOrder: 40
         },
         {
             name: 'float',
             type: 'float',
             label: 'Float',
-            required: true
+            required: true,
+            sortOrder: 50
         },
         {
             name: 'currency',
             type: 'money',
             label: 'Cost',
-            currencyFormat: 'USD'
+            currencyFormat: 'USD',
+            sortOrder: 60
         },
         {
             name: 'percent',
             type: 'percentage',
             label: 'Percentage',
-            required: true
+            required: true,
+            sortOrder: 70
         },
         {
             name: 'date',
             type: 'date',
             label: 'Date',
-            required: true
+            required: true,
+            sortOrder: 90
         },
         {
             name: 'time',
             type: 'time',
             label: 'Time',
-            required: true
+            required: true,
+            sortOrder: 100
         },
         {
             name: 'datetime',
             type: 'date-time',
             label: 'DateTime',
             dataSpecialization: 'DATETIME',
-            required: true
+            required: true,
+            sortOrder: 110
         },
         {
             name: 'status',
@@ -82,7 +91,8 @@ export default {
                     value: 'TRIGGER',
                     label: 'TRIGGER'
                 }
-            ]
+            ],
+            sortOrder: 120
         },
         {
             name: 'nextAction',
@@ -103,7 +113,8 @@ export default {
                     value: 'appointment',
                     label: 'Appointment'
                 }
-            ]
+            ],
+            sortOrder: 130
         },
         {
             name: 'state',
@@ -123,26 +134,30 @@ export default {
                     'New York', 'North Dakota', 'North Carolina', 'Ohio', 'Oklahoma', 'Oregon', 'Pennsylvania', 'Rhode Island',
                     'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont', 'Virginia', 'Washington',
                     'West Virginia', 'Wisconsin', 'Wyoming']
-            }
+            },
+            sortOrder: 530
         }, {
             name: 'startDate',
             type: 'datetime',
             dataType: 'Timestamp',
             label: 'Start Date',
-            required: true
+            required: true,
+            sortOrder: 540
         }, {
             name: 'quota',
             type: 'number',
             dataType: 'Integer',
             label: 'Quota',
-            required: true
+            required: true,
+            sortOrder: 550
         }, {
             name: 'secret',
             type: 'hidden',
             dataType: 'String',
             label: 'Top Secret',
             required: true,
-            defaultValue: 'The secret code is: 08322'
+            defaultValue: 'The secret code is: 08322',
+            sortOrder: 560
         }, {
             name: 'categories',
             type: 'picker',
@@ -170,7 +185,8 @@ export default {
                     value: 'TRIGGER',
                     label: 'TRIGGER'
                 }
-            ]
+            ],
+            sortOrder: 570
         }, {
             name: 'owner',
             type: 'entity',
@@ -187,7 +203,8 @@ export default {
             associatedEntity: {
                 entity: 'CorporateUser',
                 label: 'Corporate User'
-            }
+            },
+            sortOrder: 580
         }, {
             name: 'address',
             type: 'address',
@@ -299,32 +316,51 @@ export default {
                     maxLength: 0,
                     optional: true
                 }
-            ]
+            ],
+            sortOrder: 590
         },
         {
             name: 'checkbox',
             type: 'checkbox',
-            label: 'Checkbox'
+            label: 'Checkbox',
+            sortOrder: 600
         },
         {
             name: 'checklist',
             type: 'checklist',
             label: 'CheckList',
             options: ['Morning', 'Day', 'Night', 'Overnight'],
-            required: true
+            required: true,
+            sortOrder: 610
         },
         {
             name: 'address',
             type: 'address',
             label: 'Address',
-            required: true
+            required: true,
+            sortOrder: 620
         },
         {
             name: 'attachments',
             type: 'file',
             label: 'Attachments',
             multiValue: true,
-            required: true
+            required: true,
+            sortOrder: 630
         }
     ]
 };
+export const MockMetaHeaders = {
+    sectionHeaders: [{
+          'label': 'Section 2',
+          'name': 'sectionHeader1',
+          'sortOrder': 500,
+          'enabled': true
+        }, {
+          'label': 'Section 1',
+          'name': 'sectionHeader2',
+          'sortOrder': 45,
+          'enabled': true
+    }],
+};
+Object.assign(MockMetaHeaders, MockMeta);

--- a/demo/pages/elements/form/templates/DynamicForm.html
+++ b/demo/pages/elements/form/templates/DynamicForm.html
@@ -1,6 +1,6 @@
 <button theme="secondary" *ngIf="!myform.showingAllFields && !(myform.allFieldsRequired || myform.allFieldsNotRequired)" (click)="myform.showAllFields()">Show All Fields</button>
 <button theme="secondary" *ngIf="!myform.showingRequiredFields && !(myform.allFieldsRequired || myform.allFieldsNotRequired)" (click)="myform.showOnlyRequired()">Show Required Fields</button>
-<novo-dynamic-form class="dynamic" [controls]="dynamic" [(form)]="dynamicForm" #myform></novo-dynamic-form>
+<novo-dynamic-form class="dynamic" [fieldsets]="dynamic" [(form)]="dynamicForm" #myform></novo-dynamic-form>
 <footer class="dynamic-demo-footer">
     <button (click)="save(myform)" theme="primary" icon="check">Save</button>
     <button (click)="clear()" theme="secondary" icon="check">Clear</button>

--- a/demo/pages/elements/form/templates/DynamicFormFieldSets.html
+++ b/demo/pages/elements/form/templates/DynamicFormFieldSets.html
@@ -1,0 +1,10 @@
+<button theme="secondary" *ngIf="!myFieldsetsForm.showingAllFields && !(myFieldsetsForm.allFieldsRequired || myFieldsetsForm.allFieldsNotRequired)" (click)="myFieldsetsForm.showAllFields()">Show All Fields</button>
+<button theme="secondary" *ngIf="!myFieldsetsForm.showingRequiredFields && !(myFieldsetsForm.allFieldsRequired || myFieldsetsForm.allFieldsNotRequired)" (click)="myFieldsetsForm.showOnlyRequired()">Show Required Fields</button>
+<novo-dynamic-form class="dynamic" layout="vertical" [fieldsets]="fieldsets" [(form)]="fieldsetsForm" #myFieldsetsForm></novo-dynamic-form>
+<footer class="dynamic-demo-footer">
+    <button (click)="save(myform)" theme="primary" icon="check">Save</button>
+    <button (click)="clear()" theme="secondary" icon="check">Clear</button>
+</footer>
+<div class="final-value">Valid: {{myform.isValid | json}}</div>
+<div class="final-value">Values: {{myform.values | json}}</div>
+<div class="final-value">Updated Values: {{myform.updatedValues() | json}}</div>

--- a/src/elements/form/Form.module.ts
+++ b/src/elements/form/Form.module.ts
@@ -14,9 +14,12 @@ import { NovoDateTimePickerModule } from './../date-time-picker/DateTimePicker.m
 import { NovoNovoCKEditorModule } from './../ckeditor/CKEditor.module';
 import { NovoQuickNoteModule } from './../quick-note/QuickNote.module';
 import { NovoDynamicFormElement } from './DynamicForm';
+import { NovoFieldsetElement } from './DynamicForm';
+import { NovoFieldsetHeaderElement } from './DynamicForm';
 import { NovoFormElement } from './Form';
 import { NovoControlElement } from './Control';
 import { NovoFormExtrasModule } from './extras/FormExtras.module';
+import { NovoHeaderModule } from './../header/Header.module';
 
 @NgModule({
     imports: [
@@ -32,10 +35,11 @@ import { NovoFormExtrasModule } from './extras/FormExtras.module';
         NovoNovoCKEditorModule,
         NovoFormExtrasModule,
         NovoQuickNoteModule,
-        NovoDateTimePickerModule
+        NovoDateTimePickerModule,
+        NovoHeaderModule
     ],
-    declarations: [NovoControlElement, NovoDynamicFormElement, NovoFormElement],
-    exports: [NovoDynamicFormElement, NovoControlElement, NovoFormElement]
+    declarations: [NovoControlElement, NovoDynamicFormElement, NovoFormElement, NovoFieldsetElement, NovoFieldsetHeaderElement],
+    exports: [NovoDynamicFormElement, NovoControlElement, NovoFormElement, NovoFieldsetHeaderElement]
 })
 export class NovoFormModule {
 }

--- a/src/elements/form/Form.scss
+++ b/src/elements/form/Form.scss
@@ -18,8 +18,24 @@ novo-form {
 
         form {
             width: 100%;
+            novo-fieldset-header {
+              background: $off-white;
+              box-sizing: content-box;
+              padding: 1em 1em 1em;
+              margin-bottom: 2em;
+              display: flex;
+              margin-left: -1.5em;
+              margin-right: -1.5em;
+              i {
+                  margin-right: 10px;
+              }
 
-            > div.novo-form-row {
+              h6 {
+                  font-weight: 400;
+                  padding: 0;
+              }
+            }
+            div.novo-form-row {
                 width: 100%;
 
                 &:first-child {
@@ -497,7 +513,7 @@ novo-form {
     &[layout="vertical"] {
         .novo-form-container {
             form {
-                > div.novo-form-row {
+                div.novo-form-row {
                     novo-control {
                         margin-top: 0;
 


### PR DESCRIPTION
form fieldsets aka sections
##### **What did you change?**

- a fieldset is a group of form controls
- if novo-dynamic-form has a fieldsets input, it will ignore controls input
- fieldsets can have headers
- fieldset structure is defined by the NovoFieldset Interface

##### **Reviewers**
* @jgodi @bvkimball @asibilia 

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices
- form controls can be grouped as fieldsets
- form will either use controls or use fieldsets as input