### PR TITLE
fix(FileInput): files should be set to value, even if passed in value is an empty array …

### DIFF
--- a/src/elements/form/extras/file/FileInput.ts
+++ b/src/elements/form/extras/file/FileInput.ts
@@ -140,7 +140,7 @@ export class NovoFileInputElement implements ControlValueAccessor, OnInit, OnDes
     }
 
     setInitialFileList() {
-        if (this.value && this.value.length > 0) {
+        if (this.value) {
             this.files = this.value;
         }
     }


### PR DESCRIPTION

##### **Description**

files should be set to value, even if passed in value is an empty array. Fixes a bug with mergePdf when initializing page without starting files.

##### **What did you change?**
FileInput


##### **Reviewers**
* @jgodi
* @more