### PR TITLE
(feat) Field Interaction async loading animations, add/remove fields and open lists

### DIFF
--- a/demo/pages/elements/field-interactions/FieldInteractionsDemo.ts
+++ b/demo/pages/elements/field-interactions/FieldInteractionsDemo.ts
@@ -49,7 +49,7 @@ const template = `
                 <p><label>init</label> -- gets fired only when the form is initialized</p>
                 <p><label>change</label> -- gets fired when the value of the form control changes</p>
                 <p><label>focus</label> -- gets fired when the field gets focused</p>
-                <p><label>blue</label> -- gets fired when the field loses focus</p>
+                <p><label>blur</label> -- gets fired when the field loses focus</p>
                 <p>The script function represents the function that will be fired for the event, you can see examples of these below.</p>
                 <p>Lastly, "invokeOnInit" will also trigger the Field Interaction when the form is created as well.</p>
             </novo-nav-content>
@@ -143,9 +143,8 @@ const template = `
             </novo-nav-content>
             <novo-nav-content>
                 <h5>Adding / Removing Fields</h5>
-                <p>With the API you can quickly add/remove fields into the form.</p>
+                <p>With the API you can quickly add and remove fields on the form.</p>
                 <p><b>ONLY WORKS WITH DYNAMIC FORMS</b></p>
-                <p><b>ALSO ONLY USE WITH <code>init</code> SCRIPTS!</b></p>
                 <div class="example field-interaction-demo">${AddingRemovingTpl}</div>
                 <multi-code-snippet [code]="snippets.addingRemoving"></multi-code-snippet>
             </novo-nav-content>
@@ -352,31 +351,47 @@ export class FieldInteractionsDemoComponent {
             console.log('[FieldInteractionDemo] - addingRemovingFunction'); // tslint:disable-line
             // Control above field
             API.addControl('cat', {
-                name: 'fieldAbove',
+                key: 'fieldAbove',
                 type: 'text',
                 label: 'Added Above Cat'
             }, FieldInteractionApi.FIELD_POSITIONS.ABOVE_FIELD, 'DEFAULT');
             // Control below field
             API.addControl('name', {
-                name: 'fieldBelow',
+                key: 'fieldBelow',
                 type: 'text',
                 label: 'Added Below Name'
             }, FieldInteractionApi.FIELD_POSITIONS.BELOW_FIELD, ':)');
             // Control at the top of the form
             API.addControl('name', {
-                name: 'top',
+                key: 'top',
                 type: 'text',
                 label: 'Added To The Very Top'
             }, FieldInteractionApi.FIELD_POSITIONS.TOP_OF_FORM, 'HIGHEST');
             // Control at the bottom of the form
             API.addControl('name', {
-                name: 'bottom',
+                key: 'bottom',
                 type: 'text',
                 label: 'Added To The Very Bottom'
             }, FieldInteractionApi.FIELD_POSITIONS.BOTTOM_OF_FORM, 'LOWEST');
             // Remove the jersey color field
             API.removeControl('jersey-color');
         };
