### PR TITLE
Change to allow CKEditor to have a minimal configuration

### DIFF
--- a/demo/pages/elements/editor/EditorDemo.ts
+++ b/demo/pages/elements/editor/EditorDemo.ts
@@ -2,17 +2,24 @@
 import { Component } from '@angular/core';
 // APP
 let BasicDemoTpl = require('./templates/BasicEditorDemo.html');
+let MinimalDemoTpl = require('./templates/MinimalEditorDemo.html');
 
 const template = `
 <div class="container">
     <h1>CK Editor <small><a target="_blank" href="https://github.com/bullhorn/novo-elements/blob/master/src/elements/ckeditor">(source)</a></small></h1>
     <p>Basic HTML editor using CK Editor.</p>
 
-    <h5>Basic</h5>
-    <button theme="primary" (click)="insertText(editor)">Insert "Hello World" at Cursor</button>
+    <h5>Basic Example</h5>
+    <button theme="primary" (click)="insertText(editor1)">Insert "Hello World" at Cursor</button>
     <br />
     <div class="example editor-demo">${BasicDemoTpl}</div>
     <code-snippet [code]="BasicDemoTpl"></code-snippet>
+
+    <h5>Minimal Example</h5>
+    <button theme="primary" (click)="insertText(editor2)">Insert "Hello World" at Cursor</button>
+    <br />
+    <div class="example editor-demo">${MinimalDemoTpl}</div>
+    <code-snippet [code]="MinimalDemoTpl"></code-snippet>
 </div>
 `;
 
