### PR TITLE
bug(Form): form interactions removes required after every change, should only be on required state change

### DIFF
--- a/src/elements/form/FormUtils.ts
+++ b/src/elements/form/FormUtils.ts
@@ -67,7 +67,7 @@ export class NovoFormControl extends FormControl {
             this.setValidators(validators);
             this.updateValueAndValidity();
             this.hasRequiredValidator = this.required;
-        } else if (this.hasRequiredValidator) {
+        } else if (!this.required && this.hasRequiredValidator) {
             let validators: any = [...this.validators];
             this.setValidators(validators);
             this.updateValueAndValidity();


### PR DESCRIPTION
form interactions removes required after every change, should only be on required state change

##### **What did you change?**
FormUtils.ts


##### **Reviewers**
* @bvkimball @jgodi 

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices