### PR TITLE
fix(Table): column filtering with options should not have text input if values are not strings

### DIFF
--- a/src/elements/table/Table.ts
+++ b/src/elements/table/Table.ts
@@ -72,7 +72,7 @@ export class NovoTableHeaderElement {
                                             <span>{{ labels.filters }}</span>
                                             <button theme="dialogue" color="negative" icon="times" (click)="onFilterClear(column)" *ngIf="column.filter">{{ labels.clear }}</button>
                                         </div>
-                                        <input type="text" [attr.id]="column.name + '-input'" [novoTableFilter]="column" (onFilterChange)="onFilterKeywords($event)" [(ngModel)]="column.freetextFilter"/>
+                                        <input type="text" *ngIf="showOptionsTextInput(column)" [attr.id]="column.name + '-input'" [novoTableFilter]="column" (onFilterChange)="onFilterKeywords($event)" [(ngModel)]="column.freetextFilter"/>
                                     </item>
                                     <item [ngClass]="{ active: isFilterActive(column, option) }" *ngFor="let option of column.options" (click)="onFilterClick(column, option)" [attr.data-automation-id]="getOptionDataAutomationId(option)">
                                         {{ option?.label || option }} <i class="bhi-check" *ngIf="isFilterActive(column, option)"></i>
@@ -686,5 +686,9 @@ export class NovoTableElement implements DoCheck {
             config.filtering.options = config.filtering.originalOptions;
         }
         this.onFilterChange();
+    }
+
+    showOptionsTextInput(column) {
+        return typeof (column.options[0].value) === 'string';
     }
 }


### PR DESCRIPTION
Column filtering with options should not have text input if values are not strings

##### **What did you change?**
Table.ts


##### **Reviewers**
* @bvkimball @jgodi

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices