### PR TITLE
Fall back to sorting by name if sortOrder is equal

### DIFF
--- a/src/elements/form/FormUtils.ts
+++ b/src/elements/form/FormUtils.ts
@@ -252,7 +252,7 @@ export class FormUtils {
                     field.sortOrder = Number.MAX_SAFE_INTEGER - 1;
                 }
                 return field;
-            }).sort(Helpers.sortByField('sortOrder'));
+            }).sort(Helpers.sortByField(['sortOrder', 'name']));
             if (meta.sectionHeaders && meta.sectionHeaders.length) {
                 meta.sectionHeaders.sort(Helpers.sortByField('sortOrder'));
                 meta.sectionHeaders.forEach((item, i) => {

--- a/src/utils/Helpers.ts
+++ b/src/utils/Helpers.ts
@@ -87,7 +87,7 @@ export class Helpers {
             if (!Array.isArray(fields)) {
                 fields = [fields];
             }
-            for (let i:number=0;i<fields.length;i++) {
+            for (let i = 0; i < fields.length; i++) {
                 let field: string = fields[i];
                 let first = previous[field] || '';
                 let second = current[field] || '';

--- a/src/utils/Helpers.ts
+++ b/src/utils/Helpers.ts
@@ -77,34 +77,40 @@ export class Helpers {
         return obj instanceof Date;
     }
 
-    static sortByField(field: any, reverse = false) {
+    static sortByField(fields: any, reverse = false) {
         return (previous: any, current: any) => {
             //return (a[field] < b[field]) ? -1 : (a[field] > b[field]) ? 1 : 0; // eslint-disable-line
             // Custom compare function on the column
-            if (Helpers.isFunction(field)) {
-                return field((reverse) ? 'desc' : 'asc', previous, current);
+            if (Helpers.isFunction(fields)) {
+                return fields((reverse) ? 'desc' : 'asc', previous, current);
             }
-            let first = previous[field] || '';
-            let second = current[field] || '';
-
-            if (Helpers.isDate(first) && Helpers.isDate(second)) {
-                // Dates
-                first = first.getTime();
-                second = second.getTime();
-            } else if (Helpers.isString(first) && Helpers.isString(second)) {
-                // Basic strings
-                first = first.toLowerCase();
-                second = second.toLowerCase();
-            } else {
-                // Numbers
-                first = isNaN(Number(first)) ? first : Number(first);
-                second = isNaN(Number(second)) ? second : Number(second);
+            if (!Array.isArray(fields)) {
+                fields = [fields];
             }
+            for (let i:number=0;i<fields.length;i++) {
+                let field: string = fields[i];
+                let first = previous[field] || '';
+                let second = current[field] || '';
 
-            if (first > second) {
-                return (reverse) ? -1 : 1;
-            } else if (first < second) {
-                return (reverse) ? 1 : -1;
+                if (Helpers.isDate(first) && Helpers.isDate(second)) {
+                    // Dates
+                    first = first.getTime();
+                    second = second.getTime();
+                } else if (Helpers.isString(first) && Helpers.isString(second)) {
+                    // Basic strings
+                    first = first.toLowerCase();
+                    second = second.toLowerCase();
+                } else {
+                    // Numbers
+                    first = isNaN(Number(first)) ? first : Number(first);
+                    second = isNaN(Number(second)) ? second : Number(second);
+                }
+
+                if (first > second) {
+                    return (reverse) ? -1 : 1;
+                } else if (first < second) {
+                    return (reverse) ? 1 : -1;
+                }
             }
             return 0;
         };


### PR DESCRIPTION
Fall back to sorting by name if sortOrder is equal

##### **What did you change?**
 Helpers.sortByField can now take in an array of fields to sort by


##### **Reviewers**
* @user

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices