### PR TITLE
fix: datePickerInput events

### DIFF
--- a/src/platform/elements/date-picker/DatePickerInput.ts
+++ b/src/platform/elements/date-picker/DatePickerInput.ts
@@ -23,7 +23,7 @@ const DATE_VALUE_ACCESSOR = {
   selector: 'novo-date-picker-input',
   providers: [DATE_VALUE_ACCESSOR],
   template: `
-        <input type="text" [name]="name" [(ngModel)]="formattedValue" [textMask]="maskOptions" [placeholder]="placeholder" (focus)="openPanel()" (keydown)="_handleKeydown($event)" (input)="_handleEvent($event, false)" (blur)="_handleEvent($event, true)" #input data-automation-id="date-input"/>
+        <input type="text" [name]="name" [(ngModel)]="formattedValue" [textMask]="maskOptions" [placeholder]="placeholder" (focus)="openPanel()" (keydown)="_handleKeydown($event)" (input)="_handleInput($event)" (blur)="_handleBlur($event)" #input data-automation-id="date-input"/>
         <i *ngIf="!hasValue" (click)="openPanel()" class="bhi-calendar"></i>
         <i *ngIf="hasValue" (click)="clearValue()" class="bhi-times"></i>
 
@@ -89,11 +89,17 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
     }
   }
 
-  _handleEvent(event: Event, blur: boolean): void {
-    blur ? this._handleInput(event, blur) : document.activeElement === event.target && this._handleInput(event, blur);
+  _handleInput(event: KeyboardEvent): void {
+    if (document.activeElement === event.target) {
+      this._handleEvent(event, false);
+    }
   }
 
-  _handleInput(event: Event, blur: boolean): void {
+  _handleBlur(event: FocusEvent): void {
+    this._handleEvent(event, true);
+  }
+
+  _handleEvent(event: Event, blur: boolean): void {
     let value = (event.target as HTMLInputElement).value;
     try {
       let dateTimeValue = Date.parse(value);


### PR DESCRIPTION
## **Description**
before:
- input event triggered both the calendar and form value update. This basically made it impossible for any user to key in values outside of a date picker.  

after:
- restrict input event to update the calendar value only and leave the form value. 
- add blur event to compute the form value when the blur event is initiated. 

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

##### **Screenshots**
before:
![employeedob](https://user-images.githubusercontent.com/12078842/42044705-ac727cc4-7ac7-11e8-8427-ea4c55b08d46.PNG)

after:
![screen shot 2018-06-28 at 11 38 26 am](https://user-images.githubusercontent.com/12078842/42044774-d67d4bf2-7ac7-11e8-8e27-95010af6790f.png)
