### PR TITLE
Add Emitter for NovoFormControl Changes

### DIFF
--- a/src/platform/elements/form/FieldInteractionApi.ts
+++ b/src/platform/elements/form/FieldInteractionApi.ts
@@ -13,6 +13,7 @@ import { ControlConfirmModal, ControlPromptModal } from './FieldInteractionModal
 import { Helpers } from '../../utils/Helpers';
 import { AppBridge } from '../../utils/app-bridge/AppBridge';
 import { NovoLabelService } from '../../services/novo-label-service';
+import { IFieldInteractionEvent} from './FormInterfaces';
 
 @Injectable()
 export class FieldInteractionApi {
@@ -153,7 +154,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.setValue(value, options);
-            this.form.novoConfigChange.emit({value: value});
+            this.form.triggerEvent({controlKey: key, prop: 'value', value: value });
         }
     }
 
@@ -166,6 +167,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.setValue(value, options);
+            this.form.triggerEvent({controlKey: key, prop: 'value', value: value });
         }
     }
 
@@ -173,7 +175,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.setReadOnly(isReadOnly);
-            this.form.novoConfigChange.emit({readOnly: isReadOnly});
+            this.form.triggerEvent({controlKey: key, prop: 'readOnly', value: isReadOnly });
         }
     }
 
@@ -181,7 +183,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.setRequired(required);
-            this.form.novoConfigChange.emit({required: required});
+            this.form.triggerEvent({controlKey: key, prop: 'hidden', value: true });
         }
     }
 
@@ -190,7 +192,7 @@ export class FieldInteractionApi {
         if (control) {
             control.hide(clearValue);
             this.disable(key, { emitEvent: false });
-            this.form.novoConfigChange.emit({hidden: true});
+            this.form.triggerEvent({controlKey: key, prop: 'hidden', value: true });
         }
     }
 
@@ -199,7 +201,7 @@ export class FieldInteractionApi {
         if (control) {
             control.show();
             this.enable(key, { emitEvent: false });
-            this.form.novoConfigChange.emit({hidden: false});
+            this.form.triggerEvent({controlKey: key, prop: 'hidden', value: false });
         }
     }
 
@@ -210,7 +212,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.disable(options);
-            this.form.novoConfigChange.emit({readOnly: true});
+            this.form.triggerEvent({controlKey: key, prop: 'readOnly', value: false });
         }
     }
 
@@ -221,7 +223,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.enable(options);
-            this.form.novoConfigChange.emit({readOnly: false});
+            this.form.triggerEvent({controlKey: key, prop: 'readOnly', value: true });
         }
     }
 
@@ -312,14 +314,15 @@ export class FieldInteractionApi {
                 icon: icon,
                 button: allowDismiss
             };
+            this.form.triggerEvent({controlKey: key, prop: 'tipWell', value: tip });
         }
     }
 
     public setTooltip(key: string, tooltip: string): void {
         let control = this.getControl(key);
         if (control) {
-            control.setTooltip(tooltip);
-            this.form.novoConfigChange.emit({tooltip: tooltip});
+            control.tooltip = tooltip;
+            this.form.triggerEvent({controlKey: key, prop: 'tooltip', value: tooltip });
         }
     }
 
@@ -346,7 +349,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control[prop] = value;
-            this.form.novoConfigChange.emit({prop: value});
+            this.form.triggerEvent({controlKey: key, prop: prop, value: value });
         }
     }
 
@@ -395,6 +398,7 @@ export class FieldInteractionApi {
                 }
                 this.setProperty(key, 'options', [...currentOptions, optionToAdd]);
             }
+            this.form.triggerEvent({controlKey: key, prop: 'options', value: [...currentOptions, optionToAdd] });
         }
     }
 
@@ -444,6 +448,7 @@ export class FieldInteractionApi {
                 }
                 this.setProperty(key, 'options', [...currentOptions]);
             }
+            this.form.triggerEvent({controlKey: key, prop: 'options', value: control.options });
         }
     }
 
