### PR TITLE
fix(Dropdown): Defaulting dropdowns to use dynamic width

### DIFF
--- a/src/app/pages/elements/dropdown/templates/DropdownDemo.html
+++ b/src/app/pages/elements/dropdown/templates/DropdownDemo.html
@@ -10,7 +10,7 @@
     <item tooltip="Test tooltip :)"
           tooltipPosition="right"
           [disabled]="true"
-          (action)="clickMe()">Poop</item>
+          (action)="clickMe()">Menu Item With Lots of Text in it to Show Dynamic Width</item>
     <dropdown-item-header>Section 2</dropdown-item-header>
     <item (action)="clickMe('Hello!')">Germany</item>
     <item (action)="clickMe('Another!')">Algebra</item>
@@ -37,5 +37,6 @@
     <item>Action 8</item>
     <item>Action 9</item>
     <item>Action 10</item>
+    <item>Menu Item With Lots of Text in it to Show Dynamic Width</item>
   </list>
 </novo-dropdown>

--- a/src/platform/elements/dropdown/Dropdown.ts
+++ b/src/platform/elements/dropdown/Dropdown.ts
@@ -50,7 +50,7 @@ export class NovoDropdownElement implements OnInit, OnDestroy {
     'default';
   @Input() scrollStrategy: 'reposition' | 'block' | 'close' = 'reposition';
   @Input() height: number;
-  @Input() width: number = 180;
+  @Input() width: number = -1; // Defaults to dynamic width (no hardcoded width value and no host width lookup)
   @Input() appendToBody: boolean = false; // Deprecated
 
   @Output() toggled: EventEmitter<boolean> = new EventEmitter<boolean>();


### PR DESCRIPTION
## **Description**

Changed the default width value for dropdowns to be dynamic. Updated tests to verify behavior.

#### **Verify that...**

- [ ] Any related demos where added and `npm start` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**

![image](https://user-images.githubusercontent.com/3843503/45504994-fcb83f00-b750-11e8-8102-9943c13b4c7f.png)
