### PR TITLE
F/tooltip size

### DIFF
--- a/src/app/pages/elements/field-interactions/FieldInteractionsDemo.ts
+++ b/src/app/pages/elements/field-interactions/FieldInteractionsDemo.ts
@@ -19,6 +19,8 @@ let ConfirmTpl = require('./templates/Confirm.html');
 let AddingRemovingTpl = require('./templates/AddingRemoving.html');
 let TooltipTpl = require('./templates/Tooltip.html');
 import { MockMeta, MockMetaHeaders } from './MockMeta';
+import {RadioControl} from "../../../../platform/elements/form/controls/radio/RadioControl";
+import {TilesControl} from "../../../../platform/elements/form/controls/tiles/TilesControl";
 
 const template = `
 <div class="container">
@@ -429,6 +431,12 @@ export class FieldInteractionsDemoComponent {
             API.setTooltip(API.getActiveKey(), API.getActiveValue());
         }
 
+        let tooltipUpdateFunction = (API: FieldInteractionApi) => {
+            console.log('[FieldInteractionDemo] - tooltipUpdateFunction'); // tslint:disable-line
+            API.getControl(this.controls.tooltip.tooltipControl.key).tooltipSize = API.getValue(this.controls.tooltip.tooltipSizeControl.key);
+            API.getControl(this.controls.tooltip.tooltipControl.key).tooltipPreline = API.getValue(this.controls.tooltip.tooltipPrelineControl.key);
+        }
+
         // Validation Field Interactions
         this.controls.validation.validationControl = new TextBoxControl({
             type: 'number',
@@ -705,7 +713,30 @@ export class FieldInteractionsDemoComponent {
                 { event: 'change', script: tooltipFunction }
             ]
         });
-        this.forms.tooltip = formUtils.toFormGroup([this.controls.tooltip.tooltipControl]);
+
+        this.controls.tooltip.tooltipSizeControl = new TilesControl({
+            key: 'tooltipSize',
+            label: 'Tooltip Size',
+            description: 'Changing me will set a fixed width on the tooltip',
+            options: [{ value: 'small', label: 'Small' }, { value: 'medium', label: 'Medium' }, { value: 'large', label: 'Large' } ],
+            initialValue: 'small',
+            interactions: [
+                { event: 'change', script: tooltipUpdateFunction }
+            ]
+        });
+
+        this.controls.tooltip.tooltipPrelineControl = new TilesControl({
+            key: 'tooltipPreline',
+            label: 'Tooltip Multiline',
+            description: 'Should the tooltip be multiple lines tall or all on one line?',
+            options: [ { value: true, label: 'Yes'}, { value: false, label: 'No'} ],
+            initialValue: false,
+            interactions: [
+                { event: 'change', script: tooltipUpdateFunction }
+            ]
+        });
+
+        this.forms.tooltip = formUtils.toFormGroup([this.controls.tooltip.tooltipControl, this.controls.tooltip.tooltipSizeControl, this.controls.tooltip.tooltipPrelineControl]);
 
         // Snippets
         this.snippets.validation = {

--- a/src/app/pages/elements/field-interactions/FieldInteractionsDemo.ts
+++ b/src/app/pages/elements/field-interactions/FieldInteractionsDemo.ts
@@ -718,7 +718,6 @@ export class FieldInteractionsDemoComponent {
             label: 'Tooltip Size',
             description: 'Changing me will set a fixed width on the tooltip',
             options: [{ value: 'small', label: 'Small' }, { value: 'medium', label: 'Medium' }, { value: 'large', label: 'Large' } ],
-            initialValue: 'small',
             interactions: [
                 { event: 'change', script: tooltipUpdateFunction }
             ]
@@ -729,7 +728,6 @@ export class FieldInteractionsDemoComponent {
             label: 'Tooltip Multiline',
             description: 'Should the tooltip be multiple lines tall or all on one line?',
             options: [ { value: true, label: 'Yes'}, { value: false, label: 'No'} ],
-            initialValue: false,
             interactions: [
                 { event: 'change', script: tooltipUpdateFunction }
             ]

--- a/src/app/pages/elements/field-interactions/FieldInteractionsDemo.ts
+++ b/src/app/pages/elements/field-interactions/FieldInteractionsDemo.ts
@@ -18,12 +18,11 @@ let AsyncTpl = require('./templates/Async.html');
 let ConfirmTpl = require('./templates/Confirm.html');
 let AddingRemovingTpl = require('./templates/AddingRemoving.html');
 let TooltipTpl = require('./templates/Tooltip.html');
-import { MockMeta, MockMetaHeaders } from './MockMeta';
-import {RadioControl} from "../../../../platform/elements/form/controls/radio/RadioControl";
-import {TilesControl} from "../../../../platform/elements/form/controls/tiles/TilesControl";
+import { MockMetaHeaders } from './MockMeta';
+import { TilesControl } from '../../../../platform/elements/form/controls/tiles/TilesControl';
 
 const template = `
