### PR TITLE
fix(picker): Change to handle empty use case

### DIFF
--- a/src/platform/elements/picker/extras/base-picker-results/BasePickerResults.ts
+++ b/src/platform/elements/picker/extras/base-picker-results/BasePickerResults.ts
@@ -348,9 +348,8 @@ export class BasePickerResults {
    * @description This function should return a <strong>-tag wrapped HTML string.
    */
   highlight(match, query) {
-    query = query.trim();
     // Replaces the capture string with a the same string inside of a "strong" tag
-    return query ? match.replace(new RegExp(this.escapeRegexp(query), 'gi'), '<strong>$&</strong>') : match;
+    return query ? match.replace(new RegExp(this.escapeRegexp(query.trim()), 'gi'), '<strong>$&</strong>') : match;
   }
 
   preselected(match) {

--- a/src/platform/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
+++ b/src/platform/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
@@ -105,9 +105,8 @@ export class EntityPickerResult {
    * @description This function should return a <strong>-tag wrapped HTML string.
    */
   highlight(match, query) {
-    query = query.trim();
     // Replaces the capture string with a the same string inside of a "strong" tag
-    return query && match ? match.replace(new RegExp(this.escapeRegexp(query), 'gi'), '<strong>$&</strong>') : match;
+    return query && match ? match.replace(new RegExp(this.escapeRegexp(query.trim()), 'gi'), '<strong>$&</strong>') : match;
   }
 
   getIconForResult(result?: any): string {


### PR DESCRIPTION
## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**