### PR TITLE
Fixed characterCount on text fields to display correct value

### DIFF
--- a/src/app/pages/elements/form/FormDemo.ts
+++ b/src/app/pages/elements/form/FormDemo.ts
@@ -104,7 +104,8 @@ export class FormDemoComponent {
   private UpdatingFormDemoTpl: string = UpdatingFormDemoTpl;
   private AddressControlDemoTpl: string = AddressControlDemoTpl;
   private quickNoteConfig: any;
-  private textControl: any;
+  private textControl: TextBoxControl;
+  private disabledTextControl: TextBoxControl;
   private emailControl: any;
   private numberControl: any;
   private currencyControl: any;
@@ -112,7 +113,7 @@ export class FormDemoComponent {
   private floatControl: any;
   private percentageControl: any;
   private quickNoteControl: any;
-  private textForm: any;
+  private textForm: NovoFormGroup;
   private checkControl: any;
   private textAreaControl: any;
   private checkListControl: any;
@@ -171,7 +172,8 @@ export class FormDemoComponent {
       },
     };
     // Text-based Controls
-    this.textControl = new TextBoxControl({ key: 'text', label: 'Text Box', tooltip: 'Textbox', readOnly: true, value: 'HI', required: true });
+    this.textControl = new TextBoxControl({ key: 'text', label: 'Text Box', tooltip: 'Textbox', readOnly: false, value: '', required: true, maxlength: 30 });
+    this.disabledTextControl = new TextBoxControl({ key: 'disabledText', label: 'Disabled Text Box', tooltip: 'Textbox', readOnly: true, value: 'Disabled Text Control', required: true, maxlength: 30 });
     this.textAreaControl = new TextAreaControl({
       key: 'textarea',
       label: 'Text Area',
@@ -187,6 +189,7 @@ export class FormDemoComponent {
     this.aceEditorControl = new AceEditorControl({ key: 'ace', label: 'CODE', value: 'var i = 0;' });
     this.textForm = formUtils.toFormGroup([
       this.textControl,
+      this.disabledTextControl,
       this.emailControl,
       this.textAreaControl,
       this.numberControl,
@@ -196,6 +199,22 @@ export class FormDemoComponent {
       this.quickNoteControl,
       this.aceEditorControl,
     ]);
+
+    // Test text field character count when set after initialization
+    setTimeout(() => {
+      this.textForm.setValue({
+        text: 'Initial Value',
+        disabledText: this.textForm.value.disabledText,
+        textarea: this.textForm.value.textarea,
+        email: this.textForm.value.email,
+        number: this.textForm.value.number,
+        currency: this.textForm.value.currency,
+        float: this.textForm.value.float,
+        percentage: this.textForm.value.percentage,
+        note: this.textForm.value.note,
+        ace: this.textForm.value.ace,
+      });
+    }, 2000);
 
     // Check box controls
     this.checkControl = new CheckboxControl({ key: 'check', label: 'Checkbox' });

--- a/src/app/pages/elements/form/templates/TextBasedControls.html
+++ b/src/app/pages/elements/form/templates/TextBasedControls.html
@@ -8,6 +8,9 @@
         <novo-control [form]="textForm" [control]="textControl"></novo-control>
     </div>
     <div class="novo-form-row">
+        <novo-control [form]="textForm" [control]="disabledTextControl"></novo-control>
+    </div>
+    <div class="novo-form-row">
         <novo-control [autoFocus]="true" [form]="textForm" [control]="emailControl"></novo-control>
     </div>
     <div class="novo-form-row">

--- a/src/platform/elements/form/Control.ts
+++ b/src/platform/elements/form/Control.ts
@@ -334,13 +334,7 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
   }
 
   ngOnInit() {
-    // Make sure to initially format the time controls
-    if (this.control && this.form.controls[this.control.key].value) {
-      if (this.form.controls[this.control.key].controlType === 'textbox' || this.form.controls[this.control.key].controlType === 'text-area') {
-        this.characterCount = this.form.controls[this.control.key].value.length;
-      }
-    }
-    // this.maxLenghtCount = form.controls[control.key].maxlength;
+    this.setInitialCharacterCount();
     if (this.control) {
       // Listen to clear events
       this.forceClearSubscription = this.control.forceClear.subscribe(() => {
@@ -483,6 +477,7 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
   handleFocus(event: FocusEvent, field) {
     this._focused = true;
     this.focusedField = field;
+    this.setInitialCharacterCount();
     if (!Helpers.isBlank(this.characterCountField) && this.characterCountField === field) {
       this.showCount = true;
     } else if (this.form.controls[this.control.key].controlType === 'address' &&
@@ -603,6 +598,14 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
         this.maxLengthMetErrorfields.push(data.field);
       } else {
         this.maxLengthMetErrorfields = this.maxLengthMetErrorfields.filter((field: string) => field !== data.field);
+      }
+    }
+  }
+
+  private setInitialCharacterCount() {
+    if (this.control && this.form.controls[this.control.key].value) {
+      if (this.form.controls[this.control.key].controlType === 'textbox' || this.form.controls[this.control.key].controlType === 'text-area') {
+        this.characterCount = this.form.controls[this.control.key].value.length;
       }
     }
   }


### PR DESCRIPTION
## **Description**

If a text field value is set after the control has been initialized,
the character count will still be set to the initial value, not the new
value. This will happen util the user changes the value and the count
is recalculated. Now calculating on init and focus.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run compile` still works

##### **Screenshots**