### PR TITLE
add ability to put HTML in a tipwell

### DIFF
--- a/src/app/pages/elements/tip-well/TipWellDemo.ts
+++ b/src/app/pages/elements/tip-well/TipWellDemo.ts
@@ -4,6 +4,7 @@ import { Component } from '@angular/core';
 let TipWellDemoTpl = require('./templates/TipWellDemo.html');
 let TipWellNoButtonDemoTpl = require('./templates/TipWellNoButtonDemo.html');
 let TipWellIconDemoTpl = require('./templates/TipWellIconDemo.html');
+let TipWellHtmlDemoTpl = require('./templates/TipWellHtmlDemo.html');
 
 const template = `
 <div class="container">
@@ -32,21 +33,51 @@ const template = `
     <br />
     <h4>Code</h4>
     <code-snippet [code]="TipWellIconDemoTpl"></code-snippet>
+    <h4>HTML Demo</h4>
+    <div>${TipWellHtmlDemoTpl}</div>
+    <br />
+    <p>Did you hide the TipWell?</p>
+    <button theme="primary" color="success" icon="refresh" (click)="clearLocalStorage()">Reset localStorage and Reload</button>
+    <br />
+    <h4>Code</h4>
+    <code-snippet [code]="TipWellHtmlDemoTpl"></code-snippet>
 </div>
 `;
 
 @Component({
-    selector: 'tip-well-demo',
-    template: template
+  selector: 'tip-well-demo',
+  template: template,
 })
 export class TipWellDemoComponent {
-    private TipWellDemoTpl: string = TipWellDemoTpl;
-    private TipWellNoButtonDemoTpl: string = TipWellNoButtonDemoTpl;
-    private TipWellIconDemoTpl: string = TipWellIconDemoTpl;
-    private demoTip: string = 'Sed sodales ligula et fermentum bibendum. Aliquam tincidunt sagittis leo eget auctor. Fusce eu sagittis metus, ut viverra magna. Mauris mollis nisl nec libero tincidunt posuere.';
+  private TipWellDemoTpl: string = TipWellDemoTpl;
+  private TipWellNoButtonDemoTpl: string = TipWellNoButtonDemoTpl;
+  private TipWellIconDemoTpl: string = TipWellIconDemoTpl;
+  private TipWellHtmlDemoTpl: string = TipWellHtmlDemoTpl;
+  private demoTip: string =
+    'Sed sodales ligula et fermentum bibendum. Aliquam tincidunt sagittis leo eget auctor. Fusce eu sagittis metus, ut viverra magna. Mauris mollis nisl nec libero tincidunt posuere.';
+  private demoHtmlTip: string = `
+    <h2>Title</h2>
+    <p>Sed sodales ligula et fermentum bibendum. Aliquam tincidunt sagittis leo eget auctor. Fusce eu sagittis metus, ut viverra magna. Mauris mollis nisl nec libero tincidunt posuere.</p>
+    <table>
+        <tr>
+            <th width="305px">Firstname</th>
+            <th width="305px">Lastname</th> 
+            <th>Age</th>
+        </tr>
+        <tr>
+            <td>Jeff</td>
+            <td>Smith</td> 
+            <td>20</td>
+        </tr>
+        <tr>
+            <td>Seve</td>
+            <td>White</td> 
+            <td>25</td>
+        </tr>
+    </table>`;
 
-    clearLocalStorage() {
-        localStorage.removeItem('novo-tw_Demo');
-        location.reload();
-    }
+  clearLocalStorage() {
+    localStorage.removeItem('novo-tw_Demo');
+    location.reload();
+  }
 }

--- a/src/app/pages/elements/tip-well/templates/TipWellHtmlDemo.html
+++ b/src/app/pages/elements/tip-well/templates/TipWellHtmlDemo.html
@@ -1,0 +1,1 @@
+<novo-tip-well name="Demo" [tip]="demoHtmlTip"></novo-tip-well>

--- a/src/app/pages/elements/tip-well/templates/TipWellHtmlDemo.html
+++ b/src/app/pages/elements/tip-well/templates/TipWellHtmlDemo.html
@@ -1,1 +1,1 @@
-<novo-tip-well name="Demo" [tip]="demoHtmlTip"></novo-tip-well>
+<novo-tip-well name="Demo" [sanitize]="false" [tip]="demoHtmlTip"></novo-tip-well>

--- a/src/platform/elements/tip-well/TipWell.ts
+++ b/src/platform/elements/tip-well/TipWell.ts
@@ -4,73 +4,81 @@ import { Component, Input, OnInit, Output, EventEmitter } from '@angular/core';
 import { NovoLabelService } from '../../services/novo-label-service';
 
 @Component({
-    selector: 'novo-tip-well',
-    template: `
+  selector: 'novo-tip-well',
+  template: `
         <div *ngIf="isActive">
             <div>
                 <i class="bhi-{{ icon }}" *ngIf="icon" [attr.data-automation-id]="'novo-tip-well-icon-' + name"></i>
-                <p [attr.data-automation-id]="'novo-tip-well-tip-' + name">{{ tip }}</p>
+                <p [attr.data-automation-id]="'novo-tip-well-tip-' + name" [innerHTML]="tip"></p>
             </div>
             <button theme="dialogue" (click)="hideTip()" *ngIf="button" [attr.data-automation-id]="'novo-tip-well-button-' + name">{{ buttonText }}</button>
         </div>
     `,
-    host: {
-        '[class.active]': 'isActive'
-    }
+  host: {
+    '[class.active]': 'isActive',
+  },
 })
 export class NovoTipWellElement implements OnInit {
-    @Input() name: string | number;
-    @Input() tip: string;
-    @Input() buttonText: string;
-    @Input() button: boolean = true;
-    @Input() icon: string;
-    @Output() confirmed = new EventEmitter();
+  @Input()
+  name: string | number;
+  @Input()
+  tip: string;
+  @Input()
+  buttonText: string;
+  @Input()
+  button: boolean = true;
+  @Input()
+  icon: string;
+  @Output()
+  confirmed = new EventEmitter();
 
-    isActive: boolean = true;
-    isLocalStorageEnabled: any;
-    localStorageKey: string;
+  isActive: boolean = true;
+  isLocalStorageEnabled: any;
+  localStorageKey: string;
 
-    constructor(private labels: NovoLabelService) {
-        this.isActive = true;
-        // Check if localStorage is enabled
-        this.isLocalStorageEnabled = (() => {
-            let isEnabled = false;
-            if (typeof localStorage === 'object') {
-                try {
-                    localStorage.setItem('lsTest', '1');
-                    localStorage.removeItem('lsTest');
-                    isEnabled = true;
-                } catch (e) {
-                    console.warn('This web browser does not support storing settings locally. In Safari, the most common cause of this is using "Private Browsing Mode". Some settings may not save or some features may not work properly for you.');
-                }
-            }
-            return isEnabled;
-        })();
-    }
-
-    ngOnInit() {
-        this.tip = this.tip || '';
-        this.buttonText = this.buttonText || this.labels.okGotIt;
-        this.button = typeof this.button === 'string' ? this.button === 'true' : this.button;
-        this.icon = this.icon || null;
-        // Set a (semi) unique name for the tip-well
-        this.name = this.name || Math.round(Math.random() * 100);
-        this.localStorageKey = `novo-tw_${this.name}`;
-        // Check localStorage for state
-        if (this.isLocalStorageEnabled) {
-            let storedValue = JSON.parse(localStorage.getItem(this.localStorageKey));
-            this.isActive = storedValue !== false;
+  constructor(private labels: NovoLabelService) {
+    this.isActive = true;
+    // Check if localStorage is enabled
+    this.isLocalStorageEnabled = (() => {
+      let isEnabled = false;
+      if (typeof localStorage === 'object') {
+        try {
+          localStorage.setItem('lsTest', '1');
+          localStorage.removeItem('lsTest');
+          isEnabled = true;
+        } catch (e) {
+          console.warn(
+            'This web browser does not support storing settings locally. In Safari, the most common cause of this is using "Private Browsing Mode". Some settings may not save or some features may not work properly for you.',
+          );
         }
-    }
+      }
+      return isEnabled;
+    })();
+  }
 
-    /**
-     * @name hideTip
-     */
-    hideTip() {
-        if (this.isLocalStorageEnabled) {
-            localStorage.setItem(this.localStorageKey, JSON.stringify(false));
-        }
-        this.isActive = false;
-        this.confirmed.emit();
+  ngOnInit() {
+    this.tip = this.tip || '';
+    this.buttonText = this.buttonText || this.labels.okGotIt;
+    this.button = typeof this.button === 'string' ? this.button === 'true' : this.button;
+    this.icon = this.icon || null;
+    // Set a (semi) unique name for the tip-well
+    this.name = this.name || Math.round(Math.random() * 100);
+    this.localStorageKey = `novo-tw_${this.name}`;
+    // Check localStorage for state
+    if (this.isLocalStorageEnabled) {
+      let storedValue = JSON.parse(localStorage.getItem(this.localStorageKey));
+      this.isActive = storedValue !== false;
     }
+  }
+
+  /**
+   * @name hideTip
+   */
+  hideTip() {
+    if (this.isLocalStorageEnabled) {
+      localStorage.setItem(this.localStorageKey, JSON.stringify(false));
+    }
+    this.isActive = false;
+    this.confirmed.emit();
+  }
 }

--- a/src/platform/elements/tip-well/TipWell.ts
+++ b/src/platform/elements/tip-well/TipWell.ts
@@ -9,7 +9,8 @@ import { NovoLabelService } from '../../services/novo-label-service';
         <div *ngIf="isActive">
             <div>
                 <i class="bhi-{{ icon }}" *ngIf="icon" [attr.data-automation-id]="'novo-tip-well-icon-' + name"></i>
-                <p [attr.data-automation-id]="'novo-tip-well-tip-' + name" [innerHTML]="tip"></p>
+                <p *ngIf="sanitize" [attr.data-automation-id]="'novo-tip-well-tip-' + name">{{ tip }}</p>
+                <p *ngIf="!sanitize" [attr.data-automation-id]="'novo-tip-well-tip-' + name" [innerHTML]="tip"></p>
             </div>
             <button theme="dialogue" (click)="hideTip()" *ngIf="button" [attr.data-automation-id]="'novo-tip-well-button-' + name">{{ buttonText }}</button>
         </div>
@@ -29,6 +30,8 @@ export class NovoTipWellElement implements OnInit {
   button: boolean = true;
   @Input()
   icon: string;
+  @Input()
+  sanitize: boolean = true;
   @Output()
   confirmed = new EventEmitter();
 


### PR DESCRIPTION
## **Description**

I added the ability to use HTML in a tipwell for more structured information.

![image](https://user-images.githubusercontent.com/4327754/45360136-4a3b7d00-b594-11e8-9397-7f5dae9c9802.png)

### Before (existing tipwell demo)
![image](https://user-images.githubusercontent.com/4327754/45360192-70611d00-b594-11e8-89b8-dfee7b12ad72.png)


### After (existing tipwell demo)
![image](https://user-images.githubusercontent.com/4327754/45360156-57586c00-b594-11e8-93fa-dbeaf8b2a749.png)

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**