### PR TITLE
NovoTable - Allowing for an extra colspan in row detail if checkboxes are a visible column

### DIFF
--- a/src/platform/elements/table/Table.ts
+++ b/src/platform/elements/table/Table.ts
@@ -170,7 +170,7 @@ export enum NovoTableMode {
                         </tr>
                         <tr class="details-row" *ngIf="config.hasDetails" [hidden]="!row._expanded" [attr.data-automation-id]="'details-row-'+row.id">
                             <td class="row-actions"></td>
-                            <td [attr.colspan]="columns.length">
+                            <td [attr.colspan]="config.rowSelectionStyle === 'checkbox' ? (columns.length + 1) : columns.length">
                                 <novo-row-details [data]="row" [renderer]="config.detailsRenderer"></novo-row-details>
                             </td>
                         </tr>


### PR DESCRIPTION
## **Description**

Fixes a bug where detail row is short by a cell because the checkbox column is not being accounted for in determining the row's column span. No new demos were added.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**