### PR TITLE
Added support for array in getLabels for Picker Element, unit tests and code cleanup

### DIFF
--- a/src/platform/elements/chips/Chips.ts
+++ b/src/platform/elements/chips/Chips.ts
@@ -189,7 +189,7 @@ export class NovoChipsElement implements OnInit {
                 }
             }
             if (noLabels.length > 0 && this.source && this.source.getLabels && typeof this.source.getLabels === 'function') {
-                this.source.getLabels(noLabels).then(result => {
+                this.source.getLabels(noLabels).then((result) => {
                     for (let value of result) {
                         if (value.hasOwnProperty('label')) {
                             this.items.push({
@@ -261,7 +261,7 @@ export class NovoChipsElement implements OnInit {
         this.items.splice(this.items.indexOf(item), 1);
         this.deselectAll();
         this.value = this.items.map(i => i.value);
-        this.changed.emit({value: this.value.length ? this.value : '', rawValue: this.items});        
+        this.changed.emit({value: this.value.length ? this.value : '', rawValue: this.items});
         this.onModelChange(this.value.length ? this.value : '');
         this._items.next(this.items);
     }

--- a/src/platform/elements/picker/Picker.spec.ts
+++ b/src/platform/elements/picker/Picker.spec.ts
@@ -91,7 +91,7 @@ describe('Elements: NovoPickerElement', () => {
         });
     });
 
-    fdescribe('Method: writeValue()', () => {
+    describe('Method: writeValue()', () => {
         beforeEach(() => {
             component.clearValueOnSelect = false;
             component.config = {};

--- a/src/platform/elements/picker/Picker.spec.ts
+++ b/src/platform/elements/picker/Picker.spec.ts
@@ -150,6 +150,16 @@ describe('Elements: NovoPickerElement', () => {
             component.writeValue({ name: 'NAME' });
             expect(component.term).toEqual('NAME');
         });
+        it('should use getLabels for a number if present.', fakeAsync(() => {
+            component.config = {
+                getLabels: () => new Promise(resolve => {
+                    resolve({ label: 'DYNAMIC_LABEL' })
+                })
+            };
+            component.writeValue(123);
+            tick();
+            expect(component.term).toEqual('DYNAMIC_LABEL');
+        }));
         it('should use getLabels for a complex object if present.', fakeAsync(() => {
             component.config = {
                 getLabels: () => new Promise(resolve => {
@@ -189,46 +199,6 @@ describe('Elements: NovoPickerElement', () => {
             component.writeValue({ id: 123 });
             tick();
             expect(component.term).toEqual({ id: 123 });
-        }));
-        it('should not call getLabels for string values that do not parse to integers even if getLabels is present.', fakeAsync(() => {
-            component.config = {
-                getLabels: () => new Promise(resolve => {
-                    resolve({ label: 'DYNAMIC LABEL' })
-                })
-            };
-            component.writeValue('John Smith');
-            tick();
-            expect(component.term).toEqual('John Smith');
-        }));
-        it('should call getLabels for string values that parse to integers if getLabels is present.', fakeAsync(() => {
-            component.config = {
-                getLabels: () => new Promise(resolve => {
-                    resolve({ label: 'DYNAMIC LABEL' })
-                })
-            };
-            component.writeValue('123');
-            tick();
-            expect(component.term).toEqual('DYNAMIC LABEL');
-        }));
-        it('should call getLabels for string values that parse to integers if getLabels is present - empty object.', fakeAsync(() => {
-            component.config = {
-                getLabels: () => new Promise(resolve => {
-                    resolve({})
-                })
-            };
-            component.writeValue('123');
-            tick();
-            expect(component.term).toEqual('');
-        }));
-        it('should call getLabels for string values that parse to integers if getLabels is present - null value.', fakeAsync(() => {
-            component.config = {
-                getLabels: () => new Promise(resolve => {
-                    resolve(null)
-                })
-            };
-            component.writeValue('123');
-            tick();
-            expect(component.term).toEqual('123');
         }));
         it('should call getLabels for array values that parse to integers if getLabels is present.', fakeAsync(() => {
             component.config = {

--- a/src/platform/elements/picker/Picker.spec.ts
+++ b/src/platform/elements/picker/Picker.spec.ts
@@ -160,6 +160,16 @@ describe('Elements: NovoPickerElement', () => {
             tick();
             expect(component.term).toEqual('DYNAMIC_LABEL');
         }));
+        it('should use getLabels for a number array if present.', fakeAsync(() => {
+            component.config = {
+                getLabels: () => new Promise(resolve => {
+                    resolve({ label: 'DYNAMIC_LABEL' })
+                })
+            };
+            component.writeValue([123, 456, 789]);
+            tick();
+            expect(component.term).toEqual('DYNAMIC_LABEL');
+        }));
         it('should use getLabels for a complex object if present.', fakeAsync(() => {
             component.config = {
                 getLabels: () => new Promise(resolve => {
@@ -219,6 +229,26 @@ describe('Elements: NovoPickerElement', () => {
             component.writeValue(['123', '345', '678']);
             tick();
             expect(component.term).toEqual('DYNAMIC LABEL');
+        }));
+        it('should handle getLabels that returns an array by using the first array element.', fakeAsync(() => {
+            component.config = {
+                getLabels: () => new Promise(resolve => {
+                    resolve([{ label: 'DYNAMIC LABEL' }])
+                })
+            };
+            component.writeValue(123);
+            tick();
+            expect(component.term).toEqual('DYNAMIC LABEL');
+        }));
+        it('should handle getLabels that returns an array by using the first array element - empty string case.', fakeAsync(() => {
+            component.config = {
+                getLabels: () => new Promise(resolve => {
+                    resolve([{ notALabel: 'NOT_A_LABEL' }])
+                })
+            };
+            component.writeValue(123);
+            tick();
+            expect(component.term).toEqual('');
         }));
     });
 

--- a/src/platform/elements/picker/Picker.ts
+++ b/src/platform/elements/picker/Picker.ts
@@ -1,5 +1,5 @@
 // NG2
-import { Component, EventEmitter, ElementRef, ViewContainerRef, forwardRef, ViewChild, Input, Output, OnInit, DoCheck, HostListener, ChangeDetectorRef } from '@angular/core';
+import { Component, EventEmitter, ElementRef, ViewContainerRef, forwardRef, ViewChild, Input, Output, OnInit, ChangeDetectorRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 // Vendor
 import { Observable } from 'rxjs/Observable';
@@ -8,12 +8,10 @@ import 'rxjs/add/observable/fromEvent';
 import 'rxjs/add/operator/debounceTime';
 import 'rxjs/add/operator/distinctUntilChanged';
 // APP
-import { OutsideClick } from '../../utils/outside-click/OutsideClick';
 import { KeyCodes } from '../../utils/key-codes/KeyCodes';
 import { PickerResults } from './extras/picker-results/PickerResults';
 import { ComponentUtils } from '../../utils/component-utils/ComponentUtils';
 import { Helpers } from '../../utils/Helpers';
-import { NovoPickerContainer } from './extras/picker-container/PickerContainer';
 import { NovoOverlayTemplate } from '../overlay/Overlay';
 
 

--- a/src/platform/elements/picker/Picker.ts
+++ b/src/platform/elements/picker/Picker.ts
@@ -306,17 +306,7 @@ export class NovoPickerElement implements OnInit {
         if (this.clearValueOnSelect) {
             this.term = '';
         } else {
-            if (typeof this.config.getLabels === 'function' &&
-                (typeof value === 'string' && parseInt(value) || Array.isArray(value) && value.length && parseInt(value[0]))) {
-                const val = typeof value === 'string' ? value : value[0];
-                this.config.getLabels(val).then(result => {
-                    if (result) {
-                        this.term = Array.isArray(result) ? result[0].label : result.label || '';
-                    } else {
-                        this.term = val;
-                    }
-                });
-            } else if (typeof value === 'string') {
+            if (typeof value === 'string') {
                 this.term = value;
             } else if (value && value.label) {
                 this.term = value.label;

--- a/src/platform/elements/picker/Picker.ts
+++ b/src/platform/elements/picker/Picker.ts
@@ -304,26 +304,33 @@ export class NovoPickerElement implements OnInit {
     }
 
     // From ControlValueAccessor interface
-    writeValue(value) {
+    writeValue(value: any) {
         if (this.clearValueOnSelect) {
             this.term = '';
         } else {
-            if (typeof value === 'string') {
-                this.term = value;
-            } else if (value && value.label) {
-                this.term = value.label;
-            } else if (value && value.firstName) {
-                this.term = `${value.firstName} ${value.lastName}`;
-            } else if (value && value.name) {
-                this.term = value.name;
-            } else if (this.config.getLabels && typeof this.config.getLabels === 'function') {
-                this.config.getLabels(value).then(result => {
-                    if (result) {
-                        this.term = result.label || '';
-                    } else {
-                        this.term = value;
-                    }
-                });
+            if (typeof value === 'string' || Array.isArray(value)) {
+                const val = typeof value === 'string' ? value : value[0];
+                if (parseInt(val) > 0 && typeof this.config.getLabels === 'function') {
+                    this.config.getLabels(val).then((result) => {
+                        if (result) {
+                            this.term = Array.isArray(result) ? result[0].label : result.label || '';
+                        } else {
+                            this.term = val;
+                        }
+                    });
+                } else {
+                    this.term = val;
+                }
+            } else if (value === Object(value)) {
+                if (value.hasOwnProperty('label')) {
+                    this.term = value.label;
+                } else if (value.hasOwnProperty('firstName')) {
+                    this.term = value.firstName + ' ' + value.lastName;
+                } else if (value.hasOwnProperty('name')) {
+                    this.term = value.name;
+                } else {
+                    this.term = value || '';
+                }
             } else {
                 this.term = value || '';
             }

--- a/src/platform/elements/picker/Picker.ts
+++ b/src/platform/elements/picker/Picker.ts
@@ -317,7 +317,7 @@ export class NovoPickerElement implements OnInit {
             } else if (typeof this.config.getLabels === 'function') {
                 this.config.getLabels(value).then(result => {
                     if (result) {
-                        this.term = result.label || '';
+                        this.term = result.length ? result[0].label || '' : result.label || '';
                     } else {
                         this.term = value;
                     }

--- a/src/platform/elements/picker/Picker.ts
+++ b/src/platform/elements/picker/Picker.ts
@@ -306,29 +306,32 @@ export class NovoPickerElement implements OnInit {
         if (this.clearValueOnSelect) {
             this.term = '';
         } else {
-            if (typeof value === 'string' || Array.isArray(value)) {
+            if (typeof this.config.getLabels === 'function' &&
+                (typeof value === 'string' && parseInt(value) || Array.isArray(value) && value.length && parseInt(value[0]))) {
                 const val = typeof value === 'string' ? value : value[0];
-                if (parseInt(val) > 0 && typeof this.config.getLabels === 'function') {
-                    this.config.getLabels(val).then((result) => {
-                        if (result) {
-                            this.term = Array.isArray(result) ? result[0].label : result.label || '';
-                        } else {
-                            this.term = val;
-                        }
-                    });
-                } else {
-                    this.term = val;
-                }
-            } else if (value === Object(value)) {
-                if (value.hasOwnProperty('label')) {
-                    this.term = value.label;
-                } else if (value.hasOwnProperty('firstName')) {
-                    this.term = value.firstName + ' ' + value.lastName;
-                } else if (value.hasOwnProperty('name')) {
-                    this.term = value.name;
-                } else {
-                    this.term = value || '';
-                }
+                this.config.getLabels(val).then(result => {
+                    if (result) {
+                        this.term = Array.isArray(result) ? result[0].label : result.label || '';
+                    } else {
+                        this.term = val;
+                    }
+                });
+            } else if (typeof value === 'string') {
+                this.term = value;
+            } else if (value && value.label) {
+                this.term = value.label;
+            } else if (value && value.firstName) {
+                this.term = `${value.firstName} ${value.lastName}`;
+            } else if (value && value.name) {
+                this.term = value.name;
+            } else if (typeof this.config.getLabels === 'function') {
+                this.config.getLabels(value).then(result => {
+                    if (result) {
+                        this.term = result.label || '';
+                    } else {
+                        this.term = value;
+                    }
+                });
             } else {
                 this.term = value || '';
             }

--- a/src/platform/utils/form-utils/FormUtils.ts
+++ b/src/platform/utils/form-utils/FormUtils.ts
@@ -186,22 +186,22 @@ export class FormUtils {
                 controlConfig.config.resultsTemplate = overrideResultsTemplate || EntityPickerResults;
                 controlConfig.config.previewTemplate = overridePreviewTemplate || EntityPickerResult;
                 // TODO: When appendToBody picker works better in table/form
-                control = forTable ? new PickerControl(controlConfig) : new PickerControl(controlConfig);
+                control = new PickerControl(controlConfig);
                 break;
             case 'chips':
                 controlConfig.multiple = true;
                 // TODO: When appendToBody picker works better in table/form
-                control = forTable ? new PickerControl(controlConfig) : new PickerControl(controlConfig);
+                control = new PickerControl(controlConfig);
                 break;
             case 'entitypicker':
                 // TODO: This doesn't belong in this codebase
                 controlConfig.config.resultsTemplate = overrideResultsTemplate || EntityPickerResults;
                 // TODO: When appendToBody picker works better in table/form
-                control = forTable ? new PickerControl(controlConfig) : new PickerControl(controlConfig);
+                control = new PickerControl(controlConfig);
                 break;
             case 'picker':
                 // TODO: When appendToBody picker works better in table/form
-                control = forTable ? new PickerControl(controlConfig) : new PickerControl(controlConfig);
+                control = new PickerControl(controlConfig);
                 break;
             case 'datetime':
                 controlConfig.military = config ? !!config.military : false;


### PR DESCRIPTION
## **Description**

For pickers, if `getLabels` is present, use the method to display the name instead of ID

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**