### PR TITLE
BBO-2152 - (fix) added onAdd to Control Groups

### DIFF
--- a/src/elements/form/ControlGroup.ts
+++ b/src/elements/form/ControlGroup.ts
@@ -138,6 +138,7 @@ export class NovoControlGroup implements AfterContentInit, OnChanges {
 
     @Output() public onRemove: EventEmitter<any> = new EventEmitter<any>();
     @Output() public onEdit: EventEmitter<any> = new EventEmitter<any>();
+    @Output() public onAdd: EventEmitter<any> = new EventEmitter<any>();
 
     public controlLabels: { value: string, width: number }[] = [];
     public toggled: boolean = false;
@@ -195,6 +196,9 @@ export class NovoControlGroup implements AfterContentInit, OnChanges {
             edit: this.checkCanEdit(this.currentIndex),
             remove: this.checkCanRemove(this.currentIndex),
         });
+        if (!value) {
+            this.onAdd.emit();
+        }
         this.currentIndex++;
         this.ref.markForCheck();
     }


### PR DESCRIPTION
## **Description**

Added an event emitter for adding a new row to the control group class

#### **Verify that...**

- [ ] Any related demos where added and `npm start` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run compile` still works

##### **Screenshots**