### PR TITLE
f/multiFileControl-fix-dropHandler

### DIFF
--- a/src/platform/elements/form/extras/file/FileInput.ts
+++ b/src/platform/elements/form/extras/file/FileInput.ts
@@ -180,10 +180,10 @@ export class NovoFileInputElement implements ControlValueAccessor, OnInit, OnDes
       return;
     }
     let options: any = this.layoutOptions;
+    let filelist = Array.from(event.dataTransfer.files);
     if (options.customActions) {
-      this.upload.emit(event);
+      this.upload.emit(this.multiple ? filelist : [filelist[0]]);
     } else {
-      let filelist = Array.from(event.dataTransfer.files);
       this.process(this.multiple ? filelist : [filelist[0]]);
     }
     this.active = false;


### PR DESCRIPTION
## **Description**

custom dropHandler to target a dropped file when emitting an upload event.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**