### PR TITLE
f/multiFileControl - add edit btn

### DIFF
--- a/src/app/pages/elements/form/FormDemo.ts
+++ b/src/app/pages/elements/form/FormDemo.ts
@@ -278,7 +278,7 @@ export class FormDemoComponent {
       name: 'myfiles',
       label: 'Multiple Files',
       multiple: true,
-      layoutOptions: { order: 'displayFilesBelow', download: true, edit: true, customActions: true, labelStyle: 'no-box' },
+      layoutOptions: { order: 'displayFilesBelow', download: true, edit: true, labelStyle: 'no-box' },
       value: [{ name: 'yourFile.pdf', loaded: true }],
     });
     this.fileForm = formUtils.toFormGroup([this.fileControl, this.multiFileControl]);

--- a/src/app/pages/elements/form/FormDemo.ts
+++ b/src/app/pages/elements/form/FormDemo.ts
@@ -279,7 +279,7 @@ export class FormDemoComponent {
       label: 'Multiple Files',
       multiple: true,
       layoutOptions: { order: 'displayFilesBelow', download: true, edit: true, customActions: true, labelStyle: 'no-box' },
-      value: [{ name: 'yourFile.pdf', loaded: true }],
+      value: [{ name: 'yourFile.pdf', loaded: true, link: 'www.google.com', description: 'file description' }],
     });
     this.fileForm = formUtils.toFormGroup([this.fileControl, this.multiFileControl]);
 

--- a/src/app/pages/elements/form/FormDemo.ts
+++ b/src/app/pages/elements/form/FormDemo.ts
@@ -278,7 +278,7 @@ export class FormDemoComponent {
       name: 'myfiles',
       label: 'Multiple Files',
       multiple: true,
-      layoutOptions: { order: 'displayFilesBelow', download: true, edit: true, labelStyle: 'no-box' },
+      layoutOptions: { order: 'displayFilesBelow', download: true, edit: true, customActions: true, labelStyle: 'no-box' },
       value: [{ name: 'yourFile.pdf', loaded: true }],
     });
     this.fileForm = formUtils.toFormGroup([this.fileControl, this.multiFileControl]);
@@ -370,15 +370,15 @@ export class FormDemoComponent {
     console.log('I changed!', value); // tslint:disable-line
   }
 
-  handleEdit(value) {
-    console.log('This is an Edit Action!', value); // tslint:disable-line
+  handleEdit(file) {
+    console.log('This is an Edit Action!', file); // tslint:disable-line
   }
 
-  handleSave(value) {
-    console.log('This is a Save Action!', value); // tslint:disable-line
+  handleSave(file) {
+    console.log('This is a Save Action!', file); // tslint:disable-line
   }
 
-  handleDelete(value) {
-    console.log('This is a Delete Action!', value); // tslint:disable-line
+  handleDelete(file) {
+    console.log('This is a Delete Action!', file); // tslint:disable-line
   }
 }

--- a/src/app/pages/elements/form/FormDemo.ts
+++ b/src/app/pages/elements/form/FormDemo.ts
@@ -278,7 +278,7 @@ export class FormDemoComponent {
       name: 'myfiles',
       label: 'Multiple Files',
       multiple: true,
-      layoutOptions: { order: 'displayFilesBelow', download: true, edit: true, labelStyle: 'no-box' },
+      layoutOptions: { order: 'displayFilesBelow', download: true, edit: true, customActions: true, labelStyle: 'no-box' },
       value: [{ name: 'yourFile.pdf', loaded: true }],
     });
     this.fileForm = formUtils.toFormGroup([this.fileControl, this.multiFileControl]);

--- a/src/app/pages/elements/form/FormDemo.ts
+++ b/src/app/pages/elements/form/FormDemo.ts
@@ -126,7 +126,7 @@ export class FormDemoComponent {
     private entityMultiPickerControl: any;
     private pickerForm: any;
     private updatingForm: any;
-    private updatingFormControls: [any];
+    private updatingFormControls: any[];
     private required: boolean = false;
     private disabled: boolean = true;
 
@@ -203,7 +203,7 @@ export class FormDemoComponent {
 
         // File input controls
         this.fileControl = new FileControl({ key: 'file', name: 'myfile', label: 'File', tooltip: 'Files Control' });
-        this.multiFileControl = new FileControl({ key: 'files', name: 'myfiles', label: 'Multiple Files', multiple: true, layoutOptions: { order: 'displayFilesBelow', download: false, labelStyle: 'no-box' }, value: [{ name: 'yourFile.pdf', loaded: true }] });
+        this.multiFileControl = new FileControl({ key: 'files', name: 'myfiles', label: 'Multiple Files', multiple: true, layoutOptions: { order: 'displayFilesBelow', download: true, edit: true, customButtons: true, labelStyle: 'no-box' }, value: [{ name: 'yourFile.pdf', loaded: true }] });
         this.fileForm = formUtils.toFormGroup([this.fileControl, this.multiFileControl]);
 
         // Calendar input controls

--- a/src/app/pages/elements/form/FormDemo.ts
+++ b/src/app/pages/elements/form/FormDemo.ts
@@ -69,215 +69,316 @@ const template = `
 `;
 
 @Component({
-    selector: 'custom-demo-component',
-    template: `<novo-custom-control-container [formGroup]="form" [form]="form" [control]="control">
+  selector: 'custom-demo-component',
+  template: `<novo-custom-control-container [formGroup]="form" [form]="form" [control]="control">
         My Custom Input <input [formControlName]="control.key" [id]="control.key" [type]="control.type" [placeholder]="control.placeholder">
-    </novo-custom-control-container>`
+    </novo-custom-control-container>`,
 })
 export class CustomDemoComponent {
-    @Input() control;
-    @Input() form: any;
+  @Input() control;
+  @Input() form: any;
+  @Input() edit: any;
+  @Input() save: any;
+  @Input() delete: any;
 }
 
 @Component({
-    selector: 'form-demo',
-    template: template
+  selector: 'form-demo',
+  template: template,
 })
 export class FormDemoComponent {
-    private DynamicFormDemoTpl: string = DynamicFormDemoTpl;
-    private VerticalDynamicFormDemoTpl: string = VerticalDynamicFormDemoTpl;
-    private TextBasedControlsDemoTpl: string = TextBasedControlsDemoTpl;
-    private CheckBoxControlsDemoTpl: string = CheckBoxControlsDemoTpl;
-    private FileInputControlsDemoTpl: string = FileInputControlsDemoTpl;
-    private CalendarControlsDemoTpl: string = CalendarControlsDemoTpl;
-    private FieldsetsFormDemoTpl: string = FieldsetsFormDemoTpl;
-    private PickerControlsDemoTpl: string = PickerControlsDemoTpl;
-    private UpdatingFormDemoTpl: string = UpdatingFormDemoTpl;
-    private quickNoteConfig: any;
-    private textControl: any;
-    private emailControl: any;
-    private numberControl: any;
-    private currencyControl: any;
-    private aceEditorControl: any;
-    private floatControl: any;
-    private percentageControl: any;
-    private quickNoteControl: any;
-    private textForm: any;
-    private checkControl: any;
-    private textAreaControl: any;
-    private checkListControl: any;
-    private tilesControl: any;
-    private checkForm: any;
-    private fileControl: any;
-    private multiFileControl: any;
-    private fileForm: any;
-    private dateControl: any;
-    private timeControl: any;
-    private dateTimeControl: any;
-    private dynamic: any;
-    private dynamicForm: any;
-    private dynamicVertical: any;
-    private dynamicVerticalForm: any;
-    private calendarForm: any;
-    private fieldsets: Array<any>;
-    private fieldsetsForm: any;
-    private singlePickerControl: any;
-    private multiPickerControl: any;
-    private entityMultiPickerControl: any;
-    private pickerForm: any;
-    private updatingForm: any;
-    private updatingFormControls: any[];
-    private required: boolean = false;
-    private disabled: boolean = true;
+  private DynamicFormDemoTpl: string = DynamicFormDemoTpl;
+  private VerticalDynamicFormDemoTpl: string = VerticalDynamicFormDemoTpl;
+  private TextBasedControlsDemoTpl: string = TextBasedControlsDemoTpl;
+  private CheckBoxControlsDemoTpl: string = CheckBoxControlsDemoTpl;
+  private FileInputControlsDemoTpl: string = FileInputControlsDemoTpl;
+  private CalendarControlsDemoTpl: string = CalendarControlsDemoTpl;
+  private FieldsetsFormDemoTpl: string = FieldsetsFormDemoTpl;
+  private PickerControlsDemoTpl: string = PickerControlsDemoTpl;
+  private UpdatingFormDemoTpl: string = UpdatingFormDemoTpl;
+  private quickNoteConfig: any;
+  private textControl: any;
+  private emailControl: any;
+  private numberControl: any;
+  private currencyControl: any;
+  private aceEditorControl: any;
+  private floatControl: any;
+  private percentageControl: any;
+  private quickNoteControl: any;
+  private textForm: any;
+  private checkControl: any;
+  private textAreaControl: any;
+  private checkListControl: any;
+  private tilesControl: any;
+  private checkForm: any;
+  private fileControl: any;
+  private multiFileControl: any;
+  private fileForm: any;
+  private dateControl: any;
+  private timeControl: any;
+  private dateTimeControl: any;
+  private dynamic: any;
+  private dynamicForm: any;
+  private dynamicVertical: any;
+  private dynamicVerticalForm: any;
+  private calendarForm: any;
+  private fieldsets: Array<any>;
+  private fieldsetsForm: any;
+  private singlePickerControl: any;
+  private multiPickerControl: any;
+  private entityMultiPickerControl: any;
+  private pickerForm: any;
+  private updatingForm: any;
+  private updatingFormControls: any[];
+  private required: boolean = false;
+  private disabled: boolean = true;
 
-    constructor(private formUtils: FormUtils) {
-        // Quick note config
-        this.quickNoteConfig = {
-            triggers: {
-                tags: '@',
-                references: '#',
-                boos: '^'
-            },
-            options: {
-                tags: ['First', 'Second'],
-                references: ['Third', 'Fourth'],
-                boos: ['Test']
-            },
-            renderer: {
-                tags: (symbol, item) => {
-                    return `<a class="tag">${symbol}${item.label}</a>`;
-                },
-                references: (symbol, item) => {
-                    return `<a class="tag">${symbol}${item.label}</a>`;
-                },
-                boos: (symbol, item) => {
-                    return `<strong>${symbol}${item.label}</strong>`;
-                }
-            }
-        };
-        // Text-based Controls
-        this.textControl = new TextBoxControl({ key: 'text', label: 'Text Box', tooltip: 'Textbox', readOnly: true, value: 'HI', required: true });
-        this.textAreaControl = new TextAreaControl({ key: 'textarea', label: 'Text Area', value: 'Bro ipsum dolor sit amet yard sale saddle pipe, poaching cork 360 punter ACL back country cornice Whistler.  Avie Ski taco mitt, manny first tracks yard sale caballerial heli fatty.  Epic dope grab, brain bucket japan air wack bowl  mute heli corn Snowboard Whistler giblets table top.  Crunchy Snowboard washboard line grab reverse camber.  Bump epic granny gear heli sketching wheelie huckfest face plant crank pow pow chain ring  dirtbag washboard.  Flow endo ski bum sucker hole, death cookies manny schwag pipe.  Dope heli stomp yard sale, saddle shreddin booter gear jammer grom bonk OTB brain bucket bonk japan air Whistler.Clipless pow pow pow, core shot corn butter bomb hole glades face plant dust on crust.  Poaching park face shots bump, Bike cornice death cookies.  Avie cruiser sucker hole face plant switch.  ACL snake bite bonk, twin tip euro rig nose press McTwist.  Ripping skinny trucks shreddin.  Apres pow line euro sharkbite gapers lid.Snake bite derailleur wheels bomb hole.  Huck apres steeps BB first tracks bowl  daffy park euro park rat euro.  North shore death cookies snake bite carve, freshies dirtbag huck reverse camber hellflip frozen chicken heads apres taco glove gnar face shots bro.  Ride flow twister cornice afterbang saddle first tracks rig berm bro face shots.  Ride stoked wack park twin tip trucks chillax shuttle Whistler gondy laps.  Grind berm schwag, table top face shots steed liftie afterbang taco glove frozen chicken heads free ride clean huck.  Rock-ectomy white room nose press avie.Frozen chicken heads gondy bail travel huckfest big ring phat clean.  Taco couloir piste derailleur wack scream backside steeps groomer glades pipe gondy switch skid lid.  Brain bucket betty bowl, moguls gondy Whistler air hardtail.  Flow euro granny gear, McTwist cruiser bonk grom chain suck.  Trucks line huck, stomp ripper washboard euro corduroy death cookies yard sale dope face plant shreddin chain suck.ACL T-bar hellflip, first tracks gondy hardtail rip wack dust on crust schwag frontside couloir laps presta backside.  Road rash Ski ski bum gnar wack flow carve lid.  Nose white room ollie rail table top grom back country washboard dust on crust chillax gear jammer bro stomp stoked.  Lid wheels nose press frontside, park ACL dirtbag huck epic bowl  taco glove OTB.  Fatty mute whip stunt, Whistler McTwist stoked Bike.  Endo brain bucket crank dust on crust back country line ollie gapers afterbang bump stoked taco road rash granny gear.  Deck dirtbag 360 gnar snake bite couloir Bike corduroy frontside crank lid bro.Air tele schwag ollie, hardtail betty crunchy epic  face shots.  Travel flowy misty huck Bike 180 schwag drop hellflip ripping bunny slope carbon roadie tele bail.  Cornice sharkbite 360 frozen chicken heads dope hellflip clipless.  Switch sketching grind brain bucket stunt taco daffy OTB ride liftie brain bucket air huckfest park 360.' });
-        this.emailControl = new TextBoxControl({ type: 'email', key: 'email', label: 'Email', tooltip: 'Email' });
-        this.numberControl = new TextBoxControl({ type: 'number', key: 'number', label: 'Number' });
-        this.currencyControl = new TextBoxControl({ type: 'currency', key: 'currency', label: 'Currency', currencyFormat: '$ USD' });
-        this.floatControl = new TextBoxControl({ type: 'float', key: 'float', label: 'Float' });
-        this.percentageControl = new TextBoxControl({ type: 'percentage', key: 'percentage', label: 'Percent', required: true });
-        this.quickNoteControl = new QuickNoteControl({ key: 'note', label: 'Note', config: this.quickNoteConfig, required: true, tooltip: 'Quicknote' });
-        this.aceEditorControl = new AceEditorControl({ key: 'ace', label: 'CODE', value: 'var i = 0;' });
-        this.textForm = formUtils.toFormGroup([this.textControl, this.emailControl, this.textAreaControl, this.numberControl, this.currencyControl, this.floatControl, this.percentageControl, this.quickNoteControl, this.aceEditorControl]);
+  constructor(private formUtils: FormUtils) {
+    // Quick note config
+    this.quickNoteConfig = {
+      triggers: {
+        tags: '@',
+        references: '#',
+        boos: '^',
+      },
+      options: {
+        tags: ['First', 'Second'],
+        references: ['Third', 'Fourth'],
+        boos: ['Test'],
+      },
+      renderer: {
+        tags: (symbol, item) => {
+          return `<a class="tag">${symbol}${item.label}</a>`;
+        },
+        references: (symbol, item) => {
+          return `<a class="tag">${symbol}${item.label}</a>`;
+        },
+        boos: (symbol, item) => {
+          return `<strong>${symbol}${item.label}</strong>`;
+        },
+      },
+    };
+    // Text-based Controls
+    this.textControl = new TextBoxControl({ key: 'text', label: 'Text Box', tooltip: 'Textbox', readOnly: true, value: 'HI', required: true });
+    this.textAreaControl = new TextAreaControl({
+      key: 'textarea',
+      label: 'Text Area',
+      value:
+        'Bro ipsum dolor sit amet yard sale saddle pipe, poaching cork 360 punter ACL back country cornice Whistler.  Avie Ski taco mitt, manny first tracks yard sale caballerial heli fatty.  Epic dope grab, brain bucket japan air wack bowl  mute heli corn Snowboard Whistler giblets table top.  Crunchy Snowboard washboard line grab reverse camber.  Bump epic granny gear heli sketching wheelie huckfest face plant crank pow pow chain ring  dirtbag washboard.  Flow endo ski bum sucker hole, death cookies manny schwag pipe.  Dope heli stomp yard sale, saddle shreddin booter gear jammer grom bonk OTB brain bucket bonk japan air Whistler.Clipless pow pow pow, core shot corn butter bomb hole glades face plant dust on crust.  Poaching park face shots bump, Bike cornice death cookies.  Avie cruiser sucker hole face plant switch.  ACL snake bite bonk, twin tip euro rig nose press McTwist.  Ripping skinny trucks shreddin.  Apres pow line euro sharkbite gapers lid.Snake bite derailleur wheels bomb hole.  Huck apres steeps BB first tracks bowl  daffy park euro park rat euro.  North shore death cookies snake bite carve, freshies dirtbag huck reverse camber hellflip frozen chicken heads apres taco glove gnar face shots bro.  Ride flow twister cornice afterbang saddle first tracks rig berm bro face shots.  Ride stoked wack park twin tip trucks chillax shuttle Whistler gondy laps.  Grind berm schwag, table top face shots steed liftie afterbang taco glove frozen chicken heads free ride clean huck.  Rock-ectomy white room nose press avie.Frozen chicken heads gondy bail travel huckfest big ring phat clean.  Taco couloir piste derailleur wack scream backside steeps groomer glades pipe gondy switch skid lid.  Brain bucket betty bowl, moguls gondy Whistler air hardtail.  Flow euro granny gear, McTwist cruiser bonk grom chain suck.  Trucks line huck, stomp ripper washboard euro corduroy death cookies yard sale dope face plant shreddin chain suck.ACL T-bar hellflip, first tracks gondy hardtail rip wack dust on crust schwag frontside couloir laps presta backside.  Road rash Ski ski bum gnar wack flow carve lid.  Nose white room ollie rail table top grom back country washboard dust on crust chillax gear jammer bro stomp stoked.  Lid wheels nose press frontside, park ACL dirtbag huck epic bowl  taco glove OTB.  Fatty mute whip stunt, Whistler McTwist stoked Bike.  Endo brain bucket crank dust on crust back country line ollie gapers afterbang bump stoked taco road rash granny gear.  Deck dirtbag 360 gnar snake bite couloir Bike corduroy frontside crank lid bro.Air tele schwag ollie, hardtail betty crunchy epic  face shots.  Travel flowy misty huck Bike 180 schwag drop hellflip ripping bunny slope carbon roadie tele bail.  Cornice sharkbite 360 frozen chicken heads dope hellflip clipless.  Switch sketching grind brain bucket stunt taco daffy OTB ride liftie brain bucket air huckfest park 360.',
+    });
+    this.emailControl = new TextBoxControl({ type: 'email', key: 'email', label: 'Email', tooltip: 'Email' });
+    this.numberControl = new TextBoxControl({ type: 'number', key: 'number', label: 'Number' });
+    this.currencyControl = new TextBoxControl({ type: 'currency', key: 'currency', label: 'Currency', currencyFormat: '$ USD' });
+    this.floatControl = new TextBoxControl({ type: 'float', key: 'float', label: 'Float' });
+    this.percentageControl = new TextBoxControl({ type: 'percentage', key: 'percentage', label: 'Percent', required: true });
+    this.quickNoteControl = new QuickNoteControl({ key: 'note', label: 'Note', config: this.quickNoteConfig, required: true, tooltip: 'Quicknote' });
+    this.aceEditorControl = new AceEditorControl({ key: 'ace', label: 'CODE', value: 'var i = 0;' });
+    this.textForm = formUtils.toFormGroup([
+      this.textControl,
+      this.emailControl,
+      this.textAreaControl,
+      this.numberControl,
+      this.currencyControl,
+      this.floatControl,
+      this.percentageControl,
+      this.quickNoteControl,
+      this.aceEditorControl,
+    ]);
 
-        // Check box controls
-        this.checkControl = new CheckboxControl({ key: 'check', label: 'Checkbox' });
-        this.checkListControl = new CheckListControl({ key: 'checklist', label: 'Check List', options: ['One', 'Two', 'Three'], tooltip: 'CheckList', tooltipPosition: 'Top' });
-        this.tilesControl = new TilesControl({ key: 'tiles', label: 'Tiles', options: [{ value: 'one', label: 'One' }, { value: 'two', label: 'Two' }], tooltip: 'Tiles' });
-        this.checkForm = formUtils.toFormGroup([this.checkControl, this.checkListControl, this.tilesControl]);
+    // Check box controls
+    this.checkControl = new CheckboxControl({ key: 'check', label: 'Checkbox' });
+    this.checkListControl = new CheckListControl({ key: 'checklist', label: 'Check List', options: ['One', 'Two', 'Three'], tooltip: 'CheckList', tooltipPosition: 'Top' });
+    this.tilesControl = new TilesControl({ key: 'tiles', label: 'Tiles', options: [{ value: 'one', label: 'One' }, { value: 'two', label: 'Two' }], tooltip: 'Tiles' });
+    this.checkForm = formUtils.toFormGroup([this.checkControl, this.checkListControl, this.tilesControl]);
 
-        // Picker controls
-        this.singlePickerControl = new PickerControl({ key: 'singlePicker', label: 'Single', config: { options: ['One', 'Two', 'Three'] } });
-        this.multiPickerControl = new PickerControl({ key: 'multiPicker', label: 'Multiple', multiple: true, config: { options: ['One', 'Two', 'Three'], type: 'candidate' } });
-        this.entityMultiPickerControl = new PickerControl({
-            key: 'entityMultiPicker',
-            label: 'Entities',
-            required: true,
-            readOnly: false,
-            multiple: true,
-            config: {
-                resultsTemplate: EntityPickerResults,
-                previewTemplate: EntityPickerResult,
-                format: '$title',
-                options: [
-                    { title: 'Central Bank', name: 'Central Bank', email: 'new-bank-inquiries@centralbank.com', phone: '(651) 555-1234', address: { city: 'Washington', state: 'DC' }, searchEntity: 'ClientCorporation' },
-                    { title: 'Federal Bank', name: 'Federal Bank', email: 'info@federalbank.com', phone: '(545) 555-1212', address: { city: 'Arlington', state: 'VA' }, searchEntity: 'ClientCorporation' },
-                    { title: 'Aaron Burr', firstName: 'Aaron', lastName: 'Burr', name: 'Aaron Burr', companyName: 'Central Bank', email: 'aburr@centralbank.com', phone: '(333) 555-3434', address: { city: 'Washington', state: 'DC' }, status: 'Hold', searchEntity: 'ClientContact' },
-                    { title: 'Alexander Hamilton', firstName: 'Alexander', lastName: 'Hamilton', name: 'Alexander Hamilton', companyName: 'Federal Bank', email: 'ahamilton@federalbank.com', phone: '(333) 555-2222', address: { city: 'Arlington', state: 'VA' }, status: 'Active', searchEntity: 'ClientContact' },
-                    { title: 'Ben Franklin', firstName: 'Ben', lastName: 'Franklin', name: 'Ben Franklin', email: 'bfranklin@gmail.com', phone: '(654) 525-2222', address: { city: 'Boston', state: 'MA' }, status: 'Interviewing', searchEntity: 'Candidate' },
-                    { title: 'Thomas Jefferson', firstName: 'Thomas', lastName: 'Jefferson', name: 'Thomas Jefferson', email: 'tjefferson@usa.com', phone: '(123) 542-1234', address: { city: 'Arlington', state: 'VA' }, status: 'New Lead', searchEntity: 'Candidate' }]
-            }
-        });
-        let controls = [this.singlePickerControl, this.multiPickerControl, this.entityMultiPickerControl];
-        formUtils.setInitialValues(controls, {
-            entityMultiPicker: [{ 'title': 'Federal Bank', 'name': 'Federal Bank', 'email': 'info@federalbank.com', 'phone': '(545) 555-1212', 'address': { 'city': 'Arlington', 'state': 'VA' }, 'searchEntity': 'ClientCorporation' }]
-        });
-        this.pickerForm = formUtils.toFormGroup(controls);
+    // Picker controls
+    this.singlePickerControl = new PickerControl({ key: 'singlePicker', label: 'Single', config: { options: ['One', 'Two', 'Three'] } });
+    this.multiPickerControl = new PickerControl({ key: 'multiPicker', label: 'Multiple', multiple: true, config: { options: ['One', 'Two', 'Three'], type: 'candidate' } });
+    this.entityMultiPickerControl = new PickerControl({
+      key: 'entityMultiPicker',
+      label: 'Entities',
+      required: true,
+      readOnly: false,
+      multiple: true,
+      config: {
+        resultsTemplate: EntityPickerResults,
+        previewTemplate: EntityPickerResult,
+        format: '$title',
+        options: [
+          {
+            title: 'Central Bank',
+            name: 'Central Bank',
+            email: 'new-bank-inquiries@centralbank.com',
+            phone: '(651) 555-1234',
+            address: { city: 'Washington', state: 'DC' },
+            searchEntity: 'ClientCorporation',
+          },
+          { title: 'Federal Bank', name: 'Federal Bank', email: 'info@federalbank.com', phone: '(545) 555-1212', address: { city: 'Arlington', state: 'VA' }, searchEntity: 'ClientCorporation' },
+          {
+            title: 'Aaron Burr',
+            firstName: 'Aaron',
+            lastName: 'Burr',
+            name: 'Aaron Burr',
+            companyName: 'Central Bank',
+            email: 'aburr@centralbank.com',
+            phone: '(333) 555-3434',
+            address: { city: 'Washington', state: 'DC' },
+            status: 'Hold',
+            searchEntity: 'ClientContact',
+          },
+          {
+            title: 'Alexander Hamilton',
+            firstName: 'Alexander',
+            lastName: 'Hamilton',
+            name: 'Alexander Hamilton',
+            companyName: 'Federal Bank',
+            email: 'ahamilton@federalbank.com',
+            phone: '(333) 555-2222',
+            address: { city: 'Arlington', state: 'VA' },
+            status: 'Active',
+            searchEntity: 'ClientContact',
+          },
+          {
+            title: 'Ben Franklin',
+            firstName: 'Ben',
+            lastName: 'Franklin',
+            name: 'Ben Franklin',
+            email: 'bfranklin@gmail.com',
+            phone: '(654) 525-2222',
+            address: { city: 'Boston', state: 'MA' },
+            status: 'Interviewing',
+            searchEntity: 'Candidate',
+          },
+          {
+            title: 'Thomas Jefferson',
+            firstName: 'Thomas',
+            lastName: 'Jefferson',
+            name: 'Thomas Jefferson',
+            email: 'tjefferson@usa.com',
+            phone: '(123) 542-1234',
+            address: { city: 'Arlington', state: 'VA' },
+            status: 'New Lead',
+            searchEntity: 'Candidate',
+          },
+        ],
+      },
+    });
+    let controls = [this.singlePickerControl, this.multiPickerControl, this.entityMultiPickerControl];
+    formUtils.setInitialValues(controls, {
+      entityMultiPicker: [
+        { title: 'Federal Bank', name: 'Federal Bank', email: 'info@federalbank.com', phone: '(545) 555-1212', address: { city: 'Arlington', state: 'VA' }, searchEntity: 'ClientCorporation' },
+      ],
+    });
+    this.pickerForm = formUtils.toFormGroup(controls);
 
-        // File input controls
-        this.fileControl = new FileControl({ key: 'file', name: 'myfile', label: 'File', tooltip: 'Files Control' });
-        this.multiFileControl = new FileControl({ key: 'files', name: 'myfiles', label: 'Multiple Files', multiple: true, layoutOptions: { order: 'displayFilesBelow', download: true, edit: true, labelStyle: 'no-box' }, value: [{ name: 'yourFile.pdf', loaded: true }] });
-        this.fileForm = formUtils.toFormGroup([this.fileControl, this.multiFileControl]);
+    // File input controls
+    this.fileControl = new FileControl({ key: 'file', name: 'myfile', label: 'File', tooltip: 'Files Control' });
+    this.multiFileControl = new FileControl({
+      key: 'files',
+      name: 'myfiles',
+      label: 'Multiple Files',
+      multiple: true,
+      layoutOptions: { order: 'displayFilesBelow', download: true, edit: true, customActions: true, labelStyle: 'no-box' },
+      value: [{ name: 'yourFile.pdf', loaded: true }],
+    });
+    this.fileForm = formUtils.toFormGroup([this.fileControl, this.multiFileControl]);
 
-        // Calendar input controls
-        this.dateControl = new DateControl({ key: 'date', label: 'Date', tooltip: 'Date' });
-        this.timeControl = new TimeControl({ key: 'time', label: 'Time', tooltip: 'Time' });
-        this.dateTimeControl = new DateTimeControl({ key: 'dateTime', label: 'Date Time', military: true });
-        this.calendarForm = formUtils.toFormGroup([this.dateControl, this.timeControl, this.dateTimeControl]);
+    // Calendar input controls
+    this.dateControl = new DateControl({ key: 'date', label: 'Date', tooltip: 'Date' });
+    this.timeControl = new TimeControl({ key: 'time', label: 'Time', tooltip: 'Time' });
+    this.dateTimeControl = new DateTimeControl({ key: 'dateTime', label: 'Date Time', military: true });
+    this.calendarForm = formUtils.toFormGroup([this.dateControl, this.timeControl, this.dateTimeControl]);
 
-        // Dynamic
-        this.dynamic = formUtils.toFieldSets(MockMeta, '$ USD', {}, { token: 'TOKEN', military: true }, {
-            customfield: {
-                customControl: CustomDemoComponent
-            }
-        });
-        formUtils.setInitialValuesFieldsets(this.dynamic, { firstName: 'Initial F Name', number: 12 });
-        this.dynamicForm = formUtils.toFormGroupFromFieldset(this.dynamic);
+    // Dynamic
+    this.dynamic = formUtils.toFieldSets(
+      MockMeta,
+      '$ USD',
+      {},
+      { token: 'TOKEN', military: true },
+      {
+        customfield: {
+          customControl: CustomDemoComponent,
+        },
+      },
+    );
+    formUtils.setInitialValuesFieldsets(this.dynamic, { firstName: 'Initial F Name', number: 12 });
+    this.dynamicForm = formUtils.toFormGroupFromFieldset(this.dynamic);
 
-        this.dynamicVertical = formUtils.toControls(MockMeta, '$ USD', {}, { token: 'TOKEN', military: true });
-        formUtils.setInitialValues(this.dynamicVertical, { number: 0, firstName: 'Bobby Flay' });
-        this.dynamicVerticalForm = formUtils.toFormGroup(this.dynamicVertical);
+    this.dynamicVertical = formUtils.toControls(MockMeta, '$ USD', {}, { token: 'TOKEN', military: true });
+    formUtils.setInitialValues(this.dynamicVertical, { number: 0, firstName: 'Bobby Flay' });
+    this.dynamicVerticalForm = formUtils.toFormGroup(this.dynamicVertical);
 
-        // Dynamic + Fieldsets
-        this.fieldsets = formUtils.toFieldSets(MockMetaHeaders, '$ USD', {}, { token: 'TOKEN' }, {
-            customfield: {
-                customControl: CustomDemoComponent
-            }
-        });
-        formUtils.setInitialValuesFieldsets(this.fieldsets, { firstName: 'Initial F Name', number: 12 });
-        this.fieldsetsForm = formUtils.toFormGroupFromFieldset(this.fieldsets);
+    // Dynamic + Fieldsets
+    this.fieldsets = formUtils.toFieldSets(
+      MockMetaHeaders,
+      '$ USD',
+      {},
+      { token: 'TOKEN' },
+      {
+        customfield: {
+          customControl: CustomDemoComponent,
+        },
+      },
+    );
+    formUtils.setInitialValuesFieldsets(this.fieldsets, { firstName: 'Initial F Name', number: 12 });
+    this.fieldsetsForm = formUtils.toFormGroupFromFieldset(this.fieldsets);
 
-        // Updating form
-        this.updatingFormControls = [this.textControl, this.percentageControl, this.checkControl, this.singlePickerControl, this.fileControl];
-        this.updatingForm = formUtils.toFormGroup(this.updatingFormControls);
+    // Updating form
+    this.updatingFormControls = [this.textControl, this.percentageControl, this.checkControl, this.singlePickerControl, this.fileControl];
+    this.updatingForm = formUtils.toFormGroup(this.updatingFormControls);
+  }
+
+  toggleEnabled() {
+    this.disabled = !this.disabled;
+    Object.keys(this.updatingForm.controls).forEach((key) => {
+      if (this.disabled) {
+        this.updatingForm.controls[key].enable();
+      } else {
+        this.updatingForm.controls[key].disable();
+      }
+    });
+  }
+
+  toggleRequired() {
+    this.required = !this.required;
+    Object.keys(this.updatingForm.controls).forEach((key) => {
+      this.updatingForm.controls[key].setRequired(this.required);
+    });
+  }
+
+  markAsInvalid() {
+    Object.keys(this.updatingForm.controls).forEach((key) => {
+      this.updatingForm.controls[key].markAsInvalid('Custom Error!');
+    });
+  }
+
+  save(form) {
+    if (!form.isValid) {
+      form.showOnlyRequired(true);
+    } else {
+      alert('SAVING');
     }
+  }
 
-    toggleEnabled() {
-        this.disabled = !this.disabled;
-        Object.keys(this.updatingForm.controls).forEach(key => {
-            if (this.disabled) {
-                this.updatingForm.controls[key].enable();
-            } else {
-                this.updatingForm.controls[key].disable();
-            }
-        });
-    }
+  clear() {
+    this.dynamic.forEach((control) => {
+      control.forceClear.emit();
+    });
+  }
 
-    toggleRequired() {
-        this.required = !this.required;
-        Object.keys(this.updatingForm.controls).forEach(key => {
-            this.updatingForm.controls[key].setRequired(this.required);
-        });
-    }
+  onChange(value) {
+    console.log('I changed!', value); // tslint:disable-line
+  }
 
-    markAsInvalid() {
-        Object.keys(this.updatingForm.controls).forEach(key => {
-            this.updatingForm.controls[key].markAsInvalid('Custom Error!');
-        });
-    }
+  handleEdit(value) {
+    console.log('This is an Edit Action!', value); // tslint:disable-line
+  }
 
-    save(form) {
-        if (!form.isValid) {
-            form.showOnlyRequired(true);
-        } else {
-            alert('SAVING');
-        }
-    }
+  handleSave(value) {
+    console.log('This is a Save Action!', value); // tslint:disable-line
+  }
 
-    clear() {
-        this.dynamic.forEach(control => {
-            control.forceClear.emit();
-        });
-    }
-
-    onChange(value) {
-        console.log('I changed!', value); // tslint:disable-line
-    }
+  handleDelete(value) {
+    console.log('This is a Delete Action!', value); // tslint:disable-line
+  }
 }

--- a/src/app/pages/elements/form/FormDemo.ts
+++ b/src/app/pages/elements/form/FormDemo.ts
@@ -203,7 +203,7 @@ export class FormDemoComponent {
 
         // File input controls
         this.fileControl = new FileControl({ key: 'file', name: 'myfile', label: 'File', tooltip: 'Files Control' });
-        this.multiFileControl = new FileControl({ key: 'files', name: 'myfiles', label: 'Multiple Files', multiple: true, layoutOptions: { order: 'displayFilesBelow', download: true, edit: true, customButtons: true, labelStyle: 'no-box' }, value: [{ name: 'yourFile.pdf', loaded: true }] });
+        this.multiFileControl = new FileControl({ key: 'files', name: 'myfiles', label: 'Multiple Files', multiple: true, layoutOptions: { order: 'displayFilesBelow', download: true, edit: true, labelStyle: 'no-box' }, value: [{ name: 'yourFile.pdf', loaded: true }] });
         this.fileForm = formUtils.toFormGroup([this.fileControl, this.multiFileControl]);
 
         // Calendar input controls

--- a/src/app/pages/elements/form/templates/FileInputControls.html
+++ b/src/app/pages/elements/form/templates/FileInputControls.html
@@ -4,7 +4,7 @@
         <novo-control [form]="fileForm" [control]="fileControl"></novo-control>
     </div>
     <div class="novo-form-row">
-        <novo-control [form]="fileForm" [control]="multiFileControl"></novo-control>
+        <novo-control [form]="fileForm" [control]="multiFileControl" (edit)="handleEdit($event)" (save)="handleSave($event)" (delete)="handleDelete($event)"></novo-control>
     </div>
 </novo-form>
 <div class="final-value">Value: {{fileForm.value | json}}</div>

--- a/src/platform/elements/form/Control.ts
+++ b/src/platform/elements/form/Control.ts
@@ -100,8 +100,8 @@ export class NovoCustomControlContainerElement {
 }
 
 @Component({
-    selector: 'novo-control',
-    template: `
+  selector: 'novo-control',
+  template: `
         <div class="novo-control-container" [formGroup]="form" [hidden]="form.controls[control.key].hidden || form.controls[control.key].type === 'hidden' || form.controls[control.key].controlType === 'hidden'">
             <!--Encrypted Field-->
             <span [tooltip]="labels.encryptedFieldTooltip" [tooltipPosition]="'right'"><i [hidden]="!form.controls[control.key].encrypted"
@@ -153,7 +153,7 @@ export class NovoCustomControlContainerElement {
                                 <option *ngFor="let opt of form.controls[control.key].options" [value]="opt.key">{{opt.value}}</option>
                             </select>
                             <!--File-->
-                            <novo-file-input *ngSwitchCase="'file'" [formControlName]="control.key" [id]="control.key" [name]="control.key" [placeholder]="form.controls[control.key].placeholder" [value]="form.controls[control.key].value" [multiple]="form.controls[control.key].multiple" [layoutOptions]="form.controls[control.key].layoutOptions" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition"></novo-file-input>
+                            <novo-file-input *ngSwitchCase="'file'" [formControlName]="control.key" [id]="control.key" [name]="control.key" [placeholder]="form.controls[control.key].placeholder" [value]="form.controls[control.key].value" [multiple]="form.controls[control.key].multiple" [layoutOptions]="form.controls[control.key].layoutOptions" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" (edit)="handleEdit($event)" (save)="handleSave($event)" (delete)="handleDelete($event)"></novo-file-input>
                             <!--Tiles-->
                             <novo-tiles *ngSwitchCase="'tiles'" [options]="control.options" [formControlName]="control.key" (onChange)="modelChange($event)" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition"></novo-tiles>
                             <!--Picker-->
@@ -231,300 +231,318 @@ export class NovoCustomControlContainerElement {
             </div>
         </div>
     `,
-    host: {
-        '[class]': 'form.controls[control.key].controlType',
-        '[attr.data-control-type]': 'form.controls[control.key].controlType',
-        '[class.disabled]': 'form.controls[control.key].readOnly',
-        '[class.hidden]': 'form.controls[control.key].hidden',
-        '[attr.data-control-key]': 'control.key',
-    }
+  host: {
+    '[class]': 'form.controls[control.key].controlType',
+    '[attr.data-control-type]': 'form.controls[control.key].controlType',
+    '[class.disabled]': 'form.controls[control.key].readOnly',
+    '[class.hidden]': 'form.controls[control.key].hidden',
+    '[attr.data-control-key]': 'control.key',
+  },
 })
 export class NovoControlElement extends OutsideClick implements OnInit, OnDestroy, AfterViewInit {
-    @Input() control: any;
-    @Input() form: NovoFormGroup;
-    @Input() condensed: boolean = false;
-    @Input() autoFocus: boolean = false;
-    @Output() change: EventEmitter<any> = new EventEmitter();
+  @Input() control: any;
+  @Input() form: NovoFormGroup;
+  @Input() condensed: boolean = false;
+  @Input() autoFocus: boolean = false;
+  @Output() change: EventEmitter<any> = new EventEmitter();
+  @Output() edit: EventEmitter<any> = new EventEmitter();
+  @Output() save: EventEmitter<any> = new EventEmitter();
+  @Output() delete: EventEmitter<any> = new EventEmitter();
 
-    @Output('blur')
-    get onBlur(): Observable<FocusEvent> {
-        return this._blurEmitter.asObservable();
-    }
+  @Output('blur')
+  get onBlur(): Observable<FocusEvent> {
+    return this._blurEmitter.asObservable();
+  }
 
-    @Output('focus')
-    get onFocus(): Observable<FocusEvent> {
-        return this._focusEmitter.asObservable();
-    }
+  @Output('focus')
+  get onFocus(): Observable<FocusEvent> {
+    return this._focusEmitter.asObservable();
+  }
 
-    private _blurEmitter: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
-    private _focusEmitter: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
-    private _focused: boolean = false;
-    private _enteredText: string = '';
-    formattedValue: string = '';
-    percentValue: number;
-    maxLengthMet: boolean = false;
-    characterCount: number = 0;
-    private forceClearSubscription: any;
-    private percentChangeSubscription: any;
-    private valueChangeSubscription: any;
-    private dateChangeSubscription: any;
+  private _blurEmitter: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
+  private _focusEmitter: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
+  private _focused: boolean = false;
+  private _enteredText: string = '';
+  formattedValue: string = '';
+  percentValue: number;
+  maxLengthMet: boolean = false;
+  characterCount: number = 0;
+  private forceClearSubscription: any;
+  private percentChangeSubscription: any;
+  private valueChangeSubscription: any;
+  private dateChangeSubscription: any;
 
-    maskOptions: IMaskOptions;
+  maskOptions: IMaskOptions;
 
-    constructor(element: ElementRef, public labels: NovoLabelService, private dateFormatService: DateFormatService, private fieldInteractionApi: FieldInteractionApi) {
-        super(element);
-    }
+  constructor(element: ElementRef, public labels: NovoLabelService, private dateFormatService: DateFormatService, private fieldInteractionApi: FieldInteractionApi) {
+    super(element);
+  }
 
-    get showFieldMessage() {
-        return !this.errors && !this.maxLengthMet && Helpers.isBlank(this.control.description);
-    }
+  get showFieldMessage() {
+    return !this.errors && !this.maxLengthMet && Helpers.isBlank(this.control.description);
+  }
 
-    get showCount() {
-        return this.form.controls[this.control.key].maxlength && this.focused && (this.form.controls[this.control.key].controlType === 'text-area' || this.form.controls[this.control.key].controlType === 'textbox');
-    }
+  get showCount() {
+    return (
+      this.form.controls[this.control.key].maxlength &&
+      this.focused &&
+      (this.form.controls[this.control.key].controlType === 'text-area' || this.form.controls[this.control.key].controlType === 'textbox')
+    );
+  }
 
-    ngAfterViewInit() {
-        const DO_NOT_FOCUS_ME: string[] = ['picker', 'time', 'date', 'date-time'];
-        if (this.autoFocus && !DO_NOT_FOCUS_ME.includes(this.control.controlType)) {
-            setTimeout(() => {
-                let input: HTMLElement = this.element.nativeElement.querySelector('input');
-                if (input) {
-                    input.focus();
-                }
-            });
+  ngAfterViewInit() {
+    const DO_NOT_FOCUS_ME: string[] = ['picker', 'time', 'date', 'date-time'];
+    if (this.autoFocus && !DO_NOT_FOCUS_ME.includes(this.control.controlType)) {
+      setTimeout(() => {
+        let input: HTMLElement = this.element.nativeElement.querySelector('input');
+        if (input) {
+          input.focus();
         }
+      });
     }
+  }
 
-    ngOnInit() {
-        // Make sure to initially format the time controls
-        if (this.control && this.form.controls[this.control.key].value) {
-            if (this.form.controls[this.control.key].controlType === 'textbox' || this.form.controls[this.control.key].controlType === 'text-area') {
-                this.characterCount = this.form.controls[this.control.key].value.length;
-            }
+  ngOnInit() {
+    // Make sure to initially format the time controls
+    if (this.control && this.form.controls[this.control.key].value) {
+      if (this.form.controls[this.control.key].controlType === 'textbox' || this.form.controls[this.control.key].controlType === 'text-area') {
+        this.characterCount = this.form.controls[this.control.key].value.length;
+      }
+    }
+    if (this.control) {
+      // Listen to clear events
+      this.forceClearSubscription = this.control.forceClear.subscribe(() => {
+        this.clearValue();
+      });
+      // Subscribe to control interactions
+      if (this.control.interactions) {
+        for (let interaction of this.control.interactions) {
+          switch (interaction.event) {
+            case 'blur':
+              this.valueChangeSubscription = this.onBlur.debounceTime(300).subscribe(() => {
+                this.executeInteraction(interaction);
+              });
+              break;
+            case 'focus':
+              this.valueChangeSubscription = this.onFocus.debounceTime(300).subscribe(() => {
+                this.executeInteraction(interaction);
+              });
+              break;
+            case 'change':
+              this.valueChangeSubscription = this.form.controls[this.control.key].valueChanges.debounceTime(300).subscribe(() => {
+                this.executeInteraction(interaction);
+              });
+              break;
+            case 'init':
+              interaction.invokeOnInit = true;
+              break;
+            default:
+              break;
+          }
+          if (interaction.invokeOnInit) {
+            this.executeInteraction(interaction);
+          }
         }
-        if (this.control) {
-            // Listen to clear events
-            this.forceClearSubscription = this.control.forceClear.subscribe(() => {
-                this.clearValue();
-            });
-            // Subscribe to control interactions
-            if (this.control.interactions) {
-                for (let interaction of this.control.interactions) {
-                    switch (interaction.event) {
-                        case 'blur':
-                            this.valueChangeSubscription = this.onBlur.debounceTime(300).subscribe(() => {
-                                this.executeInteraction(interaction);
-                            });
-                            break;
-                        case 'focus':
-                            this.valueChangeSubscription = this.onFocus.debounceTime(300).subscribe(() => {
-                                this.executeInteraction(interaction);
-                            });
-                            break;
-                        case 'change':
-                            this.valueChangeSubscription = this.form.controls[this.control.key].valueChanges.debounceTime(300).subscribe(() => {
-                                this.executeInteraction(interaction);
-                            });
-                            break;
-                        case 'init':
-                            interaction.invokeOnInit = true;
-                            break;
-                        default:
-                            break;
-                    }
-                    if (interaction.invokeOnInit) {
-                        this.executeInteraction(interaction);
-                    }
-                }
-            }
+      }
+    }
+    if (this.form.controls[this.control.key] && this.form.controls[this.control.key].subType === 'percentage') {
+      if (!Helpers.isEmpty(this.form.controls[this.control.key].value)) {
+        this.percentValue = Number((this.form.controls[this.control.key].value * 100).toFixed(6).replace(/\.?0*$/, ''));
+      }
+      this.percentChangeSubscription = this.form.controls[this.control.key].displayValueChanges.subscribe((value) => {
+        if (!Helpers.isEmpty(value)) {
+          this.percentValue = Number((value * 100).toFixed(6).replace(/\.?0*$/, ''));
         }
-        if (this.form.controls[this.control.key] && this.form.controls[this.control.key].subType === 'percentage') {
-            if (!Helpers.isEmpty(this.form.controls[this.control.key].value)) {
-                this.percentValue = Number((this.form.controls[this.control.key].value * 100).toFixed(6).replace(/\.?0*$/, ''));
-            }
-            this.percentChangeSubscription = this.form.controls[this.control.key].displayValueChanges.subscribe(value => {
-                if (!Helpers.isEmpty(value)) {
-                    this.percentValue = Number((value * 100).toFixed(6).replace(/\.?0*$/, ''));
-                }
-            });
+      });
+    }
+  }
+
+  executeInteraction(interaction) {
+    if (interaction.script && Helpers.isFunction(interaction.script)) {
+      setTimeout(() => {
+        this.fieldInteractionApi.form = this.form;
+        this.fieldInteractionApi.currentKey = this.control.key;
+        try {
+          interaction.script(this.fieldInteractionApi, this.control.key);
+        } catch (err) {
+          console.info('Field Interaction Error!', this.control.key); // tslint:disable-line
+          console.error(err); // tslint:disable-line
         }
+      });
+    }
+  }
+
+  ngOnDestroy() {
+    // Unsubscribe from control interactions
+    if (this.valueChangeSubscription) {
+      this.valueChangeSubscription.unsubscribe();
+    }
+    // if (this.dateChangeSubscription) {
+    //     this.dateChangeSubscription.unsubscribe();
+    // }
+    if (this.forceClearSubscription) {
+      // Un-listen for clear events
+      this.forceClearSubscription.unsubscribe();
+    }
+    if (this.percentChangeSubscription) {
+      // Un-listen for clear events
+      this.percentChangeSubscription.unsubscribe();
+    }
+    if (this.dateChangeSubscription) {
+      this.dateChangeSubscription.unsubscribe();
+    }
+    super.ngOnDestroy();
+  }
+
+  get errors() {
+    return this.form.controls[this.control.key].errors;
+  }
+
+  get isValid() {
+    return this.form.controls[this.control.key].valid;
+  }
+
+  get isDirty() {
+    return this.form.controls[this.control.key].dirty || this.control.dirty;
+  }
+
+  get hasValue() {
+    return !Helpers.isEmpty(this.form.value[this.control.key]);
+  }
+
+  get focused() {
+    return this._focused;
+  }
+
+  get tooltip() {
+    return this.form.controls[this.control.key].tooltip;
+  }
+
+  get tooltipPosition() {
+    if (Helpers.isBlank(this.form.controls[this.control.key].tooltipPosition)) {
+      return 'right';
+    }
+    return this.form.controls[this.control.key].tooltipPosition;
+  }
+
+  get alwaysActive() {
+    // Controls that have the label active if there is any user entered text in the field
+    if (this.form.controls[this.control.key].controlType === 'picker' && this._enteredText.length) {
+      return true;
     }
 
-    executeInteraction(interaction) {
-        if (interaction.script && Helpers.isFunction(interaction.script)) {
-            setTimeout(() => {
-                this.fieldInteractionApi.form = this.form;
-                this.fieldInteractionApi.currentKey = this.control.key;
-                try {
-                    interaction.script(this.fieldInteractionApi, this.control.key);
-                } catch (err) {
-                    console.info('Field Interaction Error!', this.control.key); // tslint:disable-line
-                    console.error(err); // tslint:disable-line
-                }
-            });
-        }
+    // Controls that always have the label active
+    return ['tiles', 'checklist', 'checkbox', 'address', 'file', 'editor', 'ace-editor', 'radio', 'text-area', 'quick-note'].indexOf(this.form.controls[this.control.key].controlType) !== -1;
+  }
+
+  get requiresExtraSpacing() {
+    // Chips
+    if (this.form.controls[this.control.key].controlType === 'picker' && this.form.controls[this.control.key].multiple && this.hasValue) {
+      return true;
     }
+    return false;
+  }
 
-    ngOnDestroy() {
-        // Unsubscribe from control interactions
-        if (this.valueChangeSubscription) {
-            this.valueChangeSubscription.unsubscribe();
-        }
-        // if (this.dateChangeSubscription) {
-        //     this.dateChangeSubscription.unsubscribe();
-        // }
-        if (this.forceClearSubscription) {
-            // Un-listen for clear events
-            this.forceClearSubscription.unsubscribe();
-        }
-        if (this.percentChangeSubscription) {
-            // Un-listen for clear events
-            this.percentChangeSubscription.unsubscribe();
-        }
-        if (this.dateChangeSubscription) {
-            this.dateChangeSubscription.unsubscribe();
-        }
-        super.ngOnDestroy();
+  handleTyping(event: any) {
+    this._focused = event && event.length;
+    this._enteredText = event;
+  }
+
+  handleFocus(event: FocusEvent) {
+    this._focused = true;
+    this._focusEmitter.emit(event);
+  }
+
+  handleBlur(event: FocusEvent) {
+    this._focused = false;
+    this._blurEmitter.emit(event);
+  }
+
+  clearValue() {
+    this.form.controls[this.control.key].setValue(null);
+    this.formattedValue = null;
+  }
+
+  handleTextAreaInput(event) {
+    this.emitChange(event);
+    this.restrictKeys(event);
+  }
+
+  checkMaxLength(event) {
+    if (this.control && this.form.controls[this.control.key].maxlength) {
+      this.characterCount = event.target.value.length;
+      this.maxLengthMet = event.target.value.length >= this.form.controls[this.control.key].maxlength;
     }
+  }
 
-    get errors() {
-        return this.form.controls[this.control.key].errors;
+  modelChangeWithRaw(event) {
+    if (Helpers.isEmpty(event.value)) {
+      this._focused = false;
+      this._enteredText = '';
     }
+    this.form.controls[this.control.key].rawValue = event.rawValue;
+    this.change.emit(event.value);
+  }
 
-    get isValid() {
-        return this.form.controls[this.control.key].valid;
+  modelChange(value) {
+    if (Helpers.isEmpty(value)) {
+      this._focused = false;
+      this._enteredText = '';
     }
+    this.change.emit(value);
+  }
 
-    get isDirty() {
-        return this.form.controls[this.control.key].dirty || this.control.dirty;
+  restrictKeys(event) {
+    const NUMBERS_ONLY = /[0-9\-]/;
+    const NUMBERS_WITH_DECIMAL = /[0-9\.\-]/;
+    const UTILITY_KEYS = ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight', 'Tab'];
+    let key = event.key;
+    // Types
+    if (this.form.controls[this.control.key].subType === 'number' && !(NUMBERS_ONLY.test(key) || UTILITY_KEYS.includes(key))) {
+      event.preventDefault();
+    } else if (~['currency', 'float', 'percentage'].indexOf(this.form.controls[this.control.key].subType) && !(NUMBERS_WITH_DECIMAL.test(key) || UTILITY_KEYS.includes(key))) {
+      event.preventDefault();
     }
-
-    get hasValue() {
-        return !Helpers.isEmpty(this.form.value[this.control.key]);
+    // Max Length
+    if (this.form.controls[this.control.key].maxlength && event.target.value.length >= this.form.controls[this.control.key].maxlength) {
+      event.preventDefault();
     }
+  }
 
-    get focused() {
-        return this._focused;
+  handlePercentChange(event: KeyboardEvent) {
+    let value = event.target['value'];
+    let percent = Helpers.isEmpty(value) ? null : Number((value / 100).toFixed(6).replace(/\.?0*$/, ''));
+    if (!Helpers.isEmpty(percent)) {
+      this.change.emit(percent);
+      this.form.controls[this.control.key].setValue(percent);
+    } else {
+      this.change.emit(null);
+      this.form.controls[this.control.key].setValue(null);
     }
+  }
 
-    get tooltip() {
-        return this.form.controls[this.control.key].tooltip;
+  handleTabForPickers(event: any): void {
+    if (this.active && event && event.keyCode) {
+      if (event.keyCode === KeyCodes.ESC || event.keyCode === KeyCodes.TAB) {
+        this.toggleActive(event, false);
+      }
     }
+  }
 
-    get tooltipPosition() {
-        if (Helpers.isBlank(this.form.controls[this.control.key].tooltipPosition)) {
-            return 'right';
-        }
-        return this.form.controls[this.control.key].tooltipPosition;
-    }
+  emitChange(value) {
+    this.change.emit(value);
+    this.checkMaxLength(value);
+  }
 
-    get alwaysActive() {
-        // Controls that have the label active if there is any user entered text in the field
-        if (this.form.controls[this.control.key].controlType === 'picker' && this._enteredText.length) {
-            return true;
-        }
+  handleEdit(value) {
+    this.edit.emit(value);
+  }
 
-        // Controls that always have the label active
-        return ['tiles', 'checklist', 'checkbox', 'address', 'file', 'editor', 'ace-editor', 'radio', 'text-area', 'quick-note'].indexOf(this.form.controls[this.control.key].controlType) !== -1;
-    }
+  handleSave(value) {
+    this.save.emit(value);
+  }
 
-    get requiresExtraSpacing() {
-        // Chips
-        if (this.form.controls[this.control.key].controlType === 'picker' && this.form.controls[this.control.key].multiple && this.hasValue) {
-            return true;
-        }
-        return false;
-    }
-
-    handleTyping(event: any) {
-        this._focused = event && event.length;
-        this._enteredText = event;
-    }
-
-    handleFocus(event: FocusEvent) {
-        this._focused = true;
-        this._focusEmitter.emit(event);
-    }
-
-    handleBlur(event: FocusEvent) {
-        this._focused = false;
-        this._blurEmitter.emit(event);
-    }
-
-    clearValue() {
-        this.form.controls[this.control.key].setValue(null);
-        this.formattedValue = null;
-    }
-
-    handleTextAreaInput(event) {
-        this.emitChange(event);
-        this.restrictKeys(event);
-    }
-
-    checkMaxLength(event) {
-        if (this.control && this.form.controls[this.control.key].maxlength) {
-            this.characterCount = event.target.value.length;
-            this.maxLengthMet = event.target.value.length >= this.form.controls[this.control.key].maxlength;
-
-        }
-    }
-
-    modelChangeWithRaw(event) {
-        if (Helpers.isEmpty(event.value)) {
-            this._focused = false;
-            this._enteredText = '';
-        }
-        this.form.controls[this.control.key].rawValue = event.rawValue;
-        this.change.emit(event.value);
-    }
-
-    modelChange(value) {
-        if (Helpers.isEmpty(value)) {
-            this._focused = false;
-            this._enteredText = '';
-        }
-        this.change.emit(value);
-    }
-
-    restrictKeys(event) {
-        const NUMBERS_ONLY = /[0-9\-]/;
-        const NUMBERS_WITH_DECIMAL = /[0-9\.\-]/;
-        const UTILITY_KEYS = ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight', 'Tab'];
-        let key = event.key;
-        // Types
-        if (this.form.controls[this.control.key].subType === 'number' && !(NUMBERS_ONLY.test(key) || UTILITY_KEYS.includes(key))) {
-            event.preventDefault();
-        } else if (~['currency', 'float', 'percentage'].indexOf(this.form.controls[this.control.key].subType) && !(NUMBERS_WITH_DECIMAL.test(key) || UTILITY_KEYS.includes(key))) {
-            event.preventDefault();
-        }
-        // Max Length
-        if (this.form.controls[this.control.key].maxlength && event.target.value.length >= this.form.controls[this.control.key].maxlength) {
-            event.preventDefault();
-        }
-    }
-
-    handlePercentChange(event: KeyboardEvent) {
-        let value = event.target['value'];
-        let percent = Helpers.isEmpty(value) ? null : Number((value / 100).toFixed(6).replace(/\.?0*$/, ''));
-        if (!Helpers.isEmpty(percent)) {
-            this.change.emit(percent);
-            this.form.controls[this.control.key].setValue(percent);
-        } else {
-            this.change.emit(null);
-            this.form.controls[this.control.key].setValue(null);
-        }
-    }
-
-    handleTabForPickers(event: any): void {
-        if (this.active && event && event.keyCode) {
-            if (event.keyCode === KeyCodes.ESC || event.keyCode === KeyCodes.TAB) {
-                this.toggleActive(event, false);
-            }
-        }
-    }
-
-    emitChange(value) {
-        this.change.emit(value);
-        this.checkMaxLength(value);
-    }
+  handleDelete(value) {
+    this.delete.emit(value);
+  }
 }

--- a/src/platform/elements/form/Form.scss
+++ b/src/platform/elements/form/Form.scss
@@ -259,7 +259,7 @@ novo-form {
                         >div.novo-control-outer-container {
                             display: flex;
                             align-items: center;
-                            max-width: 550px;
+                            max-width: 100%;
                             position: relative;
                             width: 100%;
                             i.loading {
@@ -617,7 +617,7 @@ novo-form {
                             position: relative;
                             margin-top: 16px;
                             .novo-control-outer-container {
-                                max-width: 550px;
+                                max-width: 100%;
                                 width: 100%;
                                 .novo-control-inner-container {
                                     position: relative;

--- a/src/platform/elements/form/Form.scss
+++ b/src/platform/elements/form/Form.scss
@@ -259,7 +259,7 @@ novo-form {
                         >div.novo-control-outer-container {
                             display: flex;
                             align-items: center;
-                            max-width: 100%;
+                            max-width: 550px;
                             position: relative;
                             width: 100%;
                             i.loading {
@@ -617,7 +617,7 @@ novo-form {
                             position: relative;
                             margin-top: 16px;
                             .novo-control-outer-container {
-                                max-width: 100%;
+                                max-width: 550px;
                                 width: 100%;
                                 .novo-control-inner-container {
                                     position: relative;

--- a/src/platform/elements/form/controls/BaseControl.ts
+++ b/src/platform/elements/form/controls/BaseControl.ts
@@ -51,7 +51,7 @@ export interface NovoControlConfig {
     description?: string;
     tooltip?: string;
     tooltipPosition?: string;
-    layoutOptions?: { order?: string, download?: boolean, edit?: boolean, customButtons?: boolean, labelStyle?: string, draggable?: boolean, iconStyle?: string };
+    layoutOptions?: { order?: string, download?: boolean, edit?: boolean, labelStyle?: string, draggable?: boolean, iconStyle?: string };
     customControl?: any;
     customControlConfig?: any;
     military?: boolean;

--- a/src/platform/elements/form/controls/BaseControl.ts
+++ b/src/platform/elements/form/controls/BaseControl.ts
@@ -51,7 +51,7 @@ export interface NovoControlConfig {
     description?: string;
     tooltip?: string;
     tooltipPosition?: string;
-    layoutOptions?: { order?: string, download?: boolean, edit?: boolean, labelStyle?: string, draggable?: boolean, iconStyle?: string };
+    layoutOptions?: { order?: string, download?: boolean, edit?: boolean, customActions?: boolean, labelStyle?: string, draggable?: boolean, iconStyle?: string };
     customControl?: any;
     customControlConfig?: any;
     military?: boolean;

--- a/src/platform/elements/form/controls/BaseControl.ts
+++ b/src/platform/elements/form/controls/BaseControl.ts
@@ -51,7 +51,7 @@ export interface NovoControlConfig {
     description?: string;
     tooltip?: string;
     tooltipPosition?: string;
-    layoutOptions?: { order?: string, download?: boolean, labelStyle?: string, draggable?: boolean, iconStyle?: string };
+    layoutOptions?: { order?: string, download?: boolean, edit?: boolean, customButtons?: boolean, labelStyle?: string, draggable?: boolean, iconStyle?: string };
     customControl?: any;
     customControlConfig?: any;
     military?: boolean;

--- a/src/platform/elements/form/controls/BaseControl.ts
+++ b/src/platform/elements/form/controls/BaseControl.ts
@@ -51,7 +51,7 @@ export interface NovoControlConfig {
     description?: string;
     tooltip?: string;
     tooltipPosition?: string;
-    layoutOptions?: { order?: string, download?: boolean, edit?: boolean, customActions?: boolean, labelStyle?: string, draggable?: boolean, iconStyle?: string };
+    layoutOptions?: { order?: string, download?: boolean, edit?: boolean, labelStyle?: string, draggable?: boolean, iconStyle?: string };
     customControl?: any;
     customControlConfig?: any;
     military?: boolean;

--- a/src/platform/elements/form/extras/file/FileInput.scss
+++ b/src/platform/elements/form/extras/file/FileInput.scss
@@ -30,6 +30,9 @@ novo-file-input {
                 white-space: nowrap;
                 text-overflow: ellipsis;
                 overflow: hidden;
+                span {
+                    margin: 0 8px;
+                }
             }
             button {
                 font-size: 1.4rem;

--- a/src/platform/elements/form/extras/file/FileInput.scss
+++ b/src/platform/elements/form/extras/file/FileInput.scss
@@ -54,7 +54,6 @@ novo-file-input {
             position: absolute;
             width: 100% !important;
             height: 100% !important;
-            ;
             cursor: pointer;
         }
         &:hover,

--- a/src/platform/elements/form/extras/file/FileInput.spec.ts
+++ b/src/platform/elements/form/extras/file/FileInput.spec.ts
@@ -116,6 +116,36 @@ describe('Elements: NovoFileInputElement', () => {
             expect(component.element.nativeElement.removeEventListener).toHaveBeenCalled();
         });
     });
+
+    describe('Method: customEdit(file)', () => {
+        beforeEach(() => {
+            spyOn(component.edit, 'emit');
+        })
+        it('should emit an event', () => {
+            component.customEdit({ name: 'file.pdf', loaded: true})
+            expect(component.edit.emit).toHaveBeenCalledWith({ name: 'file.pdf', loaded: true });
+        });
+    })
+
+    describe('Method: customSave(file)', () => {
+        beforeEach(() => {
+        spyOn(component.save, 'emit');
+        });
+        it('should emit an event', () => {
+        component.customSave({ name: 'file.pdf', loaded: true });
+        expect(component.save.emit).toHaveBeenCalledWith({ name: 'file.pdf', loaded: true });
+        });
+    });
+
+    describe('Method: customDelete(file)', () => {
+        beforeEach(() => {
+        spyOn(component.delete, 'emit');
+        });
+        it('should emit an event', () => {
+        component.customDelete({ name: 'file.pdf', loaded: true });
+        expect(component.delete.emit).toHaveBeenCalledWith({ name: 'file.pdf', loaded: true });
+        });
+    });
     //
     // describe('Method: dragEnterHandler(event)', () => {
     //     it('should set active to true.', () => {

--- a/src/platform/elements/form/extras/file/FileInput.spec.ts
+++ b/src/platform/elements/form/extras/file/FileInput.spec.ts
@@ -87,7 +87,7 @@ describe('Elements: NovoFileInputElement', () => {
     });
     describe('Method: insertTemplatesBasedOnLayout()', () => {
         beforeEach(() => {
-            component.layoutOptions = { order: 'default', download: true, labelStyle: 'default' };
+            component.layoutOptions = { order: 'default', download: true, edit: true, labelStyle: 'default' };
         });
         it('should correctly insert templates by default', () => {
             expect(component.insertTemplatesBasedOnLayout).toBeDefined();

--- a/src/platform/elements/form/extras/file/FileInput.ts
+++ b/src/platform/elements/form/extras/file/FileInput.ts
@@ -59,7 +59,7 @@ export class NovoFileInputElement implements ControlValueAccessor, OnInit, OnDes
   @Input() multiple: boolean = false;
   @Input() disabled: boolean = false;
   @Input() placeholder: string;
-  @Input() layoutOptions: { order?: string; download?: boolean; edit?: boolean; customButtons?: boolean; labelStyle?: string; draggable?: boolean };
+  @Input() layoutOptions: { order?: string; download?: boolean; edit?: boolean; labelStyle?: string; draggable?: boolean };
   @Input() value: Array<any> = [];
 
   elements: Array<any> = [];

--- a/src/platform/elements/form/extras/file/FileInput.ts
+++ b/src/platform/elements/form/extras/file/FileInput.ts
@@ -1,5 +1,5 @@
 // NG2
-import { Component, Input, ElementRef, forwardRef, OnInit, OnDestroy, OnChanges, ViewChild, ViewContainerRef, TemplateRef, SimpleChanges } from '@angular/core';
+import { Component, Input, ElementRef, forwardRef, OnInit, OnDestroy, OnChanges, ViewChild, ViewContainerRef, TemplateRef, SimpleChanges, Output, EventEmitter } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 // APP
 import { NovoLabelService } from '../../../../services/novo-label-service';
@@ -45,9 +45,9 @@ const LAYOUT_DEFAULTS = { order: 'default', download: true, labelStyle: 'default
                         <button type="button" theme="icon" icon="close" (click)="remove(file)" [attr.data-automation-id]="'file-remove'" tabindex="-1"></button>
                       </div>
                       <div *ngIf="layoutOptions.customActions">
-                        <button *ngIf="layoutOptions.edit" type="button" theme="icon" icon="edit" [attr.data-automation-id]="'file-edit'" tabindex="-1"></button>
-                        <button *ngIf="layoutOptions.download" type="button" theme="icon" icon="save" [attr.data-automation-id]="'file-download'" tabindex="-1"></button>
-                        <button type="button" theme="icon" icon="close" [attr.data-automation-id]="'file-remove'" tabindex="-1"></button>
+                        <button *ngIf="layoutOptions.edit" type="button" theme="icon" icon="edit" (click)="customEdit(file)" [attr.data-automation-id]="'file-edit'" tabindex="-1"></button>
+                        <button *ngIf="layoutOptions.download" type="button" theme="icon" icon="save" (click)="customSave(file)" [attr.data-automation-id]="'file-download'" tabindex="-1"></button>
+                        <button type="button" theme="icon" icon="close" (click)="customDelete(file)" [attr.data-automation-id]="'file-remove'" tabindex="-1"></button>
                       </div> 
                     </div>
                     <novo-loading *ngIf="!file.loaded"></novo-loading>
@@ -67,6 +67,10 @@ export class NovoFileInputElement implements ControlValueAccessor, OnInit, OnDes
   @Input() placeholder: string;
   @Input() layoutOptions: { order?: string; download?: boolean; edit?: boolean; labelStyle?: string; draggable?: boolean };
   @Input() value: Array<any> = [];
+
+  @Output() edit: EventEmitter<any> = new EventEmitter();
+  @Output() save: EventEmitter<any> = new EventEmitter();
+  @Output() delete: EventEmitter<any> = new EventEmitter();
 
   elements: Array<any> = [];
   files: Array<any> = [];
@@ -217,5 +221,17 @@ export class NovoFileInputElement implements ControlValueAccessor, OnInit, OnDes
 
   readFile(file) {
     return new NovoFile(file).read();
+  }
+
+  customEdit(file) {
+    this.edit.emit(file);
+  }
+
+  customSave(file) {
+    this.save.emit(file);
+  }
+
+  customDelete(file) {
+    this.delete.emit(file);
   }
 }

--- a/src/platform/elements/form/extras/file/FileInput.ts
+++ b/src/platform/elements/form/extras/file/FileInput.ts
@@ -40,9 +40,15 @@ const LAYOUT_DEFAULTS = { order: 'default', download: true, labelStyle: 'default
                     <i *ngIf="layoutOptions.draggable" class="bhi-move"></i>
                     <label>{{ file.name | decodeURI }}</label>
                     <div class="actions" [attr.data-automation-id]="'file-actions'" *ngIf="file.loaded">
-                        <button *ngIf="layoutOptions.edit" type="button" theme="icon" icon="edit" (click)="handleEdit(file)" [attr.data-automation-id]="'file-edit'" tabindex="-1"></button>
-                        <button *ngIf="layoutOptions.download" type="button" theme="icon" icon="save" (click)="handleSave(file)" [attr.data-automation-id]="'file-download'" tabindex="-1"></button>
-                        <button type="button" theme="icon" icon="close" (click)="handleDelete(file)" [attr.data-automation-id]="'file-remove'" tabindex="-1"></button>
+                      <div *ngIf="!layoutOptions.customActions">
+                        <button *ngIf="layoutOptions.download" type="button" theme="icon" icon="save" (click)="download(file)" [attr.data-automation-id]="'file-download'" tabindex="-1"></button>
+                        <button type="button" theme="icon" icon="close" (click)="remove(file)" [attr.data-automation-id]="'file-remove'" tabindex="-1"></button>
+                      </div>
+                      <div *ngIf="layoutOptions.customActions">
+                        <button *ngIf="layoutOptions.edit" type="button" theme="icon" icon="edit" (click)="customEdit(file)" [attr.data-automation-id]="'file-edit'" tabindex="-1"></button>
+                        <button *ngIf="layoutOptions.download" type="button" theme="icon" icon="save" (click)="customSave(file)" [attr.data-automation-id]="'file-download'" tabindex="-1"></button>
+                        <button type="button" theme="icon" icon="close" (click)="customDelete(file)" [attr.data-automation-id]="'file-remove'" tabindex="-1"></button>
+                      </div> 
                     </div>
                     <novo-loading *ngIf="!file.loaded"></novo-loading>
                 </div>
@@ -203,25 +209,29 @@ export class NovoFileInputElement implements ControlValueAccessor, OnInit, OnDes
     });
   }
 
+  download(file) {
+    window.open(file.dataURL, '_blank');
+  }
+
+  remove(file) {
+    this.files.splice(this.files.findIndex((f) => f.name === file.name && f.size === file.size), 1);
+    this.model = this.files;
+    this.onModelChange(this.model);
+  }
+
   readFile(file) {
     return new NovoFile(file).read();
   }
 
-  handleEdit(file) {
+  customEdit(file) {
     this.edit.emit(file);
   }
 
-  handleSave(file) {
-    // previously defiend method:
-      // window.open(file.dataURL, '_blank');
+  customSave(file) {
     this.save.emit(file);
   }
 
-  handleDelete(file) {
-    // previously defined method:
-      // this.files.splice(this.files.findIndex((f) => f.name === file.name && f.size === file.size), 1);
-      // this.model = this.files;
-      // this.onModelChange(this.model);
+  customDelete(file) {
     this.delete.emit(file);
   }
 }

--- a/src/platform/elements/form/extras/file/FileInput.ts
+++ b/src/platform/elements/form/extras/file/FileInput.ts
@@ -40,15 +40,9 @@ const LAYOUT_DEFAULTS = { order: 'default', download: true, labelStyle: 'default
                     <i *ngIf="layoutOptions.draggable" class="bhi-move"></i>
                     <label>{{ file.name | decodeURI }}</label>
                     <div class="actions" [attr.data-automation-id]="'file-actions'" *ngIf="file.loaded">
-                      <div *ngIf="!layoutOptions.customActions">
-                        <button *ngIf="layoutOptions.download" type="button" theme="icon" icon="save" (click)="download(file)" [attr.data-automation-id]="'file-download'" tabindex="-1"></button>
-                        <button type="button" theme="icon" icon="close" (click)="remove(file)" [attr.data-automation-id]="'file-remove'" tabindex="-1"></button>
-                      </div>
-                      <div *ngIf="layoutOptions.customActions">
-                        <button *ngIf="layoutOptions.edit" type="button" theme="icon" icon="edit" (click)="customEdit(file)" [attr.data-automation-id]="'file-edit'" tabindex="-1"></button>
-                        <button *ngIf="layoutOptions.download" type="button" theme="icon" icon="save" (click)="customSave(file)" [attr.data-automation-id]="'file-download'" tabindex="-1"></button>
-                        <button type="button" theme="icon" icon="close" (click)="customDelete(file)" [attr.data-automation-id]="'file-remove'" tabindex="-1"></button>
-                      </div> 
+                        <button *ngIf="layoutOptions.edit" type="button" theme="icon" icon="edit" (click)="handleEdit(file)" [attr.data-automation-id]="'file-edit'" tabindex="-1"></button>
+                        <button *ngIf="layoutOptions.download" type="button" theme="icon" icon="save" (click)="handleSave(file)" [attr.data-automation-id]="'file-download'" tabindex="-1"></button>
+                        <button type="button" theme="icon" icon="close" (click)="handleDelete(file)" [attr.data-automation-id]="'file-remove'" tabindex="-1"></button>
                     </div>
                     <novo-loading *ngIf="!file.loaded"></novo-loading>
                 </div>
@@ -209,29 +203,23 @@ export class NovoFileInputElement implements ControlValueAccessor, OnInit, OnDes
     });
   }
 
-  download(file) {
-    window.open(file.dataURL, '_blank');
-  }
-
-  remove(file) {
-    this.files.splice(this.files.findIndex((f) => f.name === file.name && f.size === file.size), 1);
-    this.model = this.files;
-    this.onModelChange(this.model);
-  }
-
   readFile(file) {
     return new NovoFile(file).read();
   }
 
-  customEdit(file) {
+  handleEdit(file) {
     this.edit.emit(file);
   }
 
-  customSave(file) {
+  handleSave(file) {
+    // window.open(file.dataURL, '_blank');
     this.save.emit(file);
   }
 
-  customDelete(file) {
+  handleDelete(file) {
+    // this.files.splice(this.files.findIndex((f) => f.name === file.name && f.size === file.size), 1);
+    // this.model = this.files;
+    // this.onModelChange(this.model);
     this.delete.emit(file);
   }
 }

--- a/src/platform/elements/form/extras/file/FileInput.ts
+++ b/src/platform/elements/form/extras/file/FileInput.ts
@@ -16,9 +16,9 @@ const FILE_VALUE_ACCESSOR = {
 const LAYOUT_DEFAULTS = { order: 'default', download: true, labelStyle: 'default', draggable: false };
 
 @Component({
-    selector: 'novo-file-input',
-    providers: [FILE_VALUE_ACCESSOR],
-    template: `
+  selector: 'novo-file-input',
+  providers: [FILE_VALUE_ACCESSOR],
+  template: `
         <div #container></div>
         <ng-template #fileInput>
             <div class="file-input-group" [class.disabled]="disabled" [class.active]="active">
@@ -40,178 +40,179 @@ const LAYOUT_DEFAULTS = { order: 'default', download: true, labelStyle: 'default
                     <i *ngIf="layoutOptions.draggable" class="bhi-move"></i>
                     <label>{{ file.name | decodeURI }}</label>
                     <div class="actions" [attr.data-automation-id]="'file-actions'" *ngIf="file.loaded">
+                        <button *ngIf="layoutOptions.edit" type="button" theme="icon" icon="edit" (click)="edit(file)" [attr.data-automation-id]="'file-edit'" tabindex="-1"></button>
                         <button *ngIf="layoutOptions.download" type="button" theme="icon" icon="save" (click)="download(file)" [attr.data-automation-id]="'file-download'" tabindex="-1"></button>
                         <button type="button" theme="icon" icon="close" (click)="remove(file)" [attr.data-automation-id]="'file-remove'" tabindex="-1"></button>
                     </div>
                     <novo-loading *ngIf="!file.loaded"></novo-loading>
                 </div>
             </div>
-        </ng-template>`
+        </ng-template>`,
 })
 export class NovoFileInputElement implements ControlValueAccessor, OnInit, OnDestroy, OnChanges {
-    @ViewChild('fileInput') fileInput: TemplateRef<any>;
-    @ViewChild('fileOutput') fileOutput: TemplateRef<any>;
-    @ViewChild('container', { read: ViewContainerRef }) container: ViewContainerRef;
+  @ViewChild('fileInput') fileInput: TemplateRef<any>;
+  @ViewChild('fileOutput') fileOutput: TemplateRef<any>;
+  @ViewChild('container', { read: ViewContainerRef })
+  container: ViewContainerRef;
 
-    @Input() name: string;
-    @Input() multiple: boolean = false;
-    @Input() disabled: boolean = false;
-    @Input() placeholder: string;
-    @Input() layoutOptions: { order?: string, download?: boolean, labelStyle?: string, draggable?: boolean };
-    @Input() value: Array<any> = [];
+  @Input() name: string;
+  @Input() multiple: boolean = false;
+  @Input() disabled: boolean = false;
+  @Input() placeholder: string;
+  @Input() layoutOptions: { order?: string; download?: boolean; edit?: boolean; labelStyle?: string; draggable?: boolean };
+  @Input() value: Array<any> = [];
 
-    elements: Array<any> = [];
-    files: Array<any> = [];
-    model: any;
-    active: boolean = false;
-    commands: any;
-    visible: boolean;
-    target: any;
-    fileOutputBag: string;
+  elements: Array<any> = [];
+  files: Array<any> = [];
+  model: any;
+  active: boolean = false;
+  commands: any;
+  visible: boolean;
+  target: any;
+  fileOutputBag: string;
 
-    onModelChange: Function = () => {
+  onModelChange: Function = () => {};
+  onModelTouched: Function = () => {};
+
+  constructor(private element: ElementRef, public labels: NovoLabelService, private dragula: NovoDragulaService) {
+    this.commands = {
+      dragenter: this.dragEnterHandler.bind(this),
+      dragleave: this.dragLeaveHandler.bind(this),
+      dragover: this.dragOverHandler.bind(this),
+      drop: this.dropHandler.bind(this),
     };
-    onModelTouched: Function = () => {
-    };
+  }
 
-    constructor(private element: ElementRef, public labels: NovoLabelService, private dragula: NovoDragulaService) {
-        this.commands = {
-            dragenter: this.dragEnterHandler.bind(this),
-            dragleave: this.dragLeaveHandler.bind(this),
-            dragover: this.dragOverHandler.bind(this),
-            drop: this.dropHandler.bind(this)
-        };
-    }
+  ngOnInit() {
+    ['dragenter', 'dragleave', 'dragover', 'drop'].forEach((type) => {
+      this.element.nativeElement.addEventListener(type, this.commands[type]);
+    });
+    this.updateLayout();
+    this.initializeDragula();
+    this.setInitialFileList();
+  }
 
-    ngOnInit() {
-        ['dragenter', 'dragleave', 'dragover', 'drop'].forEach(type => {
-            this.element.nativeElement.addEventListener(type, this.commands[type]);
-        });
-        this.updateLayout();
-        this.initializeDragula();
-        this.setInitialFileList();
+  ngOnDestroy() {
+    ['dragenter', 'dragleave', 'dragover', 'drop'].forEach((type) => {
+      this.element.nativeElement.removeEventListener(type, this.commands[type]);
+    });
+    let dragulaHasFileOutputBag = this.dragula.bags.length > 0 && this.dragula.bags.filter((x) => x.name === this.fileOutputBag).length > 0;
+    if (dragulaHasFileOutputBag) {
+      this.dragula.destroy(this.fileOutputBag);
     }
+  }
 
-    ngOnDestroy() {
-        ['dragenter', 'dragleave', 'dragover', 'drop'].forEach(type => {
-            this.element.nativeElement.removeEventListener(type, this.commands[type]);
-        });
-        let dragulaHasFileOutputBag = this.dragula.bags.length > 0 && this.dragula.bags.filter(x => x.name === this.fileOutputBag).length > 0;
-        if (dragulaHasFileOutputBag) {
-            this.dragula.destroy(this.fileOutputBag);
-        }
-    }
+  ngOnChanges(changes?: SimpleChanges) {
+    this.onModelChange(this.model);
+  }
 
-    ngOnChanges(changes?: SimpleChanges) {
-        this.onModelChange(this.model);
-    }
+  updateLayout() {
+    this.layoutOptions = Object.assign({}, LAYOUT_DEFAULTS, this.layoutOptions);
+    this.insertTemplatesBasedOnLayout();
+  }
 
-    updateLayout() {
-        this.layoutOptions = Object.assign({}, LAYOUT_DEFAULTS, this.layoutOptions);
-        this.insertTemplatesBasedOnLayout();
+  insertTemplatesBasedOnLayout() {
+    let order;
+    switch (this.layoutOptions['order']) {
+      case 'displayFilesBelow':
+        order = ['fileInput', 'fileOutput'];
+        break;
+      default:
+        order = ['fileOutput', 'fileInput'];
     }
+    order.forEach((template) => {
+      this.container.createEmbeddedView(this[template], 0);
+    });
+    return order;
+  }
 
-    insertTemplatesBasedOnLayout() {
-        let order;
-        switch (this.layoutOptions['order']) {
-            case 'displayFilesBelow':
-                order = ['fileInput', 'fileOutput'];
-                break;
-            default:
-                order = ['fileOutput', 'fileInput'];
-        }
-        order.forEach((template) => {
-            this.container.createEmbeddedView(this[template], 0);
-        });
-        return order;
-    }
+  initializeDragula() {
+    this.fileOutputBag = `file-output-${this.dragula.bags.length}`;
+    this.dragula.setOptions(this.fileOutputBag, {
+      moves: (el, container, handle) => {
+        return this.layoutOptions.draggable;
+      },
+    });
+  }
 
-    initializeDragula() {
-        this.fileOutputBag = `file-output-${this.dragula.bags.length}`;
-        this.dragula.setOptions(this.fileOutputBag, {
-            moves: (el, container, handle) => {
-                return this.layoutOptions.draggable;
-            }
-        });
+  setInitialFileList() {
+    if (this.value) {
+      this.files = this.value;
     }
+  }
 
-    setInitialFileList() {
-        if (this.value) {
-            this.files = this.value;
-        }
-    }
+  dragEnterHandler(event) {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'copy';
+    this.target = event.target;
+    this.active = true;
+  }
 
-    dragEnterHandler(event) {
-        event.preventDefault();
-        event.dataTransfer.dropEffect = 'copy';
-        this.target = event.target;
-        this.active = true;
+  dragLeaveHandler(event) {
+    event.preventDefault();
+    if (this.target === event.target) {
+      this.active = false;
     }
+  }
 
-    dragLeaveHandler(event) {
-        event.preventDefault();
-        if (this.target === event.target) {
-            this.active = false;
-        }
-    }
+  dragOverHandler(event) {
+    event.preventDefault();
+    // no-op
+  }
 
-    dragOverHandler(event) {
-        event.preventDefault();
-        // no-op
+  dropHandler(event) {
+    event.preventDefault();
+    this.visible = false;
+    if (event.dataTransfer.types[0] !== 'Files') {
+      return;
     }
+    let filelist = Array.from(event.dataTransfer.files);
+    this.process(this.multiple ? filelist : [filelist[0]]);
+    this.active = false;
+  }
 
-    dropHandler(event) {
-        event.preventDefault();
-        this.visible = false;
-        if (event.dataTransfer.types[0] !== 'Files') {
-            return;
-        }
-        let filelist = Array.from(event.dataTransfer.files);
-        this.process(this.multiple ? filelist : [filelist[0]]);
-        this.active = false;
-    }
+  writeValue(model: any): void {
+    this.model = model;
+  }
 
-    writeValue(model: any): void {
-        this.model = model;
-    }
+  registerOnChange(fn: Function): void {
+    this.onModelChange = fn;
+  }
 
-    registerOnChange(fn: Function): void {
-        this.onModelChange = fn;
-    }
+  registerOnTouched(fn: Function): void {
+    this.onModelTouched = fn;
+  }
 
-    registerOnTouched(fn: Function): void {
-        this.onModelTouched = fn;
-    }
+  check(event) {
+    this.process(Array.from(event.target.files));
+  }
 
-    check(event) {
-        this.process(Array.from(event.target.files));
-    }
+  process(filelist) {
+    Promise.all(filelist.map((file) => this.readFile(file))).then((files) => {
+      if (this.multiple) {
+        this.files.push(...files);
+      } else {
+        this.files = files;
+      }
+      this.model = this.files;
+      this.onModelChange(this.model);
+    });
+  }
 
-    process(filelist) {
-        Promise.all(
-            filelist.map((file) => this.readFile(file))
-        ).then((files) => {
-            if (this.multiple) {
-                this.files.push(...files);
-            } else {
-                this.files = files;
-            }
-            this.model = this.files;
-            this.onModelChange(this.model);
-        });
-    }
+  edit(file) {
+  }
 
-    download(file) {
-        window.open(file.dataURL, '_blank');
-    }
+  download(file) {
+    window.open(file.dataURL, '_blank');
+  }
 
-    remove(file) {
-        this.files.splice(this.files.findIndex(f => (f.name === file.name && f.size === file.size)), 1);
-        this.model = this.files;
-        this.onModelChange(this.model);
-    }
+  remove(file) {
+    this.files.splice(this.files.findIndex((f) => f.name === file.name && f.size === file.size), 1);
+    this.model = this.files;
+    this.onModelChange(this.model);
+  }
 
-    readFile(file) {
-        return new NovoFile(file).read();
-    }
+  readFile(file) {
+    return new NovoFile(file).read();
+  }
 }

--- a/src/platform/elements/form/extras/file/FileInput.ts
+++ b/src/platform/elements/form/extras/file/FileInput.ts
@@ -37,19 +37,20 @@ const LAYOUT_DEFAULTS = { order: 'default', download: true, labelStyle: 'default
         <ng-template #fileOutput>
             <div class="file-output-group" [dragula]="fileOutputBag" [dragulaModel]="files">
                 <div class="file-item" *ngFor="let file of files">
-                    <i *ngIf="layoutOptions.draggable" class="bhi-move"></i>
-                    <label>{{ file.name | decodeURI }}</label>
-                    <div class="actions" [attr.data-automation-id]="'file-actions'" *ngIf="file.loaded">
-                      <div *ngIf="!layoutOptions.customActions">
-                        <button *ngIf="layoutOptions.download" type="button" theme="icon" icon="save" (click)="download(file)" [attr.data-automation-id]="'file-download'" tabindex="-1"></button>
-                        <button type="button" theme="icon" icon="close" (click)="remove(file)" [attr.data-automation-id]="'file-remove'" tabindex="-1"></button>
-                      </div>
-                      <div *ngIf="layoutOptions.customActions">
-                        <button *ngIf="layoutOptions.edit" type="button" theme="icon" icon="edit" (click)="customEdit(file)" [attr.data-automation-id]="'file-edit'" tabindex="-1"></button>
-                        <button *ngIf="layoutOptions.download" type="button" theme="icon" icon="save" (click)="customSave(file)" [attr.data-automation-id]="'file-download'" tabindex="-1"></button>
-                        <button type="button" theme="icon" icon="close" (click)="customDelete(file)" [attr.data-automation-id]="'file-remove'" tabindex="-1"></button>
-                      </div> 
+                  <i *ngIf="layoutOptions.draggable" class="bhi-move"></i>
+                  <label *ngIf="file.link"><span><a href="{{ file.link }}">{{ file.name | decodeURI }}</a></span><span  *ngIf="file.description">||</span><span>{{ file.description }}</span></label> 
+                  <label *ngIf="!file.link">{{ file.name | decodeURI }}</label> 
+                  <div class="actions" [attr.data-automation-id]="'file-actions'" *ngIf="file.loaded">
+                    <div *ngIf="!layoutOptions.customActions">
+                      <button *ngIf="layoutOptions.download" type="button" theme="icon" icon="save" (click)="download(file)" [attr.data-automation-id]="'file-download'" tabindex="-1"></button>
+                      <button type="button" theme="icon" icon="close" (click)="remove(file)" [attr.data-automation-id]="'file-remove'" tabindex="-1"></button>
                     </div>
+                    <div *ngIf="layoutOptions.customActions">
+                      <button *ngIf="layoutOptions.edit" type="button" theme="icon" icon="edit" (click)="customEdit(file)" [attr.data-automation-id]="'file-edit'" tabindex="-1"></button>
+                      <button *ngIf="layoutOptions.download" type="button" theme="icon" icon="save" (click)="customSave(file)" [attr.data-automation-id]="'file-download'" tabindex="-1"></button>
+                      <button type="button" theme="icon" icon="close" (click)="customDelete(file)" [attr.data-automation-id]="'file-remove'" tabindex="-1"></button>
+                    </div> 
+                  </div>
                     <novo-loading *ngIf="!file.loaded"></novo-loading>
                 </div>
             </div>

--- a/src/platform/elements/form/extras/file/FileInput.ts
+++ b/src/platform/elements/form/extras/file/FileInput.ts
@@ -40,7 +40,7 @@ const LAYOUT_DEFAULTS = { order: 'default', download: true, labelStyle: 'default
                     <i *ngIf="layoutOptions.draggable" class="bhi-move"></i>
                     <label>{{ file.name | decodeURI }}</label>
                     <div class="actions" [attr.data-automation-id]="'file-actions'" *ngIf="file.loaded">
-                        <button *ngIf="layoutOptions.edit" type="button" theme="icon" icon="edit" (click)="edit(file)" [attr.data-automation-id]="'file-edit'" tabindex="-1"></button>
+                        <button *ngIf="layoutOptions.edit" type="button" theme="icon" icon="edit" [attr.data-automation-id]="'file-edit'" tabindex="-1"></button>
                         <button *ngIf="layoutOptions.download" type="button" theme="icon" icon="save" (click)="download(file)" [attr.data-automation-id]="'file-download'" tabindex="-1"></button>
                         <button type="button" theme="icon" icon="close" (click)="remove(file)" [attr.data-automation-id]="'file-remove'" tabindex="-1"></button>
                     </div>
@@ -59,7 +59,7 @@ export class NovoFileInputElement implements ControlValueAccessor, OnInit, OnDes
   @Input() multiple: boolean = false;
   @Input() disabled: boolean = false;
   @Input() placeholder: string;
-  @Input() layoutOptions: { order?: string; download?: boolean; edit?: boolean; labelStyle?: string; draggable?: boolean };
+  @Input() layoutOptions: { order?: string; download?: boolean; edit?: boolean; customButtons?: boolean; labelStyle?: string; draggable?: boolean };
   @Input() value: Array<any> = [];
 
   elements: Array<any> = [];
@@ -197,9 +197,6 @@ export class NovoFileInputElement implements ControlValueAccessor, OnInit, OnDes
       this.model = this.files;
       this.onModelChange(this.model);
     });
-  }
-
-  edit(file) {
   }
 
   download(file) {

--- a/src/platform/elements/form/extras/file/FileInput.ts
+++ b/src/platform/elements/form/extras/file/FileInput.ts
@@ -40,9 +40,15 @@ const LAYOUT_DEFAULTS = { order: 'default', download: true, labelStyle: 'default
                     <i *ngIf="layoutOptions.draggable" class="bhi-move"></i>
                     <label>{{ file.name | decodeURI }}</label>
                     <div class="actions" [attr.data-automation-id]="'file-actions'" *ngIf="file.loaded">
-                        <button *ngIf="layoutOptions.edit" type="button" theme="icon" icon="edit" [attr.data-automation-id]="'file-edit'" tabindex="-1"></button>
+                      <div *ngIf="!layoutOptions.customActions">
                         <button *ngIf="layoutOptions.download" type="button" theme="icon" icon="save" (click)="download(file)" [attr.data-automation-id]="'file-download'" tabindex="-1"></button>
                         <button type="button" theme="icon" icon="close" (click)="remove(file)" [attr.data-automation-id]="'file-remove'" tabindex="-1"></button>
+                      </div>
+                      <div *ngIf="layoutOptions.customActions">
+                        <button *ngIf="layoutOptions.edit" type="button" theme="icon" icon="edit" [attr.data-automation-id]="'file-edit'" tabindex="-1"></button>
+                        <button *ngIf="layoutOptions.download" type="button" theme="icon" icon="save" [attr.data-automation-id]="'file-download'" tabindex="-1"></button>
+                        <button type="button" theme="icon" icon="close" [attr.data-automation-id]="'file-remove'" tabindex="-1"></button>
+                      </div> 
                     </div>
                     <novo-loading *ngIf="!file.loaded"></novo-loading>
                 </div>

--- a/src/platform/elements/form/extras/file/FileInput.ts
+++ b/src/platform/elements/form/extras/file/FileInput.ts
@@ -212,14 +212,16 @@ export class NovoFileInputElement implements ControlValueAccessor, OnInit, OnDes
   }
 
   handleSave(file) {
-    // window.open(file.dataURL, '_blank');
+    // previously defiend method:
+      // window.open(file.dataURL, '_blank');
     this.save.emit(file);
   }
 
   handleDelete(file) {
-    // this.files.splice(this.files.findIndex((f) => f.name === file.name && f.size === file.size), 1);
-    // this.model = this.files;
-    // this.onModelChange(this.model);
+    // previously defined method:
+      // this.files.splice(this.files.findIndex((f) => f.name === file.name && f.size === file.size), 1);
+      // this.model = this.files;
+      // this.onModelChange(this.model);
     this.delete.emit(file);
   }
 }


### PR DESCRIPTION
## **Purpose**

- To support BBO NOVO attachments workflow.

## **Description**

- Add edit button as an option for multipleFileControl.
- Support custom defined actions for edit, save, delete buttons. 
- Add support for file link & description

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

##### **Screenshots**