### PR TITLE
Change to add dept and title fields to the internal picker

### DIFF
--- a/src/platform/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
+++ b/src/platform/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
@@ -6,8 +6,8 @@ import { BasePickerResults } from '../base-picker-results/BasePickerResults';
 import { NovoLabelService } from '../../../../services/novo-label-service';
 
 @Component({
-    selector: 'entity-picker-result',
-    template: `
+  selector: 'entity-picker-result',
+  template: `
         <novo-list-item *ngIf="match.data">
             <item-header>
                 <item-avatar [icon]="getIconForResult(match.data)"></item-avatar>
@@ -63,111 +63,121 @@ import { NovoLabelService } from '../../../../services/novo-label-service';
                     <i class="bhi-person"></i>
                     <span [innerHtml]="highlight(match.data.owner.name, term)"></span>
                 </p>
+                <!-- PRIMARY DEPARTMENT -->
+                <p class="primary-department" *ngIf="match.data.primaryDepartment && match.data.primaryDepartment.name && match.data.searchEntity === 'CorporateUser'">
+                    <i class="bhi-department"></i>
+                    <span [innerHtml]="highlight(match.data.primaryDepartment.name, term)"></span>
+                </p>
+                <!-- OCCUPATION -->
+                <p class="occupation" *ngIf="match.data.occupation && match.data.searchEntity === 'CorporateUser'">
+                    <i class="bhi-title"></i>
+                    <span [innerHtml]="highlight(match.data.occupation, term)"></span>
+                </p>
             </item-content>
         </novo-list-item>
-    `
+    `,
 })
 export class EntityPickerResult {
-    @Input() match: any;
-    @Input() term: any;
+  @Input() match: any;
+  @Input() term: any;
 
-    constructor(public labels: NovoLabelService) { }
+  constructor(public labels: NovoLabelService) {}
 
-    /**
-     * @name escapeRegexp
-     * @param queryToEscape
-     *
-     * @description This function captures the whole query string and replace it with the string that will be used to
-     * match.
-     */
-    escapeRegexp(queryToEscape) {
-        // Ex: if the capture is "a" the result will be \a
-        return queryToEscape.replace(/([.?*+^$[\]\\(){}|-])/g, '\\$1');
+  /**
+   * @name escapeRegexp
+   * @param queryToEscape
+   *
+   * @description This function captures the whole query string and replace it with the string that will be used to
+   * match.
+   */
+  escapeRegexp(queryToEscape) {
+    // Ex: if the capture is "a" the result will be \a
+    return queryToEscape.replace(/([.?*+^$[\]\\(){}|-])/g, '\\$1');
+  }
+
+  /**
+   * @name highlight
+   * @param match
+   * @param query
+   *
+   * @description This function should return a <strong>-tag wrapped HTML string.
+   */
+  highlight(match, query) {
+    // Replaces the capture string with a the same string inside of a "strong" tag
+    return query && match ? match.replace(new RegExp(this.escapeRegexp(query), 'gi'), '<strong>$&</strong>') : match;
+  }
+
+  getIconForResult(result?: any): string {
+    if (result) {
+      switch (result.searchEntity) {
+        case 'ClientContact':
+          return 'person contact';
+        case 'ClientCorporation':
+          return 'company';
+        case 'Opportunity':
+          return 'opportunity';
+        case 'Candidate':
+          return 'candidate';
+        case 'Lead':
+          return 'lead';
+        case 'JobOrder':
+          return 'job';
+        case 'Placement':
+          return 'star placement';
+        case 'CorporateUser':
+          return 'user';
+        default:
+          return '';
+      }
     }
+    return '';
+  }
 
-    /**
-     * @name highlight
-     * @param match
-     * @param query
-     *
-     * @description This function should return a <strong>-tag wrapped HTML string.
-     */
-    highlight(match, query) {
-        // Replaces the capture string with a the same string inside of a "strong" tag
-        return query && match ? match.replace(new RegExp(this.escapeRegexp(query), 'gi'), '<strong>$&</strong>') : match;
+  renderTimestamp(date?: any) {
+    let timestamp = '';
+    if (date) {
+      timestamp = this.labels.formatDateWithFormat(date, { year: 'numeric', month: 'numeric', day: 'numeric' });
     }
+    return timestamp;
+  }
 
-    getIconForResult(result?: any): string {
-        if (result) {
-            switch (result.searchEntity) {
-                case 'ClientContact':
-                    return 'person contact';
-                case 'ClientCorporation':
-                    return 'company';
-                case 'Opportunity':
-                    return 'opportunity';
-                case 'Candidate':
-                    return 'candidate';
-                case 'Lead':
-                    return 'lead';
-                case 'JobOrder':
-                    return 'job';
-                case 'Placement':
-                    return 'star placement';
-                case 'CorporateUser':
-                    return 'user';
-                default:
-                    return '';
-            }
-        }
-        return '';
+  getNameForResult(result?: any) {
+    if (result) {
+      switch (result.searchEntity) {
+        case 'Lead':
+        case 'CorporateUser':
+        case 'ClientContact':
+        case 'Candidate':
+        case 'Person':
+          if ('firstName' in result) {
+            return `${result.firstName} ${result.lastName}`.trim();
+          }
+          return `${result.name || ''}`.trim();
+        case 'ClientCorporation':
+          return `${result.name || ''}`.trim();
+        case 'Opportunity':
+        case 'JobOrder':
+          return `${result.title || ''}`.trim();
+        case 'Placement':
+          let label = '';
+          if (result.candidate) {
+            label = `${result.candidate.firstName} ${result.candidate.lastName}`.trim();
+          }
+          if (result.jobOrder) {
+            label = `${label} - ${result.jobOrder.title}`.trim();
+          }
+          return label;
+        default:
+          return `${result.name || ''}`.trim();
+      }
     }
-
-    renderTimestamp(date?: any) {
-        let timestamp = '';
-        if (date) {
-            timestamp = this.labels.formatDateWithFormat(date, { year: 'numeric', month: 'numeric', day: 'numeric' });
-        }
-        return timestamp;
-    }
-
-    getNameForResult(result?: any) {
-        if (result) {
-            switch (result.searchEntity) {
-                case 'Lead':
-                case 'CorporateUser':
-                case 'ClientContact':
-                case 'Candidate':
-                case 'Person':
-                    if ('firstName' in result) {
-                        return `${result.firstName} ${result.lastName}`.trim();
-                    }
-                    return `${result.name || ''}`.trim();
-                case 'ClientCorporation':
-                    return `${result.name || ''}`.trim();
-                case 'Opportunity':
-                case 'JobOrder':
-                    return `${result.title || ''}`.trim();
-                case 'Placement':
-                    let label = '';
-                    if (result.candidate) {
-                        label = `${result.candidate.firstName} ${result.candidate.lastName}`.trim();
-                    }
-                    if (result.jobOrder) {
-                        label = `${label} - ${result.jobOrder.title}`.trim();
-                    }
-                    return label;
-                default:
-                    return `${result.name || ''}`.trim();
-            }
-        }
-        return '';
-    }
+    return '';
+  }
 }
 
 @Component({
-    selector: 'entity-picker-results',
-    template: `
+  selector: 'entity-picker-results',
+  template: `
         <novo-list *ngIf="matches.length > 0" direction="vertical">
             <entity-picker-result *ngFor="let match of matches"
                     [match]="match"
@@ -181,20 +191,20 @@ export class EntityPickerResult {
         </novo-list>
         <p class="picker-error" *ngIf="hasError">{{ labels.pickerError }}</p>
         <p class="picker-null-results" *ngIf="!isLoading && !matches.length && !hasError">{{ labels.pickerEmpty }}</p>
-    `
+    `,
 })
 export class EntityPickerResults extends BasePickerResults {
-    @Output() select: EventEmitter<any> = new EventEmitter()
-    constructor(element: ElementRef, public labels: NovoLabelService, ref: ChangeDetectorRef) {
-        super(element, ref);
-    }
+  @Output() select: EventEmitter<any> = new EventEmitter();
+  constructor(element: ElementRef, public labels: NovoLabelService, ref: ChangeDetectorRef) {
+    super(element, ref);
+  }
 
-    getListElement() {
-        return this.element.nativeElement.querySelector('novo-list');
-    }
+  getListElement() {
+    return this.element.nativeElement.querySelector('novo-list');
+  }
 
-    selectMatch(event?: any, item?: any) {
-        this.select.next(item);
-        return super.selectMatch(event, item);
-    }
+  selectMatch(event?: any, item?: any) {
+    this.select.next(item);
+    return super.selectMatch(event, item);
+  }
 }

--- a/src/platform/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
+++ b/src/platform/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
@@ -70,7 +70,7 @@ import { NovoLabelService } from '../../../../services/novo-label-service';
                 </p>
                 <!-- OCCUPATION -->
                 <p class="occupation" *ngIf="match.data.occupation && match.data.searchEntity === 'CorporateUser'">
-                    <i class="bhi-title"></i>
+                    <i class="bhi-occupation"></i>
                     <span [innerHtml]="highlight(match.data.occupation, term)"></span>
                 </p>
             </item-content>


### PR DESCRIPTION
## **Description**

Added two missing fields (occupation and primary department) to the internal picker dropdown results.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**