### PR TITLE
fix(NovoRowChipsElement) set picker input closeOnSelect default to true

### DIFF
--- a/src/platform/elements/chips/RowChips.ts
+++ b/src/platform/elements/chips/RowChips.ts
@@ -1,5 +1,5 @@
 // NG2
-import { Component, forwardRef, ElementRef } from '@angular/core';
+import { Component, forwardRef, ElementRef, Input } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 // Vendor
 // APP
@@ -65,6 +65,9 @@ export class NovoRowChipElement extends NovoChipElement {
    `,
 })
 export class NovoRowChipsElement extends NovoChipsElement {
+  @Input()
+  closeOnSelect: boolean = true;
+
   constructor(element: ElementRef, componentUtils: ComponentUtils, labels: NovoLabelService) {
     super(element, componentUtils, labels);
   }


### PR DESCRIPTION
Override default closeOnSelect to true in row-chips component.

## **Description**

Set the closeOnSelect to true as default for the NovoRowChipsElement.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**