### PR TITLE
Handle overflow of header title and allow for spacing with the data-table pagination

### DIFF
--- a/src/app/pages/elements/data-table/DataTableDemo.ts
+++ b/src/app/pages/elements/data-table/DataTableDemo.ts
@@ -141,7 +141,8 @@ export class DataTableDemoComponent implements OnInit {
   public BasicDemoServiceTpl: string = BasicDemoServiceTpl;
   public RemoteDemoServiceTpl: string = RemoteDemoServiceTpl;
 
-  @ViewChild('basic') table: NovoDataTable<MockData>;
+  @ViewChild('basic')
+  table: NovoDataTable<MockData>;
 
   // Table configuration
   public dataSetOptions: any[] = [{ label: 'Dataset #1', value: 1 }, { label: 'Dataset #2', value: 2 }, { label: 'Dataset #3', value: 3 }];
@@ -326,6 +327,11 @@ export class DataTableDemoComponent implements OnInit {
   ];
   public sharedPaginationOptions: IDataTablePaginationOptions = {
     theme: 'standard',
+    pageSize: 10,
+    pageSizeOptions: [10, 50, 100, 250, 500],
+  };
+  public widePaginationOptions: IDataTablePaginationOptions = {
+    theme: 'basic-wide',
     pageSize: 10,
     pageSizeOptions: [10, 50, 100, 250, 500],
   };

--- a/src/app/pages/elements/data-table/templates/basic-remote.html
+++ b/src/app/pages/elements/data-table/templates/basic-remote.html
@@ -2,7 +2,7 @@
                  [columns]="sharedColumns"
                  [hideGlobalSearch]="!globalSearchEnabled"
                  [displayedColumns]="sharedDisplayColumns"
-                 [paginationOptions]="sharedPaginationOptions">
+                 [paginationOptions]="widePaginationOptions">
   <!-- Custom Cell -- passed with template property on Column -->
   <ng-template novoTemplate="custom"
                let-row

--- a/src/platform/elements/data-table/data-table.component.scss
+++ b/src/platform/elements/data-table/data-table.component.scss
@@ -440,7 +440,8 @@ novo-data-table {
 }
 
 novo-data-table-pagination {
-  &.basic {
+  &.basic,
+  &.basic-wide {
     display: flex;
     align-items: center;
     flex: 1;
@@ -453,12 +454,16 @@ novo-data-table-pagination {
     > .novo-data-table-range-label-long,
     > .novo-data-table-range-label-short {
       padding-right: 10px;
+      white-space: nowrap;
     }
     > .novo-data-table-range-label-long {
       display: none;
       @media (min-width: $breakpoint) {
         display: block;
       }
+    }
+    > .novo-data-table-spacer {
+      width: 100%;
     }
     > .novo-data-table-range-label-short {
       display: block;

--- a/src/platform/elements/data-table/interfaces.ts
+++ b/src/platform/elements/data-table/interfaces.ts
@@ -51,7 +51,7 @@ export interface IDataTableColumn<T> {
 }
 
 export interface IDataTablePaginationOptions {
-  theme: 'basic' | 'standard';
+  theme: 'basic' | 'standard' | 'basic-wide';
   page?: number;
   pageSize: number;
   pageSizeOptions: number[] | { value: string; label: string }[];

--- a/src/platform/elements/data-table/pagination/data-table-pagination.component.ts
+++ b/src/platform/elements/data-table/pagination/data-table-pagination.component.ts
@@ -21,7 +21,7 @@ const MAX_PAGES_DISPLAYED = 5;
 @Component({
   selector: 'novo-data-table-pagination',
   template: `
-      <ng-container *ngIf="theme === 'basic'">
+      <ng-container *ngIf="theme === 'basic' || theme === 'basic-wide'">
         <div class="novo-data-table-pagination-size">
             <novo-tiles *ngIf="displayedPageSizeOptions.length > 1"
                         [(ngModel)]="pageSize"
@@ -38,7 +38,7 @@ const MAX_PAGES_DISPLAYED = 5;
         <div class="novo-data-table-range-label-short" data-automation-id="novo-data-table-pagination-range-label-short">
             {{ shortRangeLabel }}
         </div>
-
+        <span class="spacer novo-data-table-spacer" *ngIf="theme === 'basic-wide'"></span>
         <button theme="dialogue" type="button"
                 class="novo-data-table-pagination-navigation-previous"
                 (click)="previousPage()"
@@ -124,7 +124,8 @@ export class NovoDataTablePagination<T> implements OnInit, OnDestroy {
   }
   _length: number = 0;
 
-  @Output() pageChange = new EventEmitter<IDataTablePaginationEvent>();
+  @Output()
+  pageChange = new EventEmitter<IDataTablePaginationEvent>();
 
   public displayedPageSizeOptions: { value: string; label: string }[];
   public longRangeLabel: string;

--- a/src/platform/elements/header/Header.scss
+++ b/src/platform/elements/header/Header.scss
@@ -12,11 +12,13 @@ header[theme] {
     div.header-title {
       display: flex;
       align-items: center;
+      max-width: calc(100% - 40px);
     }
     .header-titles {
       display: flex;
       flex-direction: column;
       padding: 0px 8px;
+      max-width: 100%;
       h1 {
         font-size: 1.7em;
         margin: 0;


### PR DESCRIPTION
Handle overflow of header title and allow for spacing with the data-table pagination

## **Description**

Data table prev/next can now show up on the right side of the table if you want (they have their own theme)
If a header title overflows, then correctly hide it

#### **Verify that...**

- [ ] Any related demos where added and `npm start` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**
![2018-08-10_0943](https://user-images.githubusercontent.com/181508/43961340-a99b2a00-9c82-11e8-9dab-8a3c8e861763.png)
