### PR TITLE
fix(pickers): fix for removing empty objects so they do not populate as [object Object] in multi select pickers

### DIFF
--- a/src/elements/form/FormUtils.ts
+++ b/src/elements/form/FormUtils.ts
@@ -356,6 +356,13 @@ export class FormUtils {
                 continue;
             }
 
+            if (Array.isArray(value) && value.length > 0) {
+                value = value.filter(val => !(Object.keys(val).length === 0 && val.constructor === Object));
+                if (value.length === 0) {
+                    continue;
+                }
+            }
+
             if (value.data && value.data.length === 0) {
                 continue;
             }
@@ -364,7 +371,7 @@ export class FormUtils {
                 continue;
             }
 
-            control.value = values[control.key];
+            control.value = value;
             control.dirty = !keepClean;
         }
     }


### PR DESCRIPTION
fix for removing empty objects so they do not populate as [object Object] in multi select pickers

##### **What did you change?**
FormUtils.ts


##### **Reviewers**
* @bvkimball @jgodi @krsween 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices