### PR TITLE
fix(multipicker): Values in multipicker can now be localized

### DIFF
--- a/src/elements/multi-picker/MultiPicker.ts
+++ b/src/elements/multi-picker/MultiPicker.ts
@@ -135,7 +135,8 @@ export class NovoMultiPickerElement extends OutsideClick implements OnInit {
 
     setupOptionsByType(section) {
         let formattedSection: any = {
-            type: section.type
+            type: section.type,
+            label: section.label || section.type
         };
         formattedSection.data = section.data.map(item => {
             return this.formatOption(section, item);
@@ -265,7 +266,7 @@ export class NovoMultiPickerElement extends OutsideClick implements OnInit {
                 } else {
                     count = selectedOfType.length;
                 }
-                let displayType = count === 1 ? type.singular : type.value;
+                let displayType = count === 1 ? type.singular : type.plural || type.value;
                 if (count > 0) {
                     this.notShown.push({ type: displayType, count: count });
                 }

--- a/src/elements/multi-picker/Multipicker.spec.ts
+++ b/src/elements/multi-picker/Multipicker.spec.ts
@@ -145,11 +145,20 @@ describe('Element: NovoMultiPickerElement', () => {
         });
     });
 
-    xdescribe('Method: setupOptionByType(section)', () => {
-        it('should correctly format a section of options', () => {
-            let section = { type: 'cats', data: ['Kitty'] };
+    describe('Method: setupOptionByType(section)', () => {
+        it('should correctly format a section of options without the ALL section', () => {
+            component.selectAllOption = false;
+            let section = { type: 'cats', label:'cats', data: ['Kitty'] };
+            let data = [{ value: 'Kitty', label: 'Kitty', type: 'cats', checked: undefined, isParentOf: undefined, isChildOf: undefined }];
+            let expected = { type: 'cats', label: 'cats', data: data, originalData: data };
+            let actualResult = component.setupOptionsByType(section);
+            expect(actualResult).toEqual(expected);
+        });
+        it('should correctly format a section of options with the ALL section', () => {
+            component.selectAllOption = true;
+            let section = { type: 'cats', label:'cats', data: ['Kitty'] };
             let data = [{ value: 'ALL', label: 'All cats', type: 'cats', checked: undefined, isParentOf: undefined, isChildOf: undefined }, { value: 'Kitty', label: 'Kitty', type: 'cats', checked: undefined, isParentOf: undefined, isChildOf: undefined }];
-            let expected = { type: 'cats', data: data, originalData: data };
+            let expected = { type: 'cats', label: 'cats', data: data, originalData: data };
             let actualResult = component.setupOptionsByType(section);
             expect(actualResult).toEqual(expected);
         });
@@ -310,6 +319,24 @@ describe('Element: NovoMultiPickerElement', () => {
             expect(component.notShown.length).toBe(1);
             expect(component.notShown[0].type).toBe('cats');
             expect(component.notShown[0].count).toBe(7);
+        });
+        it('should create an object with correct type, count, and singular label when count is 1 above chipsCount', () => {
+            let items = [{ value: 1, type: 'numbers' }, { value: 2, type: 'numbers' }, { value: 3, type: 'numbers' }, { value: 4, type: 'numbers' }, { value: 5, type: 'numbers' }];
+            component.chipsCount = 4;
+            component.types = [{ value: 'numbers', singular: 'singularnumber', plural: 'pluralnumbers' }];
+            component.updateDisplayText(items);
+            expect(component.notShown.length).toBe(1);
+            expect(component.notShown[0].type).toBe('singularnumber');
+            expect(component.notShown[0].count).toBe(1);
+        });
+        it('should create an object with correct type, count, and plural label when count is 2+ above chipsCount', () => {
+            let items = [{ value: 1, type: 'numbers' }, { value: 2, type: 'numbers' }, { value: 3, type: 'numbers' }, { value: 4, type: 'numbers' }, { value: 5, type: 'numbers' }, { value: 6, type: 'numbers' }];
+            component.chipsCount = 2;
+            component.types = [{ value: 'numbers', singular: 'singularnumber', plural: 'pluralnumbers' }];
+            component.updateDisplayText(items);
+            expect(component.notShown.length).toBe(1);
+            expect(component.notShown[0].type).toBe('pluralnumbers');
+            expect(component.notShown[0].count).toBe(4);
         });
     });
 

--- a/src/elements/picker/extras/checklist-picker-results/ChecklistPickerResults.ts
+++ b/src/elements/picker/extras/checklist-picker-results/ChecklistPickerResults.ts
@@ -21,7 +21,7 @@ import { Observable } from 'rxjs/Rx';
         <novo-loading theme="line" *ngIf="isLoading && !matches.length"></novo-loading>
         <ul *ngIf="matches.length > 0">
             <span *ngFor="let section of matches; let i = index">
-                <li class="header caption" *ngIf="section.data.length > 0">{{section.type}}</li>
+                <li class="header caption" *ngIf="section.data.length > 0">{{section.label}}</li>
                 <li
                     *ngFor="let match of section.data; let i = index" [ngClass]="{checked: match.checked}"
                     (click)="selectMatch($event, match)"

--- a/src/elements/picker/extras/checklist-picker-results/ChecklistPickerResults.ts
+++ b/src/elements/picker/extras/checklist-picker-results/ChecklistPickerResults.ts
@@ -21,7 +21,7 @@ import { Observable } from 'rxjs/Rx';
         <novo-loading theme="line" *ngIf="isLoading && !matches.length"></novo-loading>
         <ul *ngIf="matches.length > 0">
             <span *ngFor="let section of matches; let i = index">
-                <li class="header caption" *ngIf="section.data.length > 0">{{section.label}}</li>
+                <li class="header caption" *ngIf="section.data.length > 0">{{ section.label || section.type }}</li>
                 <li
                     *ngFor="let match of section.data; let i = index" [ngClass]="{checked: match.checked}"
                     (click)="selectMatch($event, match)"


### PR DESCRIPTION
##### **Description**
Labels for the sections in the picker dropdown need to be localized. 

##### **What did you change?**
This allows you to define the label of the types as well as allowing localized values (with spaces and special charactes) in the source.options array. Code is backwards compatible with previous way of defining the labels


##### **Reviewers**
* @jgodi
* @krsween 
* @more