@@ -486,6 +491,7 @@ export class FieldInteractionApi {
                 newConfig.options = [...config.options];
             }
             this.setProperty(key, 'config', newConfig);
+            this.form.triggerEvent({controlKey: key, prop: 'pickerConfig', value: config });
         }
     }
 
@@ -511,6 +517,7 @@ export class FieldInteractionApi {
                     this.setProperty(key, 'tipWell', null);
                 }
             }
+            this.form.triggerEvent({controlKey: key, prop: 'loading', value: loading });
         }
     }
 
@@ -575,6 +582,7 @@ export class FieldInteractionApi {
                 let formControl = new NovoFormControl(initialValue, novoControl);
                 this.form.addControl(novoControl.key, formControl);
                 this.form.fieldsets[fieldsetIndex].controls.splice(controlIndex, 0, novoControl);
+                this.form.triggerEvent({controlKey: key, prop: 'addControl', value: formControl });
             }
         }
     }
@@ -601,6 +609,7 @@ export class FieldInteractionApi {
             if (fieldsetIndex !== -1 && controlIndex !== -1) {
                 this.form.removeControl(key);
                 this.form.fieldsets[fieldsetIndex].controls.splice(controlIndex, 1);
+                this.form.triggerEvent({controlKey: key, prop: 'removeControl', value: key });
             }
         }
     }
@@ -609,5 +618,11 @@ export class FieldInteractionApi {
         let h: any;
         clearTimeout(h);
         h = setTimeout(() => func(), wait);
+    }
+
+    private triggerEvent(event: IFieldInteractionEvent): void {
+        if (this.form && this.form.fieldInteractionEvents) {
+            this.form.fieldInteractionEvents.emit(event);
+          }
     }
 }

--- a/src/platform/elements/form/FieldInteractionApi.ts
+++ b/src/platform/elements/form/FieldInteractionApi.ts
@@ -154,7 +154,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.setValue(value, options);
-            this.form.triggerEvent({controlKey: key, prop: 'value', value: value });
+            this.triggerEvent({controlKey: key, prop: 'value', value: value });
         }
     }
 
@@ -167,7 +167,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.setValue(value, options);
-            this.form.triggerEvent({controlKey: key, prop: 'value', value: value });
+            this.triggerEvent({controlKey: key, prop: 'value', value: value });
         }
     }
 
@@ -175,7 +175,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.setReadOnly(isReadOnly);
-            this.form.triggerEvent({controlKey: key, prop: 'readOnly', value: isReadOnly });
+            this.triggerEvent({controlKey: key, prop: 'readOnly', value: isReadOnly });
         }
     }
 
@@ -183,7 +183,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.setRequired(required);
-            this.form.triggerEvent({controlKey: key, prop: 'hidden', value: true });
+            this.triggerEvent({controlKey: key, prop: 'hidden', value: true });
         }
     }
 
@@ -192,7 +192,7 @@ export class FieldInteractionApi {
         if (control) {
             control.hide(clearValue);
             this.disable(key, { emitEvent: false });
-            this.form.triggerEvent({controlKey: key, prop: 'hidden', value: true });
+            this.triggerEvent({controlKey: key, prop: 'hidden', value: true });
         }
     }
 
@@ -201,7 +201,7 @@ export class FieldInteractionApi {
         if (control) {
             control.show();
             this.enable(key, { emitEvent: false });
-            this.form.triggerEvent({controlKey: key, prop: 'hidden', value: false });
+            this.triggerEvent({controlKey: key, prop: 'hidden', value: false });
         }
     }
 
@@ -212,7 +212,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.disable(options);
-            this.form.triggerEvent({controlKey: key, prop: 'readOnly', value: false });
+            this.triggerEvent({controlKey: key, prop: 'readOnly', value: false });
         }
     }
 
@@ -223,7 +223,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.enable(options);
-            this.form.triggerEvent({controlKey: key, prop: 'readOnly', value: true });
+            this.triggerEvent({controlKey: key, prop: 'readOnly', value: true });
         }
     }
 
