### PR TITLE
add back in removed masked options accidentally removed in #810

### DIFF
--- a/src/platform/elements/form/NovoFormControl.ts
+++ b/src/platform/elements/form/NovoFormControl.ts
@@ -5,6 +5,7 @@ import { EventEmitter } from '@angular/core';
 import { NovoControlConfig } from './FormControls';
 import { IFieldInteractionEvent } from './FormInterfaces';
 import { notify } from '../../utils/notifier/notifier.util';
+import { IMaskOptions } from './Control';
 
 export class NovoFormControl extends FormControl {
   displayValueChanges: EventEmitter<any> = new EventEmitter<any>();
@@ -43,7 +44,11 @@ export class NovoFormControl extends FormControl {
   layoutOptions?: { order?: string; download?: boolean; labelStyle?: string; draggable?: boolean; iconStyle?: string };
   military?: boolean;
   dateFormat?: string;
+  currencyFormat?: string;
+  startDate?: Date | Number;
+  endDate?: Date | Number;
   textMaskEnabled?: boolean;
+  maskOptions: IMaskOptions;
   allowInvalidDate?: boolean;
   tipWell?: {
     tip: string;
@@ -88,7 +93,12 @@ export class NovoFormControl extends FormControl {
     this.layoutOptions = control.layoutOptions;
     this.military = control.military;
     this.dateFormat = control.dateFormat;
+    this.currencyFormat = control.currencyFormat;
+    this.startDate = control.startDate;
+    this.endDate = control.endDate;
     this.textMaskEnabled = control.textMaskEnabled;
+    this.textMaskEnabled = control.textMaskEnabled;
+    this.maskOptions = control.maskOptions;
     this.allowInvalidDate = control.allowInvalidDate;
     this.maxlength = control.maxlength;
     this.minlength = control.minlength;


### PR DESCRIPTION
## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**