### PR TITLE
Add tooltip capability to textarea and update demo

### DIFF
--- a/src/app/pages/elements/form/FormDemo.ts
+++ b/src/app/pages/elements/form/FormDemo.ts
@@ -185,16 +185,17 @@ export class FormDemoComponent {
     this.textAreaControl = new TextAreaControl({
       key: 'textarea',
       label: 'Text Area',
+      tooltip: 'Text Area',
       value:
       'Bro ipsum dolor sit amet yard sale saddle pipe, poaching cork 360 punter ACL back country cornice Whistler.  Avie Ski taco mitt, manny first tracks yard sale caballerial heli fatty.  Epic dope grab, brain bucket japan air wack bowl  mute heli corn Snowboard Whistler giblets table top.  Crunchy Snowboard washboard line grab reverse camber.  Bump epic granny gear heli sketching wheelie huckfest face plant crank pow pow chain ring  dirtbag washboard.  Flow endo ski bum sucker hole, death cookies manny schwag pipe.  Dope heli stomp yard sale, saddle shreddin booter gear jammer grom bonk OTB brain bucket bonk japan air Whistler.Clipless pow pow pow, core shot corn butter bomb hole glades face plant dust on crust.  Poaching park face shots bump, Bike cornice death cookies.  Avie cruiser sucker hole face plant switch.  ACL snake bite bonk, twin tip euro rig nose press McTwist.  Ripping skinny trucks shreddin.  Apres pow line euro sharkbite gapers lid.Snake bite derailleur wheels bomb hole.  Huck apres steeps BB first tracks bowl  daffy park euro park rat euro.  North shore death cookies snake bite carve, freshies dirtbag huck reverse camber hellflip frozen chicken heads apres taco glove gnar face shots bro.  Ride flow twister cornice afterbang saddle first tracks rig berm bro face shots.  Ride stoked wack park twin tip trucks chillax shuttle Whistler gondy laps.  Grind berm schwag, table top face shots steed liftie afterbang taco glove frozen chicken heads free ride clean huck.  Rock-ectomy white room nose press avie.Frozen chicken heads gondy bail travel huckfest big ring phat clean.  Taco couloir piste derailleur wack scream backside steeps groomer glades pipe gondy switch skid lid.  Brain bucket betty bowl, moguls gondy Whistler air hardtail.  Flow euro granny gear, McTwist cruiser bonk grom chain suck.  Trucks line huck, stomp ripper washboard euro corduroy death cookies yard sale dope face plant shreddin chain suck.ACL T-bar hellflip, first tracks gondy hardtail rip wack dust on crust schwag frontside couloir laps presta backside.  Road rash Ski ski bum gnar wack flow carve lid.  Nose white room ollie rail table top grom back country washboard dust on crust chillax gear jammer bro stomp stoked.  Lid wheels nose press frontside, park ACL dirtbag huck epic bowl  taco glove OTB.  Fatty mute whip stunt, Whistler McTwist stoked Bike.  Endo brain bucket crank dust on crust back country line ollie gapers afterbang bump stoked taco road rash granny gear.  Deck dirtbag 360 gnar snake bite couloir Bike corduroy frontside crank lid bro.Air tele schwag ollie, hardtail betty crunchy epic  face shots.  Travel flowy misty huck Bike 180 schwag drop hellflip ripping bunny slope carbon roadie tele bail.  Cornice sharkbite 360 frozen chicken heads dope hellflip clipless.  Switch sketching grind brain bucket stunt taco daffy OTB ride liftie brain bucket air huckfest park 360.',
     });
     this.emailControl = new TextBoxControl({ type: 'email', key: 'email', label: 'Email', tooltip: 'Email' });
-    this.numberControl = new TextBoxControl({ type: 'number', key: 'number', label: 'Number' });
-    this.currencyControl = new TextBoxControl({ type: 'currency', key: 'currency', label: 'Currency', currencyFormat: '$ USD' });
-    this.floatControl = new TextBoxControl({ type: 'float', key: 'float', label: 'Float' });
-    this.percentageControl = new TextBoxControl({ type: 'percentage', key: 'percentage', label: 'Percent', required: true });
+    this.numberControl = new TextBoxControl({ type: 'number', key: 'number', tooltip: 'Number', label: 'Number' });
+    this.currencyControl = new TextBoxControl({ type: 'currency', key: 'currency', tooltip: 'Currency', label: 'Currency', currencyFormat: '$ USD' });
+    this.floatControl = new TextBoxControl({ type: 'float', key: 'float', tooltip: 'Float', label: 'Float' });
+    this.percentageControl = new TextBoxControl({ type: 'percentage', key: 'percentage', tooltip: 'Percent', label: 'Percent', required: true });
     this.quickNoteControl = new QuickNoteControl({ key: 'note', label: 'Note', config: this.quickNoteConfig, required: true, tooltip: 'Quicknote' });
-    this.aceEditorControl = new AceEditorControl({ key: 'ace', label: 'CODE', value: 'var i = 0;' });
+    this.aceEditorControl = new AceEditorControl({ key: 'ace', label: 'CODE', tooltip: 'CODE', value: 'var i = 0;' });
     this.textForm = formUtils.toFormGroup([
       this.textControl,
       this.emailControl,
@@ -208,21 +209,22 @@ export class FormDemoComponent {
     ]);
 
     // Check box controls
-    this.checkControl = new CheckboxControl({ key: 'check', label: 'Checkbox' });
+    this.checkControl = new CheckboxControl({ key: 'check', tooltip: 'Checkbox', label: 'Checkbox' });
     this.checkListControl = new CheckListControl({ key: 'checklist', label: 'Check List', options: ['One', 'Two', 'Three'], tooltip: 'CheckList', tooltipPosition: 'Top' });
     this.tilesControl = new TilesControl({ key: 'tiles', label: 'Tiles', options: [{ value: 'one', label: 'One' }, { value: 'two', label: 'Two' }, { value: 'disabled', label: 'Disabled', disabled: true }], tooltip: 'Tiles' });
     this.disabledTilesControl = new TilesControl({ key: 'disabledTiles', label: 'Disabled Tiles', readOnly: true, options: [{ value: 'one', label: 'One' }, { value: 'two', label: 'Two' }], tooltip: 'Tiles' });
     this.checkForm = formUtils.toFormGroup([this.checkControl, this.checkListControl, this.tilesControl, this.disabledTilesControl]);
 
     // Picker controls
-    this.singlePickerControl = new PickerControl({ key: 'singlePicker', label: 'Single', config: { options: ['One', 'Two', 'Three'] } });
-    this.multiPickerControl = new PickerControl({ key: 'multiPicker', label: 'Multiple', multiple: true, config: { options: ['One', 'Two', 'Three'], type: 'candidate' } });
+    this.singlePickerControl = new PickerControl({ key: 'singlePicker', tooltip: 'Single', label: 'Single', config: { options: ['One', 'Two', 'Three'] } });
+    this.multiPickerControl = new PickerControl({ key: 'multiPicker', tooltip: 'Multiple', label: 'Multiple', multiple: true, config: { options: ['One', 'Two', 'Three'], type: 'candidate' } });
     this.entityMultiPickerControl = new PickerControl({
       key: 'entityMultiPicker',
       label: 'Entities',
       required: true,
       readOnly: false,
       multiple: true,
+      tooltip: 'Entities',
       config: {
         resultsTemplate: EntityPickerResults,
         previewTemplate: EntityPickerResult,
@@ -299,6 +301,7 @@ export class FormDemoComponent {
       key: 'address',
       name: 'address',
       label: 'Address',
+      tooltip: 'Address',
       config: {
         address1: {
           label: 'Address Line 1',
@@ -340,6 +343,7 @@ export class FormDemoComponent {
       key: 'secondaryAddress',
       name: 'secondaryAddress',
       label: 'Secondary Address',
+      tooltip: 'Secondary Address',
       config: {
         address1: {
           label: 'Address Line 1',
@@ -397,6 +401,7 @@ export class FormDemoComponent {
       key: 'files',
       name: 'myfiles',
       label: 'Multiple Files',
+      tooltip: 'Multiple Files',
       multiple: true,
       layoutOptions: { order: 'displayFilesBelow', download: true, edit: true, customActions: true, labelStyle: 'no-box' },
       value: [{ name: 'yourFile.pdf', loaded: true, link: 'www.google.com', description: 'file description' }],
@@ -407,7 +412,7 @@ export class FormDemoComponent {
     this.dateControl = new DateControl({ key: 'date', label: 'Date', tooltip: 'Date' });
     this.userDefinedDateControl = new DateControl({ key: 'userDefinedFormat', label: 'User Defined Format', tooltip: 'Date', dateFormat: 'MMM Do YYYY (dd)', textMaskEnabled: false });
     this.timeControl = new TimeControl({ key: 'time', label: 'Time', tooltip: 'Time' });
-    this.dateTimeControl = new DateTimeControl({ key: 'dateTime', label: 'Date Time', military: true });
+    this.dateTimeControl = new DateTimeControl({ key: 'dateTime', tooltip: 'Date Time', label: 'Date Time', military: true });
     this.calendarForm = formUtils.toFormGroup([this.dateControl, this.userDefinedDateControl, this.timeControl, this.dateTimeControl]);
 
     // Dynamic

--- a/src/platform/elements/form/Control.ts
+++ b/src/platform/elements/form/Control.ts
@@ -145,7 +145,9 @@ export class NovoCustomControlContainerElement {
                               <label class="input-label" *ngIf="form.controls[control.key].subType === 'percentage'">%</label>
                             </div>
                             <!--TextArea-->
-                            <textarea *ngSwitchCase="'text-area'" [class.maxlength-error]="errors?.maxlength" [name]="control.key" [attr.id]="control.key" [placeholder]="form.controls[control.key].placeholder" [formControlName]="control.key" autosize (input)="handleTextAreaInput($event)" (focus)="handleFocus($event)" (blur)="handleBlur($event)" [maxlength]="control.maxlength" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" [tooltipSize]="tooltipSize" [tooltipPreline]="tooltipPreline"></textarea>
+                            <div class="novo-control-input-container novo-control-input-with-label" *ngSwitchCase="'text-area'" [tooltip]="tooltip" [tooltipPosition]="tooltipPosition" [tooltipSize]="tooltipSize" [tooltipPreline]="tooltipPreline">
+                              <textarea [class.maxlength-error]="errors?.maxlength" [name]="control.key" [attr.id]="control.key" [placeholder]="form.controls[control.key].placeholder" [formControlName]="control.key" autosize (input)="handleTextAreaInput($event)" (focus)="handleFocus($event)" (blur)="handleBlur($event)" [maxlength]="control.maxlength"></textarea>
+                            </div>
                             <!--Editor-->
                             <novo-editor *ngSwitchCase="'editor'" [name]="control.key" [formControlName]="control.key" [startupFocus]="control.startupFocus" [minimal]="control.minimal" [fileBrowserImageUploadUrl]="control.fileBrowserImageUploadUrl" (focus)="handleFocus($event)" (blur)="handleBlur($event)"></novo-editor>
                             <!--AceEditor-->


### PR DESCRIPTION
## **Description**

Added tooltip capability to textarea (previously not supported in just hint.css, needed wrapper)

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

##### **Screenshots**