### PR TITLE
BBO-2152 - Create css for first button in control row in control group

### DIFF
--- a/src/elements/form/ControlGroup.scss
+++ b/src/elements/form/ControlGroup.scss
@@ -109,6 +109,16 @@ novo-control-group {
                     display: flex;
                     align-items: center;
                 }
+                &.first {
+                    > span i {
+                        margin: 0;
+                    }
+                    min-width: 40px;
+                    max-width: 40px;
+                    margin-left: 0;
+                    display: flex;
+                    align-items: center;
+                }
                 &.last {
                     min-width: 40px;
                     max-width: 40px;


### PR DESCRIPTION
## **Description**

added css to handle the first button in a control group row. putting it here because it seems like the most useful place to have it since it's not BBO-specific.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**