### PR TITLE
F/error state count

### DIFF
--- a/src/platform/elements/form/Control.ts
+++ b/src/platform/elements/form/Control.ts
@@ -231,6 +231,7 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
 
   get showErrorState() {
     return (
+      this.showCount ||
       (this.isDirty && this.errors) ||
       (this.maxLengthMet && this.focused && this.errors && !this.errors.maxlengthFields) ||
       (this.focused && this.errors && this.errors.maxlength && this.errors.maxlengthFields && this.maxlengthErrorField)

--- a/src/platform/elements/form/Control.ts
+++ b/src/platform/elements/form/Control.ts
@@ -100,7 +100,7 @@ export class NovoAutoSize implements AfterContentInit {
                         </div>
                     </div>
                     <!--Error Message-->
-                    <div class="field-message {{ form.controls[control.key].controlType }}" *ngIf="!condensed" [class.has-tip]="form.controls[control.key].tipWell" [ngClass]="showErrorState ? 'error-shown' : 'error-hidden'">
+                    <div class="field-message {{ form.controls[control.key].controlType }}" *ngIf="!condensed" [class.has-tip]="form.controls[control.key].tipWell" [ngClass]="showErrorState || showMaxLengthMetMessage ? 'error-shown' : 'error-hidden'">
                         <div class="messages" [ngClass]="showCount ? 'count-shown' : 'count-hidden'">
                             <span class="error-text" *ngIf="showFieldMessage"></span>
                             <span class="error-text" *ngIf="isDirty && errors?.required && form.controls[control.key].controlType !== 'address'">{{ form.controls[control.key].label | uppercase }} {{ labels.isRequired }}</span>
@@ -229,10 +229,20 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
     return !this.errors && !this.maxLengthMet && Helpers.isBlank(this.control.description);
   }
 
+  get showMaxLengthMetMessage() {
+    return (
+      (this.isDirty && this.maxLengthMet && this.focused && (!this.errors || (this.errors && !this.errors.maxlength))) ||
+      (this.isDirty &&
+        this.maxlengthMetField &&
+        this.focused &&
+        (!this.errors || (this.errors && !this.errors.maxlengthFields.includes(this.maxlengthMetField))))
+    );
+  }
+
   get showErrorState() {
     return (
       (this.isDirty && this.errors) ||
-      (this.maxLengthMet && this.focused && this.errors && !this.errors.maxlengthFields) ||
+      (this.focused && this.errors && this.errors.maxlength && this.errors.maxlengthFields) ||
       (this.focused && this.errors && this.errors.maxlength && this.errors.maxlengthFields && this.maxlengthErrorField)
     );
   }

--- a/src/platform/elements/form/Control.ts
+++ b/src/platform/elements/form/Control.ts
@@ -101,7 +101,7 @@ export class NovoAutoSize implements AfterContentInit {
                     </div>
                     <!--Error Message-->
                     <div class="field-message {{ form.controls[control.key].controlType }}" *ngIf="!condensed" [class.has-tip]="form.controls[control.key].tipWell" [ngClass]="showErrorState ? 'error-shown' : 'error-hidden'">
-                        <div class="messages">
+                        <div class="messages" [ngClass]="showCount ? 'count-shown' : 'count-hidden'">
                             <span class="error-text" *ngIf="showFieldMessage"></span>
                             <span class="error-text" *ngIf="isDirty && errors?.required && form.controls[control.key].controlType !== 'address'">{{ form.controls[control.key].label | uppercase }} {{ labels.isRequired }}</span>
                             <span class="error-text" *ngIf="isDirty && errors?.minlength">{{ form.controls[control.key].label | uppercase }} {{ labels.minLength }} {{ form.controls[control.key].minlength }}</span>
@@ -231,7 +231,6 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
 
   get showErrorState() {
     return (
-      this.showCount ||
       (this.isDirty && this.errors) ||
       (this.maxLengthMet && this.focused && this.errors && !this.errors.maxlengthFields) ||
       (this.focused && this.errors && this.errors.maxlength && this.errors.maxlengthFields && this.maxlengthErrorField)


### PR DESCRIPTION
## **Description**

Setting classes based on if the error message or the word count warning is shown.

#### **Verify that...**

- [ ] Any related demos where added and `npm start` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**