### PR TITLE
feat(dropdown): adding typeahead for dropdowns

### DIFF
--- a/src/elements/select/Select.ts
+++ b/src/elements/select/Select.ts
@@ -5,6 +5,8 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { OutsideClick } from './../../utils/outside-click/OutsideClick'; // TODO - change imports
 import { KeyCodes } from './../../utils/key-codes/KeyCodes';
 import { NovoLabelService } from './../../services/novo-label-service';
+// Vendor
+import { Observable } from 'rxjs/Rx';
 
 // Value accessor for the component (supports ngModel)
 const SELECT_VALUE_ACCESSOR = {
@@ -62,9 +64,15 @@ export class NovoSelectElement extends OutsideClick implements OnInit, OnChanges
     };
     onModelTouched: Function = () => {
     };
+    filterTerm: string;
 
     constructor(element: ElementRef, public labels: NovoLabelService) {
         super(element);
+        this.filterTerm = '';
+
+        let keydown = Observable.fromEvent(document, 'keydown')
+                                .debounceTime(500);
+        keydown.subscribe(x => this.filterTerm = '');
     }
 
     ngOnInit() {
@@ -120,7 +128,6 @@ export class NovoSelectElement extends OutsideClick implements OnInit, OnChanges
         this.empty = true;
     }
 
-    // TODO: Add key listener to jump to options starting with that letter.
     onKeyDown(event) {
         if (this.active) {
             if (!this.header.open) {
@@ -158,9 +165,10 @@ export class NovoSelectElement extends OutsideClick implements OnInit, OnChanges
                 this.toggleHeader(null, true);
             } else if (event.keyCode >= 65 && event.keyCode <= 90) {
                 let char = String.fromCharCode(event.keyCode);
+                this.filterTerm = this.filterTerm.concat(char);
                 let element = this.element.nativeElement;
                 let list = element.querySelector('.novo-select-list');
-                let item = element.querySelector(`[data-automation-value^=${char}]`);
+                let item = element.querySelector(`[data-automation-value^=${this.filterTerm} i]`);
                 if (item) {
                     list.scrollTop = item.offsetTop;
                 }

--- a/src/elements/select/Select.ts
+++ b/src/elements/select/Select.ts
@@ -5,8 +5,6 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { OutsideClick } from './../../utils/outside-click/OutsideClick'; // TODO - change imports
 import { KeyCodes } from './../../utils/key-codes/KeyCodes';
 import { NovoLabelService } from './../../services/novo-label-service';
-// Vendor
-import { Observable } from 'rxjs/Rx';
 
 // Value accessor for the component (supports ngModel)
 const SELECT_VALUE_ACCESSOR = {
@@ -64,15 +62,11 @@ export class NovoSelectElement extends OutsideClick implements OnInit, OnChanges
     };
     onModelTouched: Function = () => {
     };
-    filterTerm: string;
+    filterTerm: string = '';
+    filterTermTimeout;
 
     constructor(element: ElementRef, public labels: NovoLabelService) {
         super(element);
-        this.filterTerm = '';
-
-        let keydown = Observable.fromEvent(document, 'keydown')
-                                .debounceTime(500);
-        keydown.subscribe(x => this.filterTerm = '');
     }
 
     ngOnInit() {
@@ -164,6 +158,8 @@ export class NovoSelectElement extends OutsideClick implements OnInit, OnChanges
                 this.selectedIndex--;
                 this.toggleHeader(null, true);
             } else if (event.keyCode >= 65 && event.keyCode <= 90) {
+                clearTimeout(this.filterTermTimeout);
+                this.filterTermTimeout = setTimeout(() => { this.filterTerm = ''; }, 500);
                 let char = String.fromCharCode(event.keyCode);
                 this.filterTerm = this.filterTerm.concat(char);
                 let element = this.element.nativeElement;


### PR DESCRIPTION
added a typeahead for country dropdowns

##### **What did you change?**



##### **Reviewers**
* @user

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices