### PR TITLE
fix(table): add back in custom sorting/filtering functions

### DIFF
--- a/src/elements/table/Table.ts
+++ b/src/elements/table/Table.ts
@@ -449,8 +449,9 @@ export class NovoTableElement implements DoCheck {
         if (column) {
             if (Helpers.isFunction(this.config.sorting)) {
                 this.config.sorting();
+            } else {
+                this._dataProvider.sort = [{ field: (column.compare || column.name), reverse: column.sort === 'desc' }];
             }
-            this._dataProvider.sort = [{ field: (column.compare || column.name), reverse: column.sort === 'desc' }];
         }
 
         // Fire table change event


### PR DESCRIPTION
Canvas-UI uses a custom sorting/filtering function to load sorted/filtered reports. This PR adds back in that functionality.

##### **What did you change?**
Table.ts


##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices
