### PR TITLE
fix(NovoSelectElement) - clone passed in options objects instead of m…

### DIFF
--- a/src/platform/elements/select/Select.spec.ts
+++ b/src/platform/elements/select/Select.spec.ts
@@ -60,6 +60,13 @@ describe('Elements: NovoSelectElement', () => {
       comp.ngOnChanges();
       expect(comp.filteredOptions).toEqual([{ readOnly: false, active: false }, { active: false }]);
     });
+    it('should clone each option in filteredOptions so its object reference changes', () => {
+      const option = { value: 'clone', label: 'me' };
+      comp.options = [option];
+      comp.ngOnChanges();
+      expect(comp.filteredOptions[0]).not.toBe(option);
+      expect(comp.filteredOptions[0]).toEqual({ value: 'clone', label: 'me', active: false });
+    });
     it('should invoke clear', () => {
       const mockPlaceholder = { test: true };
       comp.model = false;

--- a/src/platform/elements/select/Select.ts
+++ b/src/platform/elements/select/Select.ts
@@ -115,12 +115,16 @@ export class NovoSelectElement implements OnInit, OnChanges, OnDestroy {
         return { value: item, label: item };
       });
     } else {
-      this.filteredOptions = (this.options || []).filter((item) => {
-        return !item.readOnly;
-      });
-      this.filteredOptions.forEach((element) => {
-        element.active = false;
-      });
+      this.filteredOptions = (this.options || [])
+        .filter((item) => {
+          return !item.readOnly;
+        })
+        .map((element) => {
+          return {
+            ...element,
+            active: false,
+          };
+        });
     }
     if (!this.model && !this.createdItem) {
       this.clear();


### PR DESCRIPTION
…odifying directly

## **Description**

`<novo-select>`s used in form groups would show either the incorrectly selected option, or show more than one option as selected.  Instead of modifying the options objects directly and adding an `active` property on them, we assign a new object reference per option object and add the `active` property on the new object.  Changing this reference no longer causes `<novo-select>`s that share the same options object to conflict with one another.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**
Behavior before fix
![novo-select-previous](https://user-images.githubusercontent.com/6486532/43006198-12666b8e-8c03-11e8-8a6d-7a5397df1164.gif)

Behavior after fix
![novo-select-now](https://user-images.githubusercontent.com/6486532/43006342-74cc9582-8c03-11e8-9948-c3c8540996d9.gif)
