### PR TITLE
added the encrypted icon to the control form when the field is a customEncrypted field

### DIFF
--- a/src/elements/form/Control.ts
+++ b/src/elements/form/Control.ts
@@ -99,12 +99,14 @@ export class NovoCustomControlContainerElement {
     selector: 'novo-control',
     template: `
         <div class="novo-control-container" [formGroup]="form" [hidden]="form.controls[control.key].hidden || form.controls[control.key].type === 'hidden' || form.controls[control.key].controlType === 'hidden'">
-            <!--Encrypted Field-->
-            <i [hidden]="!isFieldEncrypted(control)"
-               class="bhi-lock">
-            </i>
             <!--Label (for horizontal)-->
-            <label [attr.for]="control.key" *ngIf="form.layout !== 'vertical' && form.controls[control.key].label && !condensed">{{ form.controls[control.key].label }}</label>
+            <label [attr.for]="control.key" *ngIf="form.layout !== 'vertical' && form.controls[control.key].label && !condensed">
+                <!--Encrypted Field-->
+                <i [hidden]="!form.controls[control.key].encrypted"
+                class="bhi-lock">
+                </i>
+                {{ form.controls[control.key].label }}
+            </label>
             <div class="novo-control-outer-container">
                 <!--Label (for vertical)-->
                 <label
@@ -327,10 +329,6 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
                 }
             });
         }
-    }
-
-    isFieldEncrypted(control: any): boolean {
-        return control.key.indexOf('customEncrypted') > -1;
     }
 
     executeInteraction(interaction) {

--- a/src/elements/form/Control.ts
+++ b/src/elements/form/Control.ts
@@ -99,6 +99,10 @@ export class NovoCustomControlContainerElement {
     selector: 'novo-control',
     template: `
         <div class="novo-control-container" [formGroup]="form" [hidden]="form.controls[control.key].hidden || form.controls[control.key].type === 'hidden' || form.controls[control.key].controlType === 'hidden'">
+            <!--Encrypted Field-->
+            <i [hidden]="!isFieldEncrypted(control)"
+               class="bhi-lock">
+            </i>
             <!--Label (for horizontal)-->
             <label [attr.for]="control.key" *ngIf="form.layout !== 'vertical' && form.controls[control.key].label && !condensed">{{ form.controls[control.key].label }}</label>
             <div class="novo-control-outer-container">
@@ -323,6 +327,10 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
                 }
             });
         }
+    }
+
+    isFieldEncrypted(control: any): boolean {
+        return control.key.indexOf('customEncrypted') > -1;
     }
 
     executeInteraction(interaction) {

--- a/src/elements/form/Form.scss
+++ b/src/elements/form/Form.scss
@@ -238,6 +238,11 @@ novo-form {
                         flex-wrap: nowrap;
                         align-items: flex-start;
                         width: 100%;
+                        i.bhi-lock {
+                            color: $grey;
+                            font-weight: 500;
+                            padding-right: 5px;
+                        }
                         >label {
                             @extend .novo-form-control-label;
                         }

--- a/src/elements/form/NovoFormControl.ts
+++ b/src/elements/form/NovoFormControl.ts
@@ -8,6 +8,7 @@ import { Helpers } from '../../utils/Helpers';
 export class NovoFormControl extends FormControl {
     displayValueChanges: EventEmitter<any> = new EventEmitter<any>();
     hidden: boolean;
+    encrypted: boolean;
     key: string;
     required: boolean;
     readOnly: boolean;
@@ -56,6 +57,7 @@ export class NovoFormControl extends FormControl {
         this.label = control.label;
         this.readOnly = control.readOnly;
         this.hidden = control.hidden;
+        this.encrypted = control.encrypted;
         this.config = control.config;
         this.type = control.type;
         this.subType = control.subType;
@@ -66,7 +68,6 @@ export class NovoFormControl extends FormControl {
         this.label = control.label;
         this.name = control.name;
         this.required = control.required;
-        this.hidden = control.hidden;
         this.sortOrder = control.sortOrder;
         this.controlType = control.controlType;
         this.placeholder = control.placeholder;

--- a/src/elements/form/controls/BaseControl.spec.ts
+++ b/src/elements/form/controls/BaseControl.spec.ts
@@ -30,6 +30,9 @@ describe('Control: BaseControl', () => {
         it('should set the hidden', () => {
             expect(control.hidden).toBe(false);
         });
+        it('should set the encrypted', () => {
+            expect(control.encrypted).toBe(false);
+        });
         it('should set the multiple', () => {
             expect(control.multiple).toBe(false);
         });
@@ -68,6 +71,7 @@ describe('Control: BaseControl', () => {
                 label: 'TEST_LABEL',
                 required: true,
                 hidden: false,
+                encrypted: true,
                 sortOrder: 2,
                 placeholder: 'TEST_PLACEHOLDER',
                 config: { test: 'TEST_CONFIG' },
@@ -98,6 +102,9 @@ describe('Control: BaseControl', () => {
         });
         it('should set the hidden', () => {
             expect(control.hidden).toBe(false);
+        });
+        it('should set the encrypted', () => {
+            expect(control.encrypted).toBe(true);
         });
         it('should set the multiple', () => {
             expect(control.multiple).toBe(true);

--- a/src/elements/form/controls/BaseControl.ts
+++ b/src/elements/form/controls/BaseControl.ts
@@ -23,6 +23,7 @@ export interface NovoControlConfig {
     checkboxLabel?: string;
     required?: boolean;
     hidden?: boolean;
+    encrypted?: boolean;
     sortOrder?: number;
     controlType?: string;
     placeholder?: string;
@@ -74,6 +75,7 @@ export class BaseControl {
     checkboxLabel: string;
     required: boolean;
     hidden: boolean;
+    encrypted: boolean;
     sortOrder: number;
     controlType: string;
     placeholder: string;
@@ -124,6 +126,7 @@ export class BaseControl {
         this.name = config.name || '';
         this.required = !!config.required;
         this.hidden = !!config.hidden;
+        this.encrypted = !!config.encrypted;
         this.sortOrder = config.sortOrder === undefined ? 1 : config.sortOrder;
         this.controlType = config.controlType || '';
         this.placeholder = config.placeholder || '';

--- a/src/utils/form-utils/FormUtils.ts
+++ b/src/utils/form-utils/FormUtils.ts
@@ -110,6 +110,10 @@ export class FormUtils {
         return type;
     }
 
+    isFieldEncrypted(key: string): boolean {
+        return key.indexOf('customEncrypted') > -1;
+    }
+
     getControlForField(field: any, http, config: { token?: string, restUrl?: string, military?: boolean }, overrides?: any, forTable: boolean = false) {
         // TODO: if field.type overrides `determineInputType` we should use it in that method or use this method
         // TODO: (cont.) as the setter of the field argument
@@ -122,6 +126,7 @@ export class FormUtils {
             placeholder: field.hint || '',
             required: field.required,
             hidden: !field.required,
+            encrypted: this.isFieldEncrypted(field.name ? field.name : ''),
             value: field.value || field.defaultValue,
             sortOrder: field.sortOrder,
             associatedEntity: field.associatedEntity,


### PR DESCRIPTION

![encryptedfields](https://user-images.githubusercontent.com/3289584/32557666-66042e7e-c468-11e7-9679-8a7232d52c79.PNG)
## **Description**

added the encrypted icon to the control form when the field is a customEncrypted field

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**