### PR TITLE
fix(control): move lock outside of label to better handle multi-line …

### DIFF
--- a/src/elements/form/Control.ts
+++ b/src/elements/form/Control.ts
@@ -99,12 +99,12 @@ export class NovoCustomControlContainerElement {
     selector: 'novo-control',
     template: `
         <div class="novo-control-container" [formGroup]="form" [hidden]="form.controls[control.key].hidden || form.controls[control.key].type === 'hidden' || form.controls[control.key].controlType === 'hidden'">
+            <!--Encrypted Field-->
+            <i [hidden]="!form.controls[control.key].encrypted"
+            class="bhi-lock">
+            </i>
             <!--Label (for horizontal)-->
-            <label [attr.for]="control.key" *ngIf="form.layout !== 'vertical' && form.controls[control.key].label && !condensed">
-                <!--Encrypted Field-->
-                <i [hidden]="!form.controls[control.key].encrypted"
-                class="bhi-lock">
-                </i>
+            <label [attr.for]="control.key" *ngIf="form.layout !== 'vertical' && form.controls[control.key].label && !condensed" [ngClass]="{'encrypted': form.controls[control.key].encrypted }">
                 {{ form.controls[control.key].label }}
             </label>
             <div class="novo-control-outer-container">

--- a/src/elements/form/Form.scss
+++ b/src/elements/form/Form.scss
@@ -15,6 +15,10 @@
     padding-top: 8px;
     word-break: word-break;
     overflow-wrap: break-word;
+    &.encrypted{
+        max-width: 110px;
+        min-width: 110px;
+    }
 }
 
 novo-dynamic-form,
@@ -239,9 +243,11 @@ novo-form {
                         align-items: flex-start;
                         width: 100%;
                         i.bhi-lock {
+                            width: 20px;
                             color: $grey;
                             font-weight: 500;
-                            padding-right: 5px;
+                            font-size: 1.2em;
+                            padding-top: 6px;
                         }
                         >label {
                             @extend .novo-form-control-label;


### PR DESCRIPTION
…label

## **Description**
update styling to better handle multi-line labels
![screen shot 2017-11-15 at 11 30 39 am](https://user-images.githubusercontent.com/7002678/32850751-abad8188-c9f8-11e7-9204-9093304f7db9.png)


#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**