### PR TITLE
fix(DatePicker): Selecting either month or year in Date Picker resets other value to default

### DIFF
--- a/src/elements/date-picker/DatePicker.ts
+++ b/src/elements/date-picker/DatePicker.ts
@@ -198,14 +198,14 @@ export class NovoDatePickerElement implements ControlValueAccessor, OnInit {
     }
 
     setMonth(month) {
-        let tmp = this.selected ? this.selected.clone().month(month) : moment().month(month);
+        let tmp = this.month ? this.month.clone().month(month) : moment().month(month);
         this.updateView(tmp, true, false);
         // Go back to days
         this.open(null, 'days');
     }
 
     setYear(year) {
-        let tmp = this.selected ? this.selected.clone().year(year) : moment().year(year);
+        let tmp = this.month ? this.month.clone().year(year) : moment().year(year);
         this.updateView(tmp, true, false);
         // Go back to days
         this.open(null, 'days');


### PR DESCRIPTION
##### **What did you change?**
DatePicker.ts


##### **Reviewers**
* @bvkimball  @jgodi @krsween 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices