### PR TITLE
properly check invalid date

### DIFF
--- a/src/platform/elements/date-picker/DatePickerInput.ts
+++ b/src/platform/elements/date-picker/DatePickerInput.ts
@@ -169,7 +169,7 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
       if (!(value instanceof Date)) {
         value = new Date(value);
       }
-      if(!(value === 'Invalid Date' && this.allowInvalidDate) ){
+      if(!(isNaN(value.valueOf()) && this.allowInvalidDate) ){
         return this.labels.formatDateWithFormat(value, {
           month: '2-digit',
           day: '2-digit',

--- a/src/platform/elements/date-picker/DatePickerInput.ts
+++ b/src/platform/elements/date-picker/DatePickerInput.ts
@@ -158,6 +158,7 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
   }
 
   public formatDateValue(value) {
+    let originalValue = value;
     try {
       if (!value) {
         return '';
@@ -165,17 +166,17 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
       if (this.userDefinedFormat && dateFns.isValid(value)) {
         return dateFns.format(value, this.format);
       }
-      if (!this.allowInvalidDate) {       
-        if (!(value instanceof Date)) {
-            value = new Date(value);
-        }
+      if (!(value instanceof Date)) {
+        value = new Date(value);
+      }
+      if(!(value === 'Invalid Date' && this.allowInvalidDate) ){
         return this.labels.formatDateWithFormat(value, {
           month: '2-digit',
           day: '2-digit',
           year: 'numeric',
         });
       } else {
-        return value
+        return originalValue;
       }
 
     } catch (err) {


### PR DESCRIPTION
## **Description**

Since its a strict comparison I can't check against the invalid date string
#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**
n/a