### PR TITLE
fix: date-picker-month-select

### DIFF
--- a/src/platform/elements/date-picker/DatePickerInput.ts
+++ b/src/platform/elements/date-picker/DatePickerInput.ts
@@ -110,10 +110,6 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
   }
 
   _handleBlur(event: FocusEvent): void {
-    if (this.value && !event.relatedTarget) {
-      this._handleEvent(event, true);
-      this.closePanel();
-    }
     this.blurEvent.emit(event);
   }
 


### PR DESCRIPTION
## **Description**

blur event bug: when month is selected in a date-picker, picker focuses out of the picker.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

##### **Screenshots**