### PR TITLE
BH-48213 - Stopped label from overriding entered text in picker control

### DIFF
--- a/src/elements/form/Control.ts
+++ b/src/elements/form/Control.ts
@@ -154,6 +154,7 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
     private _blurEmitter: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
     private _focusEmitter: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
     private _focused: boolean = false;
+    private _enteredText: string = '';
     formattedValue: string = '';
     maxLengthMet: boolean = false;
     characterCount: number = 0;
@@ -271,6 +272,11 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
     }
 
     get alwaysActive() {
+        // Controls that have the label active if there is any user entered text in the field
+        if (this.control.controlType === 'picker' && this._enteredText.length) {
+            return true;
+        }
+
         // Controls that always have the label active
         return ['tiles', 'checklist', 'checkbox', 'address', 'file', 'editor', 'radio', 'text-area', 'quick-note'].indexOf(this.control.controlType) !== -1;
     }
@@ -285,6 +291,7 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
 
     handleTyping(event: any) {
         this._focused = event && event.length;
+        this._enteredText = event;
     }
 
     handleFocus(event: FocusEvent) {
@@ -336,8 +343,9 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
     }
 
     modelChange(value) {
-        if (!value) {
+        if (Helpers.isEmpty(value)) {
             this._focused = false;
+            this._enteredText = '';
         }
         this.change.emit(value);
     }


### PR DESCRIPTION
##### **Description**

Stopped label from overriding entered text in picker control

##### **What did you change?**

Added _enteredText private variable, and check it when determining if the label is active for picker controls.

*Issue:*
![picker_text_error](https://cloud.githubusercontent.com/assets/3843503/23041068/28ff09f2-f459-11e6-8fa6-c0ce4769a69d.gif)
![chip_error](https://cloud.githubusercontent.com/assets/3843503/23042667/14bef762-f45f-11e6-861a-a284f8315da9.gif)

*Fix:*
![picker_text_fixed](https://cloud.githubusercontent.com/assets/3843503/23041059/1c37d62c-f459-11e6-9832-36a17412d7f3.gif)
![chip_fixed](https://cloud.githubusercontent.com/assets/3843503/23042668/172cc646-f45f-11e6-9b83-d33d5c60bb64.gif)


##### **Reviewers**
* @jgodi
* @more