### PR TITLE
feat(value) displaying html fields for mobile

### DIFF
--- a/src/platform/elements/value/Render.ts
+++ b/src/platform/elements/value/Render.ts
@@ -303,7 +303,9 @@ export class RenderPipe implements PipeTransform {
                 if (Array.isArray(value)) {
                     value = value.join(' ');
                 }
-                text = this.sanitizationService.bypassSecurityTrustHtml(value.replace(/\<a/gi, '<a target="_blank"'));
+                if (typeof text === 'string') {
+                    text = this.sanitizationService.bypassSecurityTrustHtml(value.replace(/\<a/gi, '<a target="_blank"'));
+                }
                 break;
             case 'CandidateComment':
                 text = value.comments ? `${this.labels.formatDateShort(value.dateLastModified)} (${value.name}) - ${value.comments}` : '';

--- a/src/platform/elements/value/Value.spec.ts
+++ b/src/platform/elements/value/Value.spec.ts
@@ -184,12 +184,19 @@ describe('Elements: NovoValueElement', () => {
             component.ngOnChanges();
             expect(component.type).toEqual(NOVO_VALUE_TYPE.LINK);
         });
-        it('should set type to html for a html fields', () => {
+        it('should set type to html for a large fields', () => {
             component.meta.name = 'companyDescription';
             component.meta.dataSpecialization = 'HTML';
             component.data = '';
             component.ngOnChanges();
             expect(component.type).toEqual(NOVO_VALUE_TYPE.HTML);
+        });
+        it('should strip html tags in large fields', () => {
+            component.meta.name = 'companyDescription';
+            component.meta.dataSpecialization = 'HTML';
+            component.data = '<span style="color:#8e44ad">test</span>';
+            component.ngOnChanges();
+            expect(component.data).toEqual('test');
         });
     });
     describe('Function: isLinkField', () => {

--- a/src/platform/elements/value/Value.spec.ts
+++ b/src/platform/elements/value/Value.spec.ts
@@ -5,7 +5,7 @@ import { NovoValueElement, NOVO_VALUE_THEME, NOVO_VALUE_TYPE } from './Value';
 // import { NovoLabelService } from '../../services/novo-label-service';
 import { NovoValueModule } from './Value.module';
 // TODO fix specs
-fdescribe('Elements: NovoValueElement', () => {
+describe('Elements: NovoValueElement', () => {
     let fixture;
     let component;
 
@@ -184,13 +184,6 @@ fdescribe('Elements: NovoValueElement', () => {
             component.ngOnChanges();
             expect(component.type).toEqual(NOVO_VALUE_TYPE.LINK);
         });
-        it('should set type to html for a large fields', () => {
-            component.meta.name = 'companyDescription';
-            component.meta.dataSpecialization = 'HTML';
-            component.data = '';
-            component.ngOnChanges();
-            expect(component.type).toEqual(NOVO_VALUE_TYPE.HTML);
-        });
         it('should strip html tags in large fields if stripHTML = true', () => {
             component.meta.name = 'companyDescription';
             component.meta.dataSpecialization = 'HTML';
@@ -213,6 +206,21 @@ fdescribe('Elements: NovoValueElement', () => {
             component.data = '<span style="color:#8e44ad">test</span>';
             component.ngOnChanges();
             expect(component.data).toEqual('<span style="color:#8e44ad">test</span>');
+        });
+        it('should set customClass from meta', () => {
+            component.meta.name = 'companyDescription';
+            component.meta.dataSpecialization = 'HTML';
+            component.meta.customClass = 'testClass';
+            component.data = '<span style="color:#8e44ad">test</span>';
+            component.ngOnChanges();
+            expect(component.customClass).toEqual('testClass');
+        });
+        it('should set customClass to empty if not defined in meta', () => {
+            component.meta.name = 'companyDescription';
+            component.meta.dataSpecialization = 'HTML';
+            component.data = '<span style="color:#8e44ad">test</span>';
+            component.ngOnChanges();
+            expect(component.customClass).toEqual('');
         });
     });
     describe('Function: isLinkField', () => {

--- a/src/platform/elements/value/Value.spec.ts
+++ b/src/platform/elements/value/Value.spec.ts
@@ -184,12 +184,26 @@ describe('Elements: NovoValueElement', () => {
             component.ngOnChanges();
             expect(component.type).toEqual(NOVO_VALUE_TYPE.LINK);
         });
+        it('should set type to html for a html fields', () => {
+            component.meta.name = 'companyDescription';
+            component.meta.dataSpecialization = 'HTML';
+            component.data = '';
+            component.ngOnChanges();
+            expect(component.type).toEqual(NOVO_VALUE_TYPE.HTML);
+        });
     });
     describe('Function: isLinkField', () => {
         it('should return true for link fields or an obvious link', () => {
             expect(component.isLinkField({ name: 'companyURL' }, '')).toBeTruthy();
             expect(component.isLinkField({ name: 'mobile' }, '')).toBeFalsy();
             expect(component.isLinkField({ name: 'customText18' }, 'www.google.com')).toBeTruthy();
+        });
+    });
+    describe('Function: isHTMLField', () => {
+        it('should return true for html fields', () => {
+            expect(component.isHTMLField({ dataSpecialization: 'HTML' })).toBeTruthy();
+            expect(component.isHTMLField({ inputType: 'TEXTAREA' })).toBeTruthy();
+            expect(component.isHTMLField({ dataSpecialization: 'NO_HTML' })).toBeFalsy();
         });
     });
 });

--- a/src/platform/elements/value/Value.spec.ts
+++ b/src/platform/elements/value/Value.spec.ts
@@ -5,7 +5,7 @@ import { NovoValueElement, NOVO_VALUE_THEME, NOVO_VALUE_TYPE } from './Value';
 // import { NovoLabelService } from '../../services/novo-label-service';
 import { NovoValueModule } from './Value.module';
 // TODO fix specs
-describe('Elements: NovoValueElement', () => {
+fdescribe('Elements: NovoValueElement', () => {
     let fixture;
     let component;
 
@@ -191,12 +191,28 @@ describe('Elements: NovoValueElement', () => {
             component.ngOnChanges();
             expect(component.type).toEqual(NOVO_VALUE_TYPE.HTML);
         });
-        it('should strip html tags in large fields', () => {
+        it('should strip html tags in large fields if stripHTML = true', () => {
+            component.meta.name = 'companyDescription';
+            component.meta.dataSpecialization = 'HTML';
+            component.meta.stripHTML = true;
+            component.data = '<span style="color:#8e44ad">test</span>';
+            component.ngOnChanges();
+            expect(component.data).toEqual('test');
+        });
+        it('should strip html tags in large fields if stripHTML = false', () => {
+            component.meta.name = 'companyDescription';
+            component.meta.dataSpecialization = 'HTML';
+            component.meta.stripHTML = false;
+            component.data = '<span style="color:#8e44ad">test</span>';
+            component.ngOnChanges();
+            expect(component.data).toEqual('<span style="color:#8e44ad">test</span>');
+        });
+        it('should strip html tags in large fields if stripHTML is not defined', () => {
             component.meta.name = 'companyDescription';
             component.meta.dataSpecialization = 'HTML';
             component.data = '<span style="color:#8e44ad">test</span>';
             component.ngOnChanges();
-            expect(component.data).toEqual('test');
+            expect(component.data).toEqual('<span style="color:#8e44ad">test</span>');
         });
     });
     describe('Function: isLinkField', () => {

--- a/src/platform/elements/value/Value.ts
+++ b/src/platform/elements/value/Value.ts
@@ -2,7 +2,7 @@
 import { Component, Input, OnInit, HostBinding, OnChanges, SimpleChanges } from '@angular/core';
 //APP
 import { Helpers } from '../../utils/Helpers';
-export enum NOVO_VALUE_TYPE { DEFAULT, ENTITY_LIST, LINK, INTERNAL_LINK };
+export enum NOVO_VALUE_TYPE { DEFAULT, ENTITY_LIST, LINK, INTERNAL_LINK, HTML };
 export enum NOVO_VALUE_THEME { DEFAULT, MOBILE };
 
 @Component({
@@ -16,6 +16,10 @@ export enum NOVO_VALUE_THEME { DEFAULT, MOBILE };
                 <novo-entity-list *ngSwitchCase="NOVO_VALUE_TYPE.ENTITY_LIST" [data]='data' [meta]="meta"></novo-entity-list>
             </div>
 
+            <div *ngSwitchCase="NOVO_VALUE_TYPE.HTML" class="value-outer html-field">
+                <label>{{ meta.label }}</label>
+                <div *ngIf="isDefault" class="value" [innerHTML]="data | render : meta"></div>
+            </div>
             <div *ngSwitchDefault class="value-outer">
                 <label>{{ meta.label }}</label>
                 <div *ngIf="isDefault" class="value" [innerHTML]="data | render : meta"></div>
@@ -96,6 +100,8 @@ export class NovoValueElement implements OnInit, OnChanges {
             }
         } else if (this.isEntityList(this.meta.type)) {
             this.type = NOVO_VALUE_TYPE.ENTITY_LIST;
+        } else if (this.isHTMLField(this.meta)) {
+            this.type = NOVO_VALUE_TYPE.HTML;
         } else if (this.meta && this.meta.associatedEntity) {
             switch (this.meta.associatedEntity.entity) {
                 case 'ClientCorporation':
@@ -120,5 +126,9 @@ export class NovoValueElement implements OnInit, OnChanges {
 
     isEntityList(type: string): boolean {
         return type === 'TO_MANY';
+    }
+
+    isHTMLField(meta: any): boolean {
+        return meta.dataSpecialization === 'HTML' || meta.inputType === 'TEXTAREA';
     }
 }

--- a/src/platform/elements/value/Value.ts
+++ b/src/platform/elements/value/Value.ts
@@ -102,7 +102,9 @@ export class NovoValueElement implements OnInit, OnChanges {
             this.type = NOVO_VALUE_TYPE.ENTITY_LIST;
         } else if (this.isHTMLField(this.meta)) {
             this.type = NOVO_VALUE_TYPE.HTML;
-            this.data = this.data.replace(/<(.|\n)+?>/gi, '');
+            if (this.meta.stripHTML) {
+                this.data = this.data.replace(/<(.|\n)+?>/gi, '');
+            }
         } else if (this.meta && this.meta.associatedEntity) {
             switch (this.meta.associatedEntity.entity) {
                 case 'ClientCorporation':

--- a/src/platform/elements/value/Value.ts
+++ b/src/platform/elements/value/Value.ts
@@ -2,7 +2,7 @@
 import { Component, Input, OnInit, HostBinding, OnChanges, SimpleChanges } from '@angular/core';
 //APP
 import { Helpers } from '../../utils/Helpers';
-export enum NOVO_VALUE_TYPE { DEFAULT, ENTITY_LIST, LINK, INTERNAL_LINK, HTML };
+export enum NOVO_VALUE_TYPE { DEFAULT, ENTITY_LIST, LINK, INTERNAL_LINK };
 export enum NOVO_VALUE_THEME { DEFAULT, MOBILE };
 
 @Component({
@@ -15,12 +15,7 @@ export enum NOVO_VALUE_THEME { DEFAULT, MOBILE };
                 <a *ngSwitchCase="NOVO_VALUE_TYPE.LINK" class="value" [href]="url" target="_blank" [innerHTML]="data | render : meta"></a>
                 <novo-entity-list *ngSwitchCase="NOVO_VALUE_TYPE.ENTITY_LIST" [data]='data' [meta]="meta"></novo-entity-list>
             </div>
-
-            <div *ngSwitchCase="NOVO_VALUE_TYPE.HTML" class="value-outer html-field">
-                <label>{{ meta.label }}</label>
-                <div *ngIf="isDefault" class="value" [innerHTML]="data | render : meta"></div>
-            </div>
-            <div *ngSwitchDefault class="value-outer">
+            <div *ngSwitchDefault class="value-outer" [ngClass]="customClass">
                 <label>{{ meta.label }}</label>
                 <div *ngIf="isDefault" class="value" [innerHTML]="data | render : meta"></div>
             </div>
@@ -39,6 +34,7 @@ export class NovoValueElement implements OnInit, OnChanges {
     NOVO_VALUE_TYPE = NOVO_VALUE_TYPE;
     NOVO_VALUE_THEME = NOVO_VALUE_THEME;
     url: string;
+    customClass: string = '';
 
     ngOnInit() {
         if (Helpers.isEmpty(this.meta)) {
@@ -101,7 +97,7 @@ export class NovoValueElement implements OnInit, OnChanges {
         } else if (this.isEntityList(this.meta.type)) {
             this.type = NOVO_VALUE_TYPE.ENTITY_LIST;
         } else if (this.isHTMLField(this.meta)) {
-            this.type = NOVO_VALUE_TYPE.HTML;
+            this.customClass = this.meta.customClass ? this.meta.customClass : '';
             if (this.meta.stripHTML && this.data) {
                 this.data = this.data.replace(/<(.|\n)+?>/gi, '');
             }

--- a/src/platform/elements/value/Value.ts
+++ b/src/platform/elements/value/Value.ts
@@ -102,6 +102,7 @@ export class NovoValueElement implements OnInit, OnChanges {
             this.type = NOVO_VALUE_TYPE.ENTITY_LIST;
         } else if (this.isHTMLField(this.meta)) {
             this.type = NOVO_VALUE_TYPE.HTML;
+            this.data = this.data.replace(/<(.|\n)+?>/gi, '');
         } else if (this.meta && this.meta.associatedEntity) {
             switch (this.meta.associatedEntity.entity) {
                 case 'ClientCorporation':

--- a/src/platform/elements/value/Value.ts
+++ b/src/platform/elements/value/Value.ts
@@ -102,7 +102,7 @@ export class NovoValueElement implements OnInit, OnChanges {
             this.type = NOVO_VALUE_TYPE.ENTITY_LIST;
         } else if (this.isHTMLField(this.meta)) {
             this.type = NOVO_VALUE_TYPE.HTML;
-            if (this.meta.stripHTML) {
+            if (this.meta.stripHTML && this.data) {
                 this.data = this.data.replace(/<(.|\n)+?>/gi, '');
             }
         } else if (this.meta && this.meta.associatedEntity) {


### PR DESCRIPTION
## **Description**

Added a case for html/text area fields display. The css class is used in mobile to add custom styles
Also added a flag to strip out the html
![screen shot 2018-03-09 at 3 53 53 pm](https://user-images.githubusercontent.com/11818430/37229495-198e4314-23b2-11e8-8443-56e8f1bcdd9e.png)

Novo will not be affected and is being tested

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**