### PR TITLE
feature(Table): added classes for main types of column headers

### DIFF
--- a/src/elements/table/Table.ts
+++ b/src/elements/table/Table.ts
@@ -48,11 +48,12 @@ export class NovoTableHeaderElement {
                     <!-- DETAILS -->
                     <th class="row-actions" *ngIf="config.hasDetails"></th>
                     <!-- CHECKBOX -->
-                    <th class="row-actions checkbox" *ngIf="config.rowSelectionStyle === 'checkbox'">
+                    <th class="row-actions checkbox mass-action" *ngIf="config.rowSelectionStyle === 'checkbox'">
                         <novo-checkbox [(ngModel)]="master" [indeterminate]="pageSelected.length > 0 && pageSelected.length < pagedData.length" (ngModelChange)="selectPage($event)" data-automation-id="select-all-checkbox" [tooltip]="master ? labels.deselectAll : labels.selectAllOnPage" tooltipPosition="right"></novo-checkbox>
                     </th>
                     <!-- TABLE HEADERS -->
-                    <th *ngFor="let column of columns" [ngClass]="{sorted: column.sort}" [novoThOrderable]="column" (onOrderChange)="onOrderChange($event)">
+                    <!-- TODO: ngClass as written couldn't work. This works*, but introduces new functionality: 'sorted': column?.sort === 'desc', 'sorted': column?.sort === 'asc'  *desc doesn't work -->
+                    <th *ngFor="let column of columns" [ngClass]="{ 'mass-action': config?.rowSelectionStyle === 'checkbox', 'actions': config?.actions?.items?.length > 0, 'preview': column?.name === 'preview' }" [novoThOrderable]="column" (onOrderChange)="onOrderChange($event)">
                         <div class="th-group" [attr.data-automation-id]="column.id || column.name" *ngIf="!column.hideHeader">
                             <!-- LABEL & SORT ARROWS -->
                             <div class="th-title" [ngClass]="(config.sorting !== false && column.sorting !== false) ? 'sortable' : ''" [novoThSortable]="config" [column]="column" (onSortChange)="onSortChange($event)">


### PR DESCRIPTION
In the Table component, the existing class setter for column headers didn't do anything. Also, it would be helpful to use that class to discern what type of column header is being used.

##### **What did you change?**

Added dynamic classes for each of the main column types.

##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices