### PR TITLE
fix(toast): Emit closed event for toasts that do not have a parent el…

### DIFF
--- a/src/platform/elements/toast/Toast.ts
+++ b/src/platform/elements/toast/Toast.ts
@@ -1,17 +1,17 @@
 // NG2
-import { Component, Input, OnInit, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, Input, OnInit, OnChanges, SimpleChanges, Output, EventEmitter } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
 @Component({
-    selector: 'novo-toast',
-    host: {
-        '[class]': 'alertTheme',
-        '[class.show]': 'show',
-        '[class.animate]': 'animate',
-        '[class.embedded]': 'embedded',
-        '(click)': '!isCloseable && clickHandler($event)'
-    },
-    template: `
+  selector: 'novo-toast',
+  host: {
+    '[class]': 'alertTheme',
+    '[class.show]': 'show',
+    '[class.animate]': 'animate',
+    '[class.embedded]': 'embedded',
+    '(click)': '!isCloseable && clickHandler($event)',
+  },
+  template: `
         <div class="toast-icon">
             <i [ngClass]="iconClass"></i>
         </div>
@@ -28,69 +28,79 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
         <div class="close-icon" *ngIf="isCloseable" (click)="close($event)">
             <i class="bhi-times"></i>
         </div>
-    `
+    `,
 })
 export class NovoToastElement implements OnInit, OnChanges {
-    @Input() theme: string = 'danger';
-    @Input() icon: string = 'caution';
-    @Input() title: string;
-    @Input() hasDialogue: boolean = false;
-    @Input() link: string;
-    @Input() isCloseable: boolean = false;
-    @Input() set message(m: string) {
-        this._message = this.sanitizer.bypassSecurityTrustHtml(m);
+  @Input() theme: string = 'danger';
+  @Input() icon: string = 'caution';
+  @Input() title: string;
+  @Input() hasDialogue: boolean = false;
+  @Input() link: string;
+  @Input() isCloseable: boolean = false;
+  @Input()
+  set message(m: string) {
+    this._message = this.sanitizer.bypassSecurityTrustHtml(m);
+  }
+  @Output() closed: EventEmitter<any> = new EventEmitter();
+
+  _message: SafeHtml;
+  show: boolean = false;
+  animate: boolean = false;
+  parent: any = null;
+  launched: boolean = false;
+  position: any;
+  time: any;
+  iconClass: string;
+  alertTheme: string;
+  embedded: any;
+
+  constructor(private sanitizer: DomSanitizer) {}
+
+  ngOnInit() {
+    if (!this.launched) {
+      // clear position and time
+      this.position = null;
+      this.time = null;
+
+      // set icon and styling
+      this.iconClass = `bhi-${this.icon}`;
+      this.alertTheme = `${this.theme} toast-container embedded`;
+      if (this.hasDialogue) {
+        this.alertTheme += ' dialogue';
+      }
     }
+  }
 
-    _message: SafeHtml;
-    show: boolean = false;
-    animate: boolean = false;
-    parent: any = null;
-    launched: boolean = false;
-    position: any;
-    time: any;
-    iconClass: string;
-    alertTheme: string;
-    embedded: any;
-
-    constructor(private sanitizer: DomSanitizer) { }
-
-    ngOnInit() {
-        if (!this.launched) {
-            // clear position and time
-            this.position = null;
-            this.time = null;
-
-            // set icon and styling
-            this.iconClass = `bhi-${this.icon}`;
-            this.alertTheme = `${this.theme} toast-container embedded`;
-            if (this.hasDialogue) { this.alertTheme += ' dialogue'; }
-        }
+  ngOnChanges(changes?: SimpleChanges) {
+    // set icon and styling
+    this.iconClass = `bhi-${this.icon}`;
+    this.alertTheme = `${this.theme} toast-container embedded`;
+    if (this.hasDialogue) {
+      this.alertTheme += ' dialogue';
     }
+  }
 
-    ngOnChanges(changes?: SimpleChanges) {
-        // set icon and styling
-        this.iconClass = `bhi-${this.icon}`;
-        this.alertTheme = `${this.theme} toast-container embedded`;
-        if (this.hasDialogue) { this.alertTheme += ' dialogue'; }
-    }
-
-    clickHandler(event) {
-        if (!this.isCloseable) {
-            if (event) {
-                event.stopPropagation();
-                event.preventDefault();
-            }
-            if (this.parent) {
-                this.parent.hide(this);
-            }
-        }
-    }
-
-    close(event) {
-        if (event) {
-            event.stopPropagation();
-            event.preventDefault();
-        }
+  clickHandler(event) {
+    if (!this.isCloseable) {
+      if (event) {
+        event.stopPropagation();
+        event.preventDefault();
+      }
+      if (this.parent) {
         this.parent.hide(this);
+      }
     }
+  }
+
+  close(event) {
+    if (event) {
+      event.stopPropagation();
+      event.preventDefault();
+    }
+    if (this.parent) {
+      this.parent.hide(this);
+    } else {
+      this.closed.emit({ closed: true });
+    }
+  }
 }

--- a/src/platform/elements/toast/Toast.ts
+++ b/src/platform/elements/toast/Toast.ts
@@ -88,6 +88,8 @@ export class NovoToastElement implements OnInit, OnChanges {
       }
       if (this.parent) {
         this.parent.hide(this);
+      } else {
+        this.closed.emit({ closed: true });
       }
     }
   }


### PR DESCRIPTION
…ement

## **Description**

Emit closed event if there is no parent element for the toast so that static toasts can be closed

#### **Verify that...**

- [ ] Any related demos where added and `npm start` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**