### PR TITLE
fix(Table): Escape apostrophes in onFilterChange

### DIFF
--- a/src/elements/table/Table.ts
+++ b/src/elements/table/Table.ts
@@ -515,7 +515,7 @@ export class NovoTableElement implements DoCheck {
                             return column.match(record, column.filter);
                         };
                     } else if (column.preFilter && Helpers.isFunction(column.preFilter)) {
-                        query = Object.assign({}, query, column.preFilter(column.filter));
+                        query = Object.assign({}, query, column.preFilter(this.escapeCharacters(column.filter)));
                     } else if (Array.isArray(column.filter)) {
                         // The filters are an array (multi-select), check value
                         let options = column.filter;
@@ -560,6 +560,12 @@ export class NovoTableElement implements DoCheck {
                 this.selectAll(false);
             }
         }
+    }
+
+    escapeCharacters(filter) {
+        if (typeof (filter) === 'string') {
+            return filter.replace(/'/g, '\'\'');
+        } return filter;
     }
 
     /**


### PR DESCRIPTION
##### **Description**
Attempting to filter the Novo table on a String with an apostrophe in it, such as "User's Test Report", would cause an error.


##### **What did you change?**
Added a function to escape apostrophes when pre-filtering the String


##### **Reviewers**
* @jgodi
* @more