### PR TITLE
fix(table) fix issue with multiple columns having sort enabled

### DIFF
--- a/src/elements/table/Table.ts
+++ b/src/elements/table/Table.ts
@@ -478,10 +478,13 @@ export class NovoTableElement implements DoCheck {
      * @param newSortColumn
      */
     onSortChange(column) {
-        if (this.currentSortColumn && this.currentSortColumn !== column) {
-            this.currentSortColumn.sort = null;
-        }
         this.currentSortColumn = column;
+        let sortedColumns: any = this.columns.filter( (thisColumn) => {
+            return thisColumn.sort && thisColumn !== this.currentSortColumn;
+        });
+        for (let sortedColumn of sortedColumns) {
+            sortedColumn.sort = null;
+        }
 
         if (column) {
             if (Helpers.isFunction(this.config.sorting)) {


### PR DESCRIPTION
Issue occurring in Canvas where clicking filter and/or sorts really fast would cause the state of the table to be bad. Multiple columns would be registered as sorted.

##### **What did you change?**
Now onSortChange will remove the sort from every other column except for the column that is currently getting sorted.


##### **Reviewers**
* @user

##### **Checklist (completed via merger)**
* [x ] Changes are limited to a single goal (no scope creep)
* [x ] Code can be automatically merged (no conflicts)
* [x ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [x ] Passes all existing automated tests
* [ ] New functions include new tests
* [x ] New functions are documented (with a description, list of inputs, and expected output)
* [x ] Visually tested in supported browsers and devices