### PR TITLE
feat(Select): Increase Form Dropdown Height by 2.5 Items #313

### DIFF
--- a/src/elements/select/Select.scss
+++ b/src/elements/select/Select.scss
@@ -11,7 +11,7 @@ novo-select {
         .novo-select-list {
             position: absolute;
             z-index: 1000;
-            max-height: 200px;
+            max-height: 219px;
             min-width: 200px;
             width: 100%;
             max-width: 800px;


### PR DESCRIPTION
##### **Description**
Increased the max height of the select containers so that the show half of the next element.

I am sorry about the new max-height, I feel dirty using 219px but its what looks best. (UX agrees)


##### **What did you change?**
select.scss


##### **Reviewers**
* @jgodi
* @more