### PR TITLE
add set tooltip method to field interactions

### DIFF
--- a/src/app/pages/elements/field-interactions/FieldInteractionsDemo.ts
+++ b/src/app/pages/elements/field-interactions/FieldInteractionsDemo.ts
@@ -961,9 +961,10 @@ export class FieldInteractionsDemoComponent {
         this.snippets.tooltip = {
             'Template': TooltipTpl,
             'Field Interaction Script (change)': `
-            (API: FieldInteractionApi) => {
-                console.log('[FieldInteractionDemo] - tooltipFunction'); // tslint:disable-line
-                API.setTooltip(API.getActiveKey(), API.getActiveValue());`
+(API: FieldInteractionApi) => {
+    console.log('[FieldInteractionDemo] - tooltipFunction'); // tslint:disable-line
+    API.setTooltip(API.getActiveKey(), API.getActiveValue());
+}`
             };
     }
 }

--- a/src/app/pages/elements/field-interactions/FieldInteractionsDemo.ts
+++ b/src/app/pages/elements/field-interactions/FieldInteractionsDemo.ts
@@ -17,6 +17,7 @@ let GlobalsTpl = require('./templates/Globals.html');
 let AsyncTpl = require('./templates/Async.html');
 let ConfirmTpl = require('./templates/Confirm.html');
 let AddingRemovingTpl = require('./templates/AddingRemoving.html');
+let TooltipTpl = require('./templates/Tooltip.html');
 import { MockMeta, MockMetaHeaders } from './MockMeta';
 
 const template = `
@@ -89,6 +90,7 @@ const template = `
             <novo-tab><span>Async Interactions</span></novo-tab>
             <novo-tab><span>Confirm Changes</span></novo-tab>
             <novo-tab><span>Adding / Removing Fields</span></novo-tab>
+            <novo-tab><span>Add Tooltip</span></novo-tab>
         </novo-nav>
 
         <novo-nav-outlet #api>
@@ -159,6 +161,12 @@ const template = `
                 <div class="example field-interaction-demo">${AddingRemovingTpl}</div>
                 <multi-code-snippet [code]="snippets.addingRemoving"></multi-code-snippet>
             </novo-nav-content>
+            <novo-nav-content>
+                <h5>Add Tooltip</h5>
+                <p>You are able to dynamically change a field's tooltip.</p>
+                <div class="example field-interaction-demo">${TooltipTpl}</div>
+                <multi-code-snippet [code]="snippets.tooltip"></multi-code-snippet>
+            </novo-nav-content>
         </novo-nav-outlet>
     </main>
 </div>
@@ -181,6 +189,7 @@ export class FieldInteractionsDemoComponent {
     public AsyncTpl: any = AsyncTpl;
     public ConfirmTpl: any = ConfirmTpl;
     public AddingRemovingTpl: any = AddingRemovingTpl;
+    public TooltipTpl: any = TooltipTpl;
 
     public forms: any = {};
     public controls: any = {
@@ -194,7 +203,8 @@ export class FieldInteractionsDemoComponent {
         globals: {},
         async: {},
         confirm: {},
-        addingRemoving: {}
+        addingRemoving: {},
+        tooltip: {}
     };
     public snippets: any = {
         validation: {},
@@ -411,6 +421,11 @@ export class FieldInteractionsDemoComponent {
                     label: 'This field will be removed'
                 }, FieldInteractionApi.FIELD_POSITIONS.BELOW_FIELD);
             }
+        }
+
+        let tooltipFunction = (API: FieldInteractionApi) => {
+            console.log('[FieldInteractionDemo] - tooltipFunction'); // tslint:disable-line
+            API.setTooltip(API.getActiveKey(), API.getActiveValue());
         }
 
         // Validation Field Interactions
@@ -679,6 +694,17 @@ export class FieldInteractionsDemoComponent {
         ];
         this.forms.addingRemoving = formUtils.toFormGroupFromFieldset(this.controls.addingRemoving);
 
+        // Tooltip Field Interactions
+        this.controls.tooltip.tooltipControl = new TextBoxControl({
+            type: 'text',
+            key: 'toolTipValue',
+            label: 'Tooltip',
+            description: 'I will add a tooltip to this control as a value is typed',
+            interactions: [
+                { event: 'change', script: tooltipFunction }
+            ]
+        });
+        this.forms.tooltip = formUtils.toFormGroup([this.controls.tooltip.tooltipControl]);
 
         // Snippets
         this.snippets.validation = {
@@ -931,5 +957,13 @@ export class FieldInteractionsDemoComponent {
 }
         `
         };
+
+        this.snippets.tooltip = {
+            'Template': TooltipTpl,
+            'Field Interaction Script (change)': `
+            (API: FieldInteractionApi) => {
+                console.log('[FieldInteractionDemo] - tooltipFunction'); // tslint:disable-line
+                API.setTooltip(API.getActiveKey(), API.getActiveValue());`
+            };
     }
 }

--- a/src/app/pages/elements/field-interactions/templates/Tooltip.html
+++ b/src/app/pages/elements/field-interactions/templates/Tooltip.html
@@ -1,0 +1,8 @@
+<novo-form [form]="forms.tooltip" layout="vertical">
+  <div class="novo-form-row">
+      <novo-control [form]="forms.tooltip" [control]="controls.tooltip.tooltipControl"></novo-control>
+  </div>
+</novo-form>
+<div class="final-value">Form Value - {{ forms.tooltip.value | json }}</div>
+<div class="final-value">Form Dirty - {{ forms.tooltip.dirty | json }}</div>
+<div class="final-value">Is Form Valid? - {{ forms.tooltip.valid | json }}</div>

--- a/src/platform/elements/form/FieldInteractionApi.ts
+++ b/src/platform/elements/form/FieldInteractionApi.ts
@@ -308,6 +308,13 @@ export class FieldInteractionApi {
         }
     }
 
+    public setTooltip(key: string, tooltip: string): void {
+        let control = this.getControl(key);
+        if (control) {
+            control.tooltip = tooltip;
+        }
+    }
+
     public confirmChanges(key: string, message?: string): Promise<boolean> {
         let history = this.getProperty(key, 'valueHistory');
         let oldValue = history[history.length - 2];


### PR DESCRIPTION
## **Description**

Added setTooltip method to be compatible with BBO Field Interactions. 

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

![image](https://user-images.githubusercontent.com/4327754/39928051-e2399a7a-54f9-11e8-9dff-debda39a7d14.png)
