### PR TITLE
Removed double scroll bar from table container in rare condition

### DIFF
--- a/src/platform/elements/table/Table.scss
+++ b/src/platform/elements/table/Table.scss
@@ -56,6 +56,7 @@ novo-table {
     }
     >.table-container {
         overflow-x: auto;
+        overflow-y: hidden;
         width: 100%;
         display: block;
     }


### PR DESCRIPTION
## **Description**

The condition occurs on some laptop screens when full-screening in
Chome on Windows 10.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**