### PR TITLE
fix(Table): spelling fix - calender should be calendar

### DIFF
--- a/src/platform/elements/data-table/cell-headers/data-table-header-cell.component.ts
+++ b/src/platform/elements/data-table/cell-headers/data-table-header-cell.component.ts
@@ -50,7 +50,7 @@ import { Helpers } from '../../../utils/Helpers';
                         <item [class.active]="labels.customDateRange === activeDateFilter" (click)="toggleCustomRange($event, true)" *ngIf="config.filterConfig.allowCustomRange && !showCustomRange" [keepOpen]="true">
                             {{ labels.customDateRange }} <i class="bhi-check" *ngIf="labels.customDateRange === activeDateFilter"></i>
                         </item>
-                        <div class="calender-container" *ngIf="showCustomRange">
+                        <div class="calendar-container" *ngIf="showCustomRange">
                             <div (click)="toggleCustomRange($event, false)"><i class="bhi-previous"></i>{{ labels.backToPresetFilters }}</div>
                             <novo-date-picker (onSelect)="filterData($event)" [(ngModel)]="filter" range="true"></novo-date-picker>
                         </div>

--- a/src/platform/elements/data-table/data-table.component.scss
+++ b/src/platform/elements/data-table/data-table.component.scss
@@ -638,7 +638,7 @@ novo-data-table-pagination {
       text-overflow: ellipsis;
     }
   }
-  .calender-container {
+  .calendar-container {
     height: 100%;
     min-height: 200px;
     width: 100%;

--- a/src/platform/elements/simple-table/cell-header.ts
+++ b/src/platform/elements/simple-table/cell-header.ts
@@ -66,7 +66,7 @@ export class NovoSimpleFilterFocus implements AfterViewInit {
                   *ngIf="config.filterConfig.allowCustomRange && !showCustomRange" [keepOpen]="true">
               {{ labels.customDateRange }} <i class="bhi-check" *ngIf="labels.customDateRange === activeDateFilter"></i>
             </item>
-            <div class="calender-container" *ngIf="showCustomRange">
+            <div class="calendar-container" *ngIf="showCustomRange">
               <div (click)="toggleCustomRange($event, false)"><i class="bhi-previous"></i>{{ labels.backToPresetFilters }}</div>
               <novo-date-picker (onSelect)="filterData($event)" [(ngModel)]="filter" range="true"></novo-date-picker>
             </div>

--- a/src/platform/elements/table/Table.scss
+++ b/src/platform/elements/table/Table.scss
@@ -358,7 +358,7 @@ novo-table {
       text-overflow: ellipsis;
     }
   }
-  .calender-container {
+  .calendar-container {
     height: 100%;
     min-height: 200px;
     width: 100%;

--- a/src/platform/elements/table/Table.ts
+++ b/src/platform/elements/table/Table.ts
@@ -136,7 +136,7 @@ export enum NovoTableMode {
                                         <item [ngClass]="{ active: isFilterActive(column, option) }" *ngFor="let option of column.options" (click)="onFilterClick(column, option)" [keepOpen]="option.range" [hidden]="column.calenderShow" [attr.data-automation-id]="(option?.label || option)">
                                             {{ option?.label || option }} <i class="bhi-check" *ngIf="isFilterActive(column, option)"></i>
                                         </item>
-                                        <div class="calender-container" [hidden]="!column.calenderShow">
+                                        <div class="calendar-container" [hidden]="!column.calenderShow">
                                             <div (click)="column.calenderShow=false"><i class="bhi-previous"></i>{{ labels.backToPresetFilters }}</div>
                                             <novo-date-picker #rangePicker (onSelect)="onCalenderSelect(column, $event)" [(ngModel)]="column.filter" range="true"></novo-date-picker>
                                         </div>


### PR DESCRIPTION
## **Description**

update calendar class so that its spelled correctly

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**