+
+        let removeAddOnChangeFunction = (API: FieldInteractionApi) => {
+            console.log('[FieldInteractionDemo] - removeAddOnChangeFunction'); // tslint:disable-line
+            // Select control with a field interaction on change event
+            let currentValue = API.getActiveValue();
+            if (currentValue === 'Yes') {
+                API.removeControl('to-be-removed');
+            } else {
+                API.addControl('remove-select', {
+                    key: 'to-be-removed',
+                    name: 'to-be-removed',
+                    type: 'text',
+                    label: 'This field will be removed'
+                }, FieldInteractionApi.FIELD_POSITIONS.BELOW_FIELD);
+            }
+        }
 
         // Validation Field Interactions
         this.controls.validation.validationControl = new TextBoxControl({
@@ -619,6 +634,9 @@ export class FieldInteractionsDemoComponent {
 
         // Adding / Removing Interactions
         this.controls.addingRemoving = formUtils.toFieldSets(MockMetaHeaders, '$ USD', {}, { token: 'TOKEN', military: true });
+        this.controls.addingRemoving[2].controls[0].interactions = [
+            { event: 'change', script: removeAddOnChangeFunction }
+        ]
         this.controls.addingRemoving[0].controls[0].interactions = [
             { event: 'init', script: addingRemovingFunction }
         ];
@@ -669,7 +687,8 @@ export class FieldInteractionsDemoComponent {
         };
         this.snippets.addingRemoving = {
             'Template': AddingRemovingTpl,
-            'Field Interaction Script': addingRemovingFunction.toString()
+            'Field Interaction Script (init)': addingRemovingFunction.toString(),
+            'Field Interaction Script (change)': removeAddOnChangeFunction.toString()
         };
     }
 }

--- a/demo/pages/elements/field-interactions/MockMeta.ts
+++ b/demo/pages/elements/field-interactions/MockMeta.ts
@@ -28,6 +28,19 @@ export const MockMeta = {
             type: 'text',
             label: 'Favorite Cat',
             sortOrder: 550
+        },
+        {
+            name: 'remove-select',
+            type: 'select',
+            label: 'Remove the field below?',
+            options: ['Yes', 'No'],
+            sortOrder: 301
+        },
+        {
+            name: 'to-be-removed',
+            type: 'text',
+            label: 'This field will be removed',
+            sortOrder: 302
         }
     ]
 };
@@ -41,6 +54,11 @@ export const MockMetaHeaders = {
         'label': 'Important',
         'name': 'sectionHeader2',
         'sortOrder': 45,
+        'enabled': true
+    }, {
+        'label': 'Remove field on change',
+        'name': 'sectionHeader3',
+        'sortOrder': 300,
         'enabled': true
     }],
 };

--- a/src/elements/form/Control.ts
+++ b/src/elements/form/Control.ts
@@ -176,9 +176,8 @@ export class NovoCustomControlContainerElement {
                     <!--Tip Wel-->
                     <novo-tip-well *ngIf="form.controls[control.key].tipWell" [name]="control.key" [tip]="form.controls[control.key]?.tipWell?.tip" [icon]="form.controls[control.key]?.tipWell?.icon" [button]="form.controls[control.key]?.tipWell?.button"></novo-tip-well>
                 </div>
-                <novo-loading *ngIf="form.controls[control.key].fieldInteractionloading && form.layout === 'vertical'" theme="multicolor"></novo-loading>
+                <novo-loading *ngIf="form.controls[control.key].fieldInteractionloading" theme="multicolor"></novo-loading>
             </div>
-            <novo-loading *ngIf="form.controls[control.key].fieldInteractionloading && form.layout !== 'vertical'" theme="multicolor"></novo-loading>
         </div>
     `,
     host: {

--- a/src/elements/form/Control.ts
+++ b/src/elements/form/Control.ts
@@ -176,7 +176,9 @@ export class NovoCustomControlContainerElement {
                     <!--Tip Wel-->
                     <novo-tip-well *ngIf="form.controls[control.key].tipWell" [name]="control.key" [tip]="form.controls[control.key]?.tipWell?.tip" [icon]="form.controls[control.key]?.tipWell?.icon" [button]="form.controls[control.key]?.tipWell?.button"></novo-tip-well>
                 </div>
+                <novo-loading *ngIf="form.controls[control.key].fieldInteractionloading && form.layout === 'vertical'" theme="multicolor"></novo-loading>
             </div>
+            <novo-loading *ngIf="form.controls[control.key].fieldInteractionloading && form.layout !== 'vertical'" theme="multicolor"></novo-loading>
         </div>
     `,
     host: {

--- a/src/elements/form/Control.ts
+++ b/src/elements/form/Control.ts
@@ -176,7 +176,19 @@ export class NovoCustomControlContainerElement {
                     <!--Tip Wel-->
                     <novo-tip-well *ngIf="form.controls[control.key].tipWell" [name]="control.key" [tip]="form.controls[control.key]?.tipWell?.tip" [icon]="form.controls[control.key]?.tipWell?.icon" [button]="form.controls[control.key]?.tipWell?.button"></novo-tip-well>
                 </div>
-                <novo-loading *ngIf="form.controls[control.key].fieldInteractionloading" theme="multicolor"></novo-loading>
+                <i *ngIf="form.controls[control.key].fieldInteractionloading" class="loading">
+                    <svg version="1.1"
+                     xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:a="http://ns.adobe.com/AdobeSVGViewerExtensions/3.0/"
+                     x="0px" y="0px" width="18.2px" height="18.5px" viewBox="0 0 18.2 18.5" style="enable-background:new 0 0 18.2 18.5;"
+                     xml:space="preserve">
+                    <style type="text/css">
+                        .spinner { fill:#FFFFFF; }
+                    </style>
+                        <path class="spinner" d="M9.2,18.5C4.1,18.5,0,14.4,0,9.2S4.1,0,9.2,0c0.9,0,1.9,0.1,2.7,0.4c0.8,0.2,1.2,1.1,1,1.9
+                            c-0.2,0.8-1.1,1.2-1.9,1C10.5,3.1,9.9,3,9.2,3C5.8,3,3,5.8,3,9.2s2.8,6.2,6.2,6.2c2.8,0,5.3-1.9,6-4.7c0.2-0.8,1-1.3,1.8-1.1
+                            c0.8,0.2,1.3,1,1.1,1.8C17.1,15.7,13.4,18.5,9.2,18.5z"/>
+                    </svg>
+                </i>
             </div>
         </div>
     `,

--- a/src/elements/form/FieldInteractionApi.ts
+++ b/src/elements/form/FieldInteractionApi.ts
@@ -438,6 +438,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             if (loading) {
+                this.form.controls[key].fieldInteractionloading = true;
                 control.setErrors({ 'loading': true });
                 // History
                 clearTimeout(this.asyncBlockTimeout);
@@ -447,6 +448,7 @@ export class FieldInteractionApi {
                     this.setProperty(key, '_displayedAsyncFailure', true);
                 }, 10000);
             } else {
+                this.form.controls[key].fieldInteractionloading = false;
                 clearTimeout(this.asyncBlockTimeout);
                 control.setErrors({ 'loading': null });
                 control.updateValueAndValidity({ emitEvent: false });

--- a/src/elements/form/FieldInteractionApi.ts
+++ b/src/elements/form/FieldInteractionApi.ts
@@ -460,10 +460,21 @@ export class FieldInteractionApi {
     }
 
     public addControl(key: string, metaForNewField: any, position: string = FieldInteractionApi.FIELD_POSITIONS.ABOVE_FIELD, initialValue?: any): void {
-        let control = this.getControl(key);
+        if (!metaForNewField.key) {
+            console.error('[FieldInteractionAPI] - missing "key" in meta for new field'); // tslint:disable-line
+            return null;
+        }
+
+        if (this.form.controls[metaForNewField.key]) {
+            // Field is already on the form
+            return null;
+        }
+
+        let control = this.form.controls[key];
+        let fieldsetIndex, controlIndex;
         if (control) {
-            let fieldsetIndex = -1;
-            let controlIndex = -1;
+            fieldsetIndex = -1;
+            controlIndex = -1;
 
             this.form.fieldsets.forEach((fieldset, fi) => {
                 fieldset.controls.forEach((fieldsetControl, ci) => {
@@ -509,6 +520,10 @@ export class FieldInteractionApi {
     }
 
     public removeControl(key: string): void {
+        if (!this.form.controls[key]) {
+            // Field is not on the form
+            return null;
+        }
         let control = this.getControl(key);
         if (control) {
             let fieldsetIndex = -1;

--- a/src/elements/form/FieldInteractionApi.ts
+++ b/src/elements/form/FieldInteractionApi.ts
@@ -437,7 +437,7 @@ export class FieldInteractionApi {
     public setLoading(key: string, loading: boolean) {
         let control = this.getControl(key);
         if (control) {
-            if (loading && control.value) {
+            if (loading) {
                 this.form.controls[key].fieldInteractionloading = true;
                 control.setErrors({ 'loading': true });
                 // History
@@ -460,9 +460,14 @@ export class FieldInteractionApi {
     }
 
     public addControl(key: string, metaForNewField: any, position: string = FieldInteractionApi.FIELD_POSITIONS.ABOVE_FIELD, initialValue?: any): void {
-        if (!metaForNewField.key) {
+        if (!metaForNewField.key && !metaForNewField.name) {
             console.error('[FieldInteractionAPI] - missing "key" in meta for new field'); // tslint:disable-line
             return null;
+        }
+
+        if (!metaForNewField.key) {
+            // If key is not explicitly declared, use name as key
+            metaForNewField.key = metaForNewField.name;
         }
 
         if (this.form.controls[metaForNewField.key]) {

--- a/src/elements/form/FieldInteractionApi.ts
+++ b/src/elements/form/FieldInteractionApi.ts
@@ -437,7 +437,7 @@ export class FieldInteractionApi {
     public setLoading(key: string, loading: boolean) {
         let control = this.getControl(key);
         if (control) {
-            if (loading) {
+            if (loading && control.value) {
                 this.form.controls[key].fieldInteractionloading = true;
                 control.setErrors({ 'loading': true });
                 // History

--- a/src/elements/form/Form.module.ts
+++ b/src/elements/form/Form.module.ts
@@ -26,8 +26,6 @@ import { NovoDragulaModule } from './../dragula/Dragula.module';
 import { NovoTipWellModule } from './../tip-well/TipWell.module';
 import { NovoModalModule } from './../modal/Modal.module';
 import { ControlConfirmModal } from './ControlConfirmModal';
-import { NovoLoadingModule } from '../loading/Loading.module';
-
 
 @NgModule({
     imports: [
@@ -50,8 +48,7 @@ import { NovoLoadingModule } from '../loading/Loading.module';
         TextMaskModule,
         NovoTipWellModule,
         NovoModalModule,
-        NovoButtonModule,
-        NovoLoadingModule
+        NovoButtonModule
     ],
     declarations: [NovoControlElement, NovoDynamicFormElement, NovoFormElement, NovoFieldsetElement, NovoFieldsetHeaderElement, NovoControlCustom, NovoCustomControlContainerElement, ControlConfirmModal],
     exports: [NovoDynamicFormElement, NovoControlElement, NovoFormElement, NovoFieldsetHeaderElement, NovoControlCustom, NovoCustomControlContainerElement],

--- a/src/elements/form/Form.module.ts
+++ b/src/elements/form/Form.module.ts
@@ -26,6 +26,8 @@ import { NovoDragulaModule } from './../dragula/Dragula.module';
 import { NovoTipWellModule } from './../tip-well/TipWell.module';
 import { NovoModalModule } from './../modal/Modal.module';
 import { ControlConfirmModal } from './ControlConfirmModal';
+import { NovoLoadingModule } from '../loading/Loading.module';
+
 
 @NgModule({
     imports: [
@@ -48,7 +50,8 @@ import { ControlConfirmModal } from './ControlConfirmModal';
         TextMaskModule,
         NovoTipWellModule,
         NovoModalModule,
-        NovoButtonModule
+        NovoButtonModule,
+        NovoLoadingModule
     ],
     declarations: [NovoControlElement, NovoDynamicFormElement, NovoFormElement, NovoFieldsetElement, NovoFieldsetHeaderElement, NovoControlCustom, NovoCustomControlContainerElement, ControlConfirmModal],
     exports: [NovoDynamicFormElement, NovoControlElement, NovoFormElement, NovoFieldsetHeaderElement, NovoControlCustom, NovoCustomControlContainerElement],

--- a/src/elements/form/Form.scss
+++ b/src/elements/form/Form.scss
@@ -240,17 +240,22 @@ novo-form {
                             align-items: center;
                             max-width: 550px;
                             position: relative;
-                            novo-loading {
+                            i.loading {
                                 display: flex;
-                                flex-direction: row;
+                                align-items: center;
+                                justify-content: center;
                                 position: absolute;
-                                top: 0;
                                 right: 0;
-                                padding: 0;
-                                flex: 1;
-                                span {
-                                    width: 0.8em;
-                                    height: 0.8em;
+                                top: 3px;
+                                animation: rotate 1200ms linear infinite;
+                                svg {
+                                    width: 100%;
+                                    height: 100%;
+                                    max-width: 15px;
+                                    max-height: 15px;
+                                    .spinner {
+                                        fill: $positive;
+                                    }
                                 }
                             }
                             .novo-control-inner-container {

--- a/src/elements/form/Form.scss
+++ b/src/elements/form/Form.scss
@@ -239,17 +239,18 @@ novo-form {
                             display: flex;
                             align-items: center;
                             max-width: 550px;
+                            position: relative;
                             novo-loading {
                                 display: flex;
                                 flex-direction: row;
-                                position: relative;
-                                top: -20px;
-                                left: 2em;
+                                position: absolute;
+                                top: 0;
+                                right: 0;
                                 padding: 0;
                                 flex: 1;
                                 span {
-                                    width: 10px;
-                                    height: 10px;
+                                    width: 0.8em;
+                                    height: 0.8em;
                                 }
                             }
                             .novo-control-inner-container {
@@ -532,9 +533,6 @@ novo-form {
                                             font-weight: 500;
                                         }
                                     }
-                                }
-                                novo-loading {
-                                    top: 0;
                                 }
                             }
                         }

--- a/src/elements/form/Form.scss
+++ b/src/elements/form/Form.scss
@@ -240,6 +240,7 @@ novo-form {
                             align-items: center;
                             max-width: 550px;
                             position: relative;
+                            width: 100%;
                             i.loading {
                                 display: flex;
                                 align-items: center;

--- a/src/elements/form/Form.scss
+++ b/src/elements/form/Form.scss
@@ -239,7 +239,19 @@ novo-form {
                             display: flex;
                             align-items: center;
                             max-width: 550px;
-                            flex: 2;
+                            novo-loading {
+                                display: flex;
+                                flex-direction: row;
+                                position: relative;
+                                top: -20px;
+                                left: 2em;
+                                padding: 0;
+                                flex: 1;
+                                span {
+                                    width: 10px;
+                                    height: 10px;
+                                }
+                            }
                             .novo-control-inner-container {
                                 display: flex;
                                 flex-direction: column;
@@ -520,6 +532,9 @@ novo-form {
                                             font-weight: 500;
                                         }
                                     }
+                                }
+                                novo-loading {
+                                    top: 0;
                                 }
                             }
                         }

--- a/src/utils/app-bridge/AppBridge.ts
+++ b/src/utils/app-bridge/AppBridge.ts
@@ -30,6 +30,7 @@ export type MosaicLists = 'Candidate' |'ClientContact' | 'ClientCorporation' |
 export interface IAppBridgeOpenListEvent {
     type: MosaicLists;
     keywords?: Array<string>;
+    criteria?: any;
 }
 
 export type NovoDataType = 'entitlements' | 'settings' | 'user';
@@ -241,7 +242,7 @@ export class AppBridge {
      */
     public openList(packet: IAppBridgeOpenListEvent): Promise<boolean> {
         let openListPacket = {};
-        Object.assign(openListPacket, { type: 'List', entityType: packet.type, keywords: packet.keywords });
+        Object.assign(openListPacket, { type: 'List', entityType: packet.type, keywords: packet.keywords, criteria: packet.criteria });
         return new Promise<boolean>((resolve, reject) => {
             if (this._handlers[AppBridgeHandler.OPEN_LIST]) {
                 this._handlers[AppBridgeHandler.OPEN_LIST](packet, (success: boolean) => {

--- a/src/utils/app-bridge/AppBridge.ts
+++ b/src/utils/app-bridge/AppBridge.ts
@@ -6,6 +6,7 @@ import { Subject } from 'rxjs/Subject';
 export enum AppBridgeHandler {
     HTTP,
     OPEN,
+    OPEN_LIST,
     CLOSE,
     REFRESH,
     PIN,
@@ -23,6 +24,14 @@ export interface IAppBridgeOpenEvent {
     passthrough?: string;
 }
 
+export type MosaicLists = 'Candidate' |'ClientContact' | 'ClientCorporation' |
+    'JobOrder' | 'JobSubmission' | 'JobPosting' | 'Placement' | 'Lead' |
+    'Opportunity';
+export interface IAppBridgeOpenListEvent {
+    type: MosaicLists;
+    keywords?: Array<string>;
+}
+
 export type NovoDataType = 'entitlements' | 'settings' | 'user';
 export interface IAppBridgeRequestDataEvent {
     type: NovoDataType;
@@ -38,6 +47,7 @@ const HTTP_VERBS = {
 const MESSAGE_TYPES = {
     REGISTER: 'register',
     OPEN: 'open',
+    OPEN_LIST: 'openList',
     CLOSE: 'close',
     REFRESH: 'refresh',
     PIN: 'pin',
@@ -110,6 +120,12 @@ export class AppBridge {
         postRobot.on(MESSAGE_TYPES.OPEN, (event) => {
             this._trace(MESSAGE_TYPES.OPEN, event);
             return this.open(event.data).then(success => {
+                return { success };
+            });
+        });
+        postRobot.on(MESSAGE_TYPES.OPEN_LIST, (event) => {
+            this._trace(MESSAGE_TYPES.OPEN_LIST, event);
+            return this.openList(event.data).then(success => {
                 return { success };
             });
         });
@@ -218,6 +234,38 @@ export class AppBridge {
             }
         });
     }
+
+    /**
+     * Fires or responds to an openList event
+     * @param packet any - packet of data to send with the open event
+     */
+    public openList(packet: IAppBridgeOpenListEvent): Promise<boolean> {
+        let openListPacket = {};
+        Object.assign(openListPacket, { type: 'List', entityType: packet.type, keywords: packet.keywords });
+        return new Promise<boolean>((resolve, reject) => {
+            if (this._handlers[AppBridgeHandler.OPEN_LIST]) {
+                this._handlers[AppBridgeHandler.OPEN_LIST](packet, (success: boolean) => {
+                    if (success) {
+                        resolve(true);
+                    } else {
+                        reject(false);
+                    }
+                });
+            } else {
+                postRobot.sendToParent(MESSAGE_TYPES.OPEN_LIST, packet).then((event) => {
+                    this._trace(`${MESSAGE_TYPES.OPEN_LIST} (callback)`, event);
+                    if (event.data) {
+                        resolve(true);
+                    } else {
+                        reject(false);
+                    }
+                }).catch((err) => {
+                    reject(false);
+                });
+            }
+        });
+    }
+
 
     /**
      * Fires or responds to an close event


### PR DESCRIPTION
## **Description**
Work on FieldInteractionApi and AppBridge

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE
- Changed AppBridge to create method for opening lists
- Changed FieldInteractionAPI to allow adding/removing fields on events other than onInit
- Added loading animation for async field interactions in Control.ts
- Styling changes to Form to allow for loading animation

#### **Verify that...**

- [ X ] Any related demos where added and `npm start` still works
- [ X ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ X ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased (no unit tests added)
- [ X ] `npm run compile` still works

##### **Screenshots**
![bluespinner](https://user-images.githubusercontent.com/3916731/30390451-cc92eb4e-987b-11e7-944b-85d3fb882981.gif)
