### PR TITLE
WIP: feat(FileInput,BaseControl): Add flag to hide remove button

### DIFF
--- a/src/platform/elements/form/controls/BaseControl.spec.ts
+++ b/src/platform/elements/form/controls/BaseControl.spec.ts
@@ -82,7 +82,7 @@ describe('Control: BaseControl', () => {
         optionsType: 'TYPE',
         maxlength: 100,
         disabled: true,
-        layoutOptions: { remove: false },
+        layoutOptions: { removable: false },
         fileBrowserImageUploadUrl: '/foo/bar/baz',
         textMaskEnabled: true,
         maskOptions: { mask: ['TEST_MASK_OPTIONS'], keepCharPositions: false, guide: true },
@@ -141,7 +141,7 @@ describe('Control: BaseControl', () => {
       expect(control.disabled).toEqual(true);
     });
     it('should set the layoutOptions', () => {
-      expect(control.layoutOptions).toEqual({ remove: false });
+      expect(control.layoutOptions).toEqual({ removable: false });
     });
     it('should set fileBrowserImageUploadUrl', () => {
       expect(control.fileBrowserImageUploadUrl).toEqual('/foo/bar/baz');

--- a/src/platform/elements/form/controls/BaseControl.spec.ts
+++ b/src/platform/elements/form/controls/BaseControl.spec.ts
@@ -82,6 +82,7 @@ describe('Control: BaseControl', () => {
         optionsType: 'TYPE',
         maxlength: 100,
         disabled: true,
+        layoutOptions: { remove: false },
         fileBrowserImageUploadUrl: '/foo/bar/baz',
         textMaskEnabled: true,
         maskOptions: { mask: ['TEST_MASK_OPTIONS'], keepCharPositions: false, guide: true },
@@ -138,6 +139,9 @@ describe('Control: BaseControl', () => {
     });
     it('should set the disabled', () => {
       expect(control.disabled).toEqual(true);
+    });
+    it('should set the layoutOptions', () => {
+      expect(control.layoutOptions).toEqual({ remove: false });
     });
     it('should set fileBrowserImageUploadUrl', () => {
       expect(control.fileBrowserImageUploadUrl).toEqual('/foo/bar/baz');

--- a/src/platform/elements/form/controls/BaseControl.ts
+++ b/src/platform/elements/form/controls/BaseControl.ts
@@ -66,7 +66,7 @@ export interface NovoControlConfig {
     labelStyle?: string;
     draggable?: boolean;
     iconStyle?: string;
-    remove?: boolean;
+    removable?: boolean;
   };
   template?: any;
   customControlConfig?: any;
@@ -140,7 +140,7 @@ export class BaseControl {
     labelStyle?: string;
     draggable?: boolean;
     iconStyle?: string;
-    remove?: boolean;
+    removable?: boolean;
   };
   template?: any;
   customControlConfig?: any;

--- a/src/platform/elements/form/controls/BaseControl.ts
+++ b/src/platform/elements/form/controls/BaseControl.ts
@@ -66,6 +66,7 @@ export interface NovoControlConfig {
     labelStyle?: string;
     draggable?: boolean;
     iconStyle?: string;
+    remove?: boolean;
   };
   template?: any;
   customControlConfig?: any;
@@ -133,7 +134,14 @@ export class BaseControl {
   tooltipPreline?: boolean;
   removeTooltipArrow?: boolean;
   tooltipAutoPosition?: boolean;
-  layoutOptions?: { order?: string; download?: boolean; labelStyle?: string; draggable?: boolean; iconStyle?: string };
+  layoutOptions?: {
+    order?: string;
+    download?: boolean;
+    labelStyle?: string;
+    draggable?: boolean;
+    iconStyle?: string;
+    remove?: boolean;
+  };
   template?: any;
   customControlConfig?: any;
   military?: boolean;

--- a/src/platform/elements/form/extras/file/FileInput.spec.ts
+++ b/src/platform/elements/form/extras/file/FileInput.spec.ts
@@ -61,12 +61,13 @@ describe('Elements: NovoFileInputElement', () => {
         });
     });
     describe('Method: updateLayout()', () => {
-        it('should set layoutOptions and call insertTemplatesBasedOnLayout', () => {
+        it('should set default layoutOptions and call insertTemplatesBasedOnLayout', () => {
             expect(component.updateLayout).toBeDefined();
             expect(component.layoutOptions).not.toBeDefined();
             spyOn(component, 'insertTemplatesBasedOnLayout');
             component.updateLayout();
             expect(component.layoutOptions).toBeDefined();
+            expect(component.layoutOptions).toEqual({ order: 'default', download: true, remove: true, labelStyle: 'default', draggable: false });
             expect(component.insertTemplatesBasedOnLayout).toHaveBeenCalled();
         });
     });

--- a/src/platform/elements/form/extras/file/FileInput.spec.ts
+++ b/src/platform/elements/form/extras/file/FileInput.spec.ts
@@ -67,7 +67,7 @@ describe('Elements: NovoFileInputElement', () => {
             spyOn(component, 'insertTemplatesBasedOnLayout');
             component.updateLayout();
             expect(component.layoutOptions).toBeDefined();
-            expect(component.layoutOptions).toEqual({ order: 'default', download: true, remove: true, labelStyle: 'default', draggable: false });
+            expect(component.layoutOptions).toEqual({ order: 'default', download: true, removable: true, labelStyle: 'default', draggable: false });
             expect(component.insertTemplatesBasedOnLayout).toHaveBeenCalled();
         });
     });

--- a/src/platform/elements/form/extras/file/FileInput.ts
+++ b/src/platform/elements/form/extras/file/FileInput.ts
@@ -13,7 +13,7 @@ const FILE_VALUE_ACCESSOR = {
     multi: true
 };
 
-const LAYOUT_DEFAULTS = { order: 'default', download: true, labelStyle: 'default', draggable: false };
+const LAYOUT_DEFAULTS = { order: 'default', download: true, remove: true, labelStyle: 'default', draggable: false };
 
 @Component({
   selector: 'novo-file-input',
@@ -44,7 +44,7 @@ const LAYOUT_DEFAULTS = { order: 'default', download: true, labelStyle: 'default
                   <div class="actions" [attr.data-automation-id]="'file-actions'" *ngIf="file.loaded">
                     <div *ngIf="!layoutOptions.customActions">
                       <button *ngIf="layoutOptions.download" type="button" theme="icon" icon="save" (click)="download(file)" [attr.data-automation-id]="'file-download'" tabindex="-1"></button>
-                      <button *ngIf="!disabled" type="button" theme="icon" icon="close" (click)="remove(file)" [attr.data-automation-id]="'file-remove'" tabindex="-1"></button>
+                      <button *ngIf="!disabled && layoutOptions.remove" type="button" theme="icon" icon="close" (click)="remove(file)" [attr.data-automation-id]="'file-remove'" tabindex="-1"></button>
                     </div>
                     <div *ngIf="layoutOptions.customActions">
                       <button *ngIf="layoutOptions.edit && !disabled" type="button" theme="icon" icon="edit" (click)="customEdit(file)" [attr.data-automation-id]="'file-edit'" tabindex="-1"></button>
@@ -67,7 +67,7 @@ export class NovoFileInputElement implements ControlValueAccessor, OnInit, OnDes
   @Input() multiple: boolean = false;
   @Input() disabled: boolean = false;
   @Input() placeholder: string;
-  @Input() layoutOptions: { order?: string; download?: boolean; edit?: boolean; labelStyle?: string; draggable?: boolean };
+  @Input() layoutOptions: { order?: string; download?: boolean; remove?: boolean; edit?: boolean; labelStyle?: string; draggable?: boolean };
   @Input() value: Array<any> = [];
 
   @Output() edit: EventEmitter<any> = new EventEmitter();

--- a/src/platform/elements/form/extras/file/FileInput.ts
+++ b/src/platform/elements/form/extras/file/FileInput.ts
@@ -13,7 +13,7 @@ const FILE_VALUE_ACCESSOR = {
     multi: true
 };
 
-const LAYOUT_DEFAULTS = { order: 'default', download: true, remove: true, labelStyle: 'default', draggable: false };
+const LAYOUT_DEFAULTS = { order: 'default', download: true, removable: true, labelStyle: 'default', draggable: false };
 
 @Component({
   selector: 'novo-file-input',
@@ -44,7 +44,7 @@ const LAYOUT_DEFAULTS = { order: 'default', download: true, remove: true, labelS
                   <div class="actions" [attr.data-automation-id]="'file-actions'" *ngIf="file.loaded">
                     <div *ngIf="!layoutOptions.customActions">
                       <button *ngIf="layoutOptions.download" type="button" theme="icon" icon="save" (click)="download(file)" [attr.data-automation-id]="'file-download'" tabindex="-1"></button>
-                      <button *ngIf="!disabled && layoutOptions.remove" type="button" theme="icon" icon="close" (click)="remove(file)" [attr.data-automation-id]="'file-remove'" tabindex="-1"></button>
+                      <button *ngIf="!disabled && layoutOptions.removable" type="button" theme="icon" icon="close" (click)="remove(file)" [attr.data-automation-id]="'file-remove'" tabindex="-1"></button>
                     </div>
                     <div *ngIf="layoutOptions.customActions">
                       <button *ngIf="layoutOptions.edit && !disabled" type="button" theme="icon" icon="edit" (click)="customEdit(file)" [attr.data-automation-id]="'file-edit'" tabindex="-1"></button>
@@ -67,7 +67,7 @@ export class NovoFileInputElement implements ControlValueAccessor, OnInit, OnDes
   @Input() multiple: boolean = false;
   @Input() disabled: boolean = false;
   @Input() placeholder: string;
-  @Input() layoutOptions: { order?: string; download?: boolean; remove?: boolean; edit?: boolean; labelStyle?: string; draggable?: boolean };
+  @Input() layoutOptions: { order?: string; download?: boolean; removable?: boolean; edit?: boolean; labelStyle?: string; draggable?: boolean };
   @Input() value: Array<any> = [];
 
   @Output() edit: EventEmitter<any> = new EventEmitter();


### PR DESCRIPTION
## **Description**

Add a flag in FileInput to hide the "remove" button.
Default the flag to true to maintain current default behavior.
Add the flag property to all relevant classes and interfaces.

#### **Verify that...**

- [ ] Any related demos where added and `npm start` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**