### PR TITLE
Novo picker changes to click behavior

### DIFF
--- a/src/platform/elements/picker/Picker.ts
+++ b/src/platform/elements/picker/Picker.ts
@@ -108,8 +108,8 @@ export class NovoPickerElement implements OnInit {
   @Output() blur: EventEmitter<any> = new EventEmitter();
   @Output() typing: EventEmitter<any> = new EventEmitter();
 
-    @ViewChild(NovoOverlayTemplateComponent) public container: NovoOverlayTemplateComponent;
-    @ViewChild('input') private input: ElementRef;
+  @ViewChild(NovoOverlayTemplateComponent) public container: NovoOverlayTemplateComponent;
+  @ViewChild('input') private input: ElementRef;
 
   closeHandler: any;
   isStatic: boolean = true;
@@ -117,10 +117,10 @@ export class NovoPickerElement implements OnInit {
   resultsComponent: any;
   popup: any;
   _value: any;
-  onModelChange: Function = () => { };
-  onModelTouched: Function = () => { };
+  onModelChange: Function = () => {};
+  onModelTouched: Function = () => {};
 
-  constructor(public element: ElementRef, private componentUtils: ComponentUtils, private ref: ChangeDetectorRef) { }
+  constructor(public element: ElementRef, private componentUtils: ComponentUtils, private ref: ChangeDetectorRef) {}
 
   ngOnInit() {
     if (this.overrideElement) {
@@ -230,7 +230,9 @@ export class NovoPickerElement implements OnInit {
    * results.
    */
   onFocus(event) {
-    this.show();
+    if (!this.panelOpen) {
+      this.show();
+    }
     this.focus.emit(event);
   }
 


### PR DESCRIPTION
## **Description**

Make clicking on a picker result behave the same as pressing enter on a result (don't re-open the entire list of results when something is selected)

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run compile` still works

##### **Screenshots**