### PR TITLE
fix(fileInput): Fix alignment of file input dropzone icon

### DIFF
--- a/src/elements/form/extras/file/FileInput.scss
+++ b/src/elements/form/extras/file/FileInput.scss
@@ -82,6 +82,10 @@ novo-file-input {
             small {
                 margin-top: 7px;
             }
+            i.bhi-dropzone {
+                float: left;
+                margin: -17px .25em 0 0;
+            }
             &.boxed {
                 border: 2px dashed $grey;
             }

--- a/src/elements/form/extras/file/FileInput.ts
+++ b/src/elements/form/extras/file/FileInput.ts
@@ -23,8 +23,8 @@ const LAYOUT_DEFAULTS = { order: 'default', download: true, labelStyle: 'default
             <div class="file-input-group" [class.disabled]="disabled" [class.active]="active">
                 <input type="file" [name]="name" [attr.id]="name" (change)="check($event)" [attr.multiple]="multiple"/>
                 <section [ngSwitch]="layoutOptions.labelStyle">
-                    <label *ngSwitchCase="'no-box'" [attr.for]="name">
-                            <span> <i class="bhi-dropzone"></i>{{ placeholder || labels.chooseAFile }} {{ labels.or }} <strong class="link">{{ labels.clickToBrowse }}</strong></span>
+                    <label *ngSwitchCase="'no-box'" [attr.for]="name" class="no-box">
+                            <div><i class="bhi-dropzone"></i>{{ placeholder || labels.chooseAFile }} {{ labels.or }} <strong class="link">{{ labels.clickToBrowse }}</strong></div>
                     </label>
                     <label *ngSwitchDefault [attr.for]="name" class="boxed">
                             <span>{{ placeholder || labels.chooseAFile }}</span>


### PR DESCRIPTION
##### **Description**

Fix alignment of text and icon - text now aligned with dot in dropzone icon, see below

![screen shot 2017-05-04 at 10 28 55 am](https://cloud.githubusercontent.com/assets/7002678/25711421/7e762324-30b4-11e7-8750-229035e65396.png)


##### **What did you change?**



##### **Reviewers**
* @jgodi
* @more