### PR TITLE
fix: event was no longer used but still lingered

### DIFF
--- a/src/elements/overlay/Overlay.ts
+++ b/src/elements/overlay/Overlay.ts
@@ -131,7 +131,7 @@ export class NovoOverlayTemplate implements OnDestroy {
                 this._overlayRef.detach();
                 this._closingActionsSubscription.unsubscribe();
             }
-            this.closing.emit(event);
+            this.closing.emit(true);
             if (this._panelOpen) {
                 this._panelOpen = false;
                 // We need to trigger change detection manually, because


### PR DESCRIPTION
## **Description**

event was left behind and some browser thought it was window.event so it worked fine.