### PR TITLE
Added min-width to address control to make flex behave in Firefox

### DIFF
--- a/src/elements/form/extras/address/Address.scss
+++ b/src/elements/form/extras/address/Address.scss
@@ -3,6 +3,7 @@ novo-address {
     flex-flow: row wrap;
 
     input {
+        min-width: 10px;
     }
 
     .street-address {


### PR DESCRIPTION
## **Description**

Added min-width to address control inputs to make flex behave in Firefox

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**