### PR TITLE
feat(tiles): Added event emitter for when selected tiles are clicked

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cleanup-dist": "rimraf dist/src",
     "build-ghpages": "ng build -prod -aot false --output-path \"dist-ghpages\"",
     "test": "ng test -cc --watch false",
-    "test-watch": "ng test",
+    "test-watch": "ng test -cc",
     "lint": "tslint --format codeFrame -c ./tslint.json \"./src/app/**/*.ts\" \"./src/platform/**/*.ts\" --project tsconfig.json",
     "precommit": "lint-staged",
     "loc": "node_modules/sloc/bin/sloc src/platform --format json > ./coverage/sloc.json",

--- a/src/app/pages/elements/tiles/TilesDemo.ts
+++ b/src/app/pages/elements/tiles/TilesDemo.ts
@@ -21,43 +21,51 @@ const template = `
 `;
 
 @Component({
-    selector: 'tiles-demo',
-    template: template
+  selector: 'tiles-demo',
+  template: template,
 })
 export class TilesDemoComponent {
-    private TilesDemoTpl: string = TilesDemoTpl;
-    private shown: boolean = false;
-    private demoTiles: Array<any> = [
-        {
-            label: 'Red',
-            value: 'red'
-        },
-        {
-            label: 'Green',
-            value: 'green'
-        },
-        {
-            label: 'Disabled',
-            value: 'disabled',
-            disabled: true
-        }
-    ];
-    private currentColor: string;
-    public value: string = 'red';
+  private TilesDemoTpl: string = TilesDemoTpl;
+  private shown: boolean = false;
+  private demoTiles: Array<any> = [
+    {
+      label: 'Red',
+      value: 'red',
+    },
+    {
+      label: 'Green',
+      value: 'green',
+    },
+    {
+      label: 'Disabled',
+      value: 'disabled',
+      disabled: true,
+    },
+  ];
+  private currentColor: string;
+  public value: string = 'red';
 
-    colorSelect(newColorValue) {
-        this.currentColor = newColorValue;
-    }
+  colorSelect(newColorValue) {
+    this.currentColor = newColorValue;
+  }
 
-    toggleShown() {
-        this.shown = !this.shown;
-    }
+  disabledClicked(tile) {
+    console.log('Disabled tile clicked: ', tile); // tslint:disable-line
+  }
 
-    addTile() {
-        this.demoTiles.push({
-            label: 'Blue',
-            value: 'blue'
-        });
-        this.demoTiles = [...this.demoTiles];
-    }
+  selectedClicked(tile) {
+    console.log('Selected tile clicked: ', tile); // tslint:disable-line
+  }
+
+  toggleShown() {
+    this.shown = !this.shown;
+  }
+
+  addTile() {
+    this.demoTiles.push({
+      label: 'Blue',
+      value: 'blue',
+    });
+    this.demoTiles = [...this.demoTiles];
+  }
 }

--- a/src/app/pages/elements/tiles/templates/TilesDemo.html
+++ b/src/app/pages/elements/tiles/templates/TilesDemo.html
@@ -1,4 +1,6 @@
-<novo-tiles [options]="demoTiles" (onChange)="colorSelect($event)" [(ngModel)]="value"></novo-tiles>
+<novo-tiles [options]="demoTiles" (onChange)="colorSelect($event)" [(ngModel)]="value"
+            (onDisabledOptionClick)="disabledClicked($event)"
+            (onSelectedOptionClick)="selectedClicked($event)"></novo-tiles>
 <hr>
 <button theme="primary" type="button" name="button" (click)="toggleShown()">Show Tiles</button>
 <button theme="primary" type="button" name="button" (click)="addTile()">Add Tile</button>

--- a/src/platform/elements/tiles/Tiles.spec.ts
+++ b/src/platform/elements/tiles/Tiles.spec.ts
@@ -1,70 +1,118 @@
 // NG2
-import { TestBed, async } from '@angular/core/testing';
+import { async, TestBed } from '@angular/core/testing';
 // APP
 import { NovoTilesElement } from './Tiles';
 
 describe('Elements: NovoTilesElement', () => {
-    let fixture;
-    let component;
+  let fixture;
+  let component;
 
-    beforeEach(async(() => {
-        TestBed.configureTestingModule({
-            declarations: [
-                NovoTilesElement
-            ]
-        }).compileComponents();
-        fixture = TestBed.createComponent(NovoTilesElement);
-        component = fixture.debugElement.componentInstance;
-    }));
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [NovoTilesElement],
+    }).compileComponents();
+    fixture = TestBed.createComponent(NovoTilesElement);
+    component = fixture.debugElement.componentInstance;
+    component.options = [
+      {
+        label: 'Red',
+        value: 'red',
+      },
+      {
+        label: 'Green',
+        value: 'green',
+      },
+      {
+        label: 'Blue',
+        value: 'blue',
+      },
+      {
+        label: 'Disabled',
+        value: 'disabled',
+        disabled: true,
+      },
+    ];
+    component.ngAfterContentInit();
+  }));
 
-    xdescribe('Method: select(event, item)', () => {
-        it('should be defined.', () => {
-            expect(component.select).toBeDefined();
-        });
-
-        it('should set label 2 with checked equal to true', () => {
-            component.options[1].checked = false;
-            component.select(false, component.options[1]);
-            expect(component.options[1].checked).toBeTruthy();
-        });
-
-        it('should only allow one tile to be checked true', () => {
-            component.ngOnInit();
-            component.select(false, component.options[0]);
-            expect(component.options[0].checked).toBeTruthy();
-            expect(component.options[1].checked).toBeFalsy();
-            expect(component.options[2].checked).toBeFalsy();
-            component.select(false, component.options[1]);
-            expect(component.options[0].checked).toBeFalsy();
-            expect(component.options[1].checked).toBeTruthy();
-            expect(component.options[2].checked).toBeFalsy();
-            component.select(false, component.options[2]);
-            expect(component.options[0].checked).toBeFalsy();
-            expect(component.options[1].checked).toBeFalsy();
-            expect(component.options[2].checked).toBeTruthy();
-        });
+  describe('Method: select(event, item)', () => {
+    it('should set label 2 with checked equal to true', () => {
+      let event: any = {
+        stopPropagation: () => {},
+        preventDefault: () => {},
+      };
+      expect(component.options[1].checked).toBeFalsy();
+      component.select(event, component.options[1]);
+      expect(component.options[1].checked).toBeTruthy();
     });
 
-    xdescribe('Method: writeValue()', () => {
-        it('should be defined.', () => {
-            expect(component.writeValue).toBeDefined();
-        });
-
-        it('should change the value', () => {
-            component.writeValue(10);
-            expect(component.model).toBe(10);
-        });
+    it('should only allow one tile to be checked true', () => {
+      component.select(false, component.options[0]);
+      expect(component.options[0].checked).toBeTruthy();
+      expect(component.options[1].checked).toBeFalsy();
+      expect(component.options[2].checked).toBeFalsy();
+      component.select(false, component.options[1]);
+      expect(component.options[0].checked).toBeFalsy();
+      expect(component.options[1].checked).toBeTruthy();
+      expect(component.options[2].checked).toBeFalsy();
+      component.select(false, component.options[2]);
+      expect(component.options[0].checked).toBeFalsy();
+      expect(component.options[1].checked).toBeFalsy();
+      expect(component.options[2].checked).toBeTruthy();
     });
 
-    describe('Method: registerOnChange()', () => {
-        it('should be defined.', () => {
-            expect(component.registerOnChange).toBeDefined();
-        });
+    it('should emit event but not allow disabled tiles to be checked', () => {
+      spyOn(component.onDisabledOptionClick, 'emit');
+      component.select(false, component.options[0]);
+      expect(component.options[0].checked).toBeTruthy();
+      expect(component.options[1].checked).toBeFalsy();
+      expect(component.options[2].checked).toBeFalsy();
+      expect(component.options[3].checked).toBeFalsy();
+      component.select(false, component.options[3]);
+      expect(component.options[0].checked).toBeTruthy();
+      expect(component.options[1].checked).toBeFalsy();
+      expect(component.options[2].checked).toBeFalsy();
+      expect(component.options[3].checked).toBeFalsy();
+      expect(component.onDisabledOptionClick.emit).toHaveBeenCalledTimes(1);
     });
 
-    describe('Method: registerOnTouched()', () => {
-        it('should be defined.', () => {
-            expect(component.registerOnTouched).toBeDefined();
-        });
+    it('should emit event when checked tiles are clicked', () => {
+      spyOn(component.onSelectedOptionClick, 'emit');
+      component.select(false, component.options[0]);
+      expect(component.options[0].checked).toBeTruthy();
+      expect(component.options[1].checked).toBeFalsy();
+      expect(component.options[2].checked).toBeFalsy();
+      expect(component.options[3].checked).toBeFalsy();
+      component.select(false, component.options[0]);
+      expect(component.options[0].checked).toBeTruthy();
+      expect(component.options[1].checked).toBeFalsy();
+      expect(component.options[2].checked).toBeFalsy();
+      expect(component.options[3].checked).toBeFalsy();
+      component.select(false, component.options[0]);
+      expect(component.options[0].checked).toBeTruthy();
+      expect(component.options[1].checked).toBeFalsy();
+      expect(component.options[2].checked).toBeFalsy();
+      expect(component.options[3].checked).toBeFalsy();
+      expect(component.onSelectedOptionClick.emit).toHaveBeenCalledTimes(2);
     });
+  });
+
+  describe('Method: writeValue()', () => {
+    it('should change the value', () => {
+      component.writeValue(10);
+      expect(component.model).toBe(10);
+    });
+  });
+
+  describe('Method: registerOnChange()', () => {
+    it('should be defined.', () => {
+      expect(component.registerOnChange).toBeDefined();
+    });
+  });
+
+  describe('Method: registerOnTouched()', () => {
+    it('should be defined.', () => {
+      expect(component.registerOnTouched).toBeDefined();
+    });
+  });
 });

--- a/src/platform/elements/tiles/Tiles.ts
+++ b/src/platform/elements/tiles/Tiles.ts
@@ -64,6 +64,7 @@ export class NovoTilesElement implements ControlValueAccessor, AfterContentInit,
   @Input() required: boolean;
   @Input('controlDisabled') disabled: boolean = false;
   @Output() onChange: EventEmitter<any> = new EventEmitter();
+  @Output() onSelectedOptionClick: EventEmitter<any> = new EventEmitter();
   @Output() onDisabledOptionClick: EventEmitter<any> = new EventEmitter();
 
   _options: Array<any> = [];
@@ -121,6 +122,7 @@ export class NovoTilesElement implements ControlValueAccessor, AfterContentInit,
       event.preventDefault();
     }
     if (item.checked) {
+      this.onSelectedOptionClick.emit(item);
       return;
     }
 


### PR DESCRIPTION
## **Description**

Allowing for event emitters when selected tiles are clicked. This enables consumers of Novo Elements to key off of any clicks that happen in the tiles element.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**

![](http://g.recordit.co/ejQvkAQHth.gif)
