### PR TITLE
style(tiles): Added white background to tiles

### DIFF
--- a/src/platform/elements/tiles/Tiles.scss
+++ b/src/platform/elements/tiles/Tiles.scss
@@ -16,6 +16,7 @@ novo-tiles {
   & > .tile-container {
     display: flex;
     text-align: center;
+    background-color: $white;
     border: $border-properties;
     border-radius: $border-radius;
     position: relative;


### PR DESCRIPTION
## **Description**

Added white background so that the tiles will always have a white background on non-white pages.

#### **Verify that...**

- [ ] Any related demos where added and `npm start` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run compile` still works

##### **Screenshots**