### PR TITLE
format date to proper locale when manually entering date

### DIFF
--- a/src/platform/elements/date-picker/DatePickerInput.spec.ts
+++ b/src/platform/elements/date-picker/DatePickerInput.spec.ts
@@ -1,0 +1,35 @@
+// NG2
+import { TestBed, async } from '@angular/core/testing';
+// App
+import { NovoDatePickerInputElement } from './DatePickerInput';
+import { NovoLabelService } from '../../services/novo-label-service';
+import { NovoDatePickerModule } from './DatePicker.module';
+import { DateFormatService } from '../../services/date-format/DateFormat';
+
+describe('Elements: NovoDatePickerInputElement', () => {
+  let fixture;
+  let component;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      // declarations: [
+      //     NovoDatePickerInputElement
+      // ],
+      providers: [{ provide: NovoLabelService, useClass: NovoLabelService }, DateFormatService],
+      imports: [NovoDatePickerModule],
+    }).compileComponents();
+    fixture = TestBed.createComponent(NovoDatePickerInputElement);
+    component = fixture.debugElement.componentInstance;
+  }));
+
+  describe('Method: formatDate()', () => {
+    it('should call parseString from the dateFormatService and then dispatchOnChange.', () => {
+      spyOn(component.dateFormatService, 'parseString').and.callThrough();
+      spyOn(component, 'dispatchOnChange');
+      let mockValue: String = '01/01/2020';
+      component.formatDate(mockValue, true);
+      expect(component.dateFormatService.parseString).toHaveBeenCalled();
+      expect(component.dispatchOnChange).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/platform/elements/date-picker/DatePickerInput.ts
+++ b/src/platform/elements/date-picker/DatePickerInput.ts
@@ -126,6 +126,11 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
 
   _handleEvent(event: Event, blur: boolean): void {
     let value = (event.target as HTMLInputElement).value;
+    this.formatDate(value, blur);
+    this.openPanel();
+  }
+
+  protected formatDate(value: string, blur: boolean) {
     try {
       let [dateTimeValue, formatted] = this.dateFormatService.parseString(value, false, 'date');
       if (!isNaN(dateTimeValue.getUTCDate())) {
@@ -135,7 +140,6 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
         this.dispatchOnChange(null, blur);
       }
     } catch (err) {}
-    this.openPanel();
   }
 
   writeValue(value: any): void {

--- a/src/platform/elements/date-picker/DatePickerInput.ts
+++ b/src/platform/elements/date-picker/DatePickerInput.ts
@@ -23,6 +23,7 @@ import { NovoDatePickerElement } from './DatePicker';
 import { NovoOverlayTemplateComponent } from '../overlay/Overlay';
 import { NovoLabelService } from '../../services/novo-label-service';
 import { Helpers } from '../../utils/Helpers';
+import { DateFormatService } from '../../services/date-format/DateFormat';
 
 // Value accessor for the component (supports ngModel)
 const DATE_VALUE_ACCESSOR = {
@@ -65,7 +66,12 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
   /** Element for the panel containing the autocomplete options. */
   @ViewChild(NovoOverlayTemplateComponent) overlay: NovoOverlayTemplateComponent;
 
-  constructor(public element: ElementRef, public labels: NovoLabelService, private _changeDetectorRef: ChangeDetectorRef) {
+  constructor(
+    public element: ElementRef,
+    public labels: NovoLabelService,
+    private _changeDetectorRef: ChangeDetectorRef,
+    public dateFormatService: DateFormatService,
+  ) {
     this.placeholder = this.labels.dateFormatPlaceholder;
   }
 
@@ -121,8 +127,8 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
   _handleEvent(event: Event, blur: boolean): void {
     let value = (event.target as HTMLInputElement).value;
     try {
-      let dateTimeValue = Date.parse(value);
-      if (!isNaN(dateTimeValue)) {
+      let [dateTimeValue, formatted] = this.dateFormatService.parseString(value, false, 'date');
+      if (!isNaN(dateTimeValue.getUTCDate())) {
         let dt = new Date(dateTimeValue);
         this.dispatchOnChange(dt, blur);
       } else {


### PR DESCRIPTION
## **Description**

Allows users to type dates in the dd/mm/yyyy format

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`