@@ -314,7 +314,7 @@ export class FieldInteractionApi {
                 icon: icon,
                 button: allowDismiss
             };
-            this.form.triggerEvent({controlKey: key, prop: 'tipWell', value: tip });
+            this.triggerEvent({controlKey: key, prop: 'tipWell', value: tip });
         }
     }
 
@@ -322,7 +322,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.tooltip = tooltip;
-            this.form.triggerEvent({controlKey: key, prop: 'tooltip', value: tooltip });
+            this.triggerEvent({controlKey: key, prop: 'tooltip', value: tooltip });
         }
     }
 
@@ -349,7 +349,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control[prop] = value;
-            this.form.triggerEvent({controlKey: key, prop: prop, value: value });
+            this.triggerEvent({controlKey: key, prop: prop, value: value });
         }
     }
 
@@ -398,7 +398,7 @@ export class FieldInteractionApi {
                 }
                 this.setProperty(key, 'options', [...currentOptions, optionToAdd]);
             }
-            this.form.triggerEvent({controlKey: key, prop: 'options', value: [...currentOptions, optionToAdd] });
+            this.triggerEvent({controlKey: key, prop: 'options', value: [...currentOptions, optionToAdd] });
         }
     }
 
@@ -448,7 +448,7 @@ export class FieldInteractionApi {
                 }
                 this.setProperty(key, 'options', [...currentOptions]);
             }
-            this.form.triggerEvent({controlKey: key, prop: 'options', value: control.options });
+            this.triggerEvent({controlKey: key, prop: 'options', value: control.options });
         }
     }
 
@@ -491,7 +491,7 @@ export class FieldInteractionApi {
                 newConfig.options = [...config.options];
             }
             this.setProperty(key, 'config', newConfig);
-            this.form.triggerEvent({controlKey: key, prop: 'pickerConfig', value: config });
+            this.triggerEvent({controlKey: key, prop: 'pickerConfig', value: config });
         }
     }
 
@@ -517,7 +517,7 @@ export class FieldInteractionApi {
                     this.setProperty(key, 'tipWell', null);
                 }
             }
-            this.form.triggerEvent({controlKey: key, prop: 'loading', value: loading });
+            this.triggerEvent({controlKey: key, prop: 'loading', value: loading });
         }
     }
 
@@ -582,7 +582,7 @@ export class FieldInteractionApi {
                 let formControl = new NovoFormControl(initialValue, novoControl);
                 this.form.addControl(novoControl.key, formControl);
                 this.form.fieldsets[fieldsetIndex].controls.splice(controlIndex, 0, novoControl);
-                this.form.triggerEvent({controlKey: key, prop: 'addControl', value: formControl });
+                this.triggerEvent({controlKey: key, prop: 'addControl', value: formControl });
             }
         }
     }
@@ -609,7 +609,7 @@ export class FieldInteractionApi {
             if (fieldsetIndex !== -1 && controlIndex !== -1) {
                 this.form.removeControl(key);
                 this.form.fieldsets[fieldsetIndex].controls.splice(controlIndex, 1);
-                this.form.triggerEvent({controlKey: key, prop: 'removeControl', value: key });
+                this.triggerEvent({controlKey: key, prop: 'removeControl', value: key });
             }
         }
     }

--- a/src/platform/elements/form/FieldInteractionApi.ts
+++ b/src/platform/elements/form/FieldInteractionApi.ts
@@ -183,7 +183,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.setRequired(required);
-            this.triggerEvent({controlKey: key, prop: 'hidden', value: true });
+            this.triggerEvent({controlKey: key, prop: 'required', value: required });
         }
     }
 

--- a/src/platform/elements/form/FieldInteractionApi.ts
+++ b/src/platform/elements/form/FieldInteractionApi.ts
@@ -311,7 +311,7 @@ export class FieldInteractionApi {
     public setTooltip(key: string, tooltip: string): void {
         let control = this.getControl(key);
         if (control) {
-            control.tooltip = tooltip;
+            control.setTooltip(tooltip);
         }
     }
 

--- a/src/platform/elements/form/FieldInteractionApi.ts
+++ b/src/platform/elements/form/FieldInteractionApi.ts
@@ -153,6 +153,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.setValue(value, options);
+            this.form.novoConfigChange.emit({value: value});
         }
     }
 
