### PR TITLE
Feat (picker)/ make defaultOptions handle promise

### DIFF
--- a/src/elements/picker/extras/base-picker-results/BasePickerResults.spec.ts
+++ b/src/elements/picker/extras/base-picker-results/BasePickerResults.spec.ts
@@ -47,8 +47,14 @@ describe('Elements: BasePickerResults', () => {
 
     describe('Method: selectActiveMatch()', () => {
         it('should be defined.', () => {
+            spyOn(component, 'selectMatch');
             expect(component.selectActiveMatch).toBeDefined();
             component.selectActiveMatch();
+        });
+        it('should call selectMatch.', () => {
+            spyOn(component, 'selectMatch');
+            component.selectActiveMatch();
+            expect(component.selectMatch).toHaveBeenCalled();
         });
     });
 
@@ -56,6 +62,11 @@ describe('Elements: BasePickerResults', () => {
         it('should be defined.', () => {
             expect(component.prevActiveMatch).toBeDefined();
             component.prevActiveMatch();
+        });
+        it('should scroll to active.', () => {
+            spyOn(component, 'scrollToActive');
+            component.prevActiveMatch();
+            expect(component.scrollToActive).toHaveBeenCalled();
         });
     });
 

--- a/src/elements/picker/extras/base-picker-results/BasePickerResults.ts
+++ b/src/elements/picker/extras/base-picker-results/BasePickerResults.ts
@@ -114,9 +114,10 @@ export class BasePickerResults {
                     }
                 } else {
                     if (this.config.defaultOptions) {
-                        this.isStatic = false;
                         if (this.config.defaultOptions instanceof Function) {
-                            resolve(this.structureArray(this.config.defaultOptions()));
+                            this.config.defaultOptions(term, ++this.page)
+                            .then(this.structureArray.bind(this))
+                            .then(resolve, reject);
                         } else {
                             resolve(this.structureArray(this.config.defaultOptions));
                         }

--- a/src/elements/picker/extras/base-picker-results/BasePickerResults.ts
+++ b/src/elements/picker/extras/base-picker-results/BasePickerResults.ts
@@ -114,10 +114,16 @@ export class BasePickerResults {
                     }
                 } else {
                     if (this.config.defaultOptions) {
-                        if (this.config.defaultOptions instanceof Function) {
-                            this.config.defaultOptions(term, ++this.page)
-                            .then(this.structureArray.bind(this))
-                            .then(resolve, reject);
+                        this.isStatic = false;
+                        if (typeof this.config.defaultOptions === 'function') {
+                            let defaultOptions = this.config.defaultOptions(term, ++this.page);
+                            if (Object.getPrototypeOf(defaultOptions).hasOwnProperty('then')) {
+                                defaultOptions
+                                .then(this.structureArray.bind(this))
+                                .then(resolve, reject);
+                            } else {
+                                resolve(this.structureArray(defaultOptions));
+                            }
                         } else {
                             resolve(this.structureArray(this.config.defaultOptions));
                         }

--- a/src/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
+++ b/src/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
@@ -89,7 +89,7 @@ export class EntityPickerResult {
      */
     highlight(match, query) {
         // Replaces the capture string with a the same string inside of a "strong" tag
-        return query ? match.replace(new RegExp(this.escapeRegexp(query), 'gi'), '<strong>$&</strong>') : match;
+        return query && match ? match.replace(new RegExp(this.escapeRegexp(query), 'gi'), '<strong>$&</strong>') : match;
     }
 
     getIconForResult(result?: any) {


### PR DESCRIPTION
## **Description**
Make picker defaultOptions handle promises, as well as functions and arrays.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**