### PR TITLE
feat(address) - address subfield labels are configurable

### DIFF
--- a/src/app/pages/elements/form/FormDemo.ts
+++ b/src/app/pages/elements/form/FormDemo.ts
@@ -10,13 +10,14 @@ let CalendarControlsDemoTpl = require('./templates/CalendarInputControls.html');
 let FieldsetsFormDemoTpl = require('./templates/DynamicFormFieldSets.html');
 let PickerControlsDemoTpl = require('./templates/PickerControls.html');
 let UpdatingFormDemoTpl = require('./templates/UpdatingFormDemo.html');
+let AddressControlDemoTpl = require('./templates/AddressControl.html');
 import { MockMeta, MockMetaHeaders } from './MockMeta';
 // Vendor
 import {
     FormUtils, TextBoxControl, CheckboxControl, CheckListControl, FileControl,
     QuickNoteControl, TilesControl, DateControl, TimeControl, DateTimeControl,
     PickerControl, EntityPickerResult, EntityPickerResults, TextAreaControl,
-    NovoFormGroup, BaseControl, AceEditorControl
+    NovoFormGroup, BaseControl, AceEditorControl, AddressControl,
 } from './../../../../platform/index';
 
 const template = `
@@ -47,6 +48,10 @@ const template = `
     <div class="example form-demo">${PickerControlsDemoTpl}</div>
     <code-snippet [code]="PickerControlsDemoTpl"></code-snippet>
 
+    <h5>Address Controls</h5>
+    <div class="example form-demo">${AddressControlDemoTpl}</div>
+    <code-snippet [code]="AddressControlDemoTpl"></code-snippet>
+
     <h2>Dynamic Form</h2>
     <p>Dynamic forms are composed of one element, <code>&lt;novo-dynamic-form [controls]="controls"/&gt;</code> and allow you to pass in the controls and form and it will create the form for you.</p>
 
@@ -69,321 +74,349 @@ const template = `
 `;
 
 @Component({
-  selector: 'custom-demo-component',
-  template: `<novo-custom-control-container [formGroup]="form" [form]="form" [control]="control">
+    selector: 'custom-demo-component',
+    template: `<novo-custom-control-container [formGroup]="form" [form]="form" [control]="control">
         My Custom Input <input [formControlName]="control.key" [id]="control.key" [type]="control.type" [placeholder]="control.placeholder">
     </novo-custom-control-container>`,
 })
 export class CustomDemoComponent {
-  @Input() control;
-  @Input() form: any;
-  @Input() edit: any;
-  @Input() save: any;
-  @Input() delete: any;
-  @Input() upload: any;
+    @Input() control;
+    @Input() form: any;
+    @Input() edit: any;
+    @Input() save: any;
+    @Input() delete: any;
+    @Input() upload: any;
 }
 
 @Component({
-  selector: 'form-demo',
-  template: template,
+    selector: 'form-demo',
+    template: template,
 })
 export class FormDemoComponent {
-  private DynamicFormDemoTpl: string = DynamicFormDemoTpl;
-  private VerticalDynamicFormDemoTpl: string = VerticalDynamicFormDemoTpl;
-  private TextBasedControlsDemoTpl: string = TextBasedControlsDemoTpl;
-  private CheckBoxControlsDemoTpl: string = CheckBoxControlsDemoTpl;
-  private FileInputControlsDemoTpl: string = FileInputControlsDemoTpl;
-  private CalendarControlsDemoTpl: string = CalendarControlsDemoTpl;
-  private FieldsetsFormDemoTpl: string = FieldsetsFormDemoTpl;
-  private PickerControlsDemoTpl: string = PickerControlsDemoTpl;
-  private UpdatingFormDemoTpl: string = UpdatingFormDemoTpl;
-  private quickNoteConfig: any;
-  private textControl: any;
-  private emailControl: any;
-  private numberControl: any;
-  private currencyControl: any;
-  private aceEditorControl: any;
-  private floatControl: any;
-  private percentageControl: any;
-  private quickNoteControl: any;
-  private textForm: any;
-  private checkControl: any;
-  private textAreaControl: any;
-  private checkListControl: any;
-  private tilesControl: any;
-  private checkForm: any;
-  private fileControl: any;
-  private multiFileControl: any;
-  private fileForm: any;
-  private dateControl: any;
-  private timeControl: any;
-  private dateTimeControl: any;
-  private dynamic: any;
-  private dynamicForm: any;
-  private dynamicVertical: any;
-  private dynamicVerticalForm: any;
-  private calendarForm: any;
-  private fieldsets: Array<any>;
-  private fieldsetsForm: any;
-  private singlePickerControl: any;
-  private multiPickerControl: any;
-  private entityMultiPickerControl: any;
-  private pickerForm: any;
-  private updatingForm: any;
-  private updatingFormControls: any[];
-  private required: boolean = false;
-  private disabled: boolean = true;
+    private DynamicFormDemoTpl: string = DynamicFormDemoTpl;
+    private VerticalDynamicFormDemoTpl: string = VerticalDynamicFormDemoTpl;
+    private TextBasedControlsDemoTpl: string = TextBasedControlsDemoTpl;
+    private CheckBoxControlsDemoTpl: string = CheckBoxControlsDemoTpl;
+    private FileInputControlsDemoTpl: string = FileInputControlsDemoTpl;
+    private CalendarControlsDemoTpl: string = CalendarControlsDemoTpl;
+    private FieldsetsFormDemoTpl: string = FieldsetsFormDemoTpl;
+    private PickerControlsDemoTpl: string = PickerControlsDemoTpl;
+    private UpdatingFormDemoTpl: string = UpdatingFormDemoTpl;
+    private AddressControlDemoTpl: string = AddressControlDemoTpl;
+    private quickNoteConfig: any;
+    private textControl: any;
+    private emailControl: any;
+    private numberControl: any;
+    private currencyControl: any;
+    private aceEditorControl: any;
+    private floatControl: any;
+    private percentageControl: any;
+    private quickNoteControl: any;
+    private textForm: any;
+    private checkControl: any;
+    private textAreaControl: any;
+    private checkListControl: any;
+    private tilesControl: any;
+    private checkForm: any;
+    private fileControl: any;
+    private multiFileControl: any;
+    private fileForm: any;
+    private dateControl: any;
+    private timeControl: any;
+    private dateTimeControl: any;
+    private dynamic: any;
+    private dynamicForm: any;
+    private dynamicVertical: any;
+    private dynamicVerticalForm: any;
+    private calendarForm: any;
+    private fieldsets: Array<any>;
+    private fieldsetsForm: any;
+    private singlePickerControl: any;
+    private multiPickerControl: any;
+    private entityMultiPickerControl: any;
+    private pickerForm: any;
+    private updatingForm: any;
+    private updatingFormControls: any[];
+    private required: boolean = false;
+    private disabled: boolean = true;
+    private addressControl: any;
+    private addressForm: any;
+    private addressFormControls: any;
 
-  constructor(private formUtils: FormUtils) {
-    // Quick note config
-    this.quickNoteConfig = {
-      triggers: {
-        tags: '@',
-        references: '#',
-        boos: '^',
-      },
-      options: {
-        tags: ['First', 'Second'],
-        references: ['Third', 'Fourth'],
-        boos: ['Test'],
-      },
-      renderer: {
-        tags: (symbol, item) => {
-          return `<a class="tag">${symbol}${item.label}</a>`;
-        },
-        references: (symbol, item) => {
-          return `<a class="tag">${symbol}${item.label}</a>`;
-        },
-        boos: (symbol, item) => {
-          return `<strong>${symbol}${item.label}</strong>`;
-        },
-      },
-    };
-    // Text-based Controls
-    this.textControl = new TextBoxControl({ key: 'text', label: 'Text Box', tooltip: 'Textbox', readOnly: true, value: 'HI', required: true });
-    this.textAreaControl = new TextAreaControl({
-      key: 'textarea',
-      label: 'Text Area',
-      value:
-        'Bro ipsum dolor sit amet yard sale saddle pipe, poaching cork 360 punter ACL back country cornice Whistler.  Avie Ski taco mitt, manny first tracks yard sale caballerial heli fatty.  Epic dope grab, brain bucket japan air wack bowl  mute heli corn Snowboard Whistler giblets table top.  Crunchy Snowboard washboard line grab reverse camber.  Bump epic granny gear heli sketching wheelie huckfest face plant crank pow pow chain ring  dirtbag washboard.  Flow endo ski bum sucker hole, death cookies manny schwag pipe.  Dope heli stomp yard sale, saddle shreddin booter gear jammer grom bonk OTB brain bucket bonk japan air Whistler.Clipless pow pow pow, core shot corn butter bomb hole glades face plant dust on crust.  Poaching park face shots bump, Bike cornice death cookies.  Avie cruiser sucker hole face plant switch.  ACL snake bite bonk, twin tip euro rig nose press McTwist.  Ripping skinny trucks shreddin.  Apres pow line euro sharkbite gapers lid.Snake bite derailleur wheels bomb hole.  Huck apres steeps BB first tracks bowl  daffy park euro park rat euro.  North shore death cookies snake bite carve, freshies dirtbag huck reverse camber hellflip frozen chicken heads apres taco glove gnar face shots bro.  Ride flow twister cornice afterbang saddle first tracks rig berm bro face shots.  Ride stoked wack park twin tip trucks chillax shuttle Whistler gondy laps.  Grind berm schwag, table top face shots steed liftie afterbang taco glove frozen chicken heads free ride clean huck.  Rock-ectomy white room nose press avie.Frozen chicken heads gondy bail travel huckfest big ring phat clean.  Taco couloir piste derailleur wack scream backside steeps groomer glades pipe gondy switch skid lid.  Brain bucket betty bowl, moguls gondy Whistler air hardtail.  Flow euro granny gear, McTwist cruiser bonk grom chain suck.  Trucks line huck, stomp ripper washboard euro corduroy death cookies yard sale dope face plant shreddin chain suck.ACL T-bar hellflip, first tracks gondy hardtail rip wack dust on crust schwag frontside couloir laps presta backside.  Road rash Ski ski bum gnar wack flow carve lid.  Nose white room ollie rail table top grom back country washboard dust on crust chillax gear jammer bro stomp stoked.  Lid wheels nose press frontside, park ACL dirtbag huck epic bowl  taco glove OTB.  Fatty mute whip stunt, Whistler McTwist stoked Bike.  Endo brain bucket crank dust on crust back country line ollie gapers afterbang bump stoked taco road rash granny gear.  Deck dirtbag 360 gnar snake bite couloir Bike corduroy frontside crank lid bro.Air tele schwag ollie, hardtail betty crunchy epic  face shots.  Travel flowy misty huck Bike 180 schwag drop hellflip ripping bunny slope carbon roadie tele bail.  Cornice sharkbite 360 frozen chicken heads dope hellflip clipless.  Switch sketching grind brain bucket stunt taco daffy OTB ride liftie brain bucket air huckfest park 360.',
-    });
-    this.emailControl = new TextBoxControl({ type: 'email', key: 'email', label: 'Email', tooltip: 'Email' });
-    this.numberControl = new TextBoxControl({ type: 'number', key: 'number', label: 'Number' });
-    this.currencyControl = new TextBoxControl({ type: 'currency', key: 'currency', label: 'Currency', currencyFormat: '$ USD' });
-    this.floatControl = new TextBoxControl({ type: 'float', key: 'float', label: 'Float' });
-    this.percentageControl = new TextBoxControl({ type: 'percentage', key: 'percentage', label: 'Percent', required: true });
-    this.quickNoteControl = new QuickNoteControl({ key: 'note', label: 'Note', config: this.quickNoteConfig, required: true, tooltip: 'Quicknote' });
-    this.aceEditorControl = new AceEditorControl({ key: 'ace', label: 'CODE', value: 'var i = 0;' });
-    this.textForm = formUtils.toFormGroup([
-      this.textControl,
-      this.emailControl,
-      this.textAreaControl,
-      this.numberControl,
-      this.currencyControl,
-      this.floatControl,
-      this.percentageControl,
-      this.quickNoteControl,
-      this.aceEditorControl,
-    ]);
+    constructor(private formUtils: FormUtils) {
+        // Quick note config
+        this.quickNoteConfig = {
+            triggers: {
+                tags: '@',
+                references: '#',
+                boos: '^',
+            },
+            options: {
+                tags: ['First', 'Second'],
+                references: ['Third', 'Fourth'],
+                boos: ['Test'],
+            },
+            renderer: {
+                tags: (symbol, item) => {
+                    return `<a class="tag">${symbol}${item.label}</a>`;
+                },
+                references: (symbol, item) => {
+                    return `<a class="tag">${symbol}${item.label}</a>`;
+                },
+                boos: (symbol, item) => {
+                    return `<strong>${symbol}${item.label}</strong>`;
+                },
+            },
+        };
+        // Text-based Controls
+        this.textControl = new TextBoxControl({ key: 'text', label: 'Text Box', tooltip: 'Textbox', readOnly: true, value: 'HI', required: true });
+        this.textAreaControl = new TextAreaControl({
+            key: 'textarea',
+            label: 'Text Area',
+            value:
+            'Bro ipsum dolor sit amet yard sale saddle pipe, poaching cork 360 punter ACL back country cornice Whistler.  Avie Ski taco mitt, manny first tracks yard sale caballerial heli fatty.  Epic dope grab, brain bucket japan air wack bowl  mute heli corn Snowboard Whistler giblets table top.  Crunchy Snowboard washboard line grab reverse camber.  Bump epic granny gear heli sketching wheelie huckfest face plant crank pow pow chain ring  dirtbag washboard.  Flow endo ski bum sucker hole, death cookies manny schwag pipe.  Dope heli stomp yard sale, saddle shreddin booter gear jammer grom bonk OTB brain bucket bonk japan air Whistler.Clipless pow pow pow, core shot corn butter bomb hole glades face plant dust on crust.  Poaching park face shots bump, Bike cornice death cookies.  Avie cruiser sucker hole face plant switch.  ACL snake bite bonk, twin tip euro rig nose press McTwist.  Ripping skinny trucks shreddin.  Apres pow line euro sharkbite gapers lid.Snake bite derailleur wheels bomb hole.  Huck apres steeps BB first tracks bowl  daffy park euro park rat euro.  North shore death cookies snake bite carve, freshies dirtbag huck reverse camber hellflip frozen chicken heads apres taco glove gnar face shots bro.  Ride flow twister cornice afterbang saddle first tracks rig berm bro face shots.  Ride stoked wack park twin tip trucks chillax shuttle Whistler gondy laps.  Grind berm schwag, table top face shots steed liftie afterbang taco glove frozen chicken heads free ride clean huck.  Rock-ectomy white room nose press avie.Frozen chicken heads gondy bail travel huckfest big ring phat clean.  Taco couloir piste derailleur wack scream backside steeps groomer glades pipe gondy switch skid lid.  Brain bucket betty bowl, moguls gondy Whistler air hardtail.  Flow euro granny gear, McTwist cruiser bonk grom chain suck.  Trucks line huck, stomp ripper washboard euro corduroy death cookies yard sale dope face plant shreddin chain suck.ACL T-bar hellflip, first tracks gondy hardtail rip wack dust on crust schwag frontside couloir laps presta backside.  Road rash Ski ski bum gnar wack flow carve lid.  Nose white room ollie rail table top grom back country washboard dust on crust chillax gear jammer bro stomp stoked.  Lid wheels nose press frontside, park ACL dirtbag huck epic bowl  taco glove OTB.  Fatty mute whip stunt, Whistler McTwist stoked Bike.  Endo brain bucket crank dust on crust back country line ollie gapers afterbang bump stoked taco road rash granny gear.  Deck dirtbag 360 gnar snake bite couloir Bike corduroy frontside crank lid bro.Air tele schwag ollie, hardtail betty crunchy epic  face shots.  Travel flowy misty huck Bike 180 schwag drop hellflip ripping bunny slope carbon roadie tele bail.  Cornice sharkbite 360 frozen chicken heads dope hellflip clipless.  Switch sketching grind brain bucket stunt taco daffy OTB ride liftie brain bucket air huckfest park 360.',
+        });
+        this.emailControl = new TextBoxControl({ type: 'email', key: 'email', label: 'Email', tooltip: 'Email' });
+        this.numberControl = new TextBoxControl({ type: 'number', key: 'number', label: 'Number' });
+        this.currencyControl = new TextBoxControl({ type: 'currency', key: 'currency', label: 'Currency', currencyFormat: '$ USD' });
+        this.floatControl = new TextBoxControl({ type: 'float', key: 'float', label: 'Float' });
+        this.percentageControl = new TextBoxControl({ type: 'percentage', key: 'percentage', label: 'Percent', required: true });
+        this.quickNoteControl = new QuickNoteControl({ key: 'note', label: 'Note', config: this.quickNoteConfig, required: true, tooltip: 'Quicknote' });
+        this.aceEditorControl = new AceEditorControl({ key: 'ace', label: 'CODE', value: 'var i = 0;' });
+        this.textForm = formUtils.toFormGroup([
+            this.textControl,
+            this.emailControl,
+            this.textAreaControl,
+            this.numberControl,
+            this.currencyControl,
+            this.floatControl,
+            this.percentageControl,
+            this.quickNoteControl,
+            this.aceEditorControl,
+        ]);
 
-    // Check box controls
-    this.checkControl = new CheckboxControl({ key: 'check', label: 'Checkbox' });
-    this.checkListControl = new CheckListControl({ key: 'checklist', label: 'Check List', options: ['One', 'Two', 'Three'], tooltip: 'CheckList', tooltipPosition: 'Top' });
-    this.tilesControl = new TilesControl({ key: 'tiles', label: 'Tiles', options: [{ value: 'one', label: 'One' }, { value: 'two', label: 'Two' }], tooltip: 'Tiles' });
-    this.checkForm = formUtils.toFormGroup([this.checkControl, this.checkListControl, this.tilesControl]);
+        // Check box controls
+        this.checkControl = new CheckboxControl({ key: 'check', label: 'Checkbox' });
+        this.checkListControl = new CheckListControl({ key: 'checklist', label: 'Check List', options: ['One', 'Two', 'Three'], tooltip: 'CheckList', tooltipPosition: 'Top' });
+        this.tilesControl = new TilesControl({ key: 'tiles', label: 'Tiles', options: [{ value: 'one', label: 'One' }, { value: 'two', label: 'Two' }], tooltip: 'Tiles' });
+        this.checkForm = formUtils.toFormGroup([this.checkControl, this.checkListControl, this.tilesControl]);
 
-    // Picker controls
-    this.singlePickerControl = new PickerControl({ key: 'singlePicker', label: 'Single', config: { options: ['One', 'Two', 'Three'] } });
-    this.multiPickerControl = new PickerControl({ key: 'multiPicker', label: 'Multiple', multiple: true, config: { options: ['One', 'Two', 'Three'], type: 'candidate' } });
-    this.entityMultiPickerControl = new PickerControl({
-      key: 'entityMultiPicker',
-      label: 'Entities',
-      required: true,
-      readOnly: false,
-      multiple: true,
-      config: {
-        resultsTemplate: EntityPickerResults,
-        previewTemplate: EntityPickerResult,
-        format: '$title',
-        options: [
-          {
-            title: 'Central Bank',
-            name: 'Central Bank',
-            email: 'new-bank-inquiries@centralbank.com',
-            phone: '(651) 555-1234',
-            address: { city: 'Washington', state: 'DC' },
-            searchEntity: 'ClientCorporation',
-          },
-          { title: 'Federal Bank', name: 'Federal Bank', email: 'info@federalbank.com', phone: '(545) 555-1212', address: { city: 'Arlington', state: 'VA' }, searchEntity: 'ClientCorporation' },
-          {
-            title: 'Aaron Burr',
-            firstName: 'Aaron',
-            lastName: 'Burr',
-            name: 'Aaron Burr',
-            companyName: 'Central Bank',
-            email: 'aburr@centralbank.com',
-            phone: '(333) 555-3434',
-            address: { city: 'Washington', state: 'DC' },
-            status: 'Hold',
-            searchEntity: 'ClientContact',
-          },
-          {
-            title: 'Alexander Hamilton',
-            firstName: 'Alexander',
-            lastName: 'Hamilton',
-            name: 'Alexander Hamilton',
-            companyName: 'Federal Bank',
-            email: 'ahamilton@federalbank.com',
-            phone: '(333) 555-2222',
-            address: { city: 'Arlington', state: 'VA' },
-            status: 'Active',
-            searchEntity: 'ClientContact',
-          },
-          {
-            title: 'Ben Franklin',
-            firstName: 'Ben',
-            lastName: 'Franklin',
-            name: 'Ben Franklin',
-            email: 'bfranklin@gmail.com',
-            phone: '(654) 525-2222',
-            address: { city: 'Boston', state: 'MA' },
-            status: 'Interviewing',
-            searchEntity: 'Candidate',
-          },
-          {
-            title: 'Thomas Jefferson',
-            firstName: 'Thomas',
-            lastName: 'Jefferson',
-            name: 'Thomas Jefferson',
-            email: 'tjefferson@usa.com',
-            phone: '(123) 542-1234',
-            address: { city: 'Arlington', state: 'VA' },
-            status: 'New Lead',
-            searchEntity: 'Candidate',
-          },
-        ],
-      },
-    });
-    let controls = [this.singlePickerControl, this.multiPickerControl, this.entityMultiPickerControl];
-    formUtils.setInitialValues(controls, {
-      entityMultiPicker: [
-        { title: 'Federal Bank', name: 'Federal Bank', email: 'info@federalbank.com', phone: '(545) 555-1212', address: { city: 'Arlington', state: 'VA' }, searchEntity: 'ClientCorporation' },
-      ],
-    });
-    this.pickerForm = formUtils.toFormGroup(controls);
+        // Picker controls
+        this.singlePickerControl = new PickerControl({ key: 'singlePicker', label: 'Single', config: { options: ['One', 'Two', 'Three'] } });
+        this.multiPickerControl = new PickerControl({ key: 'multiPicker', label: 'Multiple', multiple: true, config: { options: ['One', 'Two', 'Three'], type: 'candidate' } });
+        this.entityMultiPickerControl = new PickerControl({
+            key: 'entityMultiPicker',
+            label: 'Entities',
+            required: true,
+            readOnly: false,
+            multiple: true,
+            config: {
+                resultsTemplate: EntityPickerResults,
+                previewTemplate: EntityPickerResult,
+                format: '$title',
+                options: [
+                    {
+                        title: 'Central Bank',
+                        name: 'Central Bank',
+                        email: 'new-bank-inquiries@centralbank.com',
+                        phone: '(651) 555-1234',
+                        address: { city: 'Washington', state: 'DC' },
+                        searchEntity: 'ClientCorporation',
+                    },
+                    { title: 'Federal Bank', name: 'Federal Bank', email: 'info@federalbank.com', phone: '(545) 555-1212', address: { city: 'Arlington', state: 'VA' }, searchEntity: 'ClientCorporation' },
+                    {
+                        title: 'Aaron Burr',
+                        firstName: 'Aaron',
+                        lastName: 'Burr',
+                        name: 'Aaron Burr',
+                        companyName: 'Central Bank',
+                        email: 'aburr@centralbank.com',
+                        phone: '(333) 555-3434',
+                        address: { city: 'Washington', state: 'DC' },
+                        status: 'Hold',
+                        searchEntity: 'ClientContact',
+                    },
+                    {
+                        title: 'Alexander Hamilton',
+                        firstName: 'Alexander',
+                        lastName: 'Hamilton',
+                        name: 'Alexander Hamilton',
+                        companyName: 'Federal Bank',
+                        email: 'ahamilton@federalbank.com',
+                        phone: '(333) 555-2222',
+                        address: { city: 'Arlington', state: 'VA' },
+                        status: 'Active',
+                        searchEntity: 'ClientContact',
+                    },
+                    {
+                        title: 'Ben Franklin',
+                        firstName: 'Ben',
+                        lastName: 'Franklin',
+                        name: 'Ben Franklin',
+                        email: 'bfranklin@gmail.com',
+                        phone: '(654) 525-2222',
+                        address: { city: 'Boston', state: 'MA' },
+                        status: 'Interviewing',
+                        searchEntity: 'Candidate',
+                    },
+                    {
+                        title: 'Thomas Jefferson',
+                        firstName: 'Thomas',
+                        lastName: 'Jefferson',
+                        name: 'Thomas Jefferson',
+                        email: 'tjefferson@usa.com',
+                        phone: '(123) 542-1234',
+                        address: { city: 'Arlington', state: 'VA' },
+                        status: 'New Lead',
+                        searchEntity: 'Candidate',
+                    },
+                ],
+            },
+        });
+        let controls = [this.singlePickerControl, this.multiPickerControl, this.entityMultiPickerControl];
+        formUtils.setInitialValues(controls, {
+            entityMultiPicker: [
+                { title: 'Federal Bank', name: 'Federal Bank', email: 'info@federalbank.com', phone: '(545) 555-1212', address: { city: 'Arlington', state: 'VA' }, searchEntity: 'ClientCorporation' },
+            ],
+        });
+        this.pickerForm = formUtils.toFormGroup(controls);
 
-    // File input controls
-    this.fileControl = new FileControl({ key: 'file', name: 'myfile', label: 'File', tooltip: 'Files Control' });
-    this.multiFileControl = new FileControl({
-      key: 'files',
-      name: 'myfiles',
-      label: 'Multiple Files',
-      multiple: true,
-      layoutOptions: { order: 'displayFilesBelow', download: true, edit: true, customActions: true, labelStyle: 'no-box' },
-      value: [{ name: 'yourFile.pdf', loaded: true, link: 'www.google.com', description: 'file description' }],
-    });
-    this.fileForm = formUtils.toFormGroup([this.fileControl, this.multiFileControl]);
+        // Address control
+        this.addressControl = new AddressControl({
+            key: 'address',
+            label: 'Address',
+            config: {
+                address1: {
+                    label: 'Address Line 1',
+                    required: true
+                },
+                address2: {
+                    label: 'Address Line 2'
+                },
+                state: {
+                    label: 'State'
+                }
+            },
+            value: {
+                address1: '123 Summer Street',
+                address2: 'APT 2',
+                countryID: 1
+            }
+        });
+        this.addressFormControls = [this.addressControl];
+        this.addressForm = formUtils.toFormGroup([this.addressControl]);
+        // File input controls
+        this.fileControl = new FileControl({ key: 'file', name: 'myfile', label: 'File', tooltip: 'Files Control' });
+        this.multiFileControl = new FileControl({
+            key: 'files',
+            name: 'myfiles',
+            label: 'Multiple Files',
+            multiple: true,
+            layoutOptions: { order: 'displayFilesBelow', download: true, edit: true, customActions: true, labelStyle: 'no-box' },
+            value: [{ name: 'yourFile.pdf', loaded: true, link: 'www.google.com', description: 'file description' }],
+        });
+        this.fileForm = formUtils.toFormGroup([this.fileControl, this.multiFileControl]);
 
-    // Calendar input controls
-    this.dateControl = new DateControl({ key: 'date', label: 'Date', tooltip: 'Date' });
-    this.timeControl = new TimeControl({ key: 'time', label: 'Time', tooltip: 'Time' });
-    this.dateTimeControl = new DateTimeControl({ key: 'dateTime', label: 'Date Time', military: true });
-    this.calendarForm = formUtils.toFormGroup([this.dateControl, this.timeControl, this.dateTimeControl]);
+        // Calendar input controls
+        this.dateControl = new DateControl({ key: 'date', label: 'Date', tooltip: 'Date' });
+        this.timeControl = new TimeControl({ key: 'time', label: 'Time', tooltip: 'Time' });
+        this.dateTimeControl = new DateTimeControl({ key: 'dateTime', label: 'Date Time', military: true });
+        this.calendarForm = formUtils.toFormGroup([this.dateControl, this.timeControl, this.dateTimeControl]);
 
-    // Dynamic
-    this.dynamic = formUtils.toFieldSets(
-      MockMeta,
-      '$ USD',
-      {},
-      { token: 'TOKEN', military: true },
-      {
-        customfield: {
-          customControl: CustomDemoComponent,
-        },
-      },
-    );
-    formUtils.setInitialValuesFieldsets(this.dynamic, { firstName: 'Initial F Name', number: 12 });
-    this.dynamicForm = formUtils.toFormGroupFromFieldset(this.dynamic);
+        // Dynamic
+        this.dynamic = formUtils.toFieldSets(
+            MockMeta,
+            '$ USD',
+            {},
+            { token: 'TOKEN', military: true },
+            {
+                customfield: {
+                    customControl: CustomDemoComponent,
+                },
+            },
+        );
+        formUtils.setInitialValuesFieldsets(this.dynamic, { firstName: 'Initial F Name', number: 12 });
+        this.dynamicForm = formUtils.toFormGroupFromFieldset(this.dynamic);
 
-    this.dynamicVertical = formUtils.toControls(MockMeta, '$ USD', {}, { token: 'TOKEN', military: true });
-    formUtils.setInitialValues(this.dynamicVertical, { number: 0, firstName: 'Bobby Flay' });
-    this.dynamicVerticalForm = formUtils.toFormGroup(this.dynamicVertical);
+        this.dynamicVertical = formUtils.toControls(MockMeta, '$ USD', {}, { token: 'TOKEN', military: true });
+        formUtils.setInitialValues(this.dynamicVertical, { number: 0, firstName: 'Bobby Flay' });
+        this.dynamicVerticalForm = formUtils.toFormGroup(this.dynamicVertical);
 
-    // Dynamic + Fieldsets
-    this.fieldsets = formUtils.toFieldSets(
-      MockMetaHeaders,
-      '$ USD',
-      {},
-      { token: 'TOKEN' },
-      {
-        customfield: {
-          customControl: CustomDemoComponent,
-        },
-      },
-    );
-    formUtils.setInitialValuesFieldsets(this.fieldsets, { firstName: 'Initial F Name', number: 12 });
-    this.fieldsetsForm = formUtils.toFormGroupFromFieldset(this.fieldsets);
+        // Dynamic + Fieldsets
+        this.fieldsets = formUtils.toFieldSets(
+            MockMetaHeaders,
+            '$ USD',
+            {},
+            { token: 'TOKEN' },
+            {
+                customfield: {
+                    customControl: CustomDemoComponent,
+                },
+            },
+        );
+        formUtils.setInitialValuesFieldsets(this.fieldsets, { firstName: 'Initial F Name', number: 12 });
+        this.fieldsetsForm = formUtils.toFormGroupFromFieldset(this.fieldsets);
 
-    // Updating form
-    this.updatingFormControls = [this.textControl, this.percentageControl, this.checkControl, this.singlePickerControl, this.fileControl];
-    this.updatingForm = formUtils.toFormGroup(this.updatingFormControls);
-  }
-
-  toggleEnabled() {
-    this.disabled = !this.disabled;
-    Object.keys(this.updatingForm.controls).forEach((key) => {
-      if (this.disabled) {
-        this.updatingForm.controls[key].enable();
-      } else {
-        this.updatingForm.controls[key].disable();
-      }
-    });
-  }
-
-  toggleRequired() {
-    this.required = !this.required;
-    Object.keys(this.updatingForm.controls).forEach((key) => {
-      this.updatingForm.controls[key].setRequired(this.required);
-    });
-  }
-
-  markAsInvalid() {
-    Object.keys(this.updatingForm.controls).forEach((key) => {
-      this.updatingForm.controls[key].markAsInvalid('Custom Error!');
-    });
-  }
-
-  save(form) {
-    if (!form.isValid) {
-      form.showOnlyRequired(true);
-    } else {
-      alert('SAVING');
+        // Updating form
+        this.updatingFormControls = [this.textControl, this.percentageControl, this.checkControl, this.singlePickerControl, this.fileControl];
+        this.updatingForm = formUtils.toFormGroup(this.updatingFormControls);
     }
-  }
 
-  clear() {
-    this.dynamic.forEach((control) => {
-      control.forceClear.emit();
-    });
-  }
+    toggleEnabled() {
+        this.disabled = !this.disabled;
+        Object.keys(this.updatingForm.controls).forEach((key) => {
+            if (this.disabled) {
+                this.updatingForm.controls[key].enable();
+            } else {
+                this.updatingForm.controls[key].disable();
+            }
+        });
+    }
 
-  onChange(value) {
-    console.log('I changed!', value); // tslint:disable-line
-  }
+    toggleRequired() {
+        this.required = !this.required;
+        Object.keys(this.updatingForm.controls).forEach((key) => {
+            this.updatingForm.controls[key].setRequired(this.required);
+        });
+    }
 
-  handleEdit(file) {
-    console.log('This is an Edit Action!', file); // tslint:disable-line
-  }
+    markAsInvalid() {
+        Object.keys(this.updatingForm.controls).forEach((key) => {
+            this.updatingForm.controls[key].markAsInvalid('Custom Error!');
+        });
+    }
 
-  handleSave(file) {
-    console.log('This is a Save Action!', file); // tslint:disable-line
-  }
+    save(form) {
+        if (!form.isValid) {
+            form.showOnlyRequired(true);
+        } else {
+            alert('SAVING');
+        }
+    }
 
-  handleDelete(file) {
-    console.log('This is a Delete Action!', file); // tslint:disable-line
-  }
+    clear() {
+        this.dynamic.forEach((control) => {
+            control.forceClear.emit();
+        });
+    }
 
-  handleUpload(files) {
-    console.log('This is an upload Action!', files); // tslint:disable-line
-  }
+    onChange(value) {
+        console.log('I changed!', value); // tslint:disable-line
+    }
+
+    handleEdit(file) {
+        console.log('This is an Edit Action!', file); // tslint:disable-line
+    }
+
+    handleSave(file) {
+        console.log('This is a Save Action!', file); // tslint:disable-line
+    }
+
+    handleDelete(file) {
+        console.log('This is a Delete Action!', file); // tslint:disable-line
+    }
+
+    handleUpload(files) {
+        console.log('This is an upload Action!', files); // tslint:disable-line
+    }
 }

--- a/src/app/pages/elements/form/templates/AddressControl.html
+++ b/src/app/pages/elements/form/templates/AddressControl.html
@@ -1,0 +1,7 @@
+<novo-form [form]="addressForm">
+    <div class="novo-form-row">
+        <novo-control [form]="addressForm" [control]="addressControl"></novo-control>
+    </div>
+</novo-form>
+
+<div class="final-value">Value: {{addressForm.value | json}}</div>

--- a/src/platform/elements/form/Control.ts
+++ b/src/platform/elements/form/Control.ts
@@ -180,7 +180,7 @@ export class NovoCustomControlContainerElement {
                                 <novo-date-time-picker-input [attr.id]="control.key" [name]="control.key" [formControlName]="control.key" [placeholder]="form.controls[control.key].placeholder" [military]="form.controls[control.key].military"></novo-date-time-picker-input>
                             </div>
                             <!--Address-->
-                            <novo-address *ngSwitchCase="'address'" [formControlName]="control.key"></novo-address>
+                            <novo-address *ngSwitchCase="'address'" [formControlName]="control.key" [config]="control.config"></novo-address>
                             <!--Checkbox-->
                             <novo-checkbox *ngSwitchCase="'checkbox'" [formControlName]="control.key" [name]="control.key" [label]="control.checkboxLabel" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" [layoutOptions]="layoutOptions"></novo-checkbox>
                             <!--Checklist-->

--- a/src/platform/elements/form/extras/address/Address.spec.ts
+++ b/src/platform/elements/form/extras/address/Address.spec.ts
@@ -35,6 +35,15 @@ describe('Elements: NovoAddressElement', () => {
             expect(component.ngOnInit).toBeDefined();
             component.ngOnInit();
         });
+        it('should be set up label for address1', () => {
+            component.config = {};
+            component.ngOnInit();
+            expect(component.config.address1.label).toBeDefined();
+        });
+        it('should be set up config', () => {
+            component.ngOnInit();
+            expect(component.config.address1.label).toBeDefined();
+        });
     });
 
     describe('Method: onCountryChange()', () => {

--- a/src/platform/elements/form/extras/address/Address.ts
+++ b/src/platform/elements/form/extras/address/Address.ts
@@ -1,5 +1,7 @@
 // NG2
-import { Component, forwardRef, OnInit } from '@angular/core';
+import {
+    Component, forwardRef, Input, OnInit
+} from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 // APP
 import { getCountries, getStates, getStateObjects, findByCountryName, findByCountryId } from '../../../../utils/countries/Countries';
@@ -16,18 +18,19 @@ const ADDRESS_VALUE_ACCESSOR = {
     selector: 'novo-address',
     providers: [ADDRESS_VALUE_ACCESSOR],
     template: `
-        <input type="text" class="street-address" id="address1" name="address1" [placeholder]="labels.address" autocomplete="shipping street-address address-line-1" [(ngModel)]="model.address1" (ngModelChange)="updateControl()"/>
-        <input type="text" class="apt suite" id="address2" name="address2" [placeholder]="labels.apt" autocomplete="shipping address-line-2" [(ngModel)]="model.address2" (ngModelChange)="updateControl()"/>
-        <input type="text" class="city locality" id="city" name="city" [placeholder]="labels.city" autocomplete="shipping city locality" [(ngModel)]="model.city" (ngModelChange)="updateControl()"/>
-        <novo-select class="state region" id="state" [options]="states" [placeholder]="labels.state" autocomplete="shipping region" [(ngModel)]="model.state" (ngModelChange)="onStateChange($event)"></novo-select>
-        <input type="text" class="zip postal-code" id="zip" name="zip" [placeholder]="labels.zipCode" autocomplete="shipping postal-code" [(ngModel)]="model.zip" (ngModelChange)="updateControl()"/>
-        <novo-select class="country-name" id="country" [options]="countries" [placeholder]="labels.country" autocomplete="shipping country" [(ngModel)]="model.countryName" (ngModelChange)="onCountryChange($event)"></novo-select>
+        <input type="text" class="street-address" id="address1" name="address1" [placeholder]="config.address1.label" autocomplete="shipping street-address address-line-1" [(ngModel)]="model.address1" (ngModelChange)="updateControl()"/>
+        <input type="text" class="apt suite" id="address2" name="address2" [placeholder]="config.address2.label" autocomplete="shipping address-line-2" [(ngModel)]="model.address2" (ngModelChange)="updateControl()"/>
+        <input type="text" class="city locality" id="city" name="city" [placeholder]="config.city.label" autocomplete="shipping city locality" [(ngModel)]="model.city" (ngModelChange)="updateControl()"/>
+        <novo-select class="state region" id="state" [options]="states" [placeholder]="config.state.label" autocomplete="shipping region" [(ngModel)]="model.state" (ngModelChange)="onStateChange($event)"></novo-select>
+        <input type="text" class="zip postal-code" id="zip" name="zip" [placeholder]="config.zip.label" autocomplete="shipping postal-code" [(ngModel)]="model.zip" (ngModelChange)="updateControl()"/>
+        <novo-select class="country-name" id="country" [options]="countries" [placeholder]="config.country.label" autocomplete="shipping country" [(ngModel)]="model.countryName" (ngModelChange)="onCountryChange($event)"></novo-select>
     `
 })
 export class NovoAddressElement implements ControlValueAccessor, OnInit {
+    @Input() config: any;
     states: Array<any> = [];
     countries: Array<any> = getCountries();
-
+    fieldList: Array<string> = ['address1', 'address2', 'city', 'state', 'zip', 'country'];
     model: any;
     onModelChange: Function = () => {
     };
@@ -37,6 +40,17 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit {
     constructor(public labels: NovoLabelService) { }
 
     ngOnInit() {
+        if (!this.config) {
+            this.config = {
+            };
+        }
+        this.fieldList.forEach(((field: string) => {
+            if (!this.config.hasOwnProperty(field)) {
+                this.config[field] = {
+                    label: this.labels[field]
+                };
+            }
+        }));
         if (this.model) {
             this.writeValue(this.model);
             this.updateControl();
@@ -95,6 +109,8 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit {
                 }) || {};
                 this.model = Object.assign(model, { countryName: countryName, state: stateObj.name });
                 this.updateStates();
+            } else {
+                this.model = model;
             }
         }
     }

--- a/src/platform/elements/form/extras/address/Address.ts
+++ b/src/platform/elements/form/extras/address/Address.ts
@@ -14,17 +14,17 @@ const ADDRESS_VALUE_ACCESSOR = {
     multi: true
 };
 
-export interface AddressSubfieldConfig {
+export interface NovoAddressSubfieldConfig {
     label: string;
 }
 
-export interface AddressConfig {
-    address1?: AddressSubfieldConfig;
-    address2?: AddressSubfieldConfig;
-    city?: AddressSubfieldConfig;
-    state?: AddressSubfieldConfig;
-    zip?: AddressSubfieldConfig;
-    country?: AddressSubfieldConfig;
+export interface NovoAddressConfig {
+    address1?: NovoAddressSubfieldConfig;
+    address2?: NovoAddressSubfieldConfig;
+    city?: NovoAddressSubfieldConfig;
+    state?: NovoAddressSubfieldConfig;
+    zip?: NovoAddressSubfieldConfig;
+    country?: NovoAddressSubfieldConfig;
 }
 
 @Component({
@@ -40,7 +40,7 @@ export interface AddressConfig {
     `
 })
 export class NovoAddressElement implements ControlValueAccessor, OnInit {
-    @Input() config: AddressConfig;
+    @Input() config: NovoAddressConfig;
     states: Array<any> = [];
     countries: Array<any> = getCountries();
     fieldList: Array<string> = ['address1', 'address2', 'city', 'state', 'zip', 'country'];

--- a/src/platform/elements/form/extras/address/Address.ts
+++ b/src/platform/elements/form/extras/address/Address.ts
@@ -14,6 +14,19 @@ const ADDRESS_VALUE_ACCESSOR = {
     multi: true
 };
 
+export interface AddressSubfieldConfig {
+    label: string;
+}
+
+export interface AddressConfig {
+    address1?: AddressSubfieldConfig;
+    address2?: AddressSubfieldConfig;
+    city?: AddressSubfieldConfig;
+    state?: AddressSubfieldConfig;
+    zip?: AddressSubfieldConfig;
+    country?: AddressSubfieldConfig;
+}
+
 @Component({
     selector: 'novo-address',
     providers: [ADDRESS_VALUE_ACCESSOR],
@@ -27,7 +40,7 @@ const ADDRESS_VALUE_ACCESSOR = {
     `
 })
 export class NovoAddressElement implements ControlValueAccessor, OnInit {
-    @Input() config: any;
+    @Input() config: AddressConfig;
     states: Array<any> = [];
     countries: Array<any> = getCountries();
     fieldList: Array<string> = ['address1', 'address2', 'city', 'state', 'zip', 'country'];

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -41,61 +41,61 @@ export { NovoDataTableModule } from './elements/data-table/data-table.module';
 export { RemoteDataTableService } from './elements/data-table/services/remote-data-table.service';
 export { StaticDataTableService } from './elements/data-table/services/static-data-table.service';
 export {
-  IDataTableCell,
-  IDataTableChangeEvent,
-  IDataTableColumn,
-  IDataTableColumnFilterConfig,
-  IDataTableColumnFilterOption,
-  IDataTableColumnSortConfig,
-  IDataTablePaginationEvent,
-  IDataTablePaginationOptions,
-  IDataTableSearchOptions,
-  IDataTableSelectionChangeEvent,
-  IDataTableService,
-  IDataTableSortFilter,
+    IDataTableCell,
+    IDataTableChangeEvent,
+    IDataTableColumn,
+    IDataTableColumnFilterConfig,
+    IDataTableColumnFilterOption,
+    IDataTableColumnSortConfig,
+    IDataTablePaginationEvent,
+    IDataTablePaginationOptions,
+    IDataTableSearchOptions,
+    IDataTableSelectionChangeEvent,
+    IDataTableService,
+    IDataTableSortFilter,
 } from './elements/data-table/interfaces';
 export {
-  NovoTable,
-  NovoActivityTable,
-  NovoActivityTableActions,
-  NovoActivityTableCustomFilter,
-  NovoActivityTableEmptyMessage,
-  NovoActivityTableNoResultsMessage,
-  NovoActivityTableCustomHeader,
+    NovoTable,
+    NovoActivityTable,
+    NovoActivityTableActions,
+    NovoActivityTableCustomFilter,
+    NovoActivityTableEmptyMessage,
+    NovoActivityTableNoResultsMessage,
+    NovoActivityTableCustomHeader,
 } from './elements/simple-table/table';
 export {
-  NovoSimpleCell,
-  NovoSimpleCheckboxCell,
-  NovoSimpleCheckboxHeaderCell,
-  NovoSimpleHeaderCell,
-  NovoSimpleCellDef,
-  NovoSimpleHeaderCellDef,
-  NovoSimpleColumnDef,
-  NovoSimpleActionCell,
-  NovoSimpleEmptyHeaderCell,
+    NovoSimpleCell,
+    NovoSimpleCheckboxCell,
+    NovoSimpleCheckboxHeaderCell,
+    NovoSimpleHeaderCell,
+    NovoSimpleCellDef,
+    NovoSimpleHeaderCellDef,
+    NovoSimpleColumnDef,
+    NovoSimpleActionCell,
+    NovoSimpleEmptyHeaderCell,
 } from './elements/simple-table/cell';
 export { NovoSimpleHeaderRow, NovoSimpleRow, NovoSimpleHeaderRowDef, NovoSimpleRowDef } from './elements/simple-table/row';
 export { NovoSimpleCellHeader, NovoSimpleFilterFocus } from './elements/simple-table/cell-header';
 export { NovoSortFilter, NovoSelection } from './elements/simple-table/sort';
 export { NovoSimpleTablePagination } from './elements/simple-table/pagination';
 export {
-  SimpleTableColumn,
-  SimpleTablePaginationOptions,
-  SimpleTableColumnFilterConfig,
-  SimpleTableColumnFilterOption,
-  SimpleTableSearchOptions,
-  SimpleTableActionColumnOption,
-  SimpleTableActionColumn,
-  NovoSimpleSortFilter,
-  NovoSimpleTableChange,
-  NovoSimpleSelectionChange,
-  NovoSimplePaginationEvent,
+    SimpleTableColumn,
+    SimpleTablePaginationOptions,
+    SimpleTableColumnFilterConfig,
+    SimpleTableColumnFilterOption,
+    SimpleTableSearchOptions,
+    SimpleTableActionColumnOption,
+    SimpleTableActionColumn,
+    NovoSimpleSortFilter,
+    NovoSimpleTableChange,
+    NovoSimpleSelectionChange,
+    NovoSimplePaginationEvent,
 } from './elements/simple-table/interfaces';
 export {
-  ActivityTableDataSource,
-  ActivityTableService,
-  RemoteActivityTableService,
-  StaticActivityTableService,
+    ActivityTableDataSource,
+    ActivityTableService,
+    RemoteActivityTableService,
+    StaticActivityTableService,
 } from './elements/simple-table/table-source';
 export { ActivityTableRenderers } from './elements/simple-table/activity-table-renderers';
 export { NovoActivityTableState } from './elements/simple-table/state';
@@ -168,42 +168,42 @@ export { OutsideClick } from './utils/outside-click/OutsideClick';
 export { KeyCodes } from './utils/key-codes/KeyCodes';
 export { Deferred } from './utils/deferred/Deferred';
 export {
-  COUNTRIES,
-  getCountries,
-  getStateObjects,
-  getStates,
-  findByCountryCode,
-  findByCountryId,
-  findByCountryName,
+    COUNTRIES,
+    getCountries,
+    getStateObjects,
+    getStates,
+    findByCountryCode,
+    findByCountryId,
+    findByCountryName,
 } from './utils/countries/Countries';
 export { Helpers } from './utils/Helpers';
 export { ComponentUtils } from './utils/component-utils/ComponentUtils';
 export {
-  CalendarEventTimesChangedEvent,
-  WeekDay,
-  EventColor,
-  EventAction,
-  CalendarEvent,
-  WeekViewEvent,
-  WeekViewEventRow,
-  MonthViewDay,
-  MonthView,
-  DayViewEvent,
-  DayView,
-  DayViewHourSegment,
-  DayViewHour,
-  IsEventInPeriodArgs,
-  GetEventsInPeriodArgs,
-  GetDayViewArgs,
+    CalendarEventTimesChangedEvent,
+    WeekDay,
+    EventColor,
+    EventAction,
+    CalendarEvent,
+    WeekViewEvent,
+    WeekViewEventRow,
+    MonthViewDay,
+    MonthView,
+    DayViewEvent,
+    DayView,
+    DayViewHourSegment,
+    DayViewHour,
+    IsEventInPeriodArgs,
+    GetEventsInPeriodArgs,
+    GetDayViewArgs,
 } from './utils/calendar-utils/CalendarUtils';
 export * from './utils/calendar-utils/CalendarUtils';
 export {
-  AppBridge,
-  AppBridgeHandler,
-  IAppBridgeOpenEvent,
-  AppBridgeService,
-  DevAppBridge,
-  DevAppBridgeService,
+    AppBridge,
+    AppBridgeHandler,
+    IAppBridgeOpenEvent,
+    AppBridgeService,
+    DevAppBridge,
+    DevAppBridgeService,
 } from './utils/app-bridge/AppBridge';
 // Providers
 export { NovoElementProviders } from './novo-elements.providers';
@@ -218,3 +218,4 @@ export { NovoListElement } from './elements/list/List';
 // interfaces
 export { NOVO_VALUE_TYPE } from './elements/value/Value';
 export { NOVO_VALUE_THEME } from './elements/value/Value';
+export { NovoAddressConfig, NovoAddressSubfieldConfig } from './elements/form/extras/address/Address';

--- a/src/platform/services/novo-label-service.ts
+++ b/src/platform/services/novo-label-service.ts
@@ -54,10 +54,13 @@ export class NovoLabelService {
   backToPresetFilters = 'Back to Preset Filters';
   okGotIt = 'Ok, Got it';
   address = 'Address';
-  apt = 'Apt';
+  address1 = 'Address';
+  apt = 'Apt';// TODO delete
+  address2 = 'Apt';
   city = 'City / Locality';
   state = 'State / Region';
-  zipCode = 'Postal Code';
+  zip = 'Postal Code';
+  zipCode = 'Postal Code';// TODO delete
   country = 'Country';
   or = 'or';
   clickToBrowse = 'click to browse';
@@ -83,8 +86,8 @@ export class NovoLabelService {
   add = 'Add';
   encryptedFieldTooltip = 'This data has been stored at the highest level of security';
 
-  constructor(@Optional() @Inject(LOCALE_ID) public userLocale: string = 'en-US') {}
-  
+  constructor( @Optional() @Inject(LOCALE_ID) public userLocale: string = 'en-US') { }
+
   getToManyPlusMore(toMany: { quantity: number }): string {
     return `+${toMany.quantity} more`;
   }

--- a/src/platform/utils/form-utils/FormUtils.ts
+++ b/src/platform/utils/form-utils/FormUtils.ts
@@ -297,6 +297,12 @@ export class FormUtils {
             case 'address':
                 if (field.fields && field.fields.length) {
                     for (let subfield of field.fields) {
+                        if (Helpers.isBlank(controlConfig.config)) {
+                            controlConfig.config = {};
+                        }
+                        controlConfig.config[subfield.name] = {
+                            label: subfield.label
+                        };
                         if (subfield.defaultValue) {
                             if (Helpers.isBlank(controlConfig.value)) {
                                 controlConfig.value = {};


### PR DESCRIPTION
## **Description**

- address subfield labels will b e configurable by providing address a `config` input
- config will be of the following format - 
```
config  = {
   address1: {
        label: 'Address'
   },
   address2: {
        label: 'Address line 2'
   },
   country:{
        label: 'Country'
   },
   zip: {
        label: 'Zip Code'
   },
   state: {
        label: 'State'
   },
}
```
- All keys are optional, defaults are retrieved from the labels service
- Config for each subfield will be enhanced in the future to allow properties like "required" or "hidden" for the ability to require or hide sub-fields.
#### **Verify that...**

- [ ] Any related demos where added and `npm start` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run compile` still works

##### **Screenshots**