### PR TITLE
fix(EntityList): prevent meta type from being overwritten - fix

### DIFF
--- a/src/platform/elements/value/EntityList.ts
+++ b/src/platform/elements/value/EntityList.ts
@@ -1,5 +1,6 @@
 // NG2
 import { Component, Input, OnInit, ChangeDetectorRef, ChangeDetectionStrategy } from '@angular/core';
+import { Helpers } from '../../utils/Helpers';
 
 @Component({
     selector: 'novo-entity-list',
@@ -7,13 +8,13 @@ import { Component, Input, OnInit, ChangeDetectorRef, ChangeDetectionStrategy } 
     template: `
         <div *ngFor="let entity of data.data" class="entity">
             <a *ngIf="entity.isLinkable" (click)="openLink(entity)">
-                <i class="bhi-circle {{ entity.class }}"></i>{{ entity | render : meta }}
+                <i class="bhi-circle {{ entity.class }}"></i>{{ entity | render : metaDisplay }}
             </a>
             <span *ngIf="!entity.isLinkable && entity.personSubtype">
-                <i class="bhi-circle {{ entity.class }}"></i>{{ entity | render : meta }}
+                <i class="bhi-circle {{ entity.class }}"></i>{{ entity | render : metaDisplay }}
             </span>
             <span *ngIf="!entity.isLinkable && !entity.personSubtype">
-                {{ entity | render : meta }}
+                {{ entity | render : metaDisplay }}
             </span>
         </div>
     `
@@ -22,6 +23,7 @@ export class EntityList implements OnInit {
     @Input() data: any;
     @Input() meta: any;
     baseEntity: string = '';
+    metaDisplay: any;
     ENTITY_SHORT_NAMES: any = {
         Lead: 'lead',
         ClientContact: 'contact',
@@ -58,6 +60,10 @@ export class EntityList implements OnInit {
     }
 
     ngOnInit(): any {
+        // use a local copy of the meta to set the type to TO_ONE for proper display
+        // without changing the input object
+        this.metaDisplay = Helpers.deepClone(this.meta);
+        this.metaDisplay.type = 'TO_ONE';
         this.baseEntity = this.meta.associatedEntity.entity;
         for (let entity of this.data.data) {
             entity.isLinkable = this.isLinkable(entity);


### PR DESCRIPTION
## **Description**

Use local variable for meta so that meta.type can be edited without changing the underlying object.

#### **Verify that...**

- [ ] Any related demos where added and `npm start` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run compile` still works