### PR TITLE
Safari Browser Fixes

### DIFF
--- a/demo/assets/styles/main.scss
+++ b/demo/assets/styles/main.scss
@@ -70,6 +70,12 @@ main.main-content {
             > * {
                 width: 50%;
             }
+
+            img {
+                max-height: 250px;
+                margin-top: auto;
+                margin-bottom: auto;
+            }
         }
     }
 

--- a/demo/pages/elements/editor/EditorDemo.ts
+++ b/demo/pages/elements/editor/EditorDemo.ts
@@ -5,7 +5,7 @@ let BasicDemoTpl = require('./templates/BasicEditorDemo.html');
 
 const template = `
 <div class="container">
-    <h1>CK Editor <small><a target="_blank" href="https://github.com/bullhorn/novo-elements/blob/master/src/elements/editor">(source)</a></small></h1>
+    <h1>CK Editor <small><a target="_blank" href="https://github.com/bullhorn/novo-elements/blob/master/src/elements/ckeditor">(source)</a></small></h1>
     <p>Basic HTML editor using CK Editor.</p>
 
     <h5>Basic</h5>

--- a/demo/pages/elements/form/FormDemo.ts
+++ b/demo/pages/elements/form/FormDemo.ts
@@ -188,7 +188,7 @@ export class FormDemoComponent {
             key: 'entityMultiPicker',
             label: 'Entities',
             required: true,
-            readOnly: true,
+            readOnly: false,
             multiple: true,
             config: {
                 resultsTemplate: EntityPickerResults,

--- a/src/elements/button/Button.scss
+++ b/src/elements/button/Button.scss
@@ -48,6 +48,8 @@ button {
                 svg {
                     width: 100%;
                     height: 100%;
+                    max-width: 15px;
+                    max-height: 15px;
                     .spinner {
                         fill: white;
                     }

--- a/src/elements/calendar/month/CalendarMonthView.scss
+++ b/src/elements/calendar/month/CalendarMonthView.scss
@@ -1,6 +1,6 @@
 .calendar-month-view {
-  background-color: $white;  
-  
+  background-color: $white;
+
   .calendar-header {
      display: flex;
      flex-flow: column;
@@ -34,7 +34,7 @@
       }
     }
   }
-  
+
   .calendar-cell-row {
     display: flex;
     &:hover {
@@ -75,7 +75,7 @@
 
   .calendar-day-cell {
     min-height: 56px;
-    
+
     &:not(:last-child) {
       border-right: 1px solid #e1e1e1;
     }
@@ -105,17 +105,6 @@
     font-weight: 400;
     opacity: 0.5;
     padding:4px;
-  }
-
-  .calendar-events {
-    flex: 1;
-    align-items: flex-end;
-    display: flex;
-    flex-wrap: wrap;
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    padding: 2px;
   }
 
   .calendar-event {

--- a/src/elements/drawer/Drawer.ts
+++ b/src/elements/drawer/Drawer.ts
@@ -31,7 +31,7 @@ export class NovoDrawerElement implements OnInit {
 
     set drawer(drawer) {
         // init drop down menu
-        this.drawerEl = drawer.el;
+        this.drawerEl = drawer.drawer.el;
 
         // add class name for the position
         this.drawerEl.nativeElement.classList.add(this.position);

--- a/src/elements/dropdown/Dropdown.scss
+++ b/src/elements/dropdown/Dropdown.scss
@@ -18,7 +18,9 @@ novo-dropdown {
         flex-direction: column;
         align-items: flex-end;
         novo-dropdown-container {
-            margin-top: 50px;
+            top: 50px;
+            right: 0;
+            margin-top: 0;
         }
     }
 }

--- a/src/elements/tabs/Tabs.scss
+++ b/src/elements/tabs/Tabs.scss
@@ -14,6 +14,7 @@ novo-nav {
         justify-content: center;
         align-items: center;
         height: 100%;
+        min-height: 45px;
         position: relative;
         &.disabled {
             .novo-tab-link {


### PR DESCRIPTION
##### **Description**

Fixing styling issues where Safari renders elements poorly. Testing against Chrome and Firefox to ensure that changes do not break any existing look and feel.

##### **What did you change?**

Fixed issue with `novo-dropdown` displaying at a bad location for Safari only. Fixed in a way that is supported by Safari, Chrome, and Firefox.

![image](https://user-images.githubusercontent.com/3843503/29038885-cde2f1bc-7b6e-11e7-849b-0990b0ae1fa6.png)

Fixed issue where images in the demo were monster sized:

![image](https://user-images.githubusercontent.com/3843503/29044078-6bdcd87e-7b83-11e7-9ec2-a717f729acb8.png)

Tamed the mega spinner:

![image](https://user-images.githubusercontent.com/3843503/29074159-df46deb4-7c13-11e7-8ec4-2defbd9acccc.png)

Fixed calendar event rendering in Big Calendar for Safari:

![image](https://user-images.githubusercontent.com/3843503/29081189-73baaf2c-7c27-11e7-8d19-29bc260a0100.png)


##### **Reviewers**
* @jgodi
* @monroepe Fi