### PR TITLE
feat(module): adding DateFormatService to novo-elements module providers

### DIFF
--- a/src/platform/novo-elements.module.ts
+++ b/src/platform/novo-elements.module.ts
@@ -41,6 +41,7 @@ import { NovoValueModule } from './elements/value/Value.module';
 import { NovoSimpleTableModule } from './elements/simple-table/simple-table.module';
 
 import { NovoOverlayModule } from './elements/overlay/Overlay.module';
+import { DateFormatService } from './services/date-format/DateFormat';
 import { NovoLabelService } from './services/novo-label-service';
 import { NovoDragulaService } from './elements/dragula/DragulaService';
 import { GooglePlacesService } from './elements/places/places.service';
@@ -95,6 +96,7 @@ import { FormUtils } from './utils/form-utils/FormUtils';
     ],
     providers: [
         { provide: ComponentUtils, useClass: ComponentUtils },
+        { provide: DateFormatService, useClass: DateFormatService },
         { provide: NovoLabelService, useClass: NovoLabelService },
         { provide: NovoDragulaService, useClass: NovoDragulaService },
         { provide: GooglePlacesService, useClass: GooglePlacesService },


### PR DESCRIPTION
## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [ ] Any related demos where added and `npm start` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run compile` still works

##### **Screenshots**