### PR TITLE
removed extra key in object literal declaration

### DIFF
--- a/src/elements/form/ControlGroup.ts
+++ b/src/elements/form/ControlGroup.ts
@@ -53,7 +53,7 @@ export interface NovoControlGroupAddConfig {
                 <div class="novo-control-group-row" *ngFor="let control of form?.controls[key]['controls']; let index = index;">
                     <ng-template
                         [ngTemplateOutlet]="rowTemplate || defaultTemplate"
-                        [ngTemplateOutletContext]="{form: form, index: index, key: key, controls: controls, key: key}">
+                        [ngTemplateOutletContext]="{form: form, index: index, key: key, controls: controls}">
                     </ng-template>
                 </div>
             </ng-container>


### PR DESCRIPTION
## **Description**

Was getting build errors in Novo due to the duplicate key in an object literal declaration. This is just to remove the duplicate.

#### **Verify that...**

- [ ] Any related demos where added and `npm start` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run compile` still works

##### **Screenshots**