### PR TITLE
BH-46763 fix for DateTimePicker style when displayed in modal

### DIFF
--- a/src/elements/date-time-picker/DateTimePicker.ts
+++ b/src/elements/date-time-picker/DateTimePicker.ts
@@ -64,7 +64,7 @@ export type componentTabStates = 'date' | 'time';
                     <span class="hours" data-automation-id="novo-time-picker-hours">{{hours}}</span>:<span class="minutes" data-automation-id="novo-time-picker-minutes">{{minutes}}</span>
                     <span *ngIf="!military" class="meridian">{{meridian}}</span>
                 </span>
-                <i class="indicator" [@indicatorState]="componentTabState"></i>
+                <i class="date-time-indicator" [@indicatorState]="componentTabState"></i>
             </div>
             <div class="view-container" [@containerState]="componentTabState">
                 <div class="calendar">

--- a/src/elements/date-time-picker/_DateTimePicker.scss
+++ b/src/elements/date-time-picker/_DateTimePicker.scss
@@ -52,7 +52,7 @@ novo-date-time-picker {
                 }
             }
 
-            .indicator {
+            .date-time-indicator {
                 position: absolute;
                 width: 50%;
                 height: 2px;


### PR DESCRIPTION
updated .indicator class of DateTimePicker to be unique

##### **What did you change?**

.indicator class on DateTimePicker was interfering with .indicator class of novo-modal, so DateTimePicker was using both when styling the picker when loading it in a modal, causing it to look funky.

##### **Reviewers**
* @user

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices