### PR TITLE
fix(control): Moving onSelect events after onModelChange call

### DIFF
--- a/src/elements/date-time-picker/DateTimePicker.ts
+++ b/src/elements/date-time-picker/DateTimePicker.ts
@@ -284,6 +284,10 @@ export class NovoDateTimePickerElement implements ControlValueAccessor, OnInit, 
         this.updateHeading();
 
         if (fireEvents && this.selected) {
+            // Also, update the ngModel
+            this.onModelChange(this.selected);
+            this.model = this.selected;
+
             // Emit our output
             this.onSelect.next({
                 month: this.labels.formatDateWithFormat(this.selected, { month: 'long' }),
@@ -291,10 +295,6 @@ export class NovoDateTimePickerElement implements ControlValueAccessor, OnInit, 
                 day: this.labels.formatDateWithFormat(this.selected, { weekday: 'long' }),
                 date: this.selected
             });
-
-            // Also, update the ngModel
-            this.onModelChange(this.selected);
-            this.model = this.selected;
             this.dispatchChange();
         }
     }
@@ -453,6 +453,10 @@ export class NovoDateTimePickerElement implements ControlValueAccessor, OnInit, 
         if (this.model) {
             value = Helpers.modifyDate({ hours: hours, minutes: this.minutes, seconds: 0 }, this.model);
         }
+        this.onModelChange(value);
+        this.model = value;
+
+        //onSelect needs to be fired after the model has been changed
         this.onSelect.next({
             hours: hours,
             minutes: this.minutes,
@@ -460,13 +464,11 @@ export class NovoDateTimePickerElement implements ControlValueAccessor, OnInit, 
             date: value,
             text: `${this.hours}:${this.minutes} ${this.meridian}`
         });
-
-        this.onModelChange(value);
-        this.model = value;
     }
 
     clearTime(): void {
         this.updateTime(null, true);
+        this.dispatchChange();
     }
 
     toggleTimePicker(tab: componentTabStates): void {

--- a/src/elements/form/Control.ts
+++ b/src/elements/form/Control.ts
@@ -120,21 +120,21 @@ export class NovoCustomControlContainerElement {
                             <div class="novo-control-input-container" *ngSwitchCase="'time'" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition">
                                 <input [formControlName]="control.key" [name]="control.key" type="text" [attr.id]="control.key" [placeholder]="control.placeholder" (click)="toggleActive($event);" [value]="formattedValue" readonly/>
                                 <i (click)="toggleActive($event)" class="bhi-clock" *ngIf="!hasValue"></i>
-                                <i (click)="clearValue()" class="bhi-times" *ngIf="hasValue"></i>
+                                <i (click)="clearValue(); modelChange($event);" class="bhi-times" *ngIf="hasValue"></i>
                                 <novo-time-picker [hidden]="!active" (onSelect)="formatTimeValue($event);" [formControlName]="control.key"></novo-time-picker>
                             </div>
                             <!--Date-->
                             <div class="novo-control-input-container" *ngSwitchCase="'date'" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition">
                                 <input [formControlName]="control.key" [name]="control.key" type="text" [attr.id]="control.key" [placeholder]="control.placeholder" (click)="toggleActive($event);" [value]="formattedValue" readonly/>
                                 <i (click)="toggleActive($event)" class="bhi-calendar" *ngIf="!hasValue"></i>
-                                <i (click)="clearValue()" class="bhi-times" *ngIf="hasValue"></i>
+                                <i (click)="clearValue(); modelChange($event);" class="bhi-times" *ngIf="hasValue"></i>
                                 <novo-date-picker inline="true" [hidden]="!active" (onSelect)="formatDateValue($event);" [formControlName]="control.key"></novo-date-picker>
                             </div>
                             <!--Date and Time-->
                             <div class="novo-control-input-container" *ngSwitchCase="'date-time'" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition">
                                 <input [formControlName]="control.key" [name]="control.key" type="text" [attr.id]="control.key" [placeholder]="control.placeholder" (click)="toggleActive($event);" [value]="formattedValue" readonly/>
                                 <i (click)="toggleActive($event)" class="bhi-calendar" *ngIf="!hasValue"></i>
-                                <i (click)="clearValue()" class="bhi-times" *ngIf="hasValue"></i>
+                                <i (click)="clearValue(); modelChange($event);" class="bhi-times" *ngIf="hasValue"></i>
                                 <novo-date-time-picker [hidden]="!active" (onSelect)="formatDateTimeValue($event); modelChange($event);" [formControlName]="control.key"></novo-date-time-picker>
                             </div>
                             <!--Address-->
@@ -382,7 +382,6 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
         });
         this.formattedValue = value;
     }
-
 
     resizeTextArea(event) {
         // Reset the heighte

--- a/src/elements/select/Select.ts
+++ b/src/elements/select/Select.ts
@@ -104,8 +104,8 @@ export class NovoSelectElement extends OutsideClick implements OnInit, OnChanges
         this.selected = option;
         this.selected.active = true;
         this.empty = false;
-        this.onSelect.emit({ selected: this.selected.value });
         this.onModelChange(this.selected.value);
+        this.onSelect.emit({ selected: this.selected.value });
     }
 
     clear() {


### PR DESCRIPTION
##### **Description**
onSelect events need to be fired after the onModelChange call because onSelect will be expecting the new values to be present in this.model



##### **What did you change?**
moved onSelect calls to be above onModelChange for date-time pickers.
added modelChange events to date, date-time, and time pickers when clearing the picker in a control.


##### **Reviewers**
* @jgodi
* @more