### PR TITLE
BH-44785:fix for table empty state for Canvas

### DIFF
--- a/src/elements/table/Table.ts
+++ b/src/elements/table/Table.ts
@@ -42,7 +42,8 @@ export class NovoTableHeaderElement {
         </header>
         <div class="table-container">
             <table class="table table-striped dataTable" [class.table-details]="config.hasDetails" role="grid">
-            <thead *ngIf="columns.length && (!dataProvider.isEmpty() || dataProvider.isFiltered())">
+            <!-- skipSortAndFilterClear is a hack right now, will be removed once Canvas is refactored -->
+            <thead *ngIf="columns.length && (!dataProvider.isEmpty() || dataProvider.isFiltered() || skipSortAndFilterClear)">
                 <tr role="row">
                     <!-- DETAILS -->
                     <th class="row-actions" *ngIf="config.hasDetails"></th>


### PR DESCRIPTION
This is a hacky fix for the time being. It will be fixed as part of next sprint when Canvas code gets refactored to use new code in novo-table. 

##### **What did you change?**
Added boolean to ngIf of novo-table header. This will allow the header to get displayed in Canvas when there is an empty state while filtering. This boolean will get removed as part of BH-47169 during the next sprint. We would like to add this hack fix in the meantime so our popover code can be used and released in 2017.2. 


##### **Reviewers**
* @bvkimball 

##### **Checklist (completed via merger)**
* [x ] Changes are limited to a single goal (no scope creep)
* [x ] Code can be automatically merged (no conflicts)
* [x ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [x ] Visually tested in supported browsers and devices