### PR TITLE
fix(FieldInteractionAPI): Fix faulty logic for enable/disable events

### DIFF
--- a/src/platform/elements/form/FieldInteractionApi.ts
+++ b/src/platform/elements/form/FieldInteractionApi.ts
@@ -212,7 +212,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.disable(options);
-            this.triggerEvent({controlKey: key, prop: 'readOnly', value: false });
+            this.triggerEvent({controlKey: key, prop: 'readOnly', value: true });
         }
     }
 
@@ -223,7 +223,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.enable(options);
-            this.triggerEvent({controlKey: key, prop: 'readOnly', value: true });
+            this.triggerEvent({controlKey: key, prop: 'readOnly', value: false });
         }
     }
 


### PR DESCRIPTION
## **Description**
Fixes minor issue to new functionality introduced in [PR 719](https://github.com/bullhorn/novo-elements/pull/719). `readOnly` should be `true` when a control is disabled and `false` when a control is enabled.
#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**