### PR TITLE
Added nextElementSibling helper method for Edge browser support

### DIFF
--- a/src/utils/Helpers.spec.ts
+++ b/src/utils/Helpers.spec.ts
@@ -65,8 +65,29 @@ describe('Utils: Helpers', () => {
     });
 
     describe('Method: getNextElementSibling(element)', () => {
-        it('should be defined.', () => {
-            expect(Helpers.getNextElementSibling).toBeDefined();
+        it('should return nextElementSibling if present.', () => {
+            let parent = document.createElement('div');
+            let origin = document.createElement('h1');
+            let sibling = document.createElement('h2');
+            parent.appendChild(origin);
+            parent.appendChild(sibling);
+            expect(Helpers.getNextElementSibling(origin)).toEqual(sibling);
+        });
+        it('should skip over non-element sibling nodes.', () => {
+            let parent = document.createElement('div');
+            let origin = document.createElement('h1');
+            let textNode = document.createTextNode('Some Text');
+            let sibling = document.createElement('h2');
+            parent.appendChild(origin);
+            parent.appendChild(textNode);
+            parent.appendChild(sibling);
+            expect(Helpers.getNextElementSibling(origin)).toEqual(sibling);
+        });
+        it('should return null if sibling is not present.', () => {
+            let parent = document.createElement('div');
+            let origin = document.createElement('h1');
+            parent.appendChild(origin);
+            expect(Helpers.getNextElementSibling(origin)).toEqual(null);
         });
     });
 

--- a/src/utils/Helpers.spec.ts
+++ b/src/utils/Helpers.spec.ts
@@ -64,6 +64,12 @@ describe('Utils: Helpers', () => {
         });
     });
 
+    describe('Method: getNextElementSibling(element)', () => {
+        it('should be defined.', () => {
+            expect(Helpers.getNextElementSibling).toBeDefined();
+        });
+    });
+
     xdescribe('Method: calcPositionOffset(position, element, side)', () => {
         it('should be defined.', () => {
             let element = new Element();

--- a/src/utils/Helpers.ts
+++ b/src/utils/Helpers.ts
@@ -252,6 +252,23 @@ export class Helpers {
         }
         return item;
     }
+
+    /**
+     * Workaround for Edge browser since Element:nextElementSibling is undefined inside of template directives
+     * @param element any document element
+     * @returns the next sibling node that is of type: Element
+     */
+    static getNextElementSibling(element: Element): Node {
+        if (element.nextElementSibling) {
+            return element.nextElementSibling;
+        } else {
+            let e = element.nextSibling;
+            while (e && 1 !== e.nodeType) {
+                e = e.nextSibling;
+            }
+            return e;
+        }
+    }
 }
 export class Can {
     obj: Object;


### PR DESCRIPTION
## **Description**

At times, Edge does not fill out the nextElementSibling. This method ensures that if it's missing, it gets calculated.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome`, `Firefox` and `Edge`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works
