### PR TITLE
FormUtils: Correctly Sort if no sortOrder was provided

### DIFF
--- a/src/elements/form/FormUtils.ts
+++ b/src/elements/form/FormUtils.ts
@@ -238,7 +238,12 @@ export class FormUtils {
         let fieldsets: Array<NovoFieldset> = [];
         let ranges = [];
         if (meta && meta.fields) {
-            meta.fields.sort(Helpers.sortByField('sortOrder'));
+            let fields = meta.fields.map(field => {
+                if (!field.hasOwnProperty('sortOrder')) {
+                    field.sortOrder = Number.MAX_SAFE_INTEGER - 1;
+                }
+                return field;
+            }).sort(Helpers.sortByField('sortOrder'));
             if (meta.sectionHeaders && meta.sectionHeaders.length) {
                 meta.sectionHeaders.sort(Helpers.sortByField('sortOrder'));
                 meta.sectionHeaders.forEach((item, i) => {
@@ -277,13 +282,9 @@ export class FormUtils {
                     fieldsetIdx: 0
                 });
             }
-            let fields = meta.fields;
 
             fields.forEach(field => {
                 if (field.name !== 'id' && (field.dataSpecialization !== 'SYSTEM' || ['address', 'billingAddress', 'secondaryAddress'].indexOf(field.name) !== -1) && !field.readOnly) {
-                    if (!field.hasOwnProperty('sortOrder')) {
-                        field.sortOrder = Number.MAX_SAFE_INTEGER - 1;
-                    }
                     let control = this.getControlForField(field, http, config);
                     // Set currency format
                     if (control.subType === 'currency') {


### PR DESCRIPTION
FormUtils: Correctly Sort if no sortOrder was provided

##### **What did you change?**

sortOrder is now populated to be the default max value before the fields are sorted


##### **Reviewers**
* @user

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices