### PR TITLE
fix capitalization to prevent unix environment build fails

### DIFF
--- a/novo-elements.scss
+++ b/novo-elements.scss
@@ -61,4 +61,4 @@
 @import "./src/elements/table/extras/dropdown-cell/DropdownCell";
 @import "./src/elements/search/SearchBox";
 @import "./src/elements/places/places.component";
-@import "./src/elements/Value/Values";
+@import "./src/elements/value/Values";


### PR DESCRIPTION
## **Description**

The capitalization was wrong for value causing build failures for projects that use novo-elements

#### **Verify that...**

- [ x ] Any related demos where added and `npm start` still works
- [ x ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ x ] `npm run lint` passes
- [ x ] `npm test` passes and code coverage is increased
- [ x ] `npm run compile` still works

##### **Screenshots**