@@ -172,6 +173,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.setReadOnly(isReadOnly);
+            this.form.novoConfigChange.emit({readOnly: isReadOnly});
         }
     }
 
@@ -179,6 +181,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.setRequired(required);
+            this.form.novoConfigChange.emit({required: required});
         }
     }
 
@@ -187,6 +190,7 @@ export class FieldInteractionApi {
         if (control) {
             control.hide(clearValue);
             this.disable(key, { emitEvent: false });
+            this.form.novoConfigChange.emit({hidden: true});
         }
     }
 
@@ -195,6 +199,7 @@ export class FieldInteractionApi {
         if (control) {
             control.show();
             this.enable(key, { emitEvent: false });
+            this.form.novoConfigChange.emit({hidden: false});
         }
     }
 
@@ -205,6 +210,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.disable(options);
+            this.form.novoConfigChange.emit({readOnly: true});
         }
     }
 
@@ -215,6 +221,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.enable(options);
+            this.form.novoConfigChange.emit({readOnly: false});
         }
     }
 
@@ -312,6 +319,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.setTooltip(tooltip);
+            this.form.novoConfigChange.emit({tooltip: tooltip});
         }
     }
 
@@ -338,6 +346,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control[prop] = value;
+            this.form.novoConfigChange.emit({prop: value});
         }
     }
 

--- a/src/platform/elements/form/FormInterfaces.ts
+++ b/src/platform/elements/form/FormInterfaces.ts
@@ -13,3 +13,9 @@ export interface NovoFieldset {
     icon?: string;
     controls: any[];
 }
+
+export interface IFieldInteractionEvent {
+    controlKey: string;
+    prop: string;
+    value: any;
+}

--- a/src/platform/elements/form/NovoFormControl.ts
+++ b/src/platform/elements/form/NovoFormControl.ts
@@ -1,6 +1,6 @@
 // NG2
 import { FormControl, Validators, FormGroup } from '@angular/forms';
-import { EventEmitter } from '@angular/core';
+import { EventEmitter, Output } from '@angular/core';
 // APP
 import { NovoControlConfig } from './FormControls';
 import { Helpers } from '../../utils/Helpers';
@@ -49,7 +49,6 @@ export class NovoFormControl extends FormControl {
         button?: boolean;
     };
     rawValue?: any;
-    public readonly tooltipChanges: Observable<any>;
 
     private historyTimeout: any;
     
@@ -102,7 +101,6 @@ export class NovoFormControl extends FormControl {
         } else {
             this.enable();
         }
