### PR TITLE
fix(EntityPickerResults): EntityPicker was using bad value for date f…

### DIFF
--- a/src/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
+++ b/src/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
@@ -121,7 +121,7 @@ export class EntityPickerResult {
     renderTimestamp(date?: any) {
         let timestamp = '';
         if (date) {
-            timestamp = this.labels.formatDateWithFormat(date, 'L');
+            timestamp = this.labels.formatDateWithFormat(date, {year: 'numeric', month: 'numeric', day: 'numeric'});
         }
         return timestamp;
     }


### PR DESCRIPTION
Error Message: 
novo-elements/src/elements/picker/extras/entity-picker-results/EntityPickerResults.ts(124,64): error TS2559: Type '"L"' has no properties in common with type 'DateTimeFormatOptions'.

##### **What did you change?**
I am using the Intl Date format options now.  I believe this was a left over bug from our old date formatting code.

##### **Reviewers**
* @jgodi
* @more