### PR TITLE
WIP bug(datetimepicker): Picker value should match display value

### DIFF
--- a/src/elements/form/Control.ts
+++ b/src/elements/form/Control.ts
@@ -212,15 +212,18 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
 
     formatDateValue(event) {
         this.formattedValue = this.labels.formatDateWithFormat(event.date, this.labels.dateFormat);
+        this.form.controls[this.control.key].setValue(this.formattedValue);
         this.toggleActive(null, false);
     }
 
     formatTimeValue(event) {
         this.formattedValue = this.labels.formatDateWithFormat(event.date, this.labels.timeFormat);
+        this.form.controls[this.control.key].setValue(this.formattedValue);
     }
 
     formatDateTimeValue(event) {
         this.formattedValue = this.labels.formatDateWithFormat(event.date, this.labels.dateTimeFormat);
+        this.form.controls[this.control.key].setValue(this.formattedValue);
     }
 
     resizeTextArea(event) {


### PR DESCRIPTION
The formatted value displayed in the input should match the value displayed in the datetime picker.

##### **What did you change?**
DateTimePicker


##### **Reviewers**
* @user jgodi

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices