### PR TITLE
fix(NovoRowChipsElement) adjust NovoRowChipsElement styling for consistency

### DIFF
--- a/src/app/pages/elements/chips/ChipsDemo.ts
+++ b/src/app/pages/elements/chips/ChipsDemo.ts
@@ -60,7 +60,7 @@ const template = `
     <p>
         By clicking on the <code>row-chips</code> element, the options list will be displayed.  Select any of the options
         by clicking on the item in the list.  The value selected will be added to the list of selected values as a new row. 
-        By clicking the delete icon at the end of the row, the row will be removec from the list of selected values.
+        By clicking the delete icon at the end of the row, the row will be removed from the list of selected values.
     </p>
     <div class="example chips-demo">${RowChipsDemoTpl}</div>
     <code-snippet [code]="RowChipsDemoTpl"></code-snippet>

--- a/src/platform/elements/chips/Chips.scss
+++ b/src/platform/elements/chips/Chips.scss
@@ -27,7 +27,8 @@ novo-entity-chips {
   &.disabled {
     border-bottom: none;
   }
-  chip {
+  chip,
+  novo-chip {
     display: flex;
     flex-grow: inherit;
     align-items: center;
@@ -143,8 +144,11 @@ novo-entity-chips {
 }
 
 chips,
-entity-chips {
-  chip {
+novo-chips,
+entity-chips,
+novo-entity-chips {
+  chip,
+  novo-chip {
     span {
       &.contact,
       &.clientcontact {

--- a/src/platform/elements/chips/Chips.scss
+++ b/src/platform/elements/chips/Chips.scss
@@ -337,7 +337,7 @@ novo-row-chip {
         flex: 0 0 275px;
       }
       span {
-        color: #26282b;
+        color: darken(#d9dadc, 10%);
         align-items: start;
         display: flex;
         overflow: hidden;

--- a/src/platform/elements/chips/Chips.ts
+++ b/src/platform/elements/chips/Chips.ts
@@ -68,7 +68,7 @@ export class NovoChipElement {
   selector: 'chips,novo-chips',
   providers: [CHIPS_VALUE_ACCESSOR],
   template: `
-        <chip
+        <novo-chip
             *ngFor="let item of _items | async"
             [type]="type || item?.value?.searchEntity"
             [class.selected]="item == selected"
@@ -76,7 +76,7 @@ export class NovoChipElement {
             (remove)="remove($event, item)"
             (select)="select($event, item)">
             {{ item.label }}
-        </chip>
+        </novo-chip>
         <div class="chip-input-container">
             <novo-picker
                 clearValueOnSelect="true"

--- a/src/platform/utils/form-utils/FormUtils.ts
+++ b/src/platform/utils/form-utils/FormUtils.ts
@@ -252,6 +252,7 @@ export class FormUtils {
       }
       if (overrides[field.name].columns) {
         controlConfig.config.columns = overrides[field.name].columns;
+        controlConfig.closeOnSelect = true;
         delete controlConfig.label;
       }
       Object.assign(controlConfig, overrides[field.name]);


### PR DESCRIPTION
## **Description**

Adjust NovoRowChipsElement styling to be more consistent with other novo-elements disabled fields. Fix typo on Chips demo page.

Update Chips styling so that selectors `chip`, `novo-chip`, `chips` and `novo-chips` have the same styling applied.
Update Chips template to use `novo-chip` tag rather than `chip` tag


#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**
![screen shot 2018-08-29 at 3 18 29 pm](https://user-images.githubusercontent.com/17855317/44810136-d023f500-ab9e-11e8-8ec1-aea36ce2fa7e.png)
