### PR TITLE
BH-51801 - Switched from third party spell checker to browser built-in

### DIFF
--- a/src/elements/ckeditor/CKEditor.spec.ts
+++ b/src/elements/ckeditor/CKEditor.spec.ts
@@ -172,9 +172,10 @@ describe('Elements: NovoCKEditorElement', () => {
         it('should work', () => {
             let config = component.getBaseConfig();
             expect(config).toEqual({
-                scayt_autoStartup: true,
+                disableNativeSpellChecker: false,
+                removePlugins: 'liststyle,tabletools,contextmenu',
                 toolbar: [
-                    { name: 'clipboard', items: ['Paste', 'PasteText', 'PasteFromWord', 'Undo', 'Redo', 'Scayt'] },
+                    { name: 'clipboard', items: ['Paste', 'PasteText', 'PasteFromWord', 'Undo', 'Redo'] },
                     { name: 'paragraph', items: ['NumberedList', 'BulletedList', 'Outdent', 'Indent', 'Blockquote', 'CreateDiv', 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock', 'BidiLtr', 'BidiRtl'] },
                     { name: 'links', items: ['Link'] },
                     { name: 'insert', items: ['Image', 'Table', 'HorizontalRule'] },

--- a/src/elements/ckeditor/CKEditor.ts
+++ b/src/elements/ckeditor/CKEditor.ts
@@ -129,9 +129,10 @@ export class NovoCKEditorElement implements OnDestroy, AfterViewInit {
 
     getBaseConfig() {
         return {
-            scayt_autoStartup: true,
+            disableNativeSpellChecker: false,
+            removePlugins: 'liststyle,tabletools,contextmenu', // allows browser based spell checking
             toolbar: [
-                { name: 'clipboard', items: ['Paste', 'PasteText', 'PasteFromWord', 'Undo', 'Redo', 'Scayt'] },
+                { name: 'clipboard', items: ['Paste', 'PasteText', 'PasteFromWord', 'Undo', 'Redo'] },
                 { name: 'paragraph', items: ['NumberedList', 'BulletedList', 'Outdent', 'Indent', 'Blockquote', 'CreateDiv', 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock', 'BidiLtr', 'BidiRtl'] },
                 { name: 'links', items: ['Link'] },
                 { name: 'insert', items: ['Image', 'Table', 'HorizontalRule'] },

--- a/src/elements/quick-note/QuickNote.ts
+++ b/src/elements/quick-note/QuickNote.ts
@@ -491,14 +491,15 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
      *
      * Sets the height of the CKEditor dynamically to the height of the wrapper upon initialization.
      * Removes the toolbar on the bottom and configures a slimmed down version of the toolbar.
+     * Removes plugins and turns off setting to allow browser based spell checking.
      */
     private getCKEditorConfig(): any {
         let editorHeight = this.wrapper.nativeElement.clientHeight - QuickNoteElement.TOOLBAR_HEIGHT;
 
         return {
-            scayt_autoStartup: true, // turns on Spell Checking As You Type
+            disableNativeSpellChecker: false,
             height: editorHeight,
-            removePlugins: 'elementspath', // removes the html tags in status bar
+            removePlugins: 'elementspath,liststyle,tabletools,contextmenu',
             resize_enabled: false, // hides the status bar
             toolbar: [{
                 name: 'basicstyles',


### PR DESCRIPTION
##### **Description**

Putting an end to this:

![image](https://user-images.githubusercontent.com/3843503/29128361-379c844e-7ce9-11e7-8a27-c47010cecf38.png)

And removed this:

![image](https://user-images.githubusercontent.com/3843503/29129766-7fcc7220-7ced-11e7-9e38-05f5b2dc7287.png)

##### **What did you change?**

Stopped using the built-in spell checker in CKEditor, which is a paid product, and switched to browser built-in spell checker instead.


##### **Reviewers**
* @jgodi
* @more