### PR TITLE
bug(Form): When removing setRequired(true) to a control the required validator is not removed from the control

### DIFF
--- a/src/elements/form/FormUtils.ts
+++ b/src/elements/form/FormUtils.ts
@@ -62,10 +62,16 @@ export class NovoFormControl extends FormControl {
 
         // Update validators to have the required
         if (this.required && !this.hasRequiredValidator) {
-            let validators = [...this.validators];
+            let validators: any = [...this.validators];
             validators.push(Validators.required);
             this.setValidators(validators);
             this.updateValueAndValidity();
+            this.hasRequiredValidator = this.required;
+        } else if (this.hasRequiredValidator) {
+            let validators: any = [...this.validators];
+            this.setValidators(validators);
+            this.updateValueAndValidity();
+            this.hasRequiredValidator = this.required;
         }
     }
 


### PR DESCRIPTION
When removing setRequired(true) on a control the required validator is not removed from the control

##### **What did you change?**
FormUtils.ts


##### **Reviewers**
* @bvkimball @jgodi @krsween 

##### **Checklist (completed via merger)**
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Visually tested in supported browsers and devices