@@ -21,8 +28,9 @@ const template = `
     template: template
 })
 export class EditorDemoComponent {
-    private BasicDemoTpl:string = BasicDemoTpl;
-    private editorValue:string = '<p>I AM A PRE-RENDERED VALUE</p><h1>TEST</h1>';
+    private BasicDemoTpl: string = BasicDemoTpl;
+    private MinimalDemoTpl: string = MinimalDemoTpl;
+    private editorValue: string = '<p>I AM A PRE-RENDERED VALUE</p><h1>TEST</h1>';
 
     insertText(editor) {
         editor.insertText('Hello World');

--- a/demo/pages/elements/editor/templates/BasicEditorDemo.html
+++ b/demo/pages/elements/editor/templates/BasicEditorDemo.html
@@ -1,7 +1,7 @@
-<novo-editor [name]="'demoEditor'" [(ngModel)]="editorValue" #editor></novo-editor>
+<novo-editor [name]="'demoEditor'" [(ngModel)]="editorValue1" #editor1></novo-editor>
 
 <p>Value:</p>
-<p [innerHtml]="editorValue"></p>
+<p [innerHtml]="editorValue1"></p>
 
 <p>HTML:</p>
-<pre><code>{{editorValue}}</code></pre>
+<pre><code>{{editorValue1}}</code></pre>

--- a/demo/pages/elements/editor/templates/MinimalEditorDemo.html
+++ b/demo/pages/elements/editor/templates/MinimalEditorDemo.html
@@ -1,0 +1,7 @@
+<novo-editor [name]="'demoEditor'" [(ngModel)]="editorValue2" [minimal]="true" #editor2></novo-editor>
+
+<p>Value:</p>
+<p [innerHtml]="editorValue2"></p>
+
+<p>HTML:</p>
+<pre><code>{{editorValue2}}</code></pre>

--- a/demo/pages/elements/form/MockMeta.ts
+++ b/demo/pages/elements/form/MockMeta.ts
@@ -452,6 +452,22 @@ export const MockMeta = {
             label: 'Custom Component',
             required: true,
             description: 'This is a custom component you can use instead'
+        }, {
+            name: 'htmlFieldFullEditor',
+            label: 'CK Editor - Full',
+            required: true,
+            sortOrder: 9011,
+            dataSpecialization: 'HTML',
+            type: 'SCALAR',
+            dataType: 'String'
+        }, {
+            name: 'htmlFieldMinimalEditor',
+            label: 'CK Editor - Minimal',
+            required: true,
+            sortOrder: 9012,
+            dataSpecialization: 'HTML-MINIMAL',
+            type: 'SCALAR',
+            dataType: 'String'
         }
     ]
 };

--- a/src/elements/ckeditor/CKEditor.spec.ts
+++ b/src/elements/ckeditor/CKEditor.spec.ts
@@ -104,7 +104,6 @@ describe('Elements: NovoCKEditorElement', () => {
                 enterMode: window['CKEDITOR'].ENTER_BR,
                 shiftEnterMode: window['CKEDITOR'].ENTER_P,
                 disableNativeSpellChecker: false,
-                resize_enabled: true,
                 removePlugins: 'liststyle,tabletools,contextmenu',
                 toolbar: [
                     { name: 'clipboard', items: ['Paste', 'PasteText', 'PasteFromWord', 'Undo', 'Redo'] },
@@ -126,7 +125,6 @@ describe('Elements: NovoCKEditorElement', () => {
                 enterMode: window['CKEDITOR'].ENTER_BR,
                 shiftEnterMode: window['CKEDITOR'].ENTER_P,
                 disableNativeSpellChecker: false,
-                resize_enabled: true,
                 removePlugins: 'liststyle,tabletools,contextmenu',
                 toolbar: [{
                     name: 'basicstyles',

--- a/src/elements/ckeditor/CKEditor.spec.ts
+++ b/src/elements/ckeditor/CKEditor.spec.ts
@@ -32,7 +32,7 @@ describe('Elements: NovoCKEditorElement', () => {
         });
     });
 
-    xdescribe('Method: ngAfterViewInit()', () => {
+    describe('Method: ngAfterViewInit()', () => {
         beforeEach(() => {
             spyOn(component, 'ckeditorInit');
         });
@@ -42,26 +42,16 @@ describe('Elements: NovoCKEditorElement', () => {
         });
 
         it('should set the base config', () => {
-            component.config = {};
+            spyOn(component, 'getBaseConfig').and.returnValue({ test: true });
             component.ngAfterViewInit();
-            expect(component.ckeditorInit).toHaveBeenCalledWith({});
+            expect(component.ckeditorInit).toHaveBeenCalledWith({ test: true });
         });
 
         it('should set with passed config', () => {
-            component.config = { test: 123 };
+            spyOn(component, 'getBaseConfig').and.returnValue({ test: false });
+            component.config = { test: true };
             component.ngAfterViewInit();
-            expect(component.ckeditorInit).toHaveBeenCalledWith({ test: 123 });
-        });
-    });
-
-    xdescribe('Method: onValueChange()', () => {
-        it('should be defined', () => {
-            expect(component.onValueChange).toBeDefined();
-        });
-
-        it('should emit the change', () => {
-            component.onValueChange();
-            expect(component.change.emit).toHaveBeenCalledWith('INITIAL VALUE');
+            expect(component.ckeditorInit).toHaveBeenCalledWith({ test: true });
         });
     });
 
@@ -109,12 +99,12 @@ describe('Elements: NovoCKEditorElement', () => {
             expect(component.getBaseConfig).toBeDefined();
         });
 
-        it('should work', () => {
-            let config = component.getBaseConfig();
-            expect(config).toEqual({
-                enterMode : window['CKEDITOR'].ENTER_BR,
+        it('should return extended config object', () => {
+            expect(component.getBaseConfig()).toEqual({
+                enterMode: window['CKEDITOR'].ENTER_BR,
                 shiftEnterMode: window['CKEDITOR'].ENTER_P,
                 disableNativeSpellChecker: false,
+                resize_enabled: true,
                 removePlugins: 'liststyle,tabletools,contextmenu',
                 toolbar: [
                     { name: 'clipboard', items: ['Paste', 'PasteText', 'PasteFromWord', 'Undo', 'Redo'] },
@@ -127,6 +117,21 @@ describe('Elements: NovoCKEditorElement', () => {
                     { name: 'styles', items: ['Styles', 'Format', 'Font', 'FontSize'] },
                     { name: 'colors', items: ['TextColor', 'BGColor'] }
                 ]
+            });
+        });
+
+        it('should return minimal config object', () => {
+            component.minimal = true;
+            expect(component.getBaseConfig()).toEqual({
+                enterMode: window['CKEDITOR'].ENTER_BR,
+                shiftEnterMode: window['CKEDITOR'].ENTER_P,
+                disableNativeSpellChecker: false,
+                resize_enabled: true,
+                removePlugins: 'liststyle,tabletools,contextmenu',
+                toolbar: [{
+                    name: 'basicstyles',
+                    items: ['Styles', 'FontSize', 'Bold', 'Italic', 'Underline', 'TextColor', '-', 'NumberedList', 'BulletedList', 'Outdent', 'Indent', 'Link']
+                }]
             });
         });
     });

--- a/src/elements/ckeditor/CKEditor.ts
+++ b/src/elements/ckeditor/CKEditor.ts
@@ -133,8 +133,7 @@ export class NovoCKEditorElement implements OnDestroy, AfterViewInit {
             enterMode: CKEDITOR.ENTER_BR,
             shiftEnterMode: CKEDITOR.ENTER_P,
             disableNativeSpellChecker: false,
-            resize_enabled: true,
-            removePlugins: 'liststyle,tabletools,contextmenu'
+            removePlugins: 'liststyle,tabletools,contextmenu' // allows browser based spell checking
         };
 
         const minimalConfig = {
@@ -151,7 +150,7 @@ export class NovoCKEditorElement implements OnDestroy, AfterViewInit {
                 { name: 'links', items: ['Link'] },
                 { name: 'insert', items: ['Image', 'Table', 'HorizontalRule'] },
                 { name: 'tools', items: ['Maximize', 'Source'] },
-                '/',
+                '/', // line break
                 { name: 'basicstyles', items: ['Bold', 'Italic', 'Underline', 'Strike', 'Subscript', 'Superscript'] },
                 { name: 'styles', items: ['Styles', 'Format', 'Font', 'FontSize'] },
                 { name: 'colors', items: ['TextColor', 'BGColor'] }

--- a/src/elements/ckeditor/CKEditor.ts
+++ b/src/elements/ckeditor/CKEditor.ts
@@ -25,6 +25,7 @@ export class NovoCKEditorElement implements OnDestroy, AfterViewInit {
     @Input() config;
     @Input() debounce;
     @Input() name;
+    @Input() minimal;
 
     @Output() change = new EventEmitter();
     @Output() ready = new EventEmitter();
@@ -128,11 +129,22 @@ export class NovoCKEditorElement implements OnDestroy, AfterViewInit {
     }
 
     getBaseConfig() {
-        return {
-            enterMode : CKEDITOR.ENTER_BR,
+        const baseConfig = {
+            enterMode: CKEDITOR.ENTER_BR,
             shiftEnterMode: CKEDITOR.ENTER_P,
             disableNativeSpellChecker: false,
-            removePlugins: 'liststyle,tabletools,contextmenu', // allows browser based spell checking
+            resize_enabled: true,
+            removePlugins: 'liststyle,tabletools,contextmenu'
+        };
+
+        const minimalConfig = {
+            toolbar: [{
+                name: 'basicstyles',
+                items: ['Styles', 'FontSize', 'Bold', 'Italic', 'Underline', 'TextColor', '-', 'NumberedList', 'BulletedList', 'Outdent', 'Indent', 'Link']
+            }]
+        };
+
+        const extendedConfig = {
             toolbar: [
                 { name: 'clipboard', items: ['Paste', 'PasteText', 'PasteFromWord', 'Undo', 'Redo'] },
                 { name: 'paragraph', items: ['NumberedList', 'BulletedList', 'Outdent', 'Indent', 'Blockquote', 'CreateDiv', 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock', 'BidiLtr', 'BidiRtl'] },
@@ -145,6 +157,8 @@ export class NovoCKEditorElement implements OnDestroy, AfterViewInit {
                 { name: 'colors', items: ['TextColor', 'BGColor'] }
             ]
         };
+
+        return Object.assign(baseConfig, this.minimal ? minimalConfig : extendedConfig);
     }
 
     writeValue(value) {

--- a/src/elements/form/Control.ts
+++ b/src/elements/form/Control.ts
@@ -141,7 +141,7 @@ export class NovoCustomControlContainerElement {
                             <!--TextArea-->
                             <textarea *ngSwitchCase="'text-area'" [name]="control.key" [attr.id]="control.key" [placeholder]="form.controls[control.key].placeholder" [formControlName]="control.key" autosize (input)="handleTextAreaInput($event)" (focus)="handleFocus($event)" (blur)="handleBlur($event)" [maxlength]="control.maxlength" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition"></textarea>
                             <!--Editor-->
-                            <novo-editor *ngSwitchCase="'editor'" [name]="control.key" [formControlName]="control.key" (focus)="handleFocus($event)" (blur)="handleBlur($event)"></novo-editor>
+                            <novo-editor *ngSwitchCase="'editor'" [name]="control.key" [formControlName]="control.key" [minimal]="control.minimal" (focus)="handleFocus($event)" (blur)="handleBlur($event)"></novo-editor>
                             <!--HTML5 Select-->
                             <select [id]="control.key" *ngSwitchCase="'native-select'" [formControlName]="control.key" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition">
                                 <option *ngIf="form.controls[control.key].placeholder" value="" disabled selected hidden>{{ form.controls[control.key].placeholder }}</option>

--- a/src/elements/form/controls/editor/EditorControl.ts
+++ b/src/elements/form/controls/editor/EditorControl.ts
@@ -3,6 +3,7 @@ import { BaseControl, NovoControlConfig } from './../BaseControl';
 
 export class EditorControl extends BaseControl {
     controlType = 'editor';
+    minimal: boolean = false;
 
     constructor(config: NovoControlConfig) {
         super('EditorControl', config);

--- a/src/utils/form-utils/FormUtils.spec.ts
+++ b/src/utils/form-utils/FormUtils.spec.ts
@@ -90,6 +90,9 @@ describe('Utils: FormUtils', () => {
             expect(formUtils.determineInputType).toBeDefined();
             expect(formUtils.determineInputType({ dataSpecialization: 'YEAR' })).toBe('year');
         });
+        it('should return the type of editor minimal correctly', () => {
+            expect(formUtils.determineInputType({ dataSpecialization: 'HTML-MINIMAL' })).toEqual('html-minimal');
+        });
         it('should return the type of timestamps correctly.', () => {
             expect(formUtils.determineInputType).toBeDefined();
             expect(formUtils.determineInputType({ dataType: 'Timestamp' })).toBe('date');
@@ -222,6 +225,10 @@ describe('Utils: FormUtils', () => {
             expect(formUtils.getControlForField).toBeDefined();
             let result = formUtils.getControlForField({ type: 'select' });
             expect(result instanceof SelectControl).toBe(true);
+        });
+        it('should return the right component for editor minimal', () => {
+            let result = formUtils.getControlForField({ type: 'editor-minimal' });
+            expect(result instanceof EditorControl).toBeTruthy();
         });
         describe('with type: address', () => {
             it('should return the right component for address', () => {

--- a/src/utils/form-utils/FormUtils.spec.ts
+++ b/src/utils/form-utils/FormUtils.spec.ts
@@ -91,7 +91,7 @@ describe('Utils: FormUtils', () => {
             expect(formUtils.determineInputType({ dataSpecialization: 'YEAR' })).toBe('year');
         });
         it('should return the type of editor minimal correctly', () => {
-            expect(formUtils.determineInputType({ dataSpecialization: 'HTML-MINIMAL' })).toEqual('html-minimal');
+            expect(formUtils.determineInputType({ dataSpecialization: 'HTML-MINIMAL' })).toEqual('editor-minimal');
         });
         it('should return the type of timestamps correctly.', () => {
             expect(formUtils.determineInputType).toBeDefined();

--- a/src/utils/form-utils/FormUtils.ts
+++ b/src/utils/form-utils/FormUtils.ts
@@ -78,6 +78,8 @@ export class FormUtils {
             type = 'percentage';
         } else if (field.dataSpecialization === 'HTML') {
             type = 'editor';
+        } else if (field.dataSpecialization === 'HTML-MINIMAL') {
+            type = 'editor-minimal';
         } else if (field.dataSpecialization === 'YEAR') {
             type = 'year';
         } else if (field.dataType === 'Timestamp') {
@@ -235,6 +237,10 @@ export class FormUtils {
                 break;
             case 'editor':
                 control = new EditorControl(controlConfig);
+                break;
+            case 'editor-minimal':
+                control = new EditorControl(controlConfig);
+                control.minimal = true;
                 break;
             case 'tiles':
                 control = new TilesControl(controlConfig);


### PR DESCRIPTION
## **Description**

Added an additional parameter to CK editor to allow for a minimal look and feel, similar to quick note without references.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**

![screen](https://user-images.githubusercontent.com/22011910/33091022-8828f14e-cebb-11e7-811d-bdf63b2198b8.PNG)