### PR TITLE
Tweaking button styling to center text/icon inside of button

### DIFF
--- a/src/platform/elements/button/Button.scss
+++ b/src/platform/elements/button/Button.scss
@@ -13,23 +13,13 @@ button {
   i {
     font-size: 1em;
   }
-  &[side='left']:not([theme='fab']) {
-    i {
-      margin-right: 5px;
-    }
-  }
-  &[side='right']:not([theme='fab']) {
-    i {
-      margin-left: 5px;
-    }
-  }
   &[icon='times'] {
     i {
       font-size: 0.9em;
     }
   }
   &[theme] {
-    padding: 6px 10px;
+    padding: 6px 12px;
     min-height: 37px;
     font-size: 1rem;
     border: none;
@@ -193,11 +183,17 @@ button {
           width: 25px;
           display: flex;
           align-items: center;
-          justify-content: center;
-          margin-left: 10px;
           &:before {
             vertical-align: baseline;
           }
+        }
+        &[side='left'] i {
+          padding-left: 0;
+          justify-content: flex-start;
+        }
+        &[side='right'] i {
+          padding-right: 0;
+          justify-content: flex-end;
         }
       }
     } // Dialoge Themed Button
@@ -215,10 +211,17 @@ button {
           width: 25px;
           display: flex;
           align-items: center;
-          justify-content: center;
           &:before {
             vertical-align: baseline;
           }
+        }
+        &[side='left'] i {
+          padding-left: 0;
+          justify-content: flex-start;
+        }
+        &[side='right'] i {
+          padding-right: 0;
+          justify-content: flex-end;
         }
       }
       &:hover,


### PR DESCRIPTION
## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**