### PR TITLE
Added expander to QuickNote to allow for resizing of the content area

### DIFF
--- a/src/app/pages/elements/quick-note/QuickNoteDemo.scss
+++ b/src/app/pages/elements/quick-note/QuickNoteDemo.scss
@@ -5,7 +5,7 @@
     &.custom-results {
         .quick-note-wrapper {
             // Tests the dynamic sizing of the CKEditor
-            height: 300px;
+            height: 600px;
         }
     }
     quick-note-results,

--- a/src/platform/elements/quick-note/QuickNote.spec.ts
+++ b/src/platform/elements/quick-note/QuickNote.spec.ts
@@ -1,5 +1,5 @@
 // NG2
-import { TestBed, tick, fakeAsync } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 // App
 import { QuickNoteElement } from './QuickNote';
@@ -118,9 +118,7 @@ describe('Elements: QuickNoteElement', () => {
          */
         fakeCkEditorInstance = {
             isPlaceholderVisible: () => this.placeholderVisible,
-            config: {
-                height: 200
-            },
+            ui: { contentsElement: { $: { style: { cssText: 'height: 200px;' } } } },
             keyEnteredByUser: (key: string, keyCode: number): void => {
                 if (key === 'Backspace') {
                     this.editorValue = this.editorValue.slice(0, -1);
@@ -295,7 +293,7 @@ describe('Elements: QuickNoteElement', () => {
             fakeCkEditorInstance.userPausedAfterEntry();
 
             expect(fakeResultsDropdown.visible).toBe(true);
-            expect(fakeResultsDropdown.nativeElementProperties).toEqual({ 'margin-top': '30px' });
+            expect(fakeResultsDropdown.nativeElementProperties).toEqual({ 'margin-top': '80px' });
             expect(fakeParentForm.getValue()).toEqual({
                 note: 'Note about: @john',
                 references: {}

--- a/src/platform/elements/quick-note/QuickNote.ts
+++ b/src/platform/elements/quick-note/QuickNote.ts
@@ -557,6 +557,9 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
         this.quickNoteResults.instance.element.nativeElement.style.setProperty('margin-top', marginTop + 'px');
     }
 
+    /**
+     * Returns the height in pixels of the content area - the text that the user has entered.
+     */
     private getContentHeight(): number {
         let contentHeight: number = 0;
         if (this.ckeInstance.ui && this.ckeInstance.ui.contentsElement && this.ckeInstance.ui.contentsElement.$ && this.ckeInstance.ui.contentsElement.$.style) {


### PR DESCRIPTION
## **Description**

Added resize bar to the bottom of the QuickNote Element, to make it work like the Editor element.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**