### PR TITLE
Remove margin causing closeable toast to have too much …

### DIFF
--- a/src/platform/elements/toast/Toast.scss
+++ b/src/platform/elements/toast/Toast.scss
@@ -51,7 +51,7 @@ novo-toast.toast-container>.close-icon {
     justify-content: center;
     align-content: center;
     align-items: center;
-    margin-bottom: 75px;
+    align-self: start;
     cursor: pointer;
     i {
         display: flex;


### PR DESCRIPTION
…margin

## **Description**

Removed margin and replaced with align-self on the close icon on closeable toasts because it was causing too much margin on the toasts.

#### **Verify that...**

- [ ] Any related demos where added and `npm start` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run compile` still works

##### **Screenshots**