### PR TITLE
feat(Table): When paging is false the start and count values are not set on the dataprovider

### DIFF
--- a/src/elements/table/Table.ts
+++ b/src/elements/table/Table.ts
@@ -74,7 +74,7 @@ export class NovoTableHeaderElement {
                                 </div>
                             </div>
                             <!-- FILTER DROP-DOWN -->
-                            <novo-dropdown side="right" *ngIf="column.filtering" class="column-filters" (toggled)="onDropdownToggled($event, column.name)" appendToBody="true" parentScrollSelector=".table-container" containerClass="table-dropdown">
+                            <novo-dropdown side="right" *ngIf="config.filtering !== false && column.filtering !== false" class="column-filters" (toggled)="onDropdownToggled($event, column.name)" appendToBody="true" parentScrollSelector=".table-container" containerClass="table-dropdown">
                                 <button type="button" theme="icon" icon="filter" [class.filtered]="column.filter || column.filter===false"></button>
                                 <!-- FILTER OPTIONS LIST -->
                                 <list *ngIf="(column?.options?.length || column?.originalOptions?.length) && column?.type !== 'date' && toggledDropdownMap[column.name]">

--- a/src/elements/table/Table.ts
+++ b/src/elements/table/Table.ts
@@ -74,7 +74,7 @@ export class NovoTableHeaderElement {
                                 </div>
                             </div>
                             <!-- FILTER DROP-DOWN -->
-                            <novo-dropdown side="right" *ngIf="config.filtering" class="column-filters" (toggled)="onDropdownToggled($event, column.name)" appendToBody="true" parentScrollSelector=".table-container" containerClass="table-dropdown">
+                            <novo-dropdown side="right" *ngIf="column.filtering" class="column-filters" (toggled)="onDropdownToggled($event, column.name)" appendToBody="true" parentScrollSelector=".table-container" containerClass="table-dropdown">
                                 <button type="button" theme="icon" icon="filter" [class.filtered]="column.filter || column.filter===false"></button>
                                 <!-- FILTER OPTIONS LIST -->
                                 <list *ngIf="(column?.options?.length || column?.originalOptions?.length) && column?.type !== 'date' && toggledDropdownMap[column.name]">

--- a/src/elements/table/Table.ts
+++ b/src/elements/table/Table.ts
@@ -74,7 +74,7 @@ export class NovoTableHeaderElement {
                                 </div>
                             </div>
                             <!-- FILTER DROP-DOWN -->
-                            <novo-dropdown side="right" *ngIf="config.filtering !== false && column.filtering !== false" class="column-filters" (toggled)="onDropdownToggled($event, column.name)" appendToBody="true" parentScrollSelector=".table-container" containerClass="table-dropdown">
+                            <novo-dropdown side="right" *ngIf="config.filtering" class="column-filters" (toggled)="onDropdownToggled($event, column.name)" appendToBody="true" parentScrollSelector=".table-container" containerClass="table-dropdown">
                                 <button type="button" theme="icon" icon="filter" [class.filtered]="column.filter || column.filter===false"></button>
                                 <!-- FILTER OPTIONS LIST -->
                                 <list *ngIf="(column?.options?.length || column?.originalOptions?.length) && column?.type !== 'date' && toggledDropdownMap[column.name]">
@@ -256,8 +256,8 @@ export class NovoTableElement implements DoCheck {
                     break;
             }
         });
-        this._dataProvider.page = this.config.paging.current;
-        this._dataProvider.pageSize = this.config.paging.itemsPerPage;
+        this._dataProvider.page = this.config.paging ? this.config.paging.current : 0;
+        this._dataProvider.pageSize = this.config.paging ? this.config.paging.itemsPerPage : 500;
         if (dp && dp.length > 0) {
             this.setupColumnDefaults();
         }

--- a/src/elements/table/Table.ts
+++ b/src/elements/table/Table.ts
@@ -257,7 +257,7 @@ export class NovoTableElement implements DoCheck {
             }
         });
         this._dataProvider.page = this.config.paging ? this.config.paging.current : 0;
-        this._dataProvider.pageSize = this.config.paging ? this.config.paging.itemsPerPage : 500;
+        this._dataProvider.pageSize = this.config.paging ? this.config.paging.itemsPerPage : 0;
         if (dp && dp.length > 0) {
             this.setupColumnDefaults();
         }


### PR DESCRIPTION
this is a fix for if config = { paging: false } which we want because we don't want to show pagination control on tables that can only contain 5 records

##### **What did you change?**



##### **Reviewers**
* @jgodi
* @more