-        this.initCustomObservable();
     }
 
     /**
@@ -195,7 +193,6 @@ export class NovoFormControl extends FormControl {
      */
     public setTooltip(tooltip: string): void {
         this.tooltip = tooltip;
-        (this.tooltipChanges as EventEmitter<string>).emit(this.tooltip);
     }
     
     /**
@@ -207,14 +204,11 @@ export class NovoFormControl extends FormControl {
         this.markAsTouched();
         this.setErrors(Object.assign({}, this.errors, { custom: message }));
     }
-
-    private initCustomObservable(): void {
-        (this as{tooltipChanges: Observable<any>}).tooltipChanges = new EventEmitter();
-      }
 }
 
 
 export class NovoFormGroup extends FormGroup {
+    @Output() public novoConfigChange: EventEmitter<any> = new EventEmitter();
     public layout: string;
     public edit: boolean;
     public currentEntity: string;

--- a/src/platform/elements/form/NovoFormControl.ts
+++ b/src/platform/elements/form/NovoFormControl.ts
@@ -5,6 +5,7 @@ import { EventEmitter, Output } from '@angular/core';
 import { NovoControlConfig } from './FormControls';
 import { Helpers } from '../../utils/Helpers';
 import { Observable } from 'rxjs/Observable';
+import { IFieldInteractionEvent } from './FormInterfaces';
 
 export class NovoFormControl extends FormControl {
     displayValueChanges: EventEmitter<any> = new EventEmitter<any>();
@@ -185,15 +186,6 @@ export class NovoFormControl extends FormControl {
             this.enable();
         }
     }
-
-    /**
-     * sets the `tooltip` property on the control
-     * @name setTooltip
-     * @param tooltip 
-     */
-    public setTooltip(tooltip: string): void {
-        this.tooltip = tooltip;
-    }
     
     /**
      * @name markAsInvalid
@@ -208,7 +200,7 @@ export class NovoFormControl extends FormControl {
 
 
 export class NovoFormGroup extends FormGroup {
-    @Output() public novoConfigChange: EventEmitter<any> = new EventEmitter();
+    public fieldInteractionEvents : EventEmitter<IFieldInteractionEvent> = new EventEmitter();
     public layout: string;
     public edit: boolean;
     public currentEntity: string;

--- a/src/platform/elements/form/NovoFormControl.ts
+++ b/src/platform/elements/form/NovoFormControl.ts
@@ -1,10 +1,9 @@
 // NG2
 import { FormControl, Validators, FormGroup } from '@angular/forms';
-import { EventEmitter, Output } from '@angular/core';
+import { EventEmitter } from '@angular/core';
 // APP
 import { NovoControlConfig } from './FormControls';
 import { Helpers } from '../../utils/Helpers';
-import { Observable } from 'rxjs/Observable';
 import { IFieldInteractionEvent } from './FormInterfaces';
 
 export class NovoFormControl extends FormControl {
@@ -52,7 +51,7 @@ export class NovoFormControl extends FormControl {
     rawValue?: any;
 
     private historyTimeout: any;
-    
+
 
     constructor(value: any, control: NovoControlConfig) {
         super(value, control.validators, control.asyncValidators);
@@ -186,7 +185,7 @@ export class NovoFormControl extends FormControl {
             this.enable();
         }
     }
-    
+
     /**
      * @name markAsInvalid
      * @param message

--- a/src/platform/elements/form/NovoFormControl.ts
+++ b/src/platform/elements/form/NovoFormControl.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from '@angular/core';
 // APP
 import { NovoControlConfig } from './FormControls';
 import { Helpers } from '../../utils/Helpers';
+import { Observable } from 'rxjs/Observable';
 
 export class NovoFormControl extends FormControl {
     displayValueChanges: EventEmitter<any> = new EventEmitter<any>();
@@ -48,8 +49,10 @@ export class NovoFormControl extends FormControl {
         button?: boolean;
     };
     rawValue?: any;
+    public readonly tooltipChanges: Observable<any>;
 
     private historyTimeout: any;
+    
 
     constructor(value: any, control: NovoControlConfig) {
         super(value, control.validators, control.asyncValidators);
@@ -99,6 +102,7 @@ export class NovoFormControl extends FormControl {
         } else {
             this.enable();
         }
+        this.initCustomObservable();
     }
 
     /**
@@ -185,6 +189,16 @@ export class NovoFormControl extends FormControl {
     }
 
     /**
+     * sets the `tooltip` property on the control
+     * @name setTooltip
+     * @param tooltip 
+     */
+    public setTooltip(tooltip: string): void {
+        this.tooltip = tooltip;
+        (this.tooltipChanges as EventEmitter<string>).emit(this.tooltip);
+    }
+    
+    /**
      * @name markAsInvalid
      * @param message
      */
@@ -193,7 +207,12 @@ export class NovoFormControl extends FormControl {
         this.markAsTouched();
         this.setErrors(Object.assign({}, this.errors, { custom: message }));
     }
+
+    private initCustomObservable(): void {
+        (this as{tooltipChanges: Observable<any>}).tooltipChanges = new EventEmitter();
+      }
 }
+
 
 export class NovoFormGroup extends FormGroup {
     public layout: string;


### PR DESCRIPTION
## **Description**

Emit if there are changes to the NovoFormControl via Field Interactions

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**