-<div class="container">
+<div class='container'>
     <h1>Field Interactions</h1>
     <p>Field Interactions is a simple API that allows you to modify NovoForms based on field changes.</p>
     <p>The Field Interaction API gives you a simple to use API object when writing your field interaction functions.</p>
@@ -31,8 +30,8 @@ const template = `
 
     <h2>Configuration</h2>
 
-    <main class="tabs">
-        <novo-nav theme="white" [outlet]="config" direction="vertical">
+    <main class='tabs'>
+        <novo-nav theme='white' [outlet]='config' direction='vertical'>
             <novo-tab><span>Inspect Form</span></novo-tab>
             <novo-tab><span>Configuration on Field</span></novo-tab>
             <novo-tab><span>Getting Current Context</span></novo-tab>
@@ -43,30 +42,30 @@ const template = `
             <novo-nav-content>
                 <h5>Inspect Form</h5>
                 <p>There is a special <code>data-control-key</code> property added to the <code>novo-control</code> element.</p>
-                <p>You can inspec the DOM at the input and see the property to know what "key" to use in the API</p>
+                <p>You can inspec the DOM at the input and see the property to know what 'key' to use in the API</p>
                 <p>By default, if you are writing a Field Interaction for the active field you can use <code>API.getActiveKey()</code></p>
             </novo-nav-content>
             <novo-nav-content>
                 <h5>Configuration on Field</h5>
-                <pre class="field-config"><code>event: 'change|focus|blur|init', script: Function, invokeOnInit?: boolean</code></pre>
-                <p>The Field Interactions are configured on a per control basis. There are three scenarios in which they will be fired: "change", "focus" and "blur".</p>
+                <pre class='field-config'><code>event: 'change|focus|blur|init', script: Function, invokeOnInit?: boolean</code></pre>
+                <p>The Field Interactions are configured on a per control basis. There are three scenarios in which they will be fired: 'change', 'focus' and 'blur'.</p>
                 <p><label>init</label> -- gets fired only when the form is initialized</p>
                 <p><label>change</label> -- gets fired when the value of the form control changes</p>
                 <p><label>focus</label> -- gets fired when the field gets focused</p>
                 <p><label>blur</label> -- gets fired when the field loses focus</p>
                 <p>The script function represents the function that will be fired for the event, you can see examples of these below.</p>
-                <p>Lastly, "invokeOnInit" will also trigger the Field Interaction when the form is created as well.</p>
+                <p>Lastly, 'invokeOnInit' will also trigger the Field Interaction when the form is created as well.</p>
             </novo-nav-content>
             <novo-nav-content>
                 <h5>Getting Current Context</h5>
                 <p>If you need to write Field Interaction based on if you are on an add or edit page, or you need to know the current entity type and ID then you can get those via:</p>
-                <p><label>edit</label>: "API.isEdit"</p>
-                <p><label>entity</label>: "API.currentEntity"</p>
-                <p><label>id</label>: "API.currentEntityId"</p>
+                <p><label>edit</label>: 'API.isEdit'</p>
+                <p><label>entity</label>: 'API.currentEntity'</p>
+                <p><label>id</label>: 'API.currentEntityId'</p>
             </novo-nav-content>
             <novo-nav-content>
                 <h5>Write Field Interaction</h5>
-                <p>Writing Field Interactions is very simple. You can refer to all the examples below. If you ever get stuck, you can always open a <a href="https://github.com/bullhorn/novo-elements/issues">Github Issue</a> as well!</p>
+                <p>Writing Field Interactions is very simple. You can refer to all the examples below. If you ever get stuck, you can always open a <a href='https://github.com/bullhorn/novo-elements/issues'>Github Issue</a> as well!</p>
                 <p><b>IMPORTANT</b></p>
                 <p>When writing field interactions, you will be writing everything only the contents of the function. <b>You do not</b> write the surrounding function.</p>
                 <p><b>All field interactions must be written in vanilla ES5 as well!</b></p>
@@ -79,8 +78,8 @@ const template = `
 
     <h2>Basic API</h2>
 
-    <main class="tabs">
-        <novo-nav theme="white" [outlet]="api" direction="vertical">
+    <main class='tabs'>
+        <novo-nav theme='white' [outlet]='api' direction='vertical'>
             <novo-tab><span>Validation</span></novo-tab>
             <novo-tab><span>Mark Fields as Required</span></novo-tab>
             <novo-tab><span>Field Calculations & Modification</span></novo-tab>
@@ -99,75 +98,75 @@ const template = `
             <novo-nav-content>
                 <h5>Validation</h5>
                 <p>If you need to perform some custom validation on a field, you can use the API to quickly mark a field as invalid</p>
-                <div class="example field-interaction-demo">${ValidationTpl}</div>
-                <multi-code-snippet [code]="snippets.validation"></multi-code-snippet>
+                <div class='example field-interaction-demo'>${ValidationTpl}</div>
+                <multi-code-snippet [code]='snippets.validation'></multi-code-snippet>
             </novo-nav-content>
             <novo-nav-content>
                 <h5>Mark Fields as Required</h5>
                 <p>If you need to mark fields as required or not based on some changes in the form, you can use the API to do that!</p>
-                <div class="example field-interaction-demo">${RequiredTpl}</div>
-                <multi-code-snippet [code]="snippets.required"></multi-code-snippet>
+                <div class='example field-interaction-demo'>${RequiredTpl}</div>
+                <multi-code-snippet [code]='snippets.required'></multi-code-snippet>
             </novo-nav-content>
             <novo-nav-content>
                 <h5>Field Calculations & Modification</h5>
                 <p>If you need to do some custom calculations based off other form data, you can do that easily with the API</p>
-                <div class="example field-interaction-demo">${CalculationTpl}</div>
-                <multi-code-snippet [code]="snippets.calculation"></multi-code-snippet>
+                <div class='example field-interaction-demo'>${CalculationTpl}</div>
+                <multi-code-snippet [code]='snippets.calculation'></multi-code-snippet>
             </novo-nav-content>
             <novo-nav-content>
                 <h5>Hide / Show Fields</h5>
                 <p>You can also hide or show certain fields based on interaction with the form. Note that the value is still present in the form's value</p>
-                <div class="example field-interaction-demo">${HideShowTpl}</div>
-                <multi-code-snippet [code]="snippets.hideShow"></multi-code-snippet>
+                <div class='example field-interaction-demo'>${HideShowTpl}</div>
+                <multi-code-snippet [code]='snippets.hideShow'></multi-code-snippet>
             </novo-nav-content>
             <novo-nav-content>
                 <h5>Enable / Disable Fields</h5>
                 <p>You can also enable or disable certain fields based on interaction with the form. Note that the value is still present in the form's value but does not respond to any interactions</p>
-                <div class="example field-interaction-demo">${EnableDisableTpl}</div>
-                <multi-code-snippet [code]="snippets.enableDisable"></multi-code-snippet>
+                <div class='example field-interaction-demo'>${EnableDisableTpl}</div>
+                <multi-code-snippet [code]='snippets.enableDisable'></multi-code-snippet>
             </novo-nav-content>
             <novo-nav-content>
                 <h5>Messaging / Notifications</h5>
                 <p>You can trigger messages to users in a few different ways using the API</p>
-                <div class="example field-interaction-demo">${MessagingTpl}</div>
-                <multi-code-snippet [code]="snippets.messaging"></multi-code-snippet>
+                <div class='example field-interaction-demo'>${MessagingTpl}</div>
+                <multi-code-snippet [code]='snippets.messaging'></multi-code-snippet>
             </novo-nav-content>
             <novo-nav-content>
                 <h5>Modifying Config on Static Pickers / Selects</h5>
                 <p>You have full control over the control, you can modify the options array of static pickers and select controls!</p>
-                <div class="example field-interaction-demo">${ModifyOptionsTpl}</div>
-                <multi-code-snippet [code]="snippets.modifyOptions"></multi-code-snippet>
+                <div class='example field-interaction-demo'>${ModifyOptionsTpl}</div>
+                <multi-code-snippet [code]='snippets.modifyOptions'></multi-code-snippet>
             </novo-nav-content>
             <novo-nav-content>
                 <h5>Using Globals</h5>
                 <p>Using the config from above, you can figure the API to have a set of global variables that you can key off of inside your field interactions</p>
-                <div class="example field-interaction-demo">${GlobalsTpl}</div>
-                <multi-code-snippet [code]="snippets.globals"></multi-code-snippet>
+                <div class='example field-interaction-demo'>${GlobalsTpl}</div>
+                <multi-code-snippet [code]='snippets.globals'></multi-code-snippet>
             </novo-nav-content>
             <novo-nav-content>
                 <h5>Async Interactions</h5>
                 <p>You can perform async interactions and keep the form from saving by setting a loading state</p>
-                <div class="example field-interaction-demo">${AsyncTpl}</div>
-                <multi-code-snippet [code]="snippets.async"></multi-code-snippet>
+                <div class='example field-interaction-demo'>${AsyncTpl}</div>
+                <multi-code-snippet [code]='snippets.async'></multi-code-snippet>
             </novo-nav-content>
             <novo-nav-content>
                 <h5>Confirm Changes</h5>
                 <p>You can prompt the user if they want to update the field or not too!</p>
-                <div class="example field-interaction-demo">${ConfirmTpl}</div>
-                <multi-code-snippet [code]="snippets.confirm"></multi-code-snippet>
+                <div class='example field-interaction-demo'>${ConfirmTpl}</div>
+                <multi-code-snippet [code]='snippets.confirm'></multi-code-snippet>
             </novo-nav-content>
             <novo-nav-content>
                 <h5>Adding / Removing Fields</h5>
                 <p>With the API you can quickly add and remove fields on the form.</p>
                 <p><b>ONLY WORKS WITH DYNAMIC FORMS</b></p>
-                <div class="example field-interaction-demo">${AddingRemovingTpl}</div>
-                <multi-code-snippet [code]="snippets.addingRemoving"></multi-code-snippet>
+                <div class='example field-interaction-demo'>${AddingRemovingTpl}</div>
+                <multi-code-snippet [code]='snippets.addingRemoving'></multi-code-snippet>
             </novo-nav-content>
             <novo-nav-content>
                 <h5>Add Tooltip</h5>
                 <p>You are able to dynamically change a field's tooltip.</p>
-                <div class="example field-interaction-demo">${TooltipTpl}</div>
-                <multi-code-snippet [code]="snippets.tooltip"></multi-code-snippet>
+                <div class='example field-interaction-demo'>${TooltipTpl}</div>
+                <multi-code-snippet [code]='snippets.tooltip'></multi-code-snippet>
             </novo-nav-content>
         </novo-nav-outlet>
     </main>

--- a/src/app/pages/elements/field-interactions/templates/Tooltip.html
+++ b/src/app/pages/elements/field-interactions/templates/Tooltip.html
@@ -2,6 +2,12 @@
   <div class="novo-form-row">
       <novo-control [form]="forms.tooltip" [control]="controls.tooltip.tooltipControl"></novo-control>
   </div>
+  <div class="novo-form-row">
+      <novo-control [form]="forms.tooltip" [control]="controls.tooltip.tooltipSizeControl"></novo-control>
+  </div>
+  <div class="novo-form-row">
+      <novo-control [form]="forms.tooltip" [control]="controls.tooltip.tooltipPrelineControl"></novo-control>
+  </div>
 </novo-form>
 <div class="final-value">Form Value - {{ forms.tooltip.value | json }}</div>
 <div class="final-value">Form Dirty - {{ forms.tooltip.dirty | json }}</div>

