### PR TITLE
fix(FieldInteractionAPI) - only copying over the resultsTemplate from existing config

### DIFF
--- a/src/platform/elements/form/FieldInteractionApi.ts
+++ b/src/platform/elements/form/FieldInteractionApi.ts
@@ -467,11 +467,11 @@ export class FieldInteractionApi {
         }
     }
 
-    public modifyPickerConfig(key: string, config: { format?: string, optionsUrl?: string, optionsUrlBuilder?: Function, optionsPromise?: any, options?: any[], resultsTemplate?: any }, mapper?: Function): void {
+    public modifyPickerConfig(key: string, config: { format?: string, optionsUrl?: string, optionsUrlBuilder?: Function, optionsPromise?: any, options?: any[] }, mapper?: Function): void {
         let control = this.getControl(key);
         if (control) {
           let newConfig: any = {
-              resultsTemplate: config.resultsTemplate,
+              resultsTemplate: control.config.resultsTemplate,
             };
             if (config.optionsUrl || config.optionsUrlBuilder || config.optionsPromise) {
                 newConfig = Object.assign(newConfig, {

--- a/src/platform/elements/form/FieldInteractionApi.ts
+++ b/src/platform/elements/form/FieldInteractionApi.ts
@@ -467,10 +467,12 @@ export class FieldInteractionApi {
         }
     }
 
-    public modifyPickerConfig(key: string, config: { format?: string, optionsUrl?: string, optionsUrlBuilder?: Function, optionsPromise?: any, options?: any[] }, mapper?: Function): void {
+    public modifyPickerConfig(key: string, config: { format?: string, optionsUrl?: string, optionsUrlBuilder?: Function, optionsPromise?: any, options?: any[], resultsTemplate?: any }, mapper?: Function): void {
         let control = this.getControl(key);
         if (control) {
-            let newConfig: any = Object.assign({}, control.config);
+          let newConfig: any = {
+              resultsTemplate: config.resultsTemplate,
+            };
             if (config.optionsUrl || config.optionsUrlBuilder || config.optionsPromise) {
                 newConfig = Object.assign(newConfig, {
                     format: config.format,


### PR DESCRIPTION


## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**