### PR TITLE
feat(Chips): Adding support for Chips labels to be displayed correctly when only value passed in

### DIFF
--- a/src/elements/chips/Chips.ts
+++ b/src/elements/chips/Chips.ts
@@ -163,6 +163,8 @@ export class NovoChipsElement extends OutsideClick implements OnInit {
                     });
                 } else if (this.source.getLabels && typeof this.source.getLabels === 'function') {
                     noLabels.push(value);
+                } else if (this.source.options) {
+                    this.items.push(this.getLabelFromOptions(value));
                 } else {
                     this.items.push({
                         value,
@@ -178,6 +180,8 @@ export class NovoChipsElement extends OutsideClick implements OnInit {
                                 value,
                                 label: value.label
                             });
+                        } else if (this.source.options) {
+                            this.items.push(this.getLabelFromOptions(value));
                         } else {
                             this.items.push(value);
                         }
@@ -187,6 +191,14 @@ export class NovoChipsElement extends OutsideClick implements OnInit {
             }
         }
         this._items.next(this.items);
+    }
+
+    getLabelFromOptions(value) {
+        let optLabel = this.source.options.find(val => val.value === value);
+        return {
+            value,
+            label: optLabel ? optLabel.label : value
+        };
     }
 
     deselectAll(event?) {


### PR DESCRIPTION
Currently if you pass in an array of string values to the Chip Picker who's options contain an array of objects (value and label) the value is displayed in the picker, not the label.

example:
set Picker value to [ 'AL'];

picker options:
[{value:'AL', label:'Alabama'}, {value:'MA', label:'Massachusetts'}]

before, would display - 'AL' in Chip

after, now displays - 'Alabama' in Chip



##### **What did you change?**
Picker.ts


##### **Reviewers**
* @bvkimball @jgodi @krsween 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices