### PR TITLE
fix(NovoChipsElement) change chip hover functionality to deselect on mouseleave event

### DIFF
--- a/src/platform/elements/chips/Chips.ts
+++ b/src/platform/elements/chips/Chips.ts
@@ -21,7 +21,7 @@ const CHIPS_VALUE_ACCESSOR = {
 @Component({
   selector: 'chip,novo-chip',
   template: `
-        <span (click)="onSelect($event)" (mouseover)="onSelect($event)" [ngClass]="_type">
+        <span (click)="onSelect($event)" (mouseenter)="onSelect($event)" (mouseleave)="onDeselect($event)" [ngClass]="_type">
             <i *ngIf="_type" class="bhi-circle"></i>
             <span><ng-content></ng-content></span>
         </span>
@@ -41,6 +41,8 @@ export class NovoChipElement {
   select: EventEmitter<any> = new EventEmitter();
   @Output()
   remove: EventEmitter<any> = new EventEmitter();
+  @Output()
+  deselect: EventEmitter<any> = new EventEmitter();
 
   entity: string;
   _type: string;
@@ -62,6 +64,15 @@ export class NovoChipElement {
     this.select.emit(e);
     return false;
   }
+
+  onDeselect(e) {
+    if (e) {
+      e.stopPropagation();
+      e.preventDefault();
+    }
+    this.deselect.emit(e);
+    return false;
+  }
 }
 
 @Component({
@@ -74,7 +85,8 @@ export class NovoChipElement {
             [class.selected]="item == selected"
             [disabled]="disablePickerInput"
             (remove)="remove($event, item)"
-            (select)="select($event, item)">
+            (select)="select($event, item)"
+            (deselect)="deselect($event, item)">
             {{ item.label }}
         </novo-chip>
         <div class="chip-input-container">
@@ -243,6 +255,11 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
     this.deselectAll();
     this.selected = item;
     this.showPreview();
+  }
+
+  deselect(event?, item?) {
+    this.blur.emit(event);
+    this.deselectAll();
   }
 
   onTyping(event?) {


### PR DESCRIPTION
## **Description**

change the mouseover event to select on `mouseenter` and deselect on `mouseleave` events so that the chip outline and preview will hide on `mouseleave`.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**
![screen shot 2018-08-29 at 3 18 29 pm](https://user-images.githubusercontent.com/17855317/45053646-95b3cf80-b058-11e8-8a87-ca88e7cf08e4.png)
