### PR TITLE
refactor(Picker): Remove term clearing from picker onActiveChange

### DIFF
--- a/src/elements/picker/Picker.ts
+++ b/src/elements/picker/Picker.ts
@@ -78,7 +78,6 @@ export class NovoPickerElement extends OutsideClick implements OnInit {
             if (!active) {
                 setTimeout(() => {
                     this.hideResults();
-                    this.term = '';
                     this.blur.emit();
                 });
             }


### PR DESCRIPTION
Clearing the picker onActiveChange cleared single value pickers.

##### **What did you change?**

Removed clearing altogether since data isn't set until the picker's dropdown's select event is fired.

##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices