### PR TITLE
fix(FieldInteractionAPI): Add duplicate check to addStaticOption method

### DIFF
--- a/src/app/pages/elements/field-interactions/FieldInteractionsDemo.ts
+++ b/src/app/pages/elements/field-interactions/FieldInteractionsDemo.ts
@@ -290,6 +290,7 @@ export class FieldInteractionsDemoComponent {
                 API.removeStaticOption('picker', 'NEW');
             } else {
                 API.addStaticOption('select', 'NEW');
+                API.addStaticOption('select', 'NEW'); // Duplicate options will be ignored
                 API.addStaticOption('picker', 'NEW');
             }
         };
@@ -800,6 +801,7 @@ export class FieldInteractionsDemoComponent {
         API.removeStaticOption('picker', 'NEW');
     } else {
         API.addStaticOption('select', 'NEW');
+        API.addStaticOption('select', 'NEW'); // Duplicate options will be ignored
         API.addStaticOption('picker', 'NEW');
     }
 };

--- a/src/platform/elements/form/FieldInteractionApi.ts
+++ b/src/platform/elements/form/FieldInteractionApi.ts
@@ -378,6 +378,7 @@ export class FieldInteractionApi {
     public addStaticOption(key: string, newOption: any): void {
         let control = this.getControl(key);
         let optionToAdd = newOption;
+        let isUnique: boolean = true;
         if (control) {
             let currentOptions = this.getProperty(key, 'options');
             if (!currentOptions || !currentOptions.length) {
@@ -396,9 +397,19 @@ export class FieldInteractionApi {
                 if (currentOptions[0].value && !optionToAdd.value) {
                     optionToAdd = { value: newOption, label: newOption };
                 }
-                this.setProperty(key, 'options', [...currentOptions, optionToAdd]);
+                // Ensure duplicate values are not added
+                currentOptions.forEach((option) => {
+                    if ((option.value && option.value === optionToAdd.value) || (option === optionToAdd)) {
+                        isUnique = false;
+                    }
+                });
+                if (isUnique) {
+                    this.setProperty(key, 'options', [...currentOptions, optionToAdd]);
+                }
             }
-            this.triggerEvent({controlKey: key, prop: 'options', value: [...currentOptions, optionToAdd] });
+            if (isUnique) {
+                this.triggerEvent({controlKey: key, prop: 'options', value: [...currentOptions, optionToAdd] });
+            }
         }
     }
 

--- a/src/platform/elements/form/FieldInteractionApi.ts
+++ b/src/platform/elements/form/FieldInteractionApi.ts
@@ -212,7 +212,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.disable(options);
-            this.triggerEvent({controlKey: key, prop: 'readOnly', value: false });
+            this.triggerEvent({controlKey: key, prop: 'readOnly', value: true });
         }
     }
 
@@ -223,7 +223,7 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.enable(options);
-            this.triggerEvent({controlKey: key, prop: 'readOnly', value: true });
+            this.triggerEvent({controlKey: key, prop: 'readOnly', value: false });
         }
     }
 


### PR DESCRIPTION
## **Description**

Add duplicate check to FieldInteractions addStaticOption method

#### **Verify that...**
- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**

![addstaticoption_ne](https://user-images.githubusercontent.com/3916731/41378985-5d1c76a4-6f26-11e8-8d32-6324098ef619.gif)