### PR TITLE
feat(Table): Split Empty and NoMatchingRecords States for Tables

### DIFF
--- a/demo/pages/elements/table/TableDemo.ts
+++ b/demo/pages/elements/table/TableDemo.ts
@@ -182,7 +182,7 @@ export class TableDemoComponent implements OnInit {
         ];
         this.basic = {
             columns: columns.slice(),
-            rows: TableData.slice(),
+            rows: [],
             config: {
                 paging: {
                     current: 1,
@@ -268,6 +268,10 @@ export class TableDemoComponent implements OnInit {
 
     ngOnInit() {
         this.theme = HEADER_COLORS[0];
+    }
+
+    reload() {
+        this.basic.rows = TableData.slice();
     }
 
     changeTheme() {

--- a/demo/pages/elements/table/templates/TableDemo.html
+++ b/demo/pages/elements/table/templates/TableDemo.html
@@ -6,4 +6,6 @@
             <button theme="secondary" (click)="changeTheme()">Change Theme!</button>
         </div>
     </novo-table-header>
+    <div classs="table-message" table-empty-message><i class="bhi-search-question"></i> Custom Empty State Template! Click RELOAD to get Data!</div>
+    <div classs="table-message" table-no-matching-records-message><i class="bhi-search-question"></i>  Custom No Matched Records</div>
 </novo-table>

--- a/src/elements/table/README.md
+++ b/src/elements/table/README.md
@@ -97,3 +97,13 @@ In general the column definition will be an object with some basic configuration
     </novo-table-actions>
 </novo-table>
 ```
+
+#### Custom State Messaging
+
+```
+<novo-table [theme]="theme" [dataProvider]="basic.rows" [columns]="basic.columns" [config]="basic.config">
+    <div classs="table-message" table-empty-message>Custom Empty State Template! Click RELOAD to get Data!</div>
+    <div classs="table-message" table-no-matching-records-message>Custom No Matched Records</div>
+    <div classs="table-message" table-error-message>Oh No! There was an Error</div>
+</div>
+```

--- a/src/elements/table/Table.scss
+++ b/src/elements/table/Table.scss
@@ -354,7 +354,9 @@ $table-border-color: #f5f5f5; // Tables
         border: 0;
     }
 
-    .no-matching-records {
+    .table-message,
+    .no-matching-records,
+    .table-empty-message {
         color: $grey;
         margin: 40px 0;
         vertical-align: middle;

--- a/src/elements/table/Table.ts
+++ b/src/elements/table/Table.ts
@@ -43,7 +43,7 @@ export class NovoTableHeaderElement {
         </header>
         <div class="table-container">
             <table class="table table-striped dataTable" [class.table-details]="config.hasDetails" role="grid">
-            <thead *ngIf="columns.length">
+            <thead *ngIf="columns.length && (!dataProvider.isEmpty() || dataProvider.isFiltered())">
                 <tr role="row">
                     <!-- DETAILS -->
                     <th class="row-actions" *ngIf="config.hasDetails"></th>
@@ -138,12 +138,23 @@ export class NovoTableHeaderElement {
                 </template>
             </tbody>
             <!-- NO TABLE DATA PLACEHOLDER -->
-            <tbody class="table-message" *ngIf="dataProvider.isEmpty()" data-automation-id="empty-table">
+            <tbody class="table-message" *ngIf="dataProvider.isEmpty() && !dataProvider.isFiltered()" data-automation-id="empty-table">
                 <tr>
                     <td colspan="100%">
                         <div #emptymessage><ng-content select="[table-empty-message]"></ng-content></div>
-                        <div class="no-matching-records" *ngIf="emptymessage.childNodes.length == 0">
+                        <div class="table-empty-message" *ngIf="emptymessage.childNodes.length == 0">
                             <h4><i class="bhi-search-question"></i> {{ labels.emptyTableMessage }}</h4>
+                        </div>
+                    </td>
+                </tr>
+            </tbody>
+            <!-- NO MATCHING RECORDS -->
+            <tbody class="table-message" *ngIf="dataProvider.isEmpty() && dataProvider.isFiltered()" data-automation-id="empty-table">
+                <tr>
+                    <td colspan="100%">
+                        <div #nomatchmessage><ng-content select="[table-no-matching-records-message]"></ng-content></div>
+                        <div class="no-matching-records" *ngIf="nomatchmessage.childNodes.length == 0">
+                            <h4><i class="bhi-search-question"></i> {{ labels.noMatchingRecordsMessage }}</h4>
                         </div>
                     </td>
                 </tr>

--- a/src/services/data-provider/ArrayCollection.ts
+++ b/src/services/data-provider/ArrayCollection.ts
@@ -56,6 +56,10 @@ export class ArrayCollection<T> implements Collection<T> {
         return false;
     }
 
+    isFiltered():boolean {
+        return (Object.keys(this._filter).length > 0);
+    }
+
     /**
      * Appends an item to the end of the data provider.
      *

--- a/src/services/data-provider/Collection.ts
+++ b/src/services/data-provider/Collection.ts
@@ -13,6 +13,8 @@ export interface Collection<T> {
 
     isEmpty():boolean;
     hasErrors():boolean;
+    isLoading():boolean;
+    isFiltered():boolean;
 
     /**
      *  Adds the specified item to the end of the list.

--- a/src/services/novo-label-service.ts
+++ b/src/services/novo-label-service.ts
@@ -7,7 +7,8 @@ import * as moment from 'moment';
 export class NovoLabelService {
     filters = 'Filter';
     clear = 'Clear';
-    emptyTableMessage = 'No Matching Records';
+    emptyTableMessage = 'No Records to display...';
+    noMatchingRecordsMessage = 'No Matching Records';
     erroredTableMessage = 'Oops! An error occurred.';
     pickerError = 'Oops! An error occurred.';
     pickerEmpty = 'No results to display...';


### PR DESCRIPTION
When Empty State was added to Tables, it was not considered that a filtered table with no records should show a different states. 

##### **What did you change?**
Table Empty State
Table No Matching Records State

##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices