### PR TITLE
add back in the checkboxLabel property to control config

### DIFF
--- a/src/app/pages/elements/form/FormDemo.ts
+++ b/src/app/pages/elements/form/FormDemo.ts
@@ -255,7 +255,7 @@ export class FormDemoComponent {
     ]);
 
     // Check box controls
-    this.checkControl = new CheckboxControl({ key: 'check', tooltip: 'Checkbox', label: 'Checkbox' });
+    this.checkControl = new CheckboxControl({ key: 'check', tooltip: 'Checkbox', label: 'Checkbox', checkboxLabel: 'Checkbox' });
     this.checkListControl = new CheckListControl({
       key: 'checklist',
       label: 'Check List',

--- a/src/platform/elements/form/NovoFormControl.ts
+++ b/src/platform/elements/form/NovoFormControl.ts
@@ -94,6 +94,7 @@ export class NovoFormControl extends FormControl {
     this.minlength = control.minlength;
     this.closeOnSelect = control.closeOnSelect;
     this.interactions = control.interactions;
+    this.checkboxLabel = control.checkboxLabel;
     this.appendToBody = control.appendToBody;
     if (this.appendToBody) {
       notify(`'appendToBody' has been deprecated. Please remove this attribute.`);

--- a/src/platform/elements/form/NovoFormControl.ts
+++ b/src/platform/elements/form/NovoFormControl.ts
@@ -52,6 +52,7 @@ export class NovoFormControl extends FormControl {
   };
   rawValue?: any;
   customControlConfig?: any;
+  checkboxLabel?: string;
   private historyTimeout: any;
 
 

--- a/src/platform/utils/form-utils/FormUtils.ts
+++ b/src/platform/utils/form-utils/FormUtils.ts
@@ -275,6 +275,7 @@ export class FormUtils {
         control = new TilesControl(controlConfig);
         break;
       case 'checkbox':
+        controlConfig.checkboxLabel = field.checkboxLabel;
         control = new CheckboxControl(controlConfig);
         break;
       case 'checklist':


### PR DESCRIPTION
## **Description**

The checkboxLabel property on checkboxes seemed to have been removed.   This is adding it back
 
#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**
![image](https://user-images.githubusercontent.com/4327754/43525847-7696de18-9568-11e8-8d69-8e9ade4addf1.png)
