### PR TITLE
chore(Form): added label property to form controls to be accessible v…

### DIFF
--- a/src/elements/form/FormUtils.ts
+++ b/src/elements/form/FormUtils.ts
@@ -27,10 +27,12 @@ export class NovoFormControl extends FormControl {
     hidden: boolean;
     required: boolean;
     initialValue: any;
+    label: string;
 
     constructor(value: any, control: NovoControlConfig) {
         super(value, control.validators, control.asyncValidators);
         this.initialValue = value;
+        this.label = control.label;
         // Setting disable/enable
         if (control.disabled) {
             this.disable();


### PR DESCRIPTION
Needed `label` value from form control.

##### **What did you change?**

Added label property to form controls to be accessible via controller (for i18n).

##### **Reviewers**
* @jgodi 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices