### PR TITLE
fix-data-table-dropdown-styling

### DIFF
--- a/src/platform/elements/data-table/data-table.component.scss
+++ b/src/platform/elements/data-table/data-table.component.scss
@@ -554,7 +554,7 @@ novo-data-table-pagination {
   }
 }
 
-.data-table-dropdown {
+.dropdown-container.data-table-dropdown {
   min-width: 230px;
   max-width: 230px;
   max-height: 500px;


### PR DESCRIPTION
## **Description**

custom range datepicker width is not responsive on the data-table

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**

![image 1](https://user-images.githubusercontent.com/12078842/43007096-5c4241a4-8c05-11e8-8b42-a446ebcfaafb.png)