### PR TITLE
fix(Chips): Validate properties before interpolating a label string

### DIFF
--- a/src/elements/chips/Chips.scss
+++ b/src/elements/chips/Chips.scss
@@ -142,6 +142,7 @@ entity-chips {
     }
 }
 
+chips,
 entity-chips {
     chip {
         span {

--- a/src/elements/chips/Chips.ts
+++ b/src/elements/chips/Chips.ts
@@ -144,7 +144,7 @@ export class NovoChipsElement extends OutsideClick implements OnInit {
             let noLabels = [];
             for (let value of this.model) {
                 let label;
-                if (this.source && this.source.format) {
+                if (this.source && this.source.format && Helpers.validateInterpolationProps(this.source.format, value)) {
                     label = Helpers.interpolate(this.source.format, value);
                 }
                 if (this.source && label && label !== this.source.format) {

--- a/src/utils/Helpers.ts
+++ b/src/utils/Helpers.ts
@@ -29,6 +29,19 @@ export class Helpers {
     }
 
     /**
+     * Verifies that an object has every property expected by a string to interpolate
+     * @param  {String} str   The string to interpolate
+     * @param  {Object} props The params to replace in string.
+     * @return {Boolean}
+     */
+    static validateInterpolationProps(str, props) {
+        let keys = str.match(/\$([\w\.]+)/g);
+        return keys.every(key => {
+            return props.hasOwnProperty(key.substr(1));
+        });
+    }
+
+    /**
      * Checks to see if the object is a string
      */
     static isString(obj: any) {


### PR DESCRIPTION
Added interpolation validator to Helpers and used it in Chips to prevent uninterpolated format params from being passed into chip labels. Also added a chip style fix for entity chip icons.

##### **Reviewers**
* @user

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices