### PR TITLE
add calibri font to ckeditor

### DIFF
--- a/src/platform/elements/ckeditor/CKEditor.spec.ts
+++ b/src/platform/elements/ckeditor/CKEditor.spec.ts
@@ -103,6 +103,17 @@ describe('Elements: NovoCKEditorElement', () => {
         disableNativeSpellChecker: false,
         removePlugins: 'liststyle,tabletools,contextmenu',
         extraAllowedContent: '*(*){*};table tbody tr td th[*];',
+        font_names:
+          'Arial/Arial, Helvetica, sans-serif;' +
+          'Calibri/Calibri, Verdana, Geneva, sans-serif;' +
+          'Comic Sans MS/Comic Sans MS, cursive;' +
+          'Courier New/Courier New, Courier, monospace;' +
+          'Georgia/Georgia, serif;' +
+          'Lucida Sans Unicode/Lucida Sans Unicode, Lucida Grande, sans-serif;' +
+          'Tahoma/Tahoma, Geneva, sans-serif;' +
+          'Times New Roman/Times New Roman, Times, serif;' +
+          'Trebuchet MS/Trebuchet MS, Helvetica, sans-serif;' +
+          'Verdana/Verdana, Geneva, sans-serif',
         toolbar: [
           { name: 'clipboard', items: ['Paste', 'PasteText', 'PasteFromWord', 'Undo', 'Redo'] },
           {
@@ -142,6 +153,17 @@ describe('Elements: NovoCKEditorElement', () => {
         disableNativeSpellChecker: false,
         removePlugins: 'liststyle,tabletools,contextmenu',
         extraAllowedContent: '*(*){*};table tbody tr td th[*];',
+        font_names:
+          'Arial/Arial, Helvetica, sans-serif;' +
+          'Calibri/Calibri, Verdana, Geneva, sans-serif;' +
+          'Comic Sans MS/Comic Sans MS, cursive;' +
+          'Courier New/Courier New, Courier, monospace;' +
+          'Georgia/Georgia, serif;' +
+          'Lucida Sans Unicode/Lucida Sans Unicode, Lucida Grande, sans-serif;' +
+          'Tahoma/Tahoma, Geneva, sans-serif;' +
+          'Times New Roman/Times New Roman, Times, serif;' +
+          'Trebuchet MS/Trebuchet MS, Helvetica, sans-serif;' +
+          'Verdana/Verdana, Geneva, sans-serif',
         toolbar: [
           { name: 'clipboard', items: ['Paste', 'PasteText', 'PasteFromWord', 'Undo', 'Redo'] },
           {
@@ -180,6 +202,17 @@ describe('Elements: NovoCKEditorElement', () => {
         disableNativeSpellChecker: false,
         removePlugins: 'liststyle,tabletools,contextmenu',
         extraAllowedContent: '*(*){*};table tbody tr td th[*];',
+        font_names:
+          'Arial/Arial, Helvetica, sans-serif;' +
+          'Calibri/Calibri, Verdana, Geneva, sans-serif;' +
+          'Comic Sans MS/Comic Sans MS, cursive;' +
+          'Courier New/Courier New, Courier, monospace;' +
+          'Georgia/Georgia, serif;' +
+          'Lucida Sans Unicode/Lucida Sans Unicode, Lucida Grande, sans-serif;' +
+          'Tahoma/Tahoma, Geneva, sans-serif;' +
+          'Times New Roman/Times New Roman, Times, serif;' +
+          'Trebuchet MS/Trebuchet MS, Helvetica, sans-serif;' +
+          'Verdana/Verdana, Geneva, sans-serif',
         toolbar: [
           {
             name: 'basicstyles',

--- a/src/platform/elements/ckeditor/CKEditor.ts
+++ b/src/platform/elements/ckeditor/CKEditor.ts
@@ -159,6 +159,17 @@ export class NovoCKEditorElement implements OnDestroy, AfterViewInit, ControlVal
       disableNativeSpellChecker: false,
       removePlugins: 'liststyle,tabletools,contextmenu', // allows browser based spell checking
       extraAllowedContent: '*(*){*};table tbody tr td th[*];', // allows class names (*) and inline styles {*} for all and attributes [*] on tables
+      font_names:
+        'Arial/Arial, Helvetica, sans-serif;' +
+        'Calibri/Calibri, Verdana, Geneva, sans-serif;' +
+        'Comic Sans MS/Comic Sans MS, cursive;' +
+        'Courier New/Courier New, Courier, monospace;' +
+        'Georgia/Georgia, serif;' +
+        'Lucida Sans Unicode/Lucida Sans Unicode, Lucida Grande, sans-serif;' +
+        'Tahoma/Tahoma, Geneva, sans-serif;' +
+        'Times New Roman/Times New Roman, Times, serif;' +
+        'Trebuchet MS/Trebuchet MS, Helvetica, sans-serif;' +
+        'Verdana/Verdana, Geneva, sans-serif',
     };
 
     const minimalConfig = {


### PR DESCRIPTION
## **Description**

add calibri as a font to ckeditor

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**