### PR TITLE
fix(Table): column filtering by options should not have text input if values are not string

### DIFF
--- a/src/elements/table/Table.ts
+++ b/src/elements/table/Table.ts
@@ -689,6 +689,10 @@ export class NovoTableElement implements DoCheck {
     }
 
     showOptionsTextInput(column) {
-        return typeof (column.options[0].value) === 'string';
+        if (column.hasOwnProperty('freetextFilter')) {
+            return true;
+        } else {
+            return typeof (column.options[0].value) === 'string';
+        }
     }
 }


### PR DESCRIPTION
Improvement over previous implementation which failed if the user search for a string which was not an option.

##### **What did you change?**
TableUtils.ts


##### **Reviewers**
* @bvkimball @jgodi 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices