### PR TITLE
BH-52302 - Fixed formatting in CKEditor to look better in emails

### DIFF
--- a/demo/pages/elements/editor/templates/BasicEditorDemo.html
+++ b/demo/pages/elements/editor/templates/BasicEditorDemo.html
@@ -2,3 +2,6 @@
 
 <p>Value:</p>
 <p [innerHtml]="editorValue"></p>
+
+<p>HTML:</p>
+<pre><code>{{editorValue}}</code></pre>

--- a/src/elements/ckeditor/CKEditor.spec.ts
+++ b/src/elements/ckeditor/CKEditor.spec.ts
@@ -5,24 +5,6 @@ import { TestBed, async } from '@angular/core/testing';
 import { NovoCKEditorElement } from './CKEditor';
 
 describe('Elements: NovoCKEditorElement', () => {
-    // let component;
-    //
-    // beforeEachProviders(() => [
-    //     CKEditor,
-    //     { provide: Renderer, useClass: MockRenderer }
-    // ]);
-    //
-    // beforeEach(inject([CKEditor], _comp => {
-    //     component = _comp;
-    //     component.instance = new MockInstance();
-    //     component.host = {
-    //         nativeElement: {
-    //             value: 'INITIAL VALUE'
-    //         }
-    //     };
-    //
-    // }));
-
     let fixture;
     let component;
 
@@ -37,11 +19,11 @@ describe('Elements: NovoCKEditorElement', () => {
         }).compileComponents();
         fixture = TestBed.createComponent(NovoCKEditorElement);
         component = fixture.debugElement.componentInstance;
-        // spyOn(component.instance, 'removeAllListeners');
-        // spyOn(component.instance, 'destroy');
-        // spyOn(component.instance, 'setData');
-        // spyOn(component.instance, 'on');
-        // spyOn(component.change, 'emit');
+
+        window['CKEDITOR'] = {
+            ENTER_P: 1,
+            ENTER_BR: 2
+        };
     }));
 
     describe('Method: ngOnDestroy()', () => {
@@ -82,48 +64,6 @@ describe('Elements: NovoCKEditorElement', () => {
             expect(component.change.emit).toHaveBeenCalledWith('INITIAL VALUE');
         });
     });
-
-    // xdescribe('Method: ckeditorInit()', () => {
-    //     beforeEach(() => {
-    //         spyOn(console, 'error');
-    //     });
-    //
-    //     it('should be defined', () => {
-    //         expect(component.ckeditorInit).toBeDefined();
-    //     });
-    //
-    //     it('should throw error if the CKEDITOR is not present', () => {
-    //         window.CKEDITOR = null;
-    //         component.ckeditorInit({});
-    //         expect(console.error).toHaveBeenCalled();
-    //     });
-    //
-    //     describe('with CKEDITOR added', () => {
-    //         beforeEach(() => {
-    //             window.CKEDITOR = new MockInstance();
-    //
-    //             spyOn(window.CKEDITOR, 'removeAllListeners');
-    //             spyOn(window.CKEDITOR, 'destroy');
-    //             spyOn(window.CKEDITOR, 'setData');
-    //             spyOn(window.CKEDITOR, 'on');
-    //         });
-    //
-    //         it('should create the instance', () => {
-    //             component.ckeditorInit({});
-    //             expect(component.instance).toBeDefined();
-    //         });
-    //
-    //         it('should set the data on the instance', () => {
-    //             component.ckeditorInit({});
-    //             expect(component.instance.setData).toHaveBeenCalled();
-    //         });
-    //
-    //         it('should setup the handlers', () => {
-    //             component.ckeditorInit({});
-    //             expect(component.instance.on).toHaveBeenCalled();
-    //         });
-    //     });
-    // });
 
     describe('Method: writeValue()', () => {
         it('should be defined', () => {
@@ -172,6 +112,8 @@ describe('Elements: NovoCKEditorElement', () => {
         it('should work', () => {
             let config = component.getBaseConfig();
             expect(config).toEqual({
+                enterMode : window['CKEDITOR'].ENTER_BR,
+                shiftEnterMode: window['CKEDITOR'].ENTER_P,
                 disableNativeSpellChecker: false,
                 removePlugins: 'liststyle,tabletools,contextmenu',
                 toolbar: [

--- a/src/elements/ckeditor/CKEditor.ts
+++ b/src/elements/ckeditor/CKEditor.ts
@@ -129,6 +129,8 @@ export class NovoCKEditorElement implements OnDestroy, AfterViewInit {
 
     getBaseConfig() {
         return {
+            enterMode : CKEDITOR.ENTER_BR,
+            shiftEnterMode: CKEDITOR.ENTER_P,
             disableNativeSpellChecker: false,
             removePlugins: 'liststyle,tabletools,contextmenu', // allows browser based spell checking
             toolbar: [

--- a/src/elements/quick-note/QuickNote.ts
+++ b/src/elements/quick-note/QuickNote.ts
@@ -497,6 +497,8 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
         let editorHeight = this.wrapper.nativeElement.clientHeight - QuickNoteElement.TOOLBAR_HEIGHT;
 
         return {
+            enterMode : CKEDITOR.ENTER_BR,
+            shiftEnterMode: CKEDITOR.ENTER_P,
             disableNativeSpellChecker: false,
             height: editorHeight,
             removePlugins: 'elementspath,liststyle,tabletools,contextmenu',


### PR DESCRIPTION
##### **Description**

The HTML that comes from the CKEditor config surrounds all line breaks with `<p>` tags, which formats with lots of whitespace when that text is sent in an email. 

![image](https://user-images.githubusercontent.com/3843503/29181667-9eeb5110-7dc1-11e7-97fe-937bdf66f37a.png)

##### **What did you change?**

Using `<br>` tag option for regular enter key presses, and `<p>` tags only for shift + enter.

##### **Reviewers**
* @jgodi
* @more