### PR TITLE
feat(editor): Allow pasting of html content with styles into the editor

### DIFF
--- a/src/platform/elements/ckeditor/CKEditor.spec.ts
+++ b/src/platform/elements/ckeditor/CKEditor.spec.ts
@@ -102,7 +102,7 @@ describe('Elements: NovoCKEditorElement', () => {
         shiftEnterMode: window['CKEDITOR'].ENTER_P,
         disableNativeSpellChecker: false,
         removePlugins: 'liststyle,tabletools,contextmenu',
-        extraAllowedContent: 'style;*[id,rel](*){*}',
+        extraAllowedContent: '*(*){*};table tbody tr td th[*];',
         toolbar: [
           { name: 'clipboard', items: ['Paste', 'PasteText', 'PasteFromWord', 'Undo', 'Redo'] },
           {
@@ -141,7 +141,7 @@ describe('Elements: NovoCKEditorElement', () => {
         shiftEnterMode: window['CKEDITOR'].ENTER_P,
         disableNativeSpellChecker: false,
         removePlugins: 'liststyle,tabletools,contextmenu',
-        extraAllowedContent: 'style;*[id,rel](*){*}',
+        extraAllowedContent: '*(*){*};table tbody tr td th[*];',
         toolbar: [
           { name: 'clipboard', items: ['Paste', 'PasteText', 'PasteFromWord', 'Undo', 'Redo'] },
           {
@@ -179,7 +179,7 @@ describe('Elements: NovoCKEditorElement', () => {
         shiftEnterMode: window['CKEDITOR'].ENTER_P,
         disableNativeSpellChecker: false,
         removePlugins: 'liststyle,tabletools,contextmenu',
-        extraAllowedContent: 'style;*[id,rel](*){*}',
+        extraAllowedContent: '*(*){*};table tbody tr td th[*];',
         toolbar: [
           {
             name: 'basicstyles',

--- a/src/platform/elements/ckeditor/CKEditor.spec.ts
+++ b/src/platform/elements/ckeditor/CKEditor.spec.ts
@@ -5,157 +5,201 @@ import { TestBed, async } from '@angular/core/testing';
 import { NovoCKEditorElement } from './CKEditor';
 
 describe('Elements: NovoCKEditorElement', () => {
-    let fixture;
-    let component;
+  let fixture;
+  let component;
 
-    beforeEach(async(() => {
-        TestBed.configureTestingModule({
-            declarations: [
-                NovoCKEditorElement
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [NovoCKEditorElement],
+      providers: [{ provide: Renderer2, useClass: Renderer2 }],
+    }).compileComponents();
+    fixture = TestBed.createComponent(NovoCKEditorElement);
+    component = fixture.debugElement.componentInstance;
+
+    window['CKEDITOR'] = {
+      ENTER_P: 1,
+      ENTER_BR: 2,
+    };
+  }));
+
+  describe('Method: ngOnDestroy()', () => {
+    it('should remove everything if we have an instance of CKEditor', () => {
+      expect(component.ngOnDestroy).toBeDefined();
+    });
+  });
+
+  describe('Method: ngAfterViewInit()', () => {
+    beforeEach(() => {
+      spyOn(component, 'ckeditorInit');
+    });
+
+    it('should be defined', () => {
+      expect(component.ngAfterViewInit).toBeDefined();
+    });
+
+    it('should set the base config', () => {
+      spyOn(component, 'getBaseConfig').and.returnValue({ test: true });
+      component.ngAfterViewInit();
+      expect(component.ckeditorInit).toHaveBeenCalledWith({ test: true });
+    });
+
+    it('should set with passed config', () => {
+      spyOn(component, 'getBaseConfig').and.returnValue({ test: false });
+      component.config = { test: true };
+      component.ngAfterViewInit();
+      expect(component.ckeditorInit).toHaveBeenCalledWith({ test: true });
+    });
+  });
+
+  describe('Method: writeValue()', () => {
+    it('should be defined', () => {
+      expect(component.writeValue).toBeDefined();
+    });
+
+    it('should work', () => {
+      component.instance = null;
+      component.writeValue({});
+      expect(component.value).toEqual({});
+    });
+
+    xit('should update the instance', () => {
+      component.writeValue({});
+      expect(component.instance.setData).toHaveBeenCalledWith({});
+    });
+  });
+
+  describe('Method: registerOnChange()', () => {
+    it('should be defined', () => {
+      expect(component.registerOnChange).toBeDefined();
+    });
+
+    it('should work', () => {
+      component.registerOnChange({});
+      expect(component.onChange).toEqual({});
+    });
+  });
+
+  describe('Method: registerOnTouched()', () => {
+    it('should be defined', () => {
+      expect(component.registerOnTouched).toBeDefined();
+    });
+
+    it('should work', () => {
+      component.registerOnTouched({});
+      expect(component.onTouched).toEqual({});
+    });
+  });
+
+  describe('Method: getBaseConfig()', () => {
+    it('should be defined', () => {
+      expect(component.getBaseConfig).toBeDefined();
+    });
+
+    it('should return extended config object #1', () => {
+      component.minimal = false;
+      expect(component.getBaseConfig()).toEqual({
+        enterMode: window['CKEDITOR'].ENTER_BR,
+        shiftEnterMode: window['CKEDITOR'].ENTER_P,
+        disableNativeSpellChecker: false,
+        removePlugins: 'liststyle,tabletools,contextmenu',
+        extraAllowedContent: 'style;*[id,rel](*){*}',
+        toolbar: [
+          { name: 'clipboard', items: ['Paste', 'PasteText', 'PasteFromWord', 'Undo', 'Redo'] },
+          {
+            name: 'paragraph',
+            items: [
+              'NumberedList',
+              'BulletedList',
+              'Outdent',
+              'Indent',
+              'Blockquote',
+              'JustifyLeft',
+              'JustifyCenter',
+              'JustifyRight',
+              'JustifyBlock',
+              'BidiLtr',
+              'BidiRtl',
             ],
-            providers: [
-                { provide: Renderer2, useClass: Renderer2 }
-            ]
-        }).compileComponents();
-        fixture = TestBed.createComponent(NovoCKEditorElement);
-        component = fixture.debugElement.componentInstance;
-
-        window['CKEDITOR'] = {
-            ENTER_P: 1,
-            ENTER_BR: 2
-        };
-    }));
-
-    describe('Method: ngOnDestroy()', () => {
-        it('should remove everything if we have an instance of CKEditor', () => {
-            expect(component.ngOnDestroy).toBeDefined();
-        });
+          },
+          { name: 'links', items: ['Link'] },
+          { name: 'insert', items: ['Image', 'Table', 'HorizontalRule'] },
+          { name: 'tools', items: ['Maximize', 'Source'] },
+          '/',
+          { name: 'basicstyles', items: ['Bold', 'Italic', 'Underline', 'Strike', 'Subscript', 'Superscript'] },
+          { name: 'styles', items: ['Styles', 'Format', 'Font', 'FontSize'] },
+          { name: 'colors', items: ['TextColor', 'BGColor'] },
+        ],
+        filebrowserImageUploadUrl: '',
+      });
     });
 
-    describe('Method: ngAfterViewInit()', () => {
-        beforeEach(() => {
-            spyOn(component, 'ckeditorInit');
-        });
-
-        it('should be defined', () => {
-            expect(component.ngAfterViewInit).toBeDefined();
-        });
-
-        it('should set the base config', () => {
-            spyOn(component, 'getBaseConfig').and.returnValue({ test: true });
-            component.ngAfterViewInit();
-            expect(component.ckeditorInit).toHaveBeenCalledWith({ test: true });
-        });
-
-        it('should set with passed config', () => {
-            spyOn(component, 'getBaseConfig').and.returnValue({ test: false });
-            component.config = { test: true };
-            component.ngAfterViewInit();
-            expect(component.ckeditorInit).toHaveBeenCalledWith({ test: true });
-        });
-    });
-
-    describe('Method: writeValue()', () => {
-        it('should be defined', () => {
-            expect(component.writeValue).toBeDefined();
-        });
-
-        it('should work', () => {
-            component.instance = null;
-            component.writeValue({});
-            expect(component.value).toEqual({});
-        });
-
-        xit('should update the instance', () => {
-            component.writeValue({});
-            expect(component.instance.setData).toHaveBeenCalledWith({});
-        });
-    });
-
-    describe('Method: registerOnChange()', () => {
-        it('should be defined', () => {
-            expect(component.registerOnChange).toBeDefined();
-        });
-
-        it('should work', () => {
-            component.registerOnChange({});
-            expect(component.onChange).toEqual({});
-        });
-    });
-
-    describe('Method: registerOnTouched()', () => {
-        it('should be defined', () => {
-            expect(component.registerOnTouched).toBeDefined();
-        });
-
-        it('should work', () => {
-            component.registerOnTouched({});
-            expect(component.onTouched).toEqual({});
-        });
-    });
-
-    describe('Method: getBaseConfig()', () => {
-        it('should be defined', () => {
-            expect(component.getBaseConfig).toBeDefined();
-        });
-
-        it('should return extended config object #1', () => {
-          component.minimal = false;
-          expect(component.getBaseConfig()).toEqual({
-                enterMode: window['CKEDITOR'].ENTER_BR,
-                shiftEnterMode: window['CKEDITOR'].ENTER_P,
-                disableNativeSpellChecker: false,
-                removePlugins: 'liststyle,tabletools,contextmenu',
-                toolbar: [
-                    { name: 'clipboard', items: ['Paste', 'PasteText', 'PasteFromWord', 'Undo', 'Redo'] },
-                    { name: 'paragraph', items: ['NumberedList', 'BulletedList', 'Outdent', 'Indent', 'Blockquote', 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock', 'BidiLtr', 'BidiRtl'] },
-                    { name: 'links', items: ['Link'] },
-                    { name: 'insert', items: ['Image', 'Table', 'HorizontalRule'] },
-                    { name: 'tools', items: ['Maximize', 'Source'] },
-                    '/',
-                    { name: 'basicstyles', items: ['Bold', 'Italic', 'Underline', 'Strike', 'Subscript', 'Superscript'] },
-                    { name: 'styles', items: ['Styles', 'Format', 'Font', 'FontSize'] },
-                    { name: 'colors', items: ['TextColor', 'BGColor'] }
-                ],
-                filebrowserImageUploadUrl: '',
-            });
-        });
-
-        it('should return extended config object #2', () => {
-          component.minimal = false;
-          component.fileBrowserImageUploadUrl = '/foo/bar/baz.cfm';
-          expect(component.getBaseConfig()).toEqual({
-            enterMode: window['CKEDITOR'].ENTER_BR,
-            shiftEnterMode: window['CKEDITOR'].ENTER_P,
-            disableNativeSpellChecker: false,
-            removePlugins: 'liststyle,tabletools,contextmenu',
-            toolbar: [
-              { name: 'clipboard', items: ['Paste', 'PasteText', 'PasteFromWord', 'Undo', 'Redo'] },
-              { name: 'paragraph', items: ['NumberedList', 'BulletedList', 'Outdent', 'Indent', 'Blockquote', 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock', 'BidiLtr', 'BidiRtl'] },
-              { name: 'links', items: ['Link'] },
-              { name: 'insert', items: ['Image', 'Table', 'HorizontalRule'] },
-              { name: 'tools', items: ['Maximize', 'Source'] },
-              '/',
-              { name: 'basicstyles', items: ['Bold', 'Italic', 'Underline', 'Strike', 'Subscript', 'Superscript'] },
-              { name: 'styles', items: ['Styles', 'Format', 'Font', 'FontSize'] },
-              { name: 'colors', items: ['TextColor', 'BGColor'] }
+    it('should return extended config object #2', () => {
+      component.minimal = false;
+      component.fileBrowserImageUploadUrl = '/foo/bar/baz.cfm';
+      expect(component.getBaseConfig()).toEqual({
+        enterMode: window['CKEDITOR'].ENTER_BR,
+        shiftEnterMode: window['CKEDITOR'].ENTER_P,
+        disableNativeSpellChecker: false,
+        removePlugins: 'liststyle,tabletools,contextmenu',
+        extraAllowedContent: 'style;*[id,rel](*){*}',
+        toolbar: [
+          { name: 'clipboard', items: ['Paste', 'PasteText', 'PasteFromWord', 'Undo', 'Redo'] },
+          {
+            name: 'paragraph',
+            items: [
+              'NumberedList',
+              'BulletedList',
+              'Outdent',
+              'Indent',
+              'Blockquote',
+              'JustifyLeft',
+              'JustifyCenter',
+              'JustifyRight',
+              'JustifyBlock',
+              'BidiLtr',
+              'BidiRtl',
             ],
-            filebrowserImageUploadUrl: '/foo/bar/baz.cfm',
-          });
-        });
-
-        it('should return minimal config object', () => {
-            component.minimal = true;
-            expect(component.getBaseConfig()).toEqual({
-                enterMode: window['CKEDITOR'].ENTER_BR,
-                shiftEnterMode: window['CKEDITOR'].ENTER_P,
-                disableNativeSpellChecker: false,
-                removePlugins: 'liststyle,tabletools,contextmenu',
-                toolbar: [{
-                    name: 'basicstyles',
-                    items: ['Styles', 'FontSize', 'Bold', 'Italic', 'Underline', 'TextColor', '-', 'NumberedList', 'BulletedList', 'Outdent', 'Indent', 'Link']
-                }]
-            });
-        });
+          },
+          { name: 'links', items: ['Link'] },
+          { name: 'insert', items: ['Image', 'Table', 'HorizontalRule'] },
+          { name: 'tools', items: ['Maximize', 'Source'] },
+          '/',
+          { name: 'basicstyles', items: ['Bold', 'Italic', 'Underline', 'Strike', 'Subscript', 'Superscript'] },
+          { name: 'styles', items: ['Styles', 'Format', 'Font', 'FontSize'] },
+          { name: 'colors', items: ['TextColor', 'BGColor'] },
+        ],
+        filebrowserImageUploadUrl: '/foo/bar/baz.cfm',
+      });
     });
+
+    it('should return minimal config object', () => {
+      component.minimal = true;
+      expect(component.getBaseConfig()).toEqual({
+        enterMode: window['CKEDITOR'].ENTER_BR,
+        shiftEnterMode: window['CKEDITOR'].ENTER_P,
+        disableNativeSpellChecker: false,
+        removePlugins: 'liststyle,tabletools,contextmenu',
+        extraAllowedContent: 'style;*[id,rel](*){*}',
+        toolbar: [
+          {
+            name: 'basicstyles',
+            items: [
+              'Styles',
+              'FontSize',
+              'Bold',
+              'Italic',
+              'Underline',
+              'TextColor',
+              '-',
+              'NumberedList',
+              'BulletedList',
+              'Outdent',
+              'Indent',
+              'Link',
+            ],
+          },
+        ],
+      });
+    });
+  });
 });

--- a/src/platform/elements/ckeditor/CKEditor.ts
+++ b/src/platform/elements/ckeditor/CKEditor.ts
@@ -140,7 +140,7 @@ export class NovoCKEditorElement implements OnDestroy, AfterViewInit {
       shiftEnterMode: CKEDITOR.ENTER_P,
       disableNativeSpellChecker: false,
       removePlugins: 'liststyle,tabletools,contextmenu', // allows browser based spell checking
-      extraAllowedContent: 'style;*[id,rel](*){*}', // allows incoming <style> element, id/rel attributes, class names (*) and inline styles {*}
+      extraAllowedContent: '*(*){*};table tbody tr td th[*];', // allows class names (*) and inline styles {*} for all and attributes [*] on tables
     };
 
     const minimalConfig = {

--- a/src/platform/elements/ckeditor/CKEditor.ts
+++ b/src/platform/elements/ckeditor/CKEditor.ts
@@ -140,6 +140,7 @@ export class NovoCKEditorElement implements OnDestroy, AfterViewInit {
       shiftEnterMode: CKEDITOR.ENTER_P,
       disableNativeSpellChecker: false,
       removePlugins: 'liststyle,tabletools,contextmenu', // allows browser based spell checking
+      extraAllowedContent: 'style;*[id,rel](*){*}', // allows incoming <style> element, id/rel attributes, class names (*) and inline styles {*}
     };
 
     const minimalConfig = {

--- a/src/platform/elements/ckeditor/CKEditor.ts
+++ b/src/platform/elements/ckeditor/CKEditor.ts
@@ -4,9 +4,9 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 // Value accessor for the component (supports ngModel)
 const CKEDITOR_CONTROL_VALUE_ACCESSOR = {
-    provide: NG_VALUE_ACCESSOR,
-    useExisting: forwardRef(() => NovoCKEditorElement),
-    multi: true
+  provide: NG_VALUE_ACCESSOR,
+  useExisting: forwardRef(() => NovoCKEditorElement),
+  multi: true,
 };
 
 declare var CKEDITOR: any;
@@ -17,178 +17,207 @@ declare var CKEDITOR: any;
  *  <novo-editor [(ngModel)]="data" [config]="{...}" debounce="500"></novo-editor>
  */
 @Component({
-    selector: 'novo-editor',
-    providers: [CKEDITOR_CONTROL_VALUE_ACCESSOR],
-    template: '<textarea [name]="name" [id]="name" #host></textarea>'
+  selector: 'novo-editor',
+  providers: [CKEDITOR_CONTROL_VALUE_ACCESSOR],
+  template: '<textarea [name]="name" [id]="name" #host></textarea>',
 })
 export class NovoCKEditorElement implements OnDestroy, AfterViewInit {
-    @Input() config;
-    @Input() debounce;
-    @Input() name;
-    @Input() minimal;
-    @Input() startupFocus: boolean = false;
-    @Input() fileBrowserImageUploadUrl: string = '';
+  @Input() config;
+  @Input() debounce;
+  @Input() name;
+  @Input() minimal;
+  @Input() startupFocus: boolean = false;
+  @Input() fileBrowserImageUploadUrl: string = '';
 
-    @Output() change = new EventEmitter();
-    @Output() ready = new EventEmitter();
-    @Output() blur = new EventEmitter();
-    @Output() focus = new EventEmitter();
-    @Output() paste = new EventEmitter();
-    @Output() loaded = new EventEmitter();
-    @ViewChild('host') host;
+  @Output() change = new EventEmitter();
+  @Output() ready = new EventEmitter();
+  @Output() blur = new EventEmitter();
+  @Output() focus = new EventEmitter();
+  @Output() paste = new EventEmitter();
+  @Output() loaded = new EventEmitter();
+  @ViewChild('host') host;
 
-    _value: string = '';
-    instance;
-    debounceTimeout;
+  _value: string = '';
+  instance;
+  debounceTimeout;
 
-    constructor(private zone: NgZone) { }
+  constructor(private zone: NgZone) {}
 
-    get value() {
-        return this._value;
+  get value() {
+    return this._value;
+  }
+
+  @Input()
+  set value(v) {
+    if (v !== this._value) {
+      this._value = v;
+      this.onChange(v);
+    }
+  }
+
+  ngOnDestroy() {
+    if (this.instance) {
+      this.instance.focusManager.blur(true); // Remove focus from editor
+      setTimeout(() => {
+        this.instance.removeAllListeners();
+        CKEDITOR.instances[this.instance.name].destroy();
+        this.instance.destroy();
+        this.instance = null;
+      });
+    }
+  }
+
+  ngAfterViewInit() {
+    let config = this.config || this.getBaseConfig();
+    if (this.startupFocus) {
+      config.startupFocus = true;
+    }
+    this.ckeditorInit(config);
+  }
+
+  updateValue(value) {
+    this.zone.run(() => {
+      this.value = value;
+      this.onChange(value);
+      this.onTouched();
+      this.change.emit(value);
+    });
+  }
+
+  ckeditorInit(config) {
+    if (!CKEDITOR) {
+      console.error('Make sure to include CKEditor sources in your dependencies!');
+      return;
     }
 
-    @Input() set value(v) {
-        if (v !== this._value) {
-            this._value = v;
-            this.onChange(v);
+    // CKEditor replace textarea
+    this.instance = CKEDITOR.replace(this.host.nativeElement, config);
+
+    // Set initial value
+    this.instance.setData(this.value);
+
+    // listen for instanceReady event
+    this.instance.on('instanceReady', (evt) => {
+      // send the evt to the EventEmitter
+      this.ready.emit(evt);
+    });
+
+    // CKEditor change event
+    this.instance.on('change', () => {
+      this.onTouched();
+      let value = this.instance.getData();
+
+      // Debounce update
+      if (this.debounce) {
+        if (this.debounceTimeout) {
+          clearTimeout(this.debounceTimeout);
         }
+        this.debounceTimeout = setTimeout(() => {
+          this.updateValue(value);
+          this.debounceTimeout = null;
+        }, parseInt(this.debounce));
+      } else {
+        this.updateValue(value);
+      }
+    });
+    this.instance.on('blur', (event) => {
+      this.blur.emit(event);
+    });
+    this.instance.on('focus', (event) => {
+      this.focus.emit(event);
+    });
+    this.instance.on('paste', (event) => {
+      this.paste.emit(event);
+    });
+    this.instance.on('loaded', (event) => {
+      this.loaded.emit(event);
+    });
+  }
+
+  getBaseConfig() {
+    const baseConfig = {
+      enterMode: CKEDITOR.ENTER_BR,
+      shiftEnterMode: CKEDITOR.ENTER_P,
+      disableNativeSpellChecker: false,
+      removePlugins: 'liststyle,tabletools,contextmenu', // allows browser based spell checking
+    };
+
+    const minimalConfig = {
+      toolbar: [
+        {
+          name: 'basicstyles',
+          items: [
+            'Styles',
+            'FontSize',
+            'Bold',
+            'Italic',
+            'Underline',
+            'TextColor',
+            '-',
+            'NumberedList',
+            'BulletedList',
+            'Outdent',
+            'Indent',
+            'Link',
+          ],
+        },
+      ],
+    };
+
+    const extendedConfig = {
+      toolbar: [
+        { name: 'clipboard', items: ['Paste', 'PasteText', 'PasteFromWord', 'Undo', 'Redo'] },
+        {
+          name: 'paragraph',
+          items: [
+            'NumberedList',
+            'BulletedList',
+            'Outdent',
+            'Indent',
+            'Blockquote',
+            'JustifyLeft',
+            'JustifyCenter',
+            'JustifyRight',
+            'JustifyBlock',
+            'BidiLtr',
+            'BidiRtl',
+          ],
+        },
+        { name: 'links', items: ['Link'] },
+        { name: 'insert', items: ['Image', 'Table', 'HorizontalRule'] },
+        { name: 'tools', items: ['Maximize', 'Source'] },
+        '/', // line break
+        { name: 'basicstyles', items: ['Bold', 'Italic', 'Underline', 'Strike', 'Subscript', 'Superscript'] },
+        { name: 'styles', items: ['Styles', 'Format', 'Font', 'FontSize'] },
+        { name: 'colors', items: ['TextColor', 'BGColor'] },
+      ],
+      filebrowserImageUploadUrl: this.fileBrowserImageUploadUrl,
+    };
+
+    return Object.assign(baseConfig, this.minimal ? minimalConfig : extendedConfig);
+  }
+
+  writeValue(value) {
+    this._value = value;
+    if (this.instance) {
+      this.instance.setData(value);
     }
+  }
 
-    ngOnDestroy() {
-        if (this.instance) {
-            this.instance.focusManager.blur(true); // Remove focus from editor
-            setTimeout(() => {
-                this.instance.removeAllListeners();
-                CKEDITOR.instances[this.instance.name].destroy();
-                this.instance.destroy();
-                this.instance = null;
-            });
-        }
-    }
+  onChange(value?: any) {}
 
-    ngAfterViewInit() {
-        let config = this.config || this.getBaseConfig();
-        if (this.startupFocus) {
-            config.startupFocus = true;
-        }
-        this.ckeditorInit(config);
-    }
+  onTouched(event?) {}
 
-    updateValue(value) {
-        this.zone.run(() => {
-            this.value = value;
-            this.onChange(value);
-            this.onTouched();
-            this.change.emit(value);
-        });
-    }
+  registerOnChange(fn) {
+    this.onChange = fn;
+  }
 
-    ckeditorInit(config) {
-        if (!CKEDITOR) {
-            console.error('Make sure to include CKEditor sources in your dependencies!');
-            return;
-        }
+  registerOnTouched(fn) {
+    this.onTouched = fn;
+  }
 
-        // CKEditor replace textarea
-        this.instance = CKEDITOR.replace(this.host.nativeElement, config);
-
-        // Set initial value
-        this.instance.setData(this.value);
-
-        // listen for instanceReady event
-        this.instance.on('instanceReady', (evt) => {
-            // send the evt to the EventEmitter
-            this.ready.emit(evt);
-        });
-
-        // CKEditor change event
-        this.instance.on('change', () => {
-            this.onTouched();
-            let value = this.instance.getData();
-
-            // Debounce update
-            if (this.debounce) {
-                if (this.debounceTimeout) {
-                    clearTimeout(this.debounceTimeout);
-                }
-                this.debounceTimeout = setTimeout(() => {
-                    this.updateValue(value);
-                    this.debounceTimeout = null;
-                }, parseInt(this.debounce));
-            } else {
-                this.updateValue(value);
-            }
-        });
-        this.instance.on('blur', (event) => {
-            this.blur.emit(event);
-        });
-        this.instance.on('focus', (event) => {
-            this.focus.emit(event);
-        });
-        this.instance.on('paste', (event) => {
-            this.paste.emit(event);
-        });
-        this.instance.on('loaded', (event) => {
-            this.loaded.emit(event);
-        });
-    }
-
-    getBaseConfig() {
-        const baseConfig = {
-            enterMode: CKEDITOR.ENTER_BR,
-            shiftEnterMode: CKEDITOR.ENTER_P,
-            disableNativeSpellChecker: false,
-            removePlugins: 'liststyle,tabletools,contextmenu' // allows browser based spell checking
-        };
-
-        const minimalConfig = {
-            toolbar: [{
-                name: 'basicstyles',
-                items: ['Styles', 'FontSize', 'Bold', 'Italic', 'Underline', 'TextColor', '-', 'NumberedList', 'BulletedList', 'Outdent', 'Indent', 'Link']
-            }]
-        };
-
-        const extendedConfig = {
-            toolbar: [
-                { name: 'clipboard', items: ['Paste', 'PasteText', 'PasteFromWord', 'Undo', 'Redo'] },
-                { name: 'paragraph', items: ['NumberedList', 'BulletedList', 'Outdent', 'Indent', 'Blockquote', 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock', 'BidiLtr', 'BidiRtl'] },
-                { name: 'links', items: ['Link'] },
-                { name: 'insert', items: ['Image', 'Table', 'HorizontalRule'] },
-                { name: 'tools', items: ['Maximize', 'Source'] },
-                '/', // line break
-                { name: 'basicstyles', items: ['Bold', 'Italic', 'Underline', 'Strike', 'Subscript', 'Superscript'] },
-                { name: 'styles', items: ['Styles', 'Format', 'Font', 'FontSize'] },
-                { name: 'colors', items: ['TextColor', 'BGColor'] }
-            ],
-            filebrowserImageUploadUrl: this.fileBrowserImageUploadUrl,
-        };
-
-        return Object.assign(baseConfig, this.minimal ? minimalConfig : extendedConfig);
-    }
-
-    writeValue(value) {
-        this._value = value;
-        if (this.instance) {
-            this.instance.setData(value);
-        }
-    }
-
-    onChange(value?: any) {
-    }
-
-    onTouched(event?) {
-    }
-
-    registerOnChange(fn) {
-        this.onChange = fn;
-    }
-
-    registerOnTouched(fn) {
-        this.onTouched = fn;
-    }
-
-    insertText(text) {
-        let trimmedText = text.trim();
-        this.instance.insertText(trimmedText);
-    }
+  insertText(text) {
+    let trimmedText = text.trim();
+    this.instance.insertText(trimmedText);
+  }
 }


### PR DESCRIPTION
## **Description**

Allowing for more styles than just the default to be used when pasting html content into CKEditor. Whether user copy/paste or programmatic setting of the html content, this allows for less stripping of styles by CKEditor. Broken up into 2 commits - the first is the prettier automatic formatting of the file. The second commit is the 1 line change.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**

![editor styles](https://user-images.githubusercontent.com/3843503/43715499-4ca4ba4e-9946-11e8-88e6-974a589b1105.gif)
