### PR TITLE
fix(Chips): Chips disabled state styling fix

### DIFF
--- a/src/platform/elements/chips/Chips.scss
+++ b/src/platform/elements/chips/Chips.scss
@@ -25,7 +25,7 @@ novo-entity-chips {
     }
   }
   &.disabled {
-    border-bottom: none;
+    border-bottom-style: dashed !important;
   }
   chip,
   novo-chip {
@@ -136,6 +136,9 @@ novo-entity-chips {
     > input {
       border: none;
       border-bottom: none !important;
+      &:disabled {
+        border-bottom: none !important;
+      }
     }
   }
   &.with-value {


### PR DESCRIPTION
## **Description**

Remove bottom border on picker inside of chips element and add a bottom border to entire chips element.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**

##### **Previous**
![screen shot 2018-09-13 at 2 19 16 pm](https://user-images.githubusercontent.com/17855317/45507844-31cc8d80-b761-11e8-9c34-39bd84b56ad3.png)
##### **Fixed**
![screen shot 2018-09-13 at 2 18 30 pm](https://user-images.githubusercontent.com/17855317/45507873-41e46d00-b761-11e8-8e26-0714ae4af10d.png)
