### PR TITLE
style(Form): Form Labels now wrap when text is to long.

### DIFF
--- a/src/elements/form/Form.scss
+++ b/src/elements/form/Form.scss
@@ -210,6 +210,8 @@ novo-form {
                             margin-right: 35px;
                             text-transform: uppercase;
                             padding-top: 8px;
+                            word-break: word-break;
+                            overflow-wrap: break-word;
                         }
                         >div.novo-control-outer-container {
                             display: flex;


### PR DESCRIPTION
##### **Description**

Form Labels now wrap when text is to long.

##### **What did you change?**

word-break: word-break;
overflow-wrap: break-word;


##### **Reviewers**
* @jgodi
* @more