### PR TITLE
fix(NovoAutoSize): Fix shrinking behavior of autosizing textareas

### DIFF
--- a/src/platform/elements/form/Control.spec.ts
+++ b/src/platform/elements/form/Control.spec.ts
@@ -1,0 +1,65 @@
+// NG2
+import { Component } from '@angular/core';
+import { TestBed, async } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+// App
+import { NovoAutoSize } from './Control';
+
+@Component({
+  selector: 'novo-auto-size-test-component',
+  template: `
+        <textarea autosize></textarea>
+    `,
+  styles: [`
+    textarea {
+      width: 100px;
+      height: 20px;
+      min-height: 20px;
+      padding: 0;
+      margin: 0;
+      border: 0;
+      line-height: 20px;
+    }
+  `]
+})
+class NovoAutoSizeTestComponent { }
+
+describe('Elements: NovoAutoSize', () => {
+  describe('Directive:', () => {
+    let fixture;
+    let component;
+    let textarea: HTMLTextAreaElement;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        declarations: [
+          NovoAutoSize,
+          NovoAutoSizeTestComponent
+        ]
+      }).compileComponents();
+      fixture = TestBed.createComponent(NovoAutoSizeTestComponent);
+      component = fixture.debugElement.componentInstance;
+      textarea = fixture.debugElement.query(By.css('textarea')).nativeElement;
+    }));
+
+    it('should initialize correctly', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should grow when content is added', () => {
+      const initialHeight = textarea.clientHeight;
+      textarea.value = 'textarea \n should \n grow'; // Three lines of text
+      textarea.dispatchEvent(new Event('input'));
+      expect(textarea.clientHeight).toBe(initialHeight * 3);
+    });
+
+    it ('should shrink when content is removed', () => {
+      textarea.value = 'textarea \n should \n shrink'; // Three lines of text
+      textarea.dispatchEvent(new Event('input'));
+      const initialHeight = textarea.clientHeight;
+      textarea.value = '';
+      textarea.dispatchEvent(new Event('input'));
+      expect(textarea.clientHeight).toBe(initialHeight / 3);
+    });
+  });
+});

--- a/src/platform/elements/form/Control.ts
+++ b/src/platform/elements/form/Control.ts
@@ -39,13 +39,9 @@ export class NovoAutoSize implements AfterContentInit {
   }
 
   adjust(): void {
-    let hasValue = this.element.nativeElement.value.length !== 0;
-    this.element.nativeElement.style.overflow = 'hidden';
-    if (hasValue) {
-      this.element.nativeElement.style.height = Math.min((this.element.nativeElement.scrollHeight - 11), 300) + 'px';
-    } else {
-      this.element.nativeElement.style.height = '14px';
-    }
+    const nativeElement = this.element.nativeElement;
+    nativeElement.style.height = nativeElement.style.minHeight;
+    nativeElement.style.height = `${nativeElement.scrollHeight}px`;
   }
 }
 

--- a/src/platform/elements/form/Form.scss
+++ b/src/platform/elements/form/Form.scss
@@ -390,6 +390,12 @@ novo-form {
                         border-bottom: 1px solid $negative;
                       }
                     }
+                    textarea[autosize] {
+                      min-height: 2rem;
+                      max-height: 300px;
+                      padding-top: 0;
+                      padding-bottom: 0;
+                    }
                     textarea:not(.quick-note-textarea) {
                       transition: height 0;
                       background: transparent !important;


### PR DESCRIPTION
## **Description**

The autosizing textarea was shrinking by one pixel on every input event, depending on content/initial height of the textarea. The method of resizing is now `resize to smallest valid input height to calculate the appropriate scrollHeight`. The heights previously set in the directive have also been moved to min/max heights in CSS. Also removed some padding to better replicate the look of a one line text input.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [ ] `npm run compile` still works

The `compile` script does not seem to exist

##### **Screenshots**

Old behavior:
![autosize-old](https://user-images.githubusercontent.com/6486532/40990264-4233a0ba-68be-11e8-877c-84b46d0c82b4.gif)

New behavior:
![autosize-new](https://user-images.githubusercontent.com/6486532/40990271-48ac11e8-68be-11e8-8823-13902506e020.gif)