--- a/src/platform/elements/form/Control.ts
+++ b/src/platform/elements/form/Control.ts
@@ -137,7 +137,7 @@ export class NovoCustomControlContainerElement {
                         <div class="novo-control-input {{ form.controls[control.key].controlType }}" [ngSwitch]="form.controls[control.key].controlType" [attr.data-automation-id]="control.key" [class.control-disabled]="form.controls[control.key].disabled">
                             <!--Text-based Inputs-->
                             <!--TODO prefix/suffix on the control-->
-                            <div class="novo-control-input-container novo-control-input-with-label" *ngSwitchCase="'textbox'" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition">
+                            <div class="novo-control-input-container novo-control-input-with-label" *ngSwitchCase="'textbox'" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" [tooltipSize]="tooltipSize" [tooltipPreline]="tooltipPreline">
                               <input *ngIf="form.controls[control.key].type !== 'number'" [class.maxlength-error]="errors?.maxlength" [formControlName]="control.key" [id]="control.key" [type]="form.controls[control.key].type" [placeholder]="form.controls[control.key].placeholder" (input)="emitChange($event)" [maxlength]="form.controls[control.key].maxlength" (focus)="handleFocus($event)" (blur)="handleBlur($event)" autocomplete>
                               <input *ngIf="form.controls[control.key].type === 'number' && form.controls[control.key].subType !== 'percentage'" [class.maxlength-error]="errors?.maxlength" [formControlName]="control.key" [id]="control.key" [type]="form.controls[control.key].type" [placeholder]="form.controls[control.key].placeholder" (keydown)="restrictKeys($event)" (input)="emitChange($event)" [maxlength]="form.controls[control.key].maxlength" (focus)="handleFocus($event)" (blur)="handleBlur($event)" step="any" (mousewheel)="numberInput.blur()" #numberInput>
                               <input *ngIf="form.controls[control.key].type === 'number' && form.controls[control.key].subType === 'percentage'" [type]="form.controls[control.key].type" [placeholder]="form.controls[control.key].placeholder" (keydown)="restrictKeys($event)" [value]="percentValue" (input)="handlePercentChange($event)" (focus)="handleFocus($event)" (blur)="handleBlur($event)" step="any" (mousewheel)="percentInput.blur()" #percentInput>
@@ -145,51 +145,51 @@ export class NovoCustomControlContainerElement {
                               <label class="input-label" *ngIf="form.controls[control.key].subType === 'percentage'">%</label>
                             </div>
                             <!--TextArea-->
-                            <textarea *ngSwitchCase="'text-area'" [class.maxlength-error]="errors?.maxlength" [name]="control.key" [attr.id]="control.key" [placeholder]="form.controls[control.key].placeholder" [formControlName]="control.key" autosize (input)="handleTextAreaInput($event)" (focus)="handleFocus($event)" (blur)="handleBlur($event)" [maxlength]="control.maxlength" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition"></textarea>
+                            <textarea *ngSwitchCase="'text-area'" [class.maxlength-error]="errors?.maxlength" [name]="control.key" [attr.id]="control.key" [placeholder]="form.controls[control.key].placeholder" [formControlName]="control.key" autosize (input)="handleTextAreaInput($event)" (focus)="handleFocus($event)" (blur)="handleBlur($event)" [maxlength]="control.maxlength" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" [tooltipSize]="tooltipSize" [tooltipPreline]="tooltipPreline"></textarea>
                             <!--Editor-->
                             <novo-editor *ngSwitchCase="'editor'" [name]="control.key" [formControlName]="control.key" [startupFocus]="control.startupFocus" [minimal]="control.minimal" [fileBrowserImageUploadUrl]="control.fileBrowserImageUploadUrl" (focus)="handleFocus($event)" (blur)="handleBlur($event)"></novo-editor>
                             <!--AceEditor-->
                             <novo-ace-editor *ngSwitchCase="'ace-editor'" [name]="control.key" [formControlName]="control.key" (focus)="handleFocus($event)" (blur)="handleBlur($event)"></novo-ace-editor>
                             <!--HTML5 Select-->
-                            <select [id]="control.key" *ngSwitchCase="'native-select'" [formControlName]="control.key" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition">
+                            <select [id]="control.key" *ngSwitchCase="'native-select'" [formControlName]="control.key" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" [tooltipSize]="tooltipSize" [tooltipPreline]="tooltipPreline">
                                 <option *ngIf="form.controls[control.key].placeholder" value="" disabled selected hidden>{{ form.controls[control.key].placeholder }}</option>
                                 <option *ngFor="let opt of form.controls[control.key].options" [value]="opt.key">{{opt.value}}</option>
                             </select>
                             <!--File-->
-                            <novo-file-input *ngSwitchCase="'file'" [formControlName]="control.key" [id]="control.key" [name]="control.key" [placeholder]="form.controls[control.key].placeholder" [value]="form.controls[control.key].value" [multiple]="form.controls[control.key].multiple" [layoutOptions]="form.controls[control.key].layoutOptions" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" (edit)="handleEdit($event)" (save)="handleSave($event)" (delete)="handleDelete($event)" (upload)="handleUpload($event)"></novo-file-input>
+                            <novo-file-input *ngSwitchCase="'file'" [formControlName]="control.key" [id]="control.key" [name]="control.key" [placeholder]="form.controls[control.key].placeholder" [value]="form.controls[control.key].value" [multiple]="form.controls[control.key].multiple" [layoutOptions]="form.controls[control.key].layoutOptions" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" [tooltipSize]="tooltipSize" [tooltipPreline]="tooltipPreline" (edit)="handleEdit($event)" (save)="handleSave($event)" (delete)="handleDelete($event)" (upload)="handleUpload($event)"></novo-file-input>
                             <!--Tiles-->
-                            <novo-tiles *ngSwitchCase="'tiles'" [options]="control.options" [formControlName]="control.key" (onChange)="modelChange($event)" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" [controlDisabled]="form.controls[control.key].disabled"></novo-tiles>
+                            <novo-tiles *ngSwitchCase="'tiles'" [options]="control.options" [formControlName]="control.key" (onChange)="modelChange($event)" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" [tooltipSize]="tooltipSize" [tooltipPreline]="tooltipPreline" [controlDisabled]="form.controls[control.key].disabled"></novo-tiles>
                             <!--Picker-->
                             <div class="novo-control-input-container" *ngSwitchCase="'picker'">
-                                <novo-picker [config]="form.controls[control.key].config" [formControlName]="control.key" [placeholder]="form.controls[control.key].placeholder" [parentScrollSelector]="form.controls[control.key].parentScrollSelector" *ngIf="!form.controls[control.key].multiple" (select)="modelChange($event);" (changed)="modelChangeWithRaw($event)" (typing)="handleTyping($event)" (focus)="handleFocus($event)" (blur)="handleBlur($event)" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition"></novo-picker>
-                                <chips [source]="form.controls[control.key].config" [type]="form.controls[control.key].config.type" [formControlName]="control.key" [placeholder]="form.controls[control.key].placeholder" *ngIf="control.multiple" [closeOnSelect]="form.controls[control.key].closeOnSelect" (changed)="modelChangeWithRaw($event)" (typing)="handleTyping($event)" (focus)="handleFocus($event)" (blur)="handleBlur($event)" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition"></chips>
+                                <novo-picker [config]="form.controls[control.key].config" [formControlName]="control.key" [placeholder]="form.controls[control.key].placeholder" [parentScrollSelector]="form.controls[control.key].parentScrollSelector" *ngIf="!form.controls[control.key].multiple" (select)="modelChange($event);" (changed)="modelChangeWithRaw($event)" (typing)="handleTyping($event)" (focus)="handleFocus($event)" (blur)="handleBlur($event)" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" [tooltipSize]="tooltipSize" [tooltipPreline]="tooltipPreline"></novo-picker>
+                                <chips [source]="form.controls[control.key].config" [type]="form.controls[control.key].config.type" [formControlName]="control.key" [placeholder]="form.controls[control.key].placeholder" *ngIf="control.multiple" [closeOnSelect]="form.controls[control.key].closeOnSelect" (changed)="modelChangeWithRaw($event)" (typing)="handleTyping($event)" (focus)="handleFocus($event)" (blur)="handleBlur($event)" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" [tooltipSize]="tooltipSize" [tooltipPreline]="tooltipPreline"></chips>
                             </div>
                             <!--Novo Select-->
-                            <novo-select *ngSwitchCase="'select'" [options]="form.controls[control.key].options" [headerConfig]="form.controls[control.key].headerConfig" [placeholder]="form.controls[control.key].placeholder" [formControlName]="control.key" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" (onSelect)="modelChange($event)"></novo-select>
+                            <novo-select *ngSwitchCase="'select'" [options]="form.controls[control.key].options" [headerConfig]="form.controls[control.key].headerConfig" [placeholder]="form.controls[control.key].placeholder" [formControlName]="control.key" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" [tooltipSize]="tooltipSize" [tooltipPreline]="tooltipPreline" (onSelect)="modelChange($event)"></novo-select>
                             <!--Radio-->
                             <div class="novo-control-input-container" *ngSwitchCase="'radio'">
-                                <novo-radio [vertical]="vertical" [name]="control.key" [formControlName]="control.key" *ngFor="let option of form.controls[control.key].options" [value]="option.value" [label]="option.label" [checked]="option.value === form.value[control.key]" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" [button]="!!option.icon" [icon]="option.icon" [attr.data-automation-id]="control.key + '-' + (option?.label || option?.value)"></novo-radio>
+                                <novo-radio [vertical]="vertical" [name]="control.key" [formControlName]="control.key" *ngFor="let option of form.controls[control.key].options" [value]="option.value" [label]="option.label" [checked]="option.value === form.value[control.key]" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" [tooltipSize]="tooltipSize" [tooltipPreline]="tooltipPreline" [button]="!!option.icon" [icon]="option.icon" [attr.data-automation-id]="control.key + '-' + (option?.label || option?.value)"></novo-radio>
                             </div>
                             <!--Time-->
-                            <div class="novo-control-input-container" *ngSwitchCase="'time'" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition">
+                            <div class="novo-control-input-container" *ngSwitchCase="'time'" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" [tooltipSize]="tooltipSize" [tooltipPreline]="tooltipPreline">
                                 <novo-time-picker-input [attr.id]="control.key" [name]="control.key" [formControlName]="control.key" [placeholder]="form.controls[control.key].placeholder" [military]="form.controls[control.key].military"></novo-time-picker-input>
                             </div>
                             <!--Date-->
-                            <div class="novo-control-input-container" *ngSwitchCase="'date'" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition">
+                            <div class="novo-control-input-container" *ngSwitchCase="'date'" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" [tooltipSize]="tooltipSize" [tooltipPreline]="tooltipPreline">
                                 <novo-date-picker-input [attr.id]="control.key" [name]="control.key" [formControlName]="control.key" [format]="form.controls[control.key].dateFormat" [allowInvalidDate]="form.controls[control.key].allowInvalidDate" [textMaskEnabled]="form.controls[control.key].textMaskEnabled" [placeholder]="form.controls[control.key].placeholder"></novo-date-picker-input>
                             </div>
                             <!--Date and Time-->
-                            <div class="novo-control-input-container" *ngSwitchCase="'date-time'" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition">
+                            <div class="novo-control-input-container" *ngSwitchCase="'date-time'" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" [tooltipSize]="tooltipSize" [tooltipPreline]="tooltipPreline">
                                 <novo-date-time-picker-input [attr.id]="control.key" [name]="control.key" [formControlName]="control.key" [placeholder]="form.controls[control.key].placeholder" [military]="form.controls[control.key].military"></novo-date-time-picker-input>
                             </div>
                             <!--Address-->
                             <novo-address *ngSwitchCase="'address'" [formControlName]="control.key" [config]="control.config" (change)="handleAddressChange($event)" (focus)="handleFocus($event.event, $event.field)" (blur)="handleBlur($event.event, $event.field)" (validityChange)="updateValidity()"></novo-address>
                             <!--Checkbox-->
-                            <novo-checkbox *ngSwitchCase="'checkbox'" [formControlName]="control.key" [name]="control.key" [label]="control.checkboxLabel" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" [layoutOptions]="layoutOptions"></novo-checkbox>
+                            <novo-checkbox *ngSwitchCase="'checkbox'" [formControlName]="control.key" [name]="control.key" [label]="control.checkboxLabel" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" [tooltipSize]="tooltipSize" [tooltipPreline]="tooltipPreline" [layoutOptions]="layoutOptions"></novo-checkbox>
                             <!--Checklist-->
-                            <novo-check-list *ngSwitchCase="'checklist'" [formControlName]="control.key" [name]="control.key" [options]="form.controls[control.key].options" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" (onSelect)="modelChange($event)"></novo-check-list>
+                            <novo-check-list *ngSwitchCase="'checklist'" [formControlName]="control.key" [name]="control.key" [options]="form.controls[control.key].options" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" [tooltipSize]="tooltipSize" [tooltipPreline]="tooltipPreline" (onSelect)="modelChange($event)"></novo-check-list>
                             <!--QuickNote-->
-                            <novo-quick-note *ngSwitchCase="'quick-note'" [formControlName]="control.key" [startupFocus]="control.startupFocus" [placeholder]="form.controls[control.key].placeholder" [config]="form.controls[control.key].config" (change)="modelChange($event)" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition"></novo-quick-note>
+                            <novo-quick-note *ngSwitchCase="'quick-note'" [formControlName]="control.key" [startupFocus]="control.startupFocus" [placeholder]="form.controls[control.key].placeholder" [config]="form.controls[control.key].config" (change)="modelChange($event)" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" [tooltipSize]="tooltipSize" [tooltipPreline]="tooltipPreline"></novo-quick-note>
                             <!--ReadOnly-->
                             <!--TODO - Handle rendering of different READONLY values-->
                             <div *ngSwitchCase="'read-only'">{{ form.value[control.key] }}</div>
@@ -468,6 +468,20 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
       return 'right';
     }
     return this.form.controls[this.control.key].tooltipPosition;
+  }
+
+  get tooltipSize() {
+    if (Helpers.isBlank(this.form.controls[this.control.key].tooltipSize)) {
+      return '';
+    }
+    return this.form.controls[this.control.key].tooltipSize;
+  }
+
+  get tooltipPreline() {
+    if (Helpers.isBlank(this.form.controls[this.control.key].tooltipPreline)) {
+      return false;
+    }
+    return this.form.controls[this.control.key].tooltipPreline;
   }
 
   get alwaysActive() {

--- a/src/platform/elements/form/FieldInteractionApi.ts
+++ b/src/platform/elements/form/FieldInteractionApi.ts
@@ -322,6 +322,10 @@ export class FieldInteractionApi {
         let control = this.getControl(key);
         if (control) {
             control.tooltip = tooltip;
+            if (tooltip.length >= 40) {
+                control.tooltipSize = 'large';
+                control.tooltipPreline = true;
+            }
             this.triggerEvent({controlKey: key, prop: 'tooltip', value: tooltip });
         }
     }
@@ -331,7 +335,7 @@ export class FieldInteractionApi {
         let oldValue = history[history.length - 2];
         let newValue = this.getValue(key);
         let label = this.getProperty(key, 'label');
-        (document.activeElement as any).blur()
+        (document.activeElement as any).blur();
         return this.modalService.open(ControlConfirmModal, { oldValue, newValue, label, message, key }).onClosed.then(result => {
             if (!result) {
                 this.setValue(key, oldValue, { emitEvent: false });

--- a/src/platform/elements/form/NovoFormControl.ts
+++ b/src/platform/elements/form/NovoFormControl.ts
@@ -17,6 +17,8 @@ export class NovoFormControl extends FormControl {
     label: string;
     tooltip: string;
     tooltipPosition: string;
+    tooltipSize?: string;
+    tooltipPreline?: boolean;
     initialValue: any;
     valueHistory: any[] = [];
     validators: any;
@@ -70,6 +72,8 @@ export class NovoFormControl extends FormControl {
         this.hasRequiredValidator = this.required;
         this.tooltip = control.tooltip;
         this.tooltipPosition = control.tooltipPosition;
+        this.tooltipSize = control.tooltipSize;
+        this.tooltipPreline = control.tooltipPreline;
         this.label = control.label;
         this.name = control.name;
         this.required = control.required;

--- a/src/platform/elements/form/controls/BaseControl.ts
+++ b/src/platform/elements/form/controls/BaseControl.ts
@@ -51,6 +51,8 @@ export interface NovoControlConfig {
   description?: string;
   tooltip?: string;
   tooltipPosition?: string;
+  tooltipSize?: string;
+  tooltipPreline?: boolean;
   layoutOptions?: { order?: string, download?: boolean, edit?: boolean, customActions?: boolean, labelStyle?: string, draggable?: boolean, iconStyle?: string };
   customControl?: any;
   customControlConfig?: any;
@@ -109,6 +111,8 @@ export class BaseControl {
   description?: string;
   tooltip?: string;
   tooltipPosition?: string;
+  tooltipSize?: string;
+  tooltipPreline?: boolean;
   layoutOptions?: { order?: string, download?: boolean, labelStyle?: string, draggable?: boolean, iconStyle?: string };
   customControl?: any;
   customControlConfig?: any;
@@ -179,6 +183,8 @@ export class BaseControl {
     if (config.tooltip) {
       this.tooltip = config.tooltip;
       this.tooltipPosition = config.tooltipPosition;
+      this.tooltipSize = config.tooltipSize;
+      this.tooltipPreline = config.tooltipPreline;
     }
     this.customControl = config.customControl;
     this.customControlConfig = config.customControlConfig;


### PR DESCRIPTION
## **Description**

Added tooltip size and multi-line as optional properties to all controls so that dynamically created controls can have different tooltip sizes when setTooltip is called on them

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**