### PR TITLE
Change to allow fileBrowserImageUploadUrl to be passed through fieldsets

### DIFF
--- a/src/platform/elements/form/Control.ts
+++ b/src/platform/elements/form/Control.ts
@@ -144,7 +144,7 @@ export class NovoCustomControlContainerElement {
                             <!--TextArea-->
                             <textarea *ngSwitchCase="'text-area'" [name]="control.key" [attr.id]="control.key" [placeholder]="form.controls[control.key].placeholder" [formControlName]="control.key" autosize (input)="handleTextAreaInput($event)" (focus)="handleFocus($event)" (blur)="handleBlur($event)" [maxlength]="control.maxlength" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition"></textarea>
                             <!--Editor-->
-                            <novo-editor *ngSwitchCase="'editor'" [name]="control.key" [formControlName]="control.key" [startupFocus]="control.startupFocus" [minimal]="control.minimal" (focus)="handleFocus($event)" (blur)="handleBlur($event)"></novo-editor>
+                            <novo-editor *ngSwitchCase="'editor'" [name]="control.key" [formControlName]="control.key" [startupFocus]="control.startupFocus" [minimal]="control.minimal" [fileBrowserImageUploadUrl]="control.fileBrowserImageUploadUrl" (focus)="handleFocus($event)" (blur)="handleBlur($event)"></novo-editor>
                             <!--AceEditor-->
                             <novo-ace-editor *ngSwitchCase="'ace-editor'" [name]="control.key" [formControlName]="control.key" (focus)="handleFocus($event)" (blur)="handleBlur($event)"></novo-ace-editor>
                             <!--HTML5 Select-->

--- a/src/platform/elements/form/controls/BaseControl.spec.ts
+++ b/src/platform/elements/form/controls/BaseControl.spec.ts
@@ -81,7 +81,8 @@ describe('Control: BaseControl', () => {
                 associatedEntity: 'ENTITY',
                 optionsType: 'TYPE',
                 maxlength: 100,
-                disabled: true
+                disabled: true,
+                fileBrowserImageUploadUrl: '/foo/bar/baz',
             });
         });
 
@@ -135,6 +136,9 @@ describe('Control: BaseControl', () => {
         });
         it('should set the disabled', () => {
             expect(control.disabled).toEqual(true);
+        });
+        it('should set fileBrowserImageUploadUrl', () => {
+            expect(control.fileBrowserImageUploadUrl).toEqual('/foo/bar/baz');
         });
     });
 });

--- a/src/platform/elements/form/controls/BaseControl.ts
+++ b/src/platform/elements/form/controls/BaseControl.ts
@@ -62,6 +62,7 @@ export interface NovoControlConfig {
     };
     width?: number;
     startupFocus?: boolean;
+    fileBrowserImageUploadUrl?: string;
 }
 
 export class BaseControl {
@@ -115,6 +116,7 @@ export class BaseControl {
     };
     width: number;
     startupFocus?: boolean;
+    fileBrowserImageUploadUrl?: string;
 
     constructor(type: string = 'BaseControl', config: NovoControlConfig = {}) {
         this.__type = type;
@@ -172,5 +174,8 @@ export class BaseControl {
         this.tipWell = config.tipWell;
         this.width = config.width;
         this.startupFocus = !!config.startupFocus;
+        if (config.fileBrowserImageUploadUrl) {
+          this.fileBrowserImageUploadUrl = config.fileBrowserImageUploadUrl;
+        }
     }
 }


### PR DESCRIPTION
## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [ ] Any related demos where added and `npm start` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run compile` still works

##### **Screenshots**