### PR TITLE
fix(form-control-group) - change detection to fix control group display

### DIFF
--- a/src/platform/elements/form/Control.ts
+++ b/src/platform/elements/form/Control.ts
@@ -1,5 +1,6 @@
 // NG2
 import {
+  ChangeDetectorRef,
   Component,
   Input,
   Output,
@@ -198,6 +199,7 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
     private dateFormatService: DateFormatService,
     private fieldInteractionApi: FieldInteractionApi,
     private templateService: NovoTemplateService,
+    private changeDetectorRef: ChangeDetectorRef,
   ) {
     super(element);
   }
@@ -249,6 +251,7 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
   ngAfterContentInit() {
     setTimeout(() => {
       this.templates = this.templateService.getAll();
+      this.changeDetectorRef.detectChanges();
     });
   }
 
@@ -262,7 +265,6 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
         this.characterCount = this.form.controls[this.control.key].value.length;
       }
     }
-    // this.maxLenghtCount = form.controls[control.key].maxlength;
     if (this.control) {
       // Listen to clear events
       this.forceClearSubscription = this.control.forceClear.subscribe(() => {


### PR DESCRIPTION
## **Description**

grouped control didn't updates after templates were instantiated because of the ChangeDection onPush strategy. Explicitly pushing changes so that it does update.
#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**