### PR TITLE
BH-52999 - Removed unneeded flex-basis - renders improperly in Safari

### DIFF
--- a/src/elements/form/Form.scss
+++ b/src/elements/form/Form.scss
@@ -153,7 +153,6 @@ novo-form {
                     novo-tip-well.active {
                         font-size: 0.8em;
                         padding: 5px 0;
-                        flex-basis: 100%;
                         margin-left: 22px;
                         margin-bottom: 5px;
                         max-width: 530px;


### PR DESCRIPTION
## **Description**

Removed unneeded flex-basis on description text for dynamic forms - renders improperly in Safari only when there is a long description text.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**

![image](https://user-images.githubusercontent.com/3843503/30292903-6508e282-96fd-11e7-9b16-da4004a31054.png)
