### PR TITLE
feat(Table): When paging is false the start and count values are not …

### DIFF
--- a/src/elements/table/Table.ts
+++ b/src/elements/table/Table.ts
@@ -256,8 +256,10 @@ export class NovoTableElement implements DoCheck {
                     break;
             }
         });
-        this._dataProvider.page = this.config.paging ? this.config.paging.current : 0;
-        this._dataProvider.pageSize = this.config.paging ? this.config.paging.itemsPerPage : 0;
+        if (this.config.paging) {
+            this._dataProvider.page = this.config.paging.current;
+            this._dataProvider.pageSize = this.config.paging.itemsPerPage;
+        }
         if (dp && dp.length > 0) {
             this.setupColumnDefaults();
         }


### PR DESCRIPTION
…set on the dataprovider

##### **Description**
Found a small issue with the previous version. this will fix by not setting any defaults. 
Defaults will be handled by the consumer like `this.dataProvider.pageSize = 5;`


##### **What did you change?**



##### **Reviewers**
* @jgodi
* @more