### PR TITLE
Fixing the quick note results dropdown positioning to be at the cursor

### DIFF
--- a/src/elements/quick-note/QuickNote.spec.ts
+++ b/src/elements/quick-note/QuickNote.spec.ts
@@ -198,8 +198,7 @@ describe('Elements: QuickNoteElement', () => {
                                 type: 3, // CKEDITOR.NODE_TEXT
                                 $: { // The native element
                                     parentElement: {
-                                        offsetTop: 100,
-                                        offsetLeft: 0
+                                        appendChild: () => {}
                                     }
                                 }
                             },
@@ -300,7 +299,7 @@ describe('Elements: QuickNoteElement', () => {
             fakeCkEditorInstance.userPausedAfterEntry();
 
             expect(fakeResultsDropdown.visible).toBe(true);
-            expect(fakeResultsDropdown.nativeElementProperties).toEqual({'margin-top': '120px'});
+            expect(fakeResultsDropdown.nativeElementProperties).toEqual({'margin-top': '30px'});
             expect(fakeParentForm.getValue()).toEqual({
                 note: 'Note about: @john',
                 references: {}

--- a/src/elements/quick-note/QuickNote.ts
+++ b/src/elements/quick-note/QuickNote.ts
@@ -497,7 +497,7 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
         let editorHeight = this.wrapper.nativeElement.clientHeight - QuickNoteElement.TOOLBAR_HEIGHT;
 
         return {
-            enterMode : CKEDITOR.ENTER_BR,
+            enterMode: CKEDITOR.ENTER_BR,
             shiftEnterMode: CKEDITOR.ENTER_P,
             disableNativeSpellChecker: false,
             height: editorHeight,
@@ -517,13 +517,24 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
      */
     private getCursorPosition(): any {
         let range = this.ckeInstance.getSelection().getRanges()[0];
-        let cursorEl = range.startContainer.$.parentElement;
-        let editorEl = this.ckeInstance.editable().$;
+        let parentElement = range.startContainer.$.parentElement;
+        let editorElement = this.ckeInstance.editable().$;
 
-        return {
-            top: cursorEl.offsetTop - editorEl.scrollTop,
-            left: cursorEl.offsetLeft - editorEl.scrollLeft
+        // Since the editor is a text node in the DOM that does not know about it's position, a temporary element has to
+        // be inserted in order to locate the cursor position.
+        let cursorElement = document.createElement('img');
+        cursorElement.setAttribute('src', 'null');
+        cursorElement.setAttribute('width', '0');
+        cursorElement.setAttribute('height', '0');
+
+        parentElement.appendChild(cursorElement);
+        let cursorPosition = {
+            top: cursorElement.offsetTop - editorElement.scrollTop,
+            left: cursorElement.offsetLeft - editorElement.scrollLeft
         };
+        cursorElement.remove();
+
+        return cursorPosition;
     }
 
     /**


### PR DESCRIPTION
## **Description**

Fixed the location of the quick note results dropdown - a previous commit started always positioning it at the top of the editor.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**

![image](https://user-images.githubusercontent.com/3843503/29425727-edbf64b0-8349-11e7-9114-e509b3620a51.png)
