### PR TITLE
bug(form-utils): Fieldmaps with no sort order are never added to the controls

### DIFF
--- a/src/elements/form/FormUtils.ts
+++ b/src/elements/form/FormUtils.ts
@@ -280,6 +280,9 @@ export class FormUtils {
             let fields = meta.fields;
             fields.forEach(field => {
                 if (field.name !== 'id' && (field.dataSpecialization !== 'SYSTEM' || field.name === 'address') && !field.readOnly) {
+                    if (!field.hasOwnProperty('sortOrder')) {
+                        field.sortOrder = 0;
+                    }
                     let control = this.getControlForField(field, http, config);
                     // Set currency format
                     if (control.subType === 'currency') {


### PR DESCRIPTION
##### **What did you change?**
Added a default sort order if no property on field


##### **Reviewers**
* @bvkimball @jgodi @krsween @amrutha-rajiv 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices