### PR TITLE
feat(forms) Custom section header icons for dynamic forms

### DIFF
--- a/demo/pages/elements/form/MockMeta.ts
+++ b/demo/pages/elements/form/MockMeta.ts
@@ -435,13 +435,19 @@ export const MockMeta = {
 };
 export const MockMetaHeaders = {
     sectionHeaders: [{
+        'label': 'Section With Custom Icon',
+        'name': 'sectionHeader3',
+        'sortOrder': 600,
+        'enabled': true,
+        'icon': 'bhi-certification'
+    }, {
         'label': 'Section 2',
-        'name': 'sectionHeader1',
+        'name': 'sectionHeader2',
         'sortOrder': 500,
         'enabled': true
     }, {
         'label': 'Section 1',
-        'name': 'sectionHeader2',
+        'name': 'sectionHeader1',
         'sortOrder': 45,
         'enabled': true
     }],

--- a/src/elements/form/DynamicForm.ts
+++ b/src/elements/form/DynamicForm.ts
@@ -8,11 +8,12 @@ import { NovoFieldset, NovoFormGroup } from './FormInterfaces';
 @Component({
     selector: 'novo-fieldset-header',
     template: `
-        <h6><i class="bhi-section"></i>{{title}}</h6>
+        <h6><i [class]="icon"></i>{{title}}</h6>
     `
 })
 export class NovoFieldsetHeaderElement {
     @Input() title: string;
+    @Input() icon: string;
 }
 
 @Component({
@@ -45,7 +46,7 @@ export class NovoControlCustom implements OnInit {
     selector: 'novo-fieldset',
     template: `
         <div class="novo-fieldset-container">
-            <novo-fieldset-header [title]="title" *ngIf="title"></novo-fieldset-header>
+            <novo-fieldset-header [icon]="icon" [title]="title" *ngIf="title"></novo-fieldset-header>
             <div *ngFor="let control of controls" class="novo-form-row" [class.disabled]="control.disabled">
                 <novo-control *ngIf="!control.customControl" [control]="control" [form]="form"></novo-control>
                 <novo-control-custom *ngIf="control.customControl" [control]="control" [form]="form"></novo-control-custom>
@@ -57,6 +58,7 @@ export class NovoFieldsetElement {
     @Input() controls: Array<any> = [];
     @Input() form: any;
     @Input() title: string;
+    @Input() icon: string;
 }
 
 @Component({
@@ -69,7 +71,7 @@ export class NovoFieldsetElement {
             </header>
             <form class="novo-form" [formGroup]="form" autocomplete="off">
                 <span *ngFor="let fieldset of form.fieldsets">
-                    <novo-fieldset *ngIf="fieldset.controls.length" [controls]="fieldset.controls" [title]="fieldset.title" [form]="form"></novo-fieldset>
+                    <novo-fieldset *ngIf="fieldset.controls.length" [icon]="fieldset.icon" [controls]="fieldset.controls" [title]="fieldset.title" [form]="form"></novo-fieldset>
                 </span>
             </form>
         </div>

--- a/src/elements/form/DynamicForm.ts
+++ b/src/elements/form/DynamicForm.ts
@@ -8,7 +8,7 @@ import { NovoFieldset, NovoFormGroup } from './FormInterfaces';
 @Component({
     selector: 'novo-fieldset-header',
     template: `
-        <h6><i [class]="icon"></i>{{title}}</h6>
+        <h6><i [class]="icon || 'bhi-section'"></i>{{title}}</h6>
     `
 })
 export class NovoFieldsetHeaderElement {

--- a/src/elements/form/FormInterfaces.ts
+++ b/src/elements/form/FormInterfaces.ts
@@ -10,5 +10,6 @@ export interface NovoFormGroup {
 
 export interface NovoFieldset {
     title?: string;
+    icon?: string;
     controls: any[];
 }

--- a/src/utils/form-utils/FormUtils.spec.ts
+++ b/src/utils/form-utils/FormUtils.spec.ts
@@ -286,6 +286,35 @@ describe('Utils: FormUtils', () => {
             expect(formUtils.toFieldSets).toBeDefined();
             formUtils.toFieldSets();
         });
+
+        it('should return an array of fieldsets with a title, icon and controls', () => {
+            let meta = {
+                entity: 'ENTITY_NAME',
+                label: 'ENTITY_LABEL',
+                fields: [
+                    {
+                        name: 'firstName',
+                        type: 'text',
+                        label: 'First Name',
+                        required: true,
+                        sortOrder: 10,
+                        maxLength: 10,
+                        description: 'First Name, Yo!'
+                    }
+                ],
+                sectionHeaders: [{
+                    'label': 'Header',
+                    'name': 'header',
+                    'sortOrder': 0,
+                    'enabled': true,
+                    'icon': 'bhi-certification'
+                }]
+            };
+            let fieldset = formUtils.toFieldSets(meta, 'USD', {}, {}, {});
+            expect(fieldset[0].title).toBe('Header');
+            expect(fieldset[0].icon).toBe('bhi-certification');
+            expect(fieldset[0].controls.length).toBe(1);
+        });
     });
 
     describe('Method: getControlOptions(field, http, config)', () => {

--- a/src/utils/form-utils/FormUtils.ts
+++ b/src/utils/form-utils/FormUtils.ts
@@ -375,7 +375,7 @@ export class FormUtils {
                         }
                         fieldsets.push({
                             title: item.label,
-                            icon: (item.icon) ? item.icon : 'bhi-section',
+                            icon: item.icon || 'bhi-section',
                             controls: []
                         });
                         ranges.push({

--- a/src/utils/form-utils/FormUtils.ts
+++ b/src/utils/form-utils/FormUtils.ts
@@ -375,6 +375,7 @@ export class FormUtils {
                         }
                         fieldsets.push({
                             title: item.label,
+                            icon: item.icon || 'bhi-section',
                             controls: []
                         });
                         ranges.push({

--- a/src/utils/form-utils/FormUtils.ts
+++ b/src/utils/form-utils/FormUtils.ts
@@ -375,7 +375,7 @@ export class FormUtils {
                         }
                         fieldsets.push({
                             title: item.label,
-                            icon: item.icon || 'bhi-section',
+                            icon: (item.icon) ? item.icon : 'bhi-section',
                             controls: []
                         });
                         ranges.push({


### PR DESCRIPTION
## **Description**

Included an icon input for DynamicForms that allows sectionHeaders to pass a custom icon in 

#### **Verify that...**

- [X ] Any related demos where added and `npm start` still works
- [ X] New demos work in `Safari`, `Chrome` and `Firefox`
- [ X] `npm run lint` passes
- [ X] `npm test` passes and code coverage is increased
- [ X] `npm run compile` still works

##### **Screenshots**
![image](https://user-images.githubusercontent.com/3916731/29685459-31886390-88db-11e7-9b43-987253d2281c.png)
