### PR TITLE
fix(EntityList): prevent meta type from being overwritten

### DIFF
--- a/src/platform/elements/value/EntityList.ts
+++ b/src/platform/elements/value/EntityList.ts
@@ -58,7 +58,6 @@ export class EntityList implements OnInit {
     }
 
     ngOnInit(): any {
-        this.meta.type = 'TO_ONE';
         this.baseEntity = this.meta.associatedEntity.entity;
         for (let entity of this.data.data) {
             entity.isLinkable = this.isLinkable(entity);


### PR DESCRIPTION
## **Description**

Meta type was being overwritten unnecessarily when displaying the entity list, which was causing the type to be misidentified when reloading the list after changes.

#### **Verify that...**

- [ ] Any related demos where added and `npm start` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run compile` still works