### PR TITLE
bug(Editable tables): Percentage cells do not render in the editable form.

### DIFF
--- a/src/elements/table/Table.spec.ts
+++ b/src/elements/table/Table.spec.ts
@@ -421,7 +421,8 @@ describe('Elements: NovoTableElement', () => {
     describe('Method: setTableEdit()', () => {
         beforeEach(() => {
             component._dataProvider = {
-                edit: () => {}
+                edit: () => { },
+                refresh: () => { }
             };
             component.columns = [
                 {
@@ -473,6 +474,58 @@ describe('Elements: NovoTableElement', () => {
                     }
                 }
             ]);
+        });
+    });
+
+    describe('Method: specialtyRenderers(control, row)', () => {
+        let row, control;
+        beforeEach(() => {
+            row = {
+                percentage: 0.22
+            };
+
+            control = {
+                name: 'percentage',
+                dataSpecialization: 'PERCENTAGE'
+            };
+        });
+
+        it('should be defined.', () => {
+            expect(component.specialtyRenderers).toBeDefined();
+        });
+
+        it('should render percentage cell value 0.22 to 22', () => {
+            component.specialtyRenderers(control, row);
+            expect(row.percentage).toBe(22);
+        });
+
+        it('should not manipulate whole numbers', () => {
+            row.percentage = 60;
+            component.specialtyRenderers(control, row);
+            expect(row.percentage).toBe(60);
+        });
+    });
+
+    describe('Method: undoSpecialtyRenderers(control, row)', () => {
+        let row, control;
+        beforeEach(() => {
+            row = {
+                percentage: 22
+            };
+
+            control = {
+                name: 'percentage',
+                dataSpecialization: 'PERCENTAGE'
+            };
+        });
+
+        it('should be defined.', () => {
+            expect(component.undoSpecialtyRenderers).toBeDefined();
+        });
+
+        it('should render percentage cell value 22 to 0.22', () => {
+            component.undoSpecialtyRenderers(control, row);
+            expect(row.percentage).toBe(0.22);
         });
     });
 

--- a/src/elements/table/Table.ts
+++ b/src/elements/table/Table.ts
@@ -866,8 +866,26 @@ export class NovoTableElement implements DoCheck {
                 } else {
                     row._editing[column.name] = false;
                 }
+                row = this.specialtyRenderers(column, row);
             });
         });
+        this._dataProvider.refresh();
+    }
+
+    specialtyRenderers(control, row): Object {
+        if (control.dataSpecialization === 'PERCENTAGE') {
+            let value = row[control.name];
+            row[control.name] = value % 1 === 0 ? value : value * 100;
+        }
+        return row;
+    }
+
+    undoSpecialtyRenderers(control, row): Object {
+        if (control.dataSpecialization === 'PERCENTAGE') {
+            let value = row[control.name];
+            row[control.name] = value % 1 === 0 ? value / 100 : value;
+        }
+        return row;
     }
 
     /**
@@ -881,9 +899,9 @@ export class NovoTableElement implements DoCheck {
             row._editing = row._editing || {};
             this.columns.forEach((column) => {
                 row._editing[column.name] = false;
+                row = this.undoSpecialtyRenderers(column, row);
             });
         });
-        this._dataProvider.undo();
         this.hideToastMessage();
     }
 


### PR DESCRIPTION
##### **Description**
Table cells have a percentage renderer that multiplies the current value by 100 (PercentageCell.ts) however when it is toggled over to edit mode the percentages show in their original 0.2 (20%) format. this is because the percentage renderer lives in bh-elements.

now logic would say we should move the percentage renderer to novo-elemnets. however this produces another problem because 0.2 then becomes 2000% because it is multiplied for both the form and the table.


##### **What did you change?**
Added some specialty renderers which would perform this calculations based on dataSpecialization. these are added when the form is toggled to edit mode only, and removed when the form leaves edit mode.


##### **Reviewers**
* @jgodi
* @more