### PR TITLE
prevent date picker overlay from opening when picker is disabled

### DIFF
--- a/src/platform/elements/date-picker/DatePickerInput.ts
+++ b/src/platform/elements/date-picker/DatePickerInput.ts
@@ -108,7 +108,9 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
 
   /** BEGIN: Convenient Panel Methods. */
   openPanel(): void {
-    this.overlay.openPanel();
+    if (!this.disabled) {
+      this.overlay.openPanel();
+    }
   }
   closePanel(): void {
     this.overlay.closePanel();


### PR DESCRIPTION
## **Description**

When you click a disabled date picker it opens the picker overlay.  This PR is to fix that.

![image](https://user-images.githubusercontent.com/4327754/45093326-ae19fd80-b0dd-11e8-8827-420ec433b5f9.png)

#### **Verify that...**

- [ ] Any related demos where added and `npm start` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**