### PR TITLE
fix(Select): Styles and timings messed with Append to body

### DIFF
--- a/demo/pages/elements/select/SelectDemo.ts
+++ b/demo/pages/elements/select/SelectDemo.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
 let BasicSelectDemoTpl = require('./templates/BasicSelectDemo.html');
 let LongSelectDemoTpl = require('./templates/LongSelectDemo.html');
 
-const template = `
+const template: string = `
 <div class="container">
     <h1>Select <small><a target="_blank" href="https://github.com/bullhorn/novo-elements/blob/master/src/elements/select">(source)</a></small></h1>
     <p>The select element (<code>novo-select</code>) represents a control that presents a menu of options. The options

--- a/demo/pages/elements/select/templates/LongSelectDemo.html
+++ b/demo/pages/elements/select/templates/LongSelectDemo.html
@@ -1,5 +1,4 @@
 <div>
-    <label>
-        <span class="caption">Selected Value:</span>{{state}}</label>
+    <label><span class="caption">Selected Value:</span>{{state}}</label>
     <novo-select [options]="states" [placeholder]="placeholder" [(ngModel)]="state"></novo-select>
 </div>

--- a/src/elements/select/Select.scss
+++ b/src/elements/select/Select.scss
@@ -59,7 +59,6 @@ novo-select {
 
 .novo-select-list {
     &.active {
-        position: absolute;
         z-index: 1000;
         max-height: 219px;
         min-width: 200px;
@@ -73,13 +72,11 @@ novo-select {
     cursor: default;
     list-style: none;
     line-height: 26px;
-    overflow: hidden;
+    overflow: auto;
     margin: 0;
-    max-height: 0;
-    position: absolute;
     padding: 0;
-    transform: translateY(-50%);
-    transition: all 0.15s cubic-bezier(0.35, 0, 0.25, 1);
+    //transform: translateY(-50%);
+    //transition: all 0.15s cubic-bezier(0.35, 0, 0.25, 1);
     width: 100%;
     box-shadow: 0 -1px 3px -2px rgba(0, 0, 0, .2), 0 2px 2px 0 rgba(0, 0, 0, .14), 0 1px 5px 0 rgba(0, 0, 0, .12);
     font-size: 1rem;

--- a/src/elements/select/Select.ts
+++ b/src/elements/select/Select.ts
@@ -21,7 +21,7 @@ const SELECT_VALUE_ACCESSOR = {
     providers: [SELECT_VALUE_ACCESSOR],
     template: `
         <div (click)="openPanel()" tabIndex="0" type="button" [class.empty]="empty">{{selected.label}}<i class="bhi-collapse"></i></div>
-        <novo-overlay-template [parent]="element">
+        <novo-overlay-template [parent]="element" position="center">
             <ul class="novo-select-list" tabIndex="-1" [class.header]="headerConfig" [class.active]="panelOpen">
                 <ng-content></ng-content>
                 <li *ngIf="headerConfig" class="select-header" [class.open]="header.open">
@@ -104,6 +104,10 @@ export class NovoSelectElement implements OnInit, OnChanges {
             this.select(item, index);
         } else {
             this.writeValue(this.model);
+        }
+
+        if ( this.panelOpen ) {
+            this.openPanel();
         }
     }
 


### PR DESCRIPTION
Styles and timings messed with Append to body

Selects pop-ups will now position appropriately when at top or bottom of the screen

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**

![screen shot 2017-09-21 at 4 10 14 pm](https://user-images.githubusercontent.com/1056055/30716275-75fc13ce-9ee7-11e7-8729-721aa04bcd79.png)

![screen shot 2017-09-21 at 4 10 28 pm](https://user-images.githubusercontent.com/1056055/30716280-79053e10-9ee7-11e7-939a-3e8407de301d.png)

![screen shot 2017-09-21 at 4 10 40 pm](https://user-images.githubusercontent.com/1056055/30716288-7d3700e0-9ee7-11e7-94ac-4f506d3b4e95.png)
