### PR TITLE
fix(Table): Binding Pagination to dataProvider

### DIFF
--- a/src/elements/table/Table.ts
+++ b/src/elements/table/Table.ts
@@ -31,10 +31,10 @@ export class NovoTableHeaderElement {
             <ng-content select="novo-table-header"></ng-content>
             <div class="header-actions">
                 <novo-pagination *ngIf="config.paging"
-                                 [page]="config.paging.current"
                                  [rowOptions]="config.customRowOptions"
+                                 [(page)]="dataProvider.page"
+                                 [(itemsPerPage)]="dataProvider.pageSize"
                                  [totalItems]="dataProvider.total"
-                                 [itemsPerPage]="config.paging.itemsPerPage"
                                  (onPageChange)="onPageChange($event)">
                 </novo-pagination>
                 <ng-content select="novo-table-actions"></ng-content>
@@ -219,8 +219,8 @@ export class NovoTableElement implements DoCheck {
     constructor(public labels:NovoLabelService) {}
 
     onPageChange(event) {
-        this.dataProvider.page = event.page;
-        this.dataProvider.pageSize = event.itemsPerPage;
+        //this.dataProvider.page = event.page;
+        //this.dataProvider.pageSize = event.itemsPerPage;
     }
 
     getOptionDataAutomationId(option) {

--- a/src/elements/table/extras/pagination/Pagination.ts
+++ b/src/elements/table/extras/pagination/Pagination.ts
@@ -22,7 +22,8 @@ export class Pagination implements OnInit, OnChanges {
     @Input() itemsPerPage: number = 10;
     @Input() rowOptions: any;
     @Input() label: string;
-
+    @Output() pageChange: EventEmitter<any> = new EventEmitter();
+    @Output() itemsPerPageChange: EventEmitter<any> = new EventEmitter();
     @Output() onPageChange: EventEmitter<any> = new EventEmitter();
 
     maxPagesDisplayed: number = 5;
@@ -57,6 +58,8 @@ export class Pagination implements OnInit, OnChanges {
         this.itemsPerPage = event.selected;
         this.totalPages = this.calculateTotalPages();
         this.pages = this.getPages(this.page, this.totalPages);
+        this.pageChange.emit(this.page);
+        this.itemsPerPageChange.emit(this.itemsPerPage);
         this.onPageChange.emit({
             page: this.page,
             itemsPerPage: this.itemsPerPage
@@ -70,6 +73,7 @@ export class Pagination implements OnInit, OnChanges {
 
         this.page = page;
         this.pages = this.getPages(this.page, this.totalPages);
+        this.pageChange.emit(this.page);
         this.onPageChange.emit({
             page: this.page,
             itemsPerPage: this.itemsPerPage


### PR DESCRIPTION
Pagination now uses two-way from the DataProvider page and pagesize.

##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices
