### PR TITLE
Added Opportunity to the list of entities rendered as internal links

### DIFF
--- a/src/platform/elements/value/Value.spec.ts
+++ b/src/platform/elements/value/Value.spec.ts
@@ -178,6 +178,11 @@ describe('Elements: NovoValueElement', () => {
             component.ngOnChanges();
             expect(component.type).toEqual(NOVO_VALUE_TYPE.INTERNAL_LINK);
         });
+        it('should set type to internalLink for Opportunity', () => {
+            component.meta.associatedEntity.entity = 'Opportunity';
+            component.ngOnChanges();
+            expect(component.type).toEqual(NOVO_VALUE_TYPE.INTERNAL_LINK);
+        });
         it('should set type to link for a link', () => {
             component.meta.name = 'companyURL';
             component.data = '';

--- a/src/platform/elements/value/Value.ts
+++ b/src/platform/elements/value/Value.ts
@@ -106,6 +106,7 @@ export class NovoValueElement implements OnInit, OnChanges {
                 case 'ClientCorporation':
                 case 'ClientContact':
                 case 'Candidate':
+                case 'Opportunity':
                 case 'JobOrder':
                 case 'Placement':
                     this.type = NOVO_VALUE_TYPE.INTERNAL_LINK;


### PR DESCRIPTION
## **Description**

Opportunity entities will now render as internal links, like Candidate, Contact, etc.

#### **Verify that...**

- [ ] Any related demos where added and `npm start` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run compile` still works

##### **Screenshots**