### PR TITLE
fix(Picker): Make picker results dynamic height so they fit on screen

### DIFF
--- a/src/platform/elements/chips/Chips.scss
+++ b/src/platform/elements/chips/Chips.scss
@@ -201,7 +201,7 @@ entity-chips {
         position: absolute;
         color: black;
         novo-list {
-            max-height: 450px;
+            max-height: 49vh;
             overflow: auto;
             novo-list-item {
                 flex: 0 0;
@@ -262,7 +262,7 @@ entity-chips {
             left: 0;
             width: 100%;
             min-width: 180px;
-            max-height: 450px;
+            max-height: 49vh;
             overflow: auto;
             z-index: 900;
             border: 1px solid #4A89DC;

--- a/src/platform/elements/picker/Picker.scss
+++ b/src/platform/elements/picker/Picker.scss
@@ -263,7 +263,7 @@ novo-picker {
 
 entity-picker-results {
     novo-list {
-        max-height: 450px;
+        max-height: 49vh;
         overflow: auto;
     }
 }


### PR DESCRIPTION
## **Description**

 Height of picker results is slightly less than half of the screen
 height so that they will always be able to be positioned above/below
 and still fit on screen. The static height of 450px was sometimes too
 tall for the window height.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**
![dynamic-picker-height](https://user-images.githubusercontent.com/3843503/44046415-fa3a2c34-9ef0-11e8-9a35-82e31adcaf7b.gif)
