### PR TITLE
fix(simple-table): fixing the custom date range filter

### DIFF
--- a/src/platform/elements/simple-table/cell-header.ts
+++ b/src/platform/elements/simple-table/cell-header.ts
@@ -166,35 +166,35 @@ export class NovoSimpleCellHeader implements NovoSimpleSortFilter, OnInit, OnDes
     }
 
     public filterData(filter?: any): void {
+        let actualFilter = filter;
         if (this.config.filterConfig.type === 'date' && filter) {
             this.activeDateFilter = filter.label || this.labels.customDateRange;
             if (filter.startDate && filter.endDate) {
-                filter = {
-                    min: dateFns.startOfDay(filter.startDate),
-                    max: dateFns.endOfDay(filter.endDate),
+                actualFilter = {
+                  min: dateFns.startOfDay(filter.startDate.date),
+                  max: dateFns.startOfDay(dateFns.addDays(dateFns.startOfDay(filter.endDate.date), 1)),
                 };
             } else {
-                filter = {
-                    min: dateFns.startOfDay(dateFns.addDays(dateFns.startOfToday(), filter.min)),
-                    max: dateFns.endOfDay(dateFns.addDays(dateFns.startOfToday(), filter.max)),
+                actualFilter = {
+                  min: filter.min ? dateFns.addDays(dateFns.startOfToday(), filter.min) : dateFns.startOfToday(),
+                  max: filter.max ? dateFns.addDays(dateFns.startOfTomorrow(), filter.max) : dateFns.startOfTomorrow(),
                 };
             }
         }
-        if (filter) {
-            if (filter.hasOwnProperty('value')) {
-                this.filter = filter.value;
-            } else {
-                this.filter = filter;
-            }
+
+        if (actualFilter && actualFilter.hasOwnProperty('value')) {
+            actualFilter = filter.value;
         }
+
         if (this.changeTimeout) {
             clearTimeout(this.changeTimeout);
         }
+
         this.changeTimeout = setTimeout(() => {
-            if (this.filter === '') {
-                this.filter = undefined;
+            if (actualFilter === '') {
+                actualFilter = undefined;
             }
-            this._sort.filter(this.id, this.filter, this._config.transforms.filter);
+            this._sort.filter(this.id, actualFilter, this.config.transforms.filter);
             this.changeDetectorRef.markForCheck();
         }, 300);
     }


### PR DESCRIPTION
## **Description**

Added the changes that were made to the datatable filterData method in order to fix the custom date range filter on the simple table

#### **Verify that...**

- [ ] Any related demos where added and `npm start` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run compile` still works

##### **Screenshots**