### PR TITLE
Override not always being respected for entityPicker

### DIFF
--- a/src/platform/utils/form-utils/FormUtils.ts
+++ b/src/platform/utils/form-utils/FormUtils.ts
@@ -356,10 +356,13 @@ export class FormUtils {
                     }
                 });
                 if (!ranges.length) {
+                    fieldsets.push({
+                        controls: []
+                    });
                     ranges.push({
                         min: 0,
                         max: Number.MAX_SAFE_INTEGER,
-                        fieldsetIdx: 0,
+                        fieldsetIdx: 0
                     });
                 }
             } else {

--- a/src/platform/utils/form-utils/FormUtils.ts
+++ b/src/platform/utils/form-utils/FormUtils.ts
@@ -355,6 +355,13 @@ export class FormUtils {
                         }
                     }
                 });
+                if (!ranges.length) {
+                    ranges.push({
+                        min: 0,
+                        max: Number.MAX_SAFE_INTEGER,
+                        fieldsetIdx: 0,
+                    });
+                }
             } else {
                 fieldsets.push({
                     controls: []


### PR DESCRIPTION
## **Description**

Made a small change to prevent controls from being tossed out if ranges and fieldsets were never populated.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**