### PR TITLE
fix(Table): Tables won't convert Dates into timestamps

### DIFF
--- a/src/elements/table/Table.ts
+++ b/src/elements/table/Table.ts
@@ -408,15 +408,15 @@ export class NovoTableElement implements DoCheck {
                         if (column.type && column.type === 'date' && column.filter.filter(fil => fil.range).length > 0) {
                             query[column.name] = column.filter.map(f => {
                                 return {
-                                    min: f.value ? new Date(f.value.startDate).getTime() : 0,
-                                    max: f.value ? new Date(f.value.endDate).getTime() : 0
+                                    min: f.value ? new Date(f.value.startDate) : 0,
+                                    max: f.value ? new Date(f.value.endDate) : 0
                                 };
                             })[0];
                         } else if (column.type && column.type === 'date') {
                             query[column.name] = column.filter.map(f => {
                                 return {
-                                    min: f.min ? Date.now() + (f.min * (24 * 60 * 60 * 1000)) : Date.now(),
-                                    max: f.max ? Date.now() + (f.max * (24 * 60 * 60 * 1000)) : Date.now()
+                                    min: f.min ? new Date(Date.now() + (f.min * (24 * 60 * 60 * 1000))) : new Date(),
+                                    max: f.max ? new Date(Date.now() + (f.max * (24 * 60 * 60 * 1000))) : new Date()
                                 };
                             })[0];
                         } else {


### PR DESCRIPTION
**WARNING**: This is a breaking change to how dates are returned in the filter.

fix(Table): Tables won't convert Dates into timestamps
Custom filter functions can now differentiate between Numbers vs a Dates

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices