### PR TITLE
BH-54679 Adding entity list to value renderer (#660)

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "karma-coverage-istanbul-reporter": "^1.2.1",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "ng-packagr": "^1.5.0-rc.1",
+    "ng-packagr": "1.6.0",
     "pre-commit": "^1.2.2",
     "rimraf": "^2.6.2",
     "rxjs": "5.5.2",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "post-robot": "5.0.5"
   },
   "devDependencies": {
+    "@angular-devkit/core": "^0.4.0",
     "@angular/animations": "^5.0.0",
     "@angular/cli": "1.5.4",
     "@angular/common": "^5.0.0",

--- a/src/app/pages/elements/value/ValueDemo.ts
+++ b/src/app/pages/elements/value/ValueDemo.ts
@@ -12,6 +12,7 @@ let FormatterValueDemoTpl = require('./templates/FormatterValueDemo.html');
 let AssociatedValueDemoTpl = require('./templates/AssociatedValueDemo.html');
 let DateTimeValueDemoTpl = require('./templates/DateTimeValueDemo.html');
 let ExternalLinkValueDemoTpl = require('./templates/ExternalLinkValueDemo.html');
+let EntityListDemoTpl = require('./templates/EntityListDemo.html');
 const template = `
 <div class="container">
     <h1>Value/Details/Summary <small><a target="_blank" href="https://github.com/bullhorn/novo-elements/blob/master/src/elements/value">(source)</a></small></h1>
@@ -55,6 +56,10 @@ const template = `
     <p>Render associated fields</p>
     <div class="example value-demo">${AssociatedValueDemoTpl}</div>
     <code-snippet [code]="AssociatedValueDemoTpl"></code-snippet>
+    <h5>Entity Lists</h5>
+    <p>Render entity lists</p>
+    <div class="example value-demo">${EntityListDemoTpl}</div>
+    <code-snippet [code]="EntityListDemoTpl"></code-snippet>
 </div>
 `;
 
@@ -72,6 +77,7 @@ export class ValueDemoComponent {
     private DateTimeValueDemoTpl: string = DateTimeValueDemoTpl;
     private AddressValueDemoTpl: string = AddressValueDemoTpl;
     private AssociatedValueDemoTpl: string = AssociatedValueDemoTpl;
+    private EntityListDemoTpl: string = EntityListDemoTpl;
     private toggleCount: number = 0;
     private checked: boolean = true;
     simpleData = 1234567890;
@@ -172,6 +178,35 @@ export class ValueDemoComponent {
         type: 'TO_ONE',
         name: 'owner',
         label: 'Owner',
+        associatedEntity: {
+            entity: 'CorporateUser'
+        }
+    };
+    entityListData = {
+        data: [{
+            id: 1,
+            firstName: 'George',
+            lastName: 'Washington',
+            personSubtype: 'Candidate',
+            openLink: (data) => {},
+        }, {
+            id: 2,
+            firstName: 'John',
+            lastName: 'Adams',
+            personSubtype: 'ClientContact',
+            openLink: (data) => {},
+        }, {
+            id: 3,
+            firstName: 'Abraham',
+            lastName: 'Lincoln',
+            personSubtype: 'Lead',
+            openLink: (data) => {},
+        }],
+    };
+    entityListMeta = {
+        type: 'TO_MANY',
+        name: 'guests',
+        label: 'Attendees',
         associatedEntity: {
             entity: 'CorporateUser'
         }

--- a/src/app/pages/elements/value/templates/EntityListDemo.html
+++ b/src/app/pages/elements/value/templates/EntityListDemo.html
@@ -1,0 +1,1 @@
+<novo-value [data]="entityListData" [meta]="entityListMeta"></novo-value>

--- a/src/platform/elements/value/EntityList.ts
+++ b/src/platform/elements/value/EntityList.ts
@@ -6,10 +6,10 @@ import { Component, Input, OnInit, ChangeDetectorRef, ChangeDetectionStrategy } 
     changeDetection: ChangeDetectionStrategy.OnPush,
     template: `
         <div *ngFor="let entity of data.data" class="entity">
-            <a *ngIf="isLinkable(entity)" (click)="openLink(entity)">
-                <i class="bhi-circle {{getClass(entity)}}"></i>{{ entity | render : meta }}
+            <a *ngIf="entity.isLinkable" (click)="openLink(entity)">
+                <i class="bhi-circle {{ entity.class }}"></i>{{ entity | render : meta }}
             </a>
-            <span *ngIf="!isLinkable(entity)">
+            <span *ngIf="!entity.isLinkable">
                 {{ entity | render : meta }}
             </span>
         </div>
@@ -57,6 +57,10 @@ export class EntityList implements OnInit {
     ngOnInit(): any {
         this.meta.type = 'TO_ONE';
         this.baseEntity = this.meta.associatedEntity.entity;
+        for (let entity of this.data.data) {
+            entity.isLinkable = this.isLinkable(entity);
+            entity.class = this.getClass(entity);
+        }
     }
 
     getClass(entity: any): any {

--- a/src/platform/elements/value/EntityList.ts
+++ b/src/platform/elements/value/EntityList.ts
@@ -1,0 +1,73 @@
+// NG2
+import { Component, Input, OnInit, ChangeDetectorRef, ChangeDetectionStrategy } from '@angular/core';
+
+@Component({
+    selector: 'entity-list',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    template: `
+        <div *ngFor="let entity of data.data" class="entity">
+            <a *ngIf="isLinkable(entity)" (click)="openLink(entity)">
+                <i class="bhi-circle {{getClass(entity)}}"></i>{{ entity | render : meta }}
+            </a>
+            <span *ngIf="!isLinkable(entity)">
+                {{ entity | render : meta }}
+            </span>
+        </div>
+    `
+})
+export class EntityList implements OnInit {
+    @Input() data: any;
+    @Input() meta: any;
+    baseEntity: string = '';
+    ENTITY_SHORT_NAMES: any = {
+        Lead: 'lead',
+        ClientContact: 'contact',
+        ClientContact1: 'contact',
+        ClientContact2: 'contact',
+        ClientContact3: 'contact',
+        ClientContact4: 'contact',
+        ClientContact5: 'contact',
+        ClientCorporation: 'company',
+        ClientCorporation1: 'company',
+        ClientCorporation2: 'company',
+        ClientCorporation3: 'company',
+        ClientCorporation4: 'company',
+        ClientCorporation5: 'company',
+        Opportunity: 'opportunity',
+        Task: 'task',
+        Note: 'note',
+        CorporateUser: 'user',
+        Candidate: 'candidate',
+        JobOrder: 'job',
+        JobOrder1: 'job',
+        JobOrder2: 'job',
+        JobOrder3: 'job',
+        JobOrder4: 'job',
+        JobOrder5: 'job',
+        Placement: 'placement',
+        JobSubmission: 'submission',
+        CandidateReference: 'references',
+        DistributionList: 'distributionList',
+        Appointment: 'appointment',
+    };
+
+    constructor() {
+    }
+
+    ngOnInit(): any {
+        this.meta.type = 'TO_ONE';
+        this.baseEntity = this.meta.associatedEntity.entity;
+    }
+
+    getClass(entity: any): any {
+        return this.ENTITY_SHORT_NAMES[entity.personSubtype];
+    }
+
+    openLink(entity: any): void {
+        entity.openLink(entity);
+    }
+
+    isLinkable(entity: any): boolean {
+        return entity.openLink;
+    }
+}

--- a/src/platform/elements/value/Value.module.ts
+++ b/src/platform/elements/value/Value.module.ts
@@ -4,11 +4,12 @@ import { CommonModule } from '@angular/common';
 // APP
 import { NovoValueElement, NOVO_VALUE_THEME, NOVO_VALUE_TYPE } from './Value';
 import { RenderPipe } from './Render';
+import { EntityList } from './EntityList'
 
 @NgModule({
     imports: [CommonModule],
-    declarations: [NovoValueElement, RenderPipe],
-    exports: [NovoValueElement, RenderPipe]
+    declarations: [NovoValueElement, RenderPipe, EntityList],
+    exports: [NovoValueElement, RenderPipe, EntityList]
 })
 export class NovoValueModule {
 }

--- a/src/platform/elements/value/Value.ts
+++ b/src/platform/elements/value/Value.ts
@@ -13,6 +13,7 @@ export enum NOVO_VALUE_THEME { DEFAULT, MOBILE };
                 <label>{{ meta.label }}</label>
                 <a *ngSwitchCase="NOVO_VALUE_TYPE.INTERNAL_LINK" class="value" (click)="openLink()" [innerHTML]="data | render : meta"></a>
                 <a *ngSwitchCase="NOVO_VALUE_TYPE.LINK" class="value" [href]="url" target="_blank" [innerHTML]="data | render : meta"></a>
+                <entity-list *ngSwitchCase="NOVO_VALUE_TYPE.ENTITY_LIST" [data]='data' [meta]="meta"></entity-list>
             </div>
 
             <div *ngSwitchDefault class="value-outer">
@@ -65,7 +66,7 @@ export class NovoValueElement implements OnInit, OnChanges {
     }
 
     public get showLabel(): boolean {
-        return this.type === NOVO_VALUE_TYPE.INTERNAL_LINK || this.type === NOVO_VALUE_TYPE.LINK;
+        return this.type === NOVO_VALUE_TYPE.INTERNAL_LINK || this.type === NOVO_VALUE_TYPE.LINK || this.type === NOVO_VALUE_TYPE.ENTITY_LIST;
     }
 
     public get showIcon(): boolean {
@@ -93,6 +94,8 @@ export class NovoValueElement implements OnInit, OnChanges {
             } else {
                 this.url = this.data;
             }
+        } else if (this.isEntityList(this.meta.type)) {
+            this.type = NOVO_VALUE_TYPE.ENTITY_LIST;
         } else if (this.meta && this.meta.associatedEntity) {
             switch (this.meta.associatedEntity.entity) {
                 case 'ClientCorporation':
@@ -113,5 +116,9 @@ export class NovoValueElement implements OnInit, OnChanges {
         let regex: any = new RegExp('^(https?:\/\/(?:www\.|(?!www))[^\s\.]+\.[^\s]{2,}|www\.[^\s]+\.[^\s]{2,})$', 'gi');
         let isURL: any = Helpers.isString(data) && regex.exec(data.trim());
         return (linkFields.indexOf(field.name) > -1) || !!isURL || field.type === NOVO_VALUE_TYPE.LINK;
+    }
+
+    isEntityList(type: string): boolean {
+        return type === 'TO_MANY';
     }
 }

--- a/src/platform/elements/value/Values.scss
+++ b/src/platform/elements/value/Values.scss
@@ -33,4 +33,22 @@ novo-value {
             color: $ocean;
         }
     }
+    entity-list {
+        display: block;
+        .entity {
+            padding-top: 6px;
+            padding-bottom: 6px;
+            font-size: 1em;
+        }
+        @each $entity,
+        $color in $entity-colors {
+            i.#{$entity} {
+                color: $color;
+            }
+        }
+        i {
+            font-size: 1.2em;
+            margin-right: 6px;
+        }
+    }
 }


### PR DESCRIPTION
* BH-54679 porting over EntityList

* BH-54679 missing imports and exports

* BH-54679 adding entity list module

* BH-54679 moving element into value directory

* BH-54679 adding entityList.ts file

* BH-54679 reverting cli version back and adding entity lists to value demo

* BH-54679 hard-coding cli version

* BH-54679 adding entity colored dot to entity list in value

* BH-54679 only make linkable if openLink method exists, and taking out novo business logic

* BH-54679 returning isLinkable for entityList if openLink function exists

## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [ ] Any related demos where added and `npm start` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run compile` still works

##### **Screenshots**