### PR TITLE
bug(QuickNote): Quick Note does not create the formatted object on writeValue.

### DIFF
--- a/src/elements/quick-note/QuickNote.ts
+++ b/src/elements/quick-note/QuickNote.ts
@@ -344,10 +344,7 @@ export class QuickNoteElement extends OutsideClick implements OnInit {
                 references: {}
             };
         }
-        // Update formatted note for the initial value
-        if (!this.basicNote) {
-            this.updateFormattedNote(this.model.note);
-        }
+        this.updateFormattedNote(this.model.note);
     }
 
     registerOnChange(fn: Function): void {


### PR DESCRIPTION
##### **Description**
The formatted note object is only created on initial value set. When the value is set dynamically more than once (injected templates for example) the note object is not formatted and appended correctly.


##### **What did you change?**



##### **Reviewers**
* @jgodi
* @more