### PR TITLE
(select): Updates to select accessibility

### DIFF
--- a/src/platform/elements/select/Select.module.ts
+++ b/src/platform/elements/select/Select.module.ts
@@ -1,16 +1,16 @@
-// NG2
+// NG
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { OverlayModule } from '@angular/cdk/overlay';
-// APP
+import { A11yModule } from '@angular/cdk/a11y';
+// App
 import { NovoOverlayModule } from '../overlay/Overlay.module';
 import { NovoSelectElement } from './Select';
 
 @NgModule({
-    imports: [CommonModule, FormsModule, OverlayModule, NovoOverlayModule],
-    declarations: [NovoSelectElement],
-    exports: [NovoSelectElement]
+  imports: [CommonModule, FormsModule, OverlayModule, A11yModule, NovoOverlayModule],
+  declarations: [NovoSelectElement],
+  exports: [NovoSelectElement],
 })
-export class NovoSelectModule {
-}
+export class NovoSelectModule {}

--- a/src/platform/elements/select/Select.spec.ts
+++ b/src/platform/elements/select/Select.spec.ts
@@ -1,4 +1,4 @@
-// NG2
+// NG
 import { TestBed, async } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 // App
@@ -8,166 +8,313 @@ import { KeyCodes } from '../../utils/key-codes/KeyCodes';
 import { NovoLabelService } from '../../services/novo-label-service';
 
 const KeyEvent = (code) => {
-    let event: any = document.createEvent('Event');
-    event.keyCode = code;
-    return event;
+  let event: any = document.createEvent('Event');
+  event.keyCode = code;
+  return event;
 };
 
-xdescribe('Elements: NovoSelectElement', () => {
-    let fixture;
-    let component;
+describe('Elements: NovoSelectElement', () => {
+  let fixture, comp;
 
-    beforeEach(async(() => {
-        TestBed.configureTestingModule({
-            imports: [
-                NovoSelectModule
-            ],
-            providers: [
-                { provide: NovoLabelService, useClass: NovoLabelService }
-            ]
-        }).compileComponents();
-        fixture = TestBed.createComponent(NovoSelectElement);
-        component = fixture.debugElement.componentInstance;
-    }));
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [NovoSelectModule],
+      providers: [
+        {
+          provide: NovoLabelService,
+          useClass: NovoLabelService,
+        },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(NovoSelectElement);
+    comp = fixture.debugElement.componentInstance;
+  }));
 
-    it('should initialize correctly', () => {
-        expect(component).toBeTruthy();
+  describe('Function: ngOnInit', () => {
+    it('should invoke ngOnChanges', () => {
+      comp.options = ['1', '2', '3'];
+      comp.ngOnInit();
+      expect(comp.filteredOptions).toBeDefined();
+      expect(comp.filteredOptions[0].value).toEqual('1');
+      expect(comp.filteredOptions[0].label).toEqual('1');
     });
+  });
 
-    describe('Method: ngOnInit()', () => {
-        it('should reformat array options to an object', () => {
-            expect(component.ngOnInit).toBeDefined();
-            component.options = ['1', '2', '3'];
-            component.ngOnInit();
-            expect(component.filteredOptions).toBeDefined();
-            expect(component.filteredOptions[0].value).toBe('1');
-            expect(component.filteredOptions[0].label).toBe('1');
-        });
+  describe('Function: ngOnChanges', () => {
+    it('should convert readOnly from a non-boolean to a boolean', () => {
+      comp.readonly = 'true';
+      comp.ngOnChanges();
+      expect(comp.readonly).toEqual(false);
     });
-
-    describe('Method: select(option, i)', () => {
-        it('should be defined.', () => {
-            expect(component.select).toBeDefined();
-        });
-
-        xit('should select second option', () => {
-            let i = 1;
-            let option = component.options[i];
-            component.select(option, i);
-            expect(component.selected).toBe(option.value);
-            expect(option.active).toBeTruthy();
-        });
+    it('should set filteredOptions to an array of objects from an array of strings', () => {
+      comp.options = ['foo', 'bar', 'baz'];
+      comp.ngOnChanges();
+      expect(comp.filteredOptions).toEqual([
+        { value: 'foo', label: 'foo' },
+        { value: 'bar', label: 'bar' },
+        { value: 'baz', label: 'baz' },
+      ]);
     });
-
-    describe('Method: clear()', () => {
-        it('should be defined.', () => {
-            expect(component.clear).toBeDefined();
-        });
-
-        it('should clear selected', () => {
-            component.selected = {
-                label: 'test',
-                value: 'test',
-                active: true
-            };
-            component.clear();
-            expect(component.selected.active).toBeFalsy();
-            expect(component.selectedIndex).toBe(-1);
-            expect(component.empty).toBeTruthy();
-        });
+    it('should set filteredOptions to an array of objects', () => {
+      comp.options = [{ readOnly: false }, { readOnly: true }, {}];
+      comp.ngOnChanges();
+      expect(comp.filteredOptions).toEqual([{ readOnly: false, active: false }, { active: false }]);
     });
-
-    describe('Method: onKeyDown(event)', () => {
-        it('should be defined.', () => {
-            expect(component.onKeyDown).toBeDefined();
-        });
-
-        it('should do nothing select is not open', () => {
-            component.active = false;
-            component.selectedIndex = 1;
-            component.onKeyDown(KeyEvent(KeyCodes.UP));
-            expect(component.selectedIndex).toBe(1);
-        });
-
-        it('should close select with ESC is pressed', () => {
-            component.openPanel();
-            spyOn(component, 'closePanel');
-            component.onKeyDown(KeyEvent(KeyCodes.ESC));
-            expect(component.closePanel).toHaveBeenCalled();
-        });
-
-        xit('should select a value and close when ENTER is pressed', () => {
-            component.openPanel();
-            component.selectedIndex = 1;
-            spyOn(component, 'closePanel');
-            spyOn(component, 'select');
-            component.onKeyDown(KeyEvent(KeyCodes.ENTER));
-            expect(component.closePanel).toHaveBeenCalled();
-            expect(component.select).toHaveBeenCalledWith({
-                label: 'two',
-                value: '2'
-            }, 1);
-        });
-
-        xit('should increment selected index when DOWN is pressed', () => {
-            component.openPanel();
-            component.selectedIndex = 1;
-            spyOn(component, 'select');
-            component.onKeyDown(KeyEvent(KeyCodes.DOWN));
-            expect(component.selectedIndex).toBe(2);
-        });
-
-        xit('should decrement selected index when UP is pressed', () => {
-            component.openPanel();
-            component.selectedIndex = 2;
-            spyOn(component, 'select');
-            component.onKeyDown(KeyEvent(KeyCodes.UP));
-            expect(component.selectedIndex).toBe(1);
-        });
-
-        it('should select a value when any letter key is pressed', () => {
-            component.openPanel();
-            component.selectedIndex = 1;
-            component.options = [ { value: 1, label: 'One' }, { value: 2, label: 'two' }];
-            component.filteredOptions = [ { value: 1, label: 'One' }, { value: 2, label: 'two' }];
-            component.element = {
-                nativeElement: {
-                    querySelector: () => {}
-                }
-            };
-            //spyOn(component, 'toggleActive');
-            spyOn(component, 'select');
-            let params = {
-                '.novo-select-list': { querySelectorAll: () => { return [ { getAttribute: () => { return [ { getAttribute: () => {} }, { getAttribute: () => {} }]; } }]; } },
-                '[data-automation-value^="C" i]': { getAttribute: () => {} }
-            };
-            //spyOn(component.element.nativeElement, 'querySelector').and.callFake(param => { return params[param]; });
-            component.onKeyDown(KeyEvent(KeyCodes.T));
-            //spyOn(Array, 'from').and.callFake(param => { return [ { getAttribute: () => {} }, { getAttribute: () => {} }]; });
-            expect(component.select).toHaveBeenCalled();
-        });
+    it('should invoke clear', () => {
+      const mockPlaceholder = { test: true };
+      comp.model = false;
+      comp.createdItem = false;
+      comp.placeholder = mockPlaceholder;
+      comp.ngOnChanges();
+      expect();
+      expect(comp.selected).toEqual({
+        label: mockPlaceholder,
+        value: null,
+        active: false,
+      });
+      expect(comp.header).toEqual({
+        open: false,
+        valid: true,
+        value: '',
+      });
+      expect(comp.selectedIndex).toEqual(-1);
+      expect(comp.empty).toEqual(true);
     });
-
-    describe('Method: writeValue()', () => {
-        it('should be defined.', () => {
-            expect(component.writeValue).toBeDefined();
-        });
-
-        it('should change the value', () => {
-            component.writeValue(10);
-            expect(component.model).toBe(10);
-        });
+    it('should invoke select', () => {
+      spyOn(comp.onSelect, 'emit');
+      comp.createdItem = 'baz';
+      comp.options = [{ label: 'foo', value: 'foo' }, { label: 'bar', value: 'bar' }, { label: 'baz', value: 'baz' }];
+      comp.ngOnChanges();
+      expect(comp.selectedIndex).toEqual(2);
+      expect(comp.selected).toEqual({ label: 'baz', value: 'baz', active: true });
+      expect(comp.empty).toEqual(false);
+      expect(comp.onSelect.emit).toHaveBeenCalledWith({ selected: 'baz' });
     });
-
-    describe('Method: registerOnChange()', () => {
-        it('should be defined.', () => {
-            expect(component.registerOnChange).toBeDefined();
-        });
+    it('should invoke writeValue', () => {
+      spyOn(comp, 'select');
+      comp.model = 'bar';
+      comp.options = [{ value: 'foo' }, { value: 'bar' }, { value: 'baz' }];
+      comp.filteredOptions = [{ value: 'foo' }, { value: 'bar' }];
+      comp.ngOnChanges();
+      expect(comp.select).toHaveBeenCalledWith({ value: 'bar', active: false }, 1, false);
+      expect(comp.empty).toEqual(false);
     });
-
-    describe('Method: registerOnTouched()', () => {
-        it('should be defined.', () => {
-            expect(component.registerOnTouched).toBeDefined();
-        });
+    it('should invoke openPanel', () => {
+      comp.overlay = {
+        panelOpen: true,
+        openPanel: jasmine.createSpy('openPanel'),
+      };
+      comp.ngOnChanges();
+      expect(comp.overlay.openPanel).toHaveBeenCalled();
     });
+  });
+
+  describe('Function: openPanel', () => {
+    it('should call overlay.openPanel', () => {
+      spyOn(comp.overlay, 'openPanel');
+      comp.openPanel();
+      expect(comp.overlay.openPanel).toHaveBeenCalled();
+    });
+  });
+
+  describe('Function: closePanel', () => {
+    it('should call overlay.closePanel', () => {
+      spyOn(comp.overlay, 'closePanel');
+      comp.closePanel();
+      expect(comp.overlay.closePanel).toHaveBeenCalled();
+    });
+  });
+
+  describe('Function: panelOpen', () => {
+    it('should return true', () => {
+      comp.overlay = { panelOpen: true };
+      expect(comp.panelOpen).toEqual(true);
+    });
+    it('should return false', () => {
+      comp.overlay = { panelOpen: false };
+      expect(comp.panelOpen).toEqual(false);
+    });
+  });
+
+  describe('Function: setValueAndClose(event)', () => {
+    it('should invoke select', () => {
+      const mockEvent: any = {
+        value: { test: true },
+        index: 1,
+      };
+      comp.setValueAndClose(mockEvent);
+      expect(comp.selectedIndex).toEqual(1);
+      expect(comp.selected).toEqual({ test: true, active: true });
+      expect(comp.empty).toEqual(false);
+    });
+    it('should invoke closePanel', () => {
+      spyOn(comp.overlay, 'closePanel');
+      comp.setValueAndClose({});
+      expect(comp.overlay.closePanel).toHaveBeenCalled();
+    });
+  });
+
+  describe('Function: select(option, i, fireEvents)', () => {
+    it('should set selectedIndex', () => {
+      comp.select({}, 1);
+      expect(comp.selectedIndex).toEqual(1);
+    });
+    it('should set selected', () => {
+      comp.select({ test: true });
+      expect(comp.selected).toEqual({ test: true, active: true });
+    });
+    it('should set empty', () => {
+      comp.select({});
+      expect(comp.empty).toEqual(false);
+    });
+    it('should invoke onModelChange', () => {
+      spyOn(comp, 'onModelChange');
+      comp.select({ value: 'foo' }, 1);
+      expect(comp.onModelChange).toHaveBeenCalledWith('foo');
+    });
+    it('should emit onSelect', () => {
+      spyOn(comp.onSelect, 'emit');
+      comp.select({ value: 'foo' });
+      expect(comp.onSelect.emit).toHaveBeenCalledWith({ selected: 'foo' });
+    });
+    it('should not invoke onModelChange', () => {
+      spyOn(comp, 'onModelChange');
+      comp.select({ value: 'foo' }, 1, false);
+      expect(comp.onModelChange).not.toHaveBeenCalled();
+    });
+    it('should not emit onSelect', () => {
+      spyOn(comp.onSelect, 'emit');
+      comp.select({ value: 'foo' }, 1, false);
+      expect(comp.onSelect.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Function: clear', () => {
+    it('should set selected', () => {
+      comp.placeholder = 'bar';
+      comp.selected = {
+        label: 'foo',
+        value: 'bar',
+        active: true,
+      };
+      comp.clear();
+      expect(comp.selected).toEqual({
+        label: 'bar',
+        value: null,
+        active: false,
+      });
+    });
+    it('should set header', () => {
+      comp.header = {
+        open: true,
+        valid: false,
+        value: 'foo',
+      };
+      comp.clear();
+      expect(comp.header).toEqual({
+        open: false,
+        valid: true,
+        value: '',
+      });
+    });
+    it('should set selectedIndex', () => {
+      comp.selectedIndex = 0;
+      comp.clear();
+      expect(comp.selectedIndex).toEqual(-1);
+    });
+    it('should set empty', () => {
+      comp.empty = false;
+      comp.clear();
+      expect(comp.empty).toEqual(true);
+    });
+  });
+
+  describe('Function: onKeyDown(event)', () => {
+    xit('should not scroll', () => {});
+    it('should close panel', () => {
+      spyOn(comp.overlay, 'closePanel');
+      const mockEvent: any = { keyCode: KeyCodes.ESC };
+      comp.header.open = true;
+      comp.onKeyDown(mockEvent);
+      mockEvent.keyCode = KeyCodes.TAB;
+      comp.onKeyDown(mockEvent);
+      expect(comp.overlay.closePanel).toHaveBeenCalledTimes(2);
+    });
+    it('should save header', () => {
+      const mockEvent: any = { keyCode: KeyCodes.ENTER };
+      comp.header = {
+        open: true,
+        value: 'foo',
+        valid: true,
+      };
+      comp.headerConfig = { onSave: jasmine.createSpy('onSave') };
+      comp.onKeyDown(mockEvent);
+      expect(comp.headerConfig.onSave).toHaveBeenCalled();
+    });
+    it('should move selection up', () => {
+      const mockEvent: any = {
+        keyCode: KeyCodes.UP,
+        preventDefault: jasmine.createSpy('preventDefault'),
+      };
+      comp.selectedIndex = 1;
+      comp.header = { open: true };
+      comp.filteredOptions = [{ value: 'foo', label: 'foo' }, { value: 'bar', label: 'bar' }, { value: 'baz', label: 'baz' }];
+      comp.overlay = {
+        _overlayRef: {
+          overlayElement: {
+            querySelector: jasmine.createSpy('querySelector').and.returnValue({
+              querySelectorAll: jasmine.createSpy('querySelectorAll').and.returnValue([{ value: 'foo' }]),
+            }),
+          },
+        },
+        panelOpen: true,
+      };
+      comp.overlay.panelOpen = true;
+      comp.onKeyDown(mockEvent);
+      expect(comp.selectedIndex).toEqual(0);
+    });
+    it('should move selection down', () => {
+      const mockEvent: any = {
+        keyCode: KeyCodes.DOWN,
+        preventDefault: jasmine.createSpy('preventDefault'),
+      };
+      comp.selectedIndex = 1;
+      comp.header = { open: true };
+      comp.filteredOptions = [{ value: 'foo', label: 'foo' }, { value: 'bar', label: 'bar' }, { value: 'baz', label: 'baz' }];
+      comp.overlay = {
+        _overlayRef: {
+          overlayElement: {
+            querySelector: jasmine.createSpy('querySelector').and.returnValue({
+              querySelectorAll: jasmine.createSpy('querySelectorAll').and.returnValue([{ value: 'foo' }]),
+            }),
+          },
+        },
+        panelOpen: true,
+      };
+      comp.onKeyDown(mockEvent);
+      expect(comp.selectedIndex).toEqual(2);
+    });
+    xit('should toggle header open', () => {});
+    xit('should toggle header closed', () => {});
+    xit('should enter filter term', () => {});
+    xit('should remove part of the filter term', () => {});
+  });
+
+  xdescribe('Function: scrollToSelected', () => {});
+
+  xdescribe('Function: scrollToIndex(index)', () => {});
+
+  xdescribe('Function: toggleHeader(event, forceValue)', () => {});
+
+  xdescribe('Function: highlight(match, query)', () => {});
+
+  xdescribe('Function: escapeRegexp(queryToEscape)', () => {});
+
+  xdescribe('Function: saveHeader', () => {});
+
+  xdescribe('Function: writeValue(model)', () => {});
+
+  xdescribe('Function: registerOnChange(fn)', () => {});
+
+  xdescribe('Function: registerOnTouched(fn)', () => {});
 });

--- a/src/platform/elements/select/Select.ts
+++ b/src/platform/elements/select/Select.ts
@@ -251,6 +251,9 @@ export class NovoSelectElement implements OnInit, OnChanges, OnDestroy {
       this.selectedIndex--;
       this.toggleHeader(null, true);
     } else if ((event.keyCode >= 65 && event.keyCode <= 90) || event.keyCode === KeyCodes.SPACE) {
+      if (event.keyCode === KeyCodes.SPACE) {
+        event.preventDefault();
+      }
       if (!this.panelOpen) {
         this.openPanel();
       }

--- a/src/platform/elements/select/Select.ts
+++ b/src/platform/elements/select/Select.ts
@@ -1,4 +1,4 @@
-// NG2
+// NG
 import {
   Component,
   Input,
@@ -12,10 +12,13 @@ import {
   SimpleChanges,
   HostListener,
   ChangeDetectorRef,
+  OnDestroy,
+  NgZone,
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { TAB, ENTER, ESCAPE } from '@angular/cdk/keycodes';
-// APP
+import { FocusMonitor } from '@angular/cdk/a11y';
+// App
 import { NovoOverlayTemplateComponent } from '../overlay/Overlay';
 import { KeyCodes } from '../../utils/key-codes/KeyCodes';
 import { NovoLabelService } from '../../services/novo-label-service';
@@ -32,32 +35,33 @@ const SELECT_VALUE_ACCESSOR = {
   selector: 'novo-select',
   providers: [SELECT_VALUE_ACCESSOR],
   template: `
-        <div (click)="openPanel()" tabIndex="0" type="button" [class.empty]="empty">{{selected.label}}<i class="bhi-collapse"></i></div>
-        <novo-overlay-template [parent]="element" position="center">
-            <ul class="novo-select-list" tabIndex="-1" [class.header]="headerConfig" [class.active]="panelOpen">
-                <ng-content></ng-content>
-                <li *ngIf="headerConfig" class="select-header" [class.open]="header.open">
-                    <button  *ngIf="!header.open" (click)="toggleHeader($event); false" tabIndex="-1" type="button" class="header"><i class="bhi-add-thin"></i>&nbsp;{{headerConfig.label}}</button>
-                    <div *ngIf="header.open" [ngClass]="{active: header.open}">
-                        <input autofocus type="text" [placeholder]="headerConfig.placeholder" [attr.id]="name" autocomplete="false" [(ngModel)]="header.value" [ngClass]="{invalid: !header.valid}"/>
-                        <footer>
-                            <button (click)="toggleHeader($event, false)">{{labels.cancel}}</button>
-                            <button (click)="saveHeader()" class="primary">{{labels.save}}</button>
-                        </footer>
-                    </div>
-                </li>
-                <li *ngFor="let option of filteredOptions; let i = index" [ngClass]="{active: option.active}" (click)="setValueAndClose({value: option, index: i})" [attr.data-automation-value]="option.label">
-                    <span [innerHtml]="highlight(option.label, filterTerm)"></span>
-                    <i *ngIf="option.active" class="bhi-check"></i>
-                </li>
-            </ul>
-        </novo-overlay-template>
-    `,
+    <div #dropdownElement (click)="togglePanel(); false" tabIndex="{{disabled ? -1 : 0}}" type="button" [class.empty]="empty">{{selected.label}}<i class="bhi-collapse"></i></div>
+    <novo-overlay-template [parent]="element" position="center" (closing)="dropdown.nativeElement.focus()">
+      <ul class="novo-select-list" tabIndex="-1" [class.header]="headerConfig" [class.active]="panelOpen">
+        <ng-content></ng-content>
+        <li *ngIf="headerConfig" class="select-header" [class.open]="header.open">
+          <button *ngIf="!header.open" (click)="toggleHeader($event); false" tabIndex="-1" type="button" class="header"><i class="bhi-add-thin"></i>&nbsp;{{headerConfig.label}}
+          </button>
+          <div *ngIf="header.open" [ngClass]="{active: header.open}">
+            <input autofocus type="text" [placeholder]="headerConfig.placeholder" [attr.id]="name" autocomplete="false" [(ngModel)]="header.value" [ngClass]="{invalid: !header.valid}" />
+            <footer>
+              <button (click)="toggleHeader($event, false)">{{labels.cancel}}</button>
+              <button (click)="saveHeader()" class="primary">{{labels.save}}</button>
+            </footer>
+          </div>
+        </li>
+        <li *ngFor="let option of filteredOptions; let i = index" [ngClass]="{active: option.active}" (click)="setValueAndClose({value: option, index: i})" [attr.data-automation-value]="option.label">
+          <span [innerHtml]="highlight(option.label, filterTerm)"></span>
+          <i *ngIf="option.active" class="bhi-check"></i>
+        </li>
+      </ul>
+    </novo-overlay-template>
+  `,
   host: {
     '(keydown)': 'onKeyDown($event)',
   },
 })
-export class NovoSelectElement implements OnInit, OnChanges {
+export class NovoSelectElement implements OnInit, OnChanges, OnDestroy {
   @Input() name: string;
   @Input() options: Array<any>;
   @Input() placeholder: string = 'Select...';
@@ -83,10 +87,24 @@ export class NovoSelectElement implements OnInit, OnChanges {
 
   /** Element for the panel containing the autocomplete options. */
   @ViewChild(NovoOverlayTemplateComponent) overlay: NovoOverlayTemplateComponent;
+  @ViewChild('dropdownElement') dropdown: ElementRef;
 
-  constructor(public element: ElementRef, public labels: NovoLabelService, public ref: ChangeDetectorRef) {}
+  constructor(
+    public element: ElementRef,
+    public labels: NovoLabelService,
+    public ref: ChangeDetectorRef,
+    private focusMonitor: FocusMonitor,
+    private ngZone: NgZone,
+  ) {}
 
   ngOnInit() {
+    this.focusMonitor.monitor(this.dropdown.nativeElement).subscribe((origin) =>
+      this.ngZone.run(() => {
+        if (origin === 'keyboard') {
+          this.openPanel();
+        }
+      }),
+    );
     this.ngOnChanges();
   }
 
@@ -104,7 +122,6 @@ export class NovoSelectElement implements OnInit, OnChanges {
         element.active = false;
       });
     }
-
     if (!this.model && !this.createdItem) {
       this.clear();
     } else if (this.createdItem) {
@@ -114,30 +131,46 @@ export class NovoSelectElement implements OnInit, OnChanges {
     } else {
       this.writeValue(this.model);
     }
-
     if (this.panelOpen) {
       this.openPanel();
     }
+  }
+
+  ngOnDestroy() {
+    this.focusMonitor.stopMonitoring(this.dropdown.nativeElement);
   }
 
   /** BEGIN: Convienient Panel Methods. */
   openPanel(): void {
     this.overlay.openPanel();
   }
+
   closePanel(): void {
     this.overlay.closePanel();
   }
+
+  togglePanel(): void {
+    if (this.panelOpen) {
+      this.closePanel();
+    } else {
+      setTimeout(() => {
+        this.dropdown.nativeElement.focus();
+      });
+      this.openPanel();
+    }
+  }
+
   get panelOpen(): boolean {
     return this.overlay && this.overlay.panelOpen;
   }
-  /** END: Convienient Panel Methods. */
+  /** END: Convenient Panel Methods. */
 
   /**
    * This method closes the panel, and if a value is specified, also sets the associated
    * control to that value. It will also mark the control as dirty if this interaction
    * stemmed from the user.
    */
-  public setValueAndClose(event: any | null): void {
+  setValueAndClose(event: any | null): void {
     if (event.value && event.index >= 0) {
       this.select(event.value, event.index);
     }
@@ -175,65 +208,69 @@ export class NovoSelectElement implements OnInit, OnChanges {
 
   @HostListener('keydown', ['$event'])
   onKeyDown(event: KeyboardEvent): void {
-    if (this.panelOpen) {
-      if (!this.header.open) {
-        // Prevent Scrolling
-        event.preventDefault();
+    // To prevent default window scrolling
+    if ([KeyCodes.UP, KeyCodes.DOWN].includes(event.keyCode)) {
+      event.preventDefault();
+    }
+    if ([KeyCodes.ESC, KeyCodes.TAB].includes(event.keyCode)) {
+      this.closePanel();
+    } else if (event.keyCode === KeyCodes.ENTER) {
+      if (this.header.open && this.header.value) {
+        this.saveHeader();
+      } else {
+        this.setValueAndClose({
+          value: this.filteredOptions[this.selectedIndex],
+          index: this.selectedIndex,
+        });
       }
-      // Close popup on escape key
-      if (event.keyCode === KeyCodes.ESC) {
-        this.closePanel();
-        return;
+    } else if (event.keyCode === KeyCodes.UP) {
+      if (!this.panelOpen) {
+        this.openPanel();
       }
-      if (event.keyCode === KeyCodes.ENTER) {
-        if (this.header.open && this.header.value) {
-          this.saveHeader();
-          return;
-        }
-        this.setValueAndClose({ value: this.filteredOptions[this.selectedIndex], index: this.selectedIndex });
-        return;
-      }
-
-      if (event.keyCode === KeyCodes.UP && this.selectedIndex > 0) {
+      if (this.selectedIndex > 0) {
         this.selectedIndex--;
         this.select(this.filteredOptions[this.selectedIndex], this.selectedIndex);
         this.scrollToSelected();
-      } else if (event.keyCode === KeyCodes.DOWN && this.selectedIndex < this.filteredOptions.length - 1) {
+      }
+    } else if (event.keyCode === KeyCodes.DOWN) {
+      if (!this.panelOpen) {
+        this.openPanel();
+      }
+      if (this.selectedIndex < this.filteredOptions.length - 1) {
         this.selectedIndex++;
         this.select(this.filteredOptions[this.selectedIndex], this.selectedIndex);
         this.scrollToSelected();
         if (this.header.open) {
           this.toggleHeader(null, false);
         }
-      } else if (event.keyCode === KeyCodes.UP && this.selectedIndex === 0) {
-        this.selectedIndex--;
-        this.toggleHeader(null, true);
-      } else if ((event.keyCode >= 65 && event.keyCode <= 90) || event.keyCode === KeyCodes.SPACE) {
-        clearTimeout(this.filterTermTimeout);
-        this.filterTermTimeout = setTimeout(() => {
-          this.filterTerm = '';
-        }, 2000);
-        let char = String.fromCharCode(event.keyCode);
-        this.filterTerm = this.filterTerm.concat(char);
-        // let element = this.element.nativeElement;
-        // let list = element.querySelector('.novo-select-list');
-        // let item = element.querySelector(`[data-automation-value^="${this.filterTerm}" i]`);
-        let item = this.filteredOptions.find((i) => i.label.toUpperCase().indexOf(this.filterTerm) === 0);
-        if (item) {
-          this.select(item, this.filteredOptions.indexOf(item));
-          this.scrollToSelected();
-        }
-      } else if ([KeyCodes.BACKSPACE, KeyCodes.DELETE].includes(event.keyCode)) {
-        clearTimeout(this.filterTermTimeout);
-        this.filterTermTimeout = setTimeout(() => {
-          this.filterTerm = '';
-        }, 2000);
-        this.filterTerm = this.filterTerm.slice(0, -1);
       }
-    } else {
-      if ([KeyCodes.DOWN, KeyCodes.UP].includes(event.keyCode)) {
-        this.panelOpen ? this.closePanel() : this.openPanel();
+    } else if (event.keyCode === KeyCodes.UP && this.selectedIndex === 0) {
+      if (!this.panelOpen) {
+        this.openPanel();
       }
+      this.selectedIndex--;
+      this.toggleHeader(null, true);
+    } else if ((event.keyCode >= 65 && event.keyCode <= 90) || event.keyCode === KeyCodes.SPACE) {
+      if (!this.panelOpen) {
+        this.openPanel();
+      }
+      clearTimeout(this.filterTermTimeout);
+      this.filterTermTimeout = setTimeout(() => {
+        this.filterTerm = '';
+      }, 2000);
+      let char = String.fromCharCode(event.keyCode);
+      this.filterTerm = this.filterTerm.concat(char);
+      let item = this.filteredOptions.find((i) => i.label.toUpperCase().indexOf(this.filterTerm) === 0);
+      if (item) {
+        this.select(item, this.filteredOptions.indexOf(item));
+        this.scrollToSelected();
+      }
+    } else if ([KeyCodes.BACKSPACE, KeyCodes.DELETE].includes(event.keyCode)) {
+      clearTimeout(this.filterTermTimeout);
+      this.filterTermTimeout = setTimeout(() => {
+        this.filterTerm = '';
+      }, 2000);
+      this.filterTerm = this.filterTerm.slice(0, -1);
     }
   }
 
@@ -313,5 +350,9 @@ export class NovoSelectElement implements OnInit, OnChanges {
 
   registerOnTouched(fn: Function): void {
     this.onModelTouched = fn;
+  }
+
+  get disabled(): boolean {
+    return Boolean(this.element.nativeElement.attributes.getNamedItem('disabled'));
   }
 }


### PR DESCRIPTION
## **Description**

Made various updates to the accessibility of the select component. See video posted below for an demo of how accessibility now is for the select component.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**