### PR TITLE
fix(AppBridge): Handling of WindowName was erroneous in register events

### DIFF
--- a/src/platform/utils/app-bridge/AppBridge.ts
+++ b/src/platform/utils/app-bridge/AppBridge.ts
@@ -127,7 +127,6 @@ export class AppBridge {
             this._trace(MESSAGE_TYPES.REGISTER, event);
             this._registeredFrames.push(event);
             return this.register(event.data).then(windowName => {
-                this.windowName = windowName;
                 return { windowName };
             });
         });
@@ -487,7 +486,7 @@ export class AppBridge {
      * @param packet any - packet of data to send with the event
      */
     public register(packet: Partial<{ title: string, url: string, color: string }> = {}): Promise<string> {
-        Object.assign(packet, { id: this.id, windowName: this.windowName });
+        Object.assign(packet, { id: this.id });
         return new Promise<string>((resolve, reject) => {
             if (this._handlers[AppBridgeHandler.REGISTER]) {
                 this._handlers[AppBridgeHandler.REGISTER](packet, (windowName: string) => {


### PR DESCRIPTION
## **Description**

Appbridge register needs to let user-define windowName so that if the endpoint redirects it can still send AppBridge calls.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**