### PR TITLE
fix(novo-control) leave padding for required icon in condensed controls

### DIFF
--- a/src/platform/elements/form/Control.ts
+++ b/src/platform/elements/form/Control.ts
@@ -40,7 +40,7 @@ export class NovoAutoSize implements AfterContentInit {
     this.adjust();
   }
 
-  constructor(public element: ElementRef) { }
+  constructor(public element: ElementRef) {}
 
   ngAfterContentInit(): void {
     setTimeout(() => {
@@ -85,7 +85,7 @@ export class NovoAutoSize implements AfterContentInit {
                       <!--Required Indicator-->
                         <i [hidden]="!form.controls[control.key].required || form.controls[control.key].readOnly"
                             class="required-indicator {{ form.controls[control.key].controlType }}"
-                            [ngClass]="{'bhi-circle': !isValid, 'bhi-check': isValid}" *ngIf="!condensed || (form.controls[control.key].required && !form.controls[control.key].readOnly)">
+                            [ngClass]="{'bhi-circle': !isValid, 'bhi-check': isValid}" *ngIf="!condensed || form.controls[control.key].required">
                         </i>
                         <!--Form Controls-->
                         <div class="novo-control-input {{ form.controls[control.key].controlType }}" [attr.data-automation-id]="control.key" [class.control-disabled]="form.controls[control.key].disabled">
@@ -329,7 +329,7 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
         toggleActive: this.toggleActive.bind(this),
       },
       form: this.form,
-    }
+    };
     this.templateContext.$implicit.tooltipPosition = this.tooltipPosition;
     this.templateContext.$implicit.tooltip = this.tooltip;
     this.templateContext.$implicit.tooltipSize = this.tooltipSize;
@@ -343,7 +343,9 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
 
     if (this.form.controls[this.control.key] && this.form.controls[this.control.key].subType === 'percentage') {
       if (!Helpers.isEmpty(this.form.controls[this.control.key].value)) {
-        this.templateContext.$implicit.percentValue = Number((this.form.controls[this.control.key].value * 100).toFixed(6).replace(/\.?0*$/, ''));
+        this.templateContext.$implicit.percentValue = Number(
+          (this.form.controls[this.control.key].value * 100).toFixed(6).replace(/\.?0*$/, ''),
+        );
       }
       this.percentChangeSubscription = this.form.controls[this.control.key].displayValueChanges.subscribe((value) => {
         if (!Helpers.isEmpty(value)) {


### PR DESCRIPTION
## **Description**

Using condensed form controls (for example, the novo-control-group component), the space allocated for the required check/cross is removed when the control is set as readonly.  When toggling a required control's readonly state, the left hand side of the control will jump as it adds the required icon.

This brings the original behavior back to the control that was removed in in #696. I spoke with @amrutha-rajiv, and this change doesn't seem negatively affect the changes from #696.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**
Before:
![form-condensed-required-shift](https://user-images.githubusercontent.com/6486532/43166535-ca1db43a-8f64-11e8-9cf1-da118959ceff.gif)

After:
![form-condensed-required-no-shift](https://user-images.githubusercontent.com/6486532/43166534-ca0c14fa-8f64-11e8-8bd2-1480cdba257e.gif)