### PR TITLE
add default option for static tooltips

### DIFF
--- a/src/platform/elements/card/Card.spec.ts
+++ b/src/platform/elements/card/Card.spec.ts
@@ -3,107 +3,99 @@ import { TestBed, async } from '@angular/core/testing';
 // App
 import { CardElement } from './Card';
 import { NovoLoadingElement } from '../loading/Loading';
-import { TooltipDirective } from '../tooltip/Tooltip';
+import { TooltipDirective } from '../tooltip/Tooltip.directive';
 import { NovoLabelService } from '../../services/novo-label-service';
 
 describe('Elements: CardElement', () => {
-    let fixture;
-    let component;
+  let fixture;
+  let component;
 
-    beforeEach(async(() => {
-        TestBed.configureTestingModule({
-            declarations: [
-                CardElement,
-                NovoLoadingElement,
-                TooltipDirective
-            ],
-            providers: [
-                { provide: NovoLabelService, useClass: NovoLabelService }
-            ]
-        }).compileComponents();
-        fixture = TestBed.createComponent(CardElement);
-        component = fixture.debugElement.componentInstance;
-    }));
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [CardElement, NovoLoadingElement, TooltipDirective],
+      providers: [{ provide: NovoLabelService, useClass: NovoLabelService }],
+    }).compileComponents();
+    fixture = TestBed.createComponent(CardElement);
+    component = fixture.debugElement.componentInstance;
+  }));
 
-    describe('Method: ngOnInit()', () => {
-        it('should initialize correctly', () => {
-            expect(component).toBeTruthy();
-            expect(component.ngOnInit).toBeDefined();
-            expect(component.onClose).toBeDefined();
-            expect(component.onRefresh).toBeDefined();
-            expect(component.padding).toBeTruthy();
-        });
+  describe('Method: ngOnInit()', () => {
+    it('should initialize correctly', () => {
+      expect(component).toBeTruthy();
+      expect(component.ngOnInit).toBeDefined();
+      expect(component.onClose).toBeDefined();
+      expect(component.onRefresh).toBeDefined();
+      expect(component.padding).toBeTruthy();
+    });
+  });
+
+  describe('Method: ngOnChanges()', () => {
+    it('should be defined', () => {
+      expect(component.ngOnChanges).toBeDefined();
     });
 
-    describe('Method: ngOnChanges()', () => {
-        it('should be defined', () => {
-            expect(component.ngOnChanges).toBeDefined();
-        });
-
-        it('should set defaults', () => {
-            component.ngOnChanges();
-            expect(component.config).toBeDefined();
-            expect(component.cardAutomationId).toBe('no-title-card');
-            expect(component.iconClass).toBeFalsy();
-            expect(component.messageIconClass).toBeFalsy();
-        });
-
-        it('should setup with value set on component', () => {
-            component.title = 'test';
-            component.icon = 'test';
-            component.messageIcon = 'test';
-            component.ngOnChanges();
-            expect(component.cardAutomationId).toBe('test-card');
-            expect(component.iconClass).toBe('bhi-test');
-            expect(component.messageIconClass).toBe('bhi-test');
-        });
-
-        it('should setup with value set in config', () => {
-            component.config = {
-                title: 'test',
-                icon: 'test',
-                messageIcon: 'test'
-            };
-            component.ngOnChanges();
-            expect(component.cardAutomationId).toBe('test-card');
-            expect(component.iconClass).toBe('bhi-test');
-            expect(component.messageIconClass).toBe('bhi-test');
-        });
+    it('should set defaults', () => {
+      component.ngOnChanges();
+      expect(component.config).toBeDefined();
+      expect(component.cardAutomationId).toBe('no-title-card');
+      expect(component.iconClass).toBeFalsy();
+      expect(component.messageIconClass).toBeFalsy();
     });
 
-    describe('Method: toggleClose()', () => {
-        it('should emit close event', () => {
-            spyOn(component.onClose, 'next');
-            component.toggleClose();
-            expect(component.onClose.next).toHaveBeenCalledWith();
-        });
-
-        it('should call close function if defined in config', () => {
-            component.config.onClose = () => {
-            };
-            spyOn(component.onClose, 'next');
-            spyOn(component.config, 'onClose');
-            component.toggleClose();
-            expect(component.onClose.next).not.toHaveBeenCalled();
-            expect(component.config.onClose).toHaveBeenCalled();
-        });
+    it('should setup with value set on component', () => {
+      component.title = 'test';
+      component.icon = 'test';
+      component.messageIcon = 'test';
+      component.ngOnChanges();
+      expect(component.cardAutomationId).toBe('test-card');
+      expect(component.iconClass).toBe('bhi-test');
+      expect(component.messageIconClass).toBe('bhi-test');
     });
 
-    describe('Method: toggleRefresh()', () => {
-        it('should emit close event', () => {
-            spyOn(component.onRefresh, 'next');
-            component.toggleRefresh();
-            expect(component.onRefresh.next).toHaveBeenCalledWith();
-        });
-
-        it('should call refresh function if defined in config', () => {
-            component.config.onRefresh = () => {
-            };
-            spyOn(component.onRefresh, 'next');
-            spyOn(component.config, 'onRefresh');
-            component.toggleRefresh();
-            expect(component.onRefresh.next).not.toHaveBeenCalled();
-            expect(component.config.onRefresh).toHaveBeenCalled();
-        });
+    it('should setup with value set in config', () => {
+      component.config = {
+        title: 'test',
+        icon: 'test',
+        messageIcon: 'test',
+      };
+      component.ngOnChanges();
+      expect(component.cardAutomationId).toBe('test-card');
+      expect(component.iconClass).toBe('bhi-test');
+      expect(component.messageIconClass).toBe('bhi-test');
     });
+  });
+
+  describe('Method: toggleClose()', () => {
+    it('should emit close event', () => {
+      spyOn(component.onClose, 'next');
+      component.toggleClose();
+      expect(component.onClose.next).toHaveBeenCalledWith();
+    });
+
+    it('should call close function if defined in config', () => {
+      component.config.onClose = () => {};
+      spyOn(component.onClose, 'next');
+      spyOn(component.config, 'onClose');
+      component.toggleClose();
+      expect(component.onClose.next).not.toHaveBeenCalled();
+      expect(component.config.onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('Method: toggleRefresh()', () => {
+    it('should emit close event', () => {
+      spyOn(component.onRefresh, 'next');
+      component.toggleRefresh();
+      expect(component.onRefresh.next).toHaveBeenCalledWith();
+    });
+
+    it('should call refresh function if defined in config', () => {
+      component.config.onRefresh = () => {};
+      spyOn(component.onRefresh, 'next');
+      spyOn(component.config, 'onRefresh');
+      component.toggleRefresh();
+      expect(component.onRefresh.next).not.toHaveBeenCalled();
+      expect(component.config.onRefresh).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/platform/elements/card/Card.spec.ts
+++ b/src/platform/elements/card/Card.spec.ts
@@ -5,6 +5,7 @@ import { CardElement } from './Card';
 import { NovoLoadingElement } from '../loading/Loading';
 import { TooltipDirective } from '../tooltip/Tooltip.directive';
 import { NovoLabelService } from '../../services/novo-label-service';
+import { OverlayModule } from '@angular/cdk/overlay';
 
 describe('Elements: CardElement', () => {
   let fixture;
@@ -14,6 +15,7 @@ describe('Elements: CardElement', () => {
     TestBed.configureTestingModule({
       declarations: [CardElement, NovoLoadingElement, TooltipDirective],
       providers: [{ provide: NovoLabelService, useClass: NovoLabelService }],
+      imports: [OverlayModule],
     }).compileComponents();
     fixture = TestBed.createComponent(CardElement);
     component = fixture.debugElement.componentInstance;

--- a/src/platform/elements/form/ControlTemplates.ts
+++ b/src/platform/elements/form/ControlTemplates.ts
@@ -12,7 +12,7 @@ import { TextMaskModule } from 'angular2-text-mask';
         </ng-template>
         <!--Textbox--->
         <ng-template novoTemplate="textbox" let-control let-form="form" let-errors="errors" let-methods="methods">
-          <div [formGroup]="form" class="novo-control-input-container novo-control-input-with-label" [tooltip]="control?.tooltip" [tooltipPosition]="control?.tooltipPosition"  [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow">
+          <div [formGroup]="form" class="novo-control-input-container novo-control-input-with-label" [tooltip]="control?.tooltip" [tooltipPosition]="control?.tooltipPosition"  [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" [tooltipAutoPosition]="control?.tooltipAutoPosition">
             <input *ngIf="control?.type !== 'number' && control?.textMaskEnabled" [textMask]="control.maskOptions" [formControlName]="control.key" [id]="control.key" [type]="control?.type" [placeholder]="control?.placeholder" (input)="methods.emitChange($event)" (focus)="methods.handleFocus($event)" (blur)="methods.handleBlur($event)" autocomplete>
             <input *ngIf="control?.type !== 'number' && !control?.textMaskEnabled" [class.maxlength-error]="errors?.maxlength" [formControlName]="control.key" [id]="control.key" [type]="control?.type" [placeholder]="control?.placeholder" (input)="methods.emitChange($event)" [maxlength]="control?.maxlength" (focus)="methods.handleFocus($event)" (blur)="methods.handleBlur($event)" autocomplete>
             <input *ngIf="control?.type === 'number' && control?.subType !== 'percentage'" [class.maxlength-error]="errors?.maxlength" [formControlName]="control.key" [id]="control.key" [type]="control?.type" [placeholder]="control?.placeholder" (keydown)="methods.restrictKeys($event)" (input)="methods.emitChange($event)" [maxlength]="control?.maxlength" (focus)="methods.handleFocus($event)" (blur)="methods.handleBlur($event)" step="any" (mousewheel)="numberInput.blur()" #numberInput>
@@ -24,7 +24,7 @@ import { TextMaskModule } from 'angular2-text-mask';
 
         <!--Textarea--->
         <ng-template novoTemplate="text-area" let-control let-form="form" let-errors="errors" let-methods="methods">
-          <div class="textarea-container" [formGroup]="form" [tooltip]="control?.tooltip" [tooltipPosition]="control?.tooltipPosition"  [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow">
+          <div class="textarea-container" [formGroup]="form" [tooltip]="control?.tooltip" [tooltipPosition]="control?.tooltipPosition"  [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" [tooltipAutoPosition]="control?.tooltipAutoPosition">
             <textarea [class.maxlength-error]="errors?.maxlength" [name]="control.key" [attr.id]="control.key" [placeholder]="control.placeholder" [formControlName]="control.key" autosize (input)="methods.handleTextAreaInput($event)" (focus)="methods.handleFocus($event)" (blur)="methods.handleBlur($event)" [maxlength]="control?.maxlength"></textarea>
           </div>
         </ng-template>
@@ -46,7 +46,7 @@ import { TextMaskModule } from 'angular2-text-mask';
         <!--HTML5 Select-->
         <ng-template novoTemplate="native-select" let-control let-form="form" let-errors="errors" let-methods="methods">
           <div [formGroup]="form">
-            <select [id]="control.key" [formControlName]="control.key" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition"  [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow">
+            <select [id]="control.key" [formControlName]="control.key" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition"  [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" [tooltipAutoPosition]="control?.tooltipAutoPosition">
                 <option *ngIf="control.placeholder" value="" disabled selected hidden>{{ control.placeholder }}</option>
                 <option *ngFor="let opt of control.options" [value]="opt.key">{{opt.value}}</option>
             </select>
@@ -56,50 +56,50 @@ import { TextMaskModule } from 'angular2-text-mask';
         <!--File-->
         <ng-template novoTemplate="file" let-control let-form="form" let-errors="errors" let-methods="methods">
           <div [formGroup]="form">
-            <novo-file-input [formControlName]="control.key" [id]="control.key" [name]="control.key" [placeholder]="control.placeholder" [value]="control.value" [multiple]="control.multiple" [layoutOptions]="control.layoutOptions" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition"  [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" (edit)="methods.handleEdit($event)" (save)="methods.handleSave($event)" (delete)="methods.handleDelete($event)" (upload)="methods.handleUpload($event)"></novo-file-input>
+            <novo-file-input [formControlName]="control.key" [id]="control.key" [name]="control.key" [placeholder]="control.placeholder" [value]="control.value" [multiple]="control.multiple" [layoutOptions]="control.layoutOptions" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition"  [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" [tooltipAutoPosition]="control?.tooltipAutoPosition" (edit)="methods.handleEdit($event)" (save)="methods.handleSave($event)" (delete)="methods.handleDelete($event)" (upload)="methods.handleUpload($event)"></novo-file-input>
           </div>
         </ng-template>
 
         <!--Tiles-->
         <ng-template novoTemplate="tiles" let-control let-form="form" let-errors="errors" let-methods="methods">
           <div [formGroup]="form">
-            <novo-tiles [options]="control.options" [formControlName]="control.key" (onChange)="methods.modelChange($event)" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition"  [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" [controlDisabled]="control.disabled"></novo-tiles>
+            <novo-tiles [options]="control.options" [formControlName]="control.key" (onChange)="methods.modelChange($event)" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition"  [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" [tooltipAutoPosition]="control?.tooltipAutoPosition" [controlDisabled]="control.disabled"></novo-tiles>
           </div>
         </ng-template>
 
         <!--Picker-->
         <ng-template novoTemplate="picker" let-control let-form="form" let-errors="errors" let-methods="methods">
           <div [formGroup]="form" class="novo-control-input-container">
-            <novo-picker [config]="control.config" [formControlName]="control.key" [placeholder]="control.placeholder" [parentScrollSelector]="control.parentScrollSelector" *ngIf="!control.multiple" (select)="methods.modelChange($event);" (changed)="methods.modelChangeWithRaw($event)" (typing)="methods.handleTyping($event)" (focus)="methods.handleFocus($event)" (blur)="methods.handleBlur($event)" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow"></novo-picker>
-            <novo-chips [source]="control.config" [type]="control.config.type" [formControlName]="control.key" [placeholder]="control.placeholder" *ngIf="control.multiple && !control.config.columns" [closeOnSelect]="control.closeOnSelect" (changed)="methods.modelChangeWithRaw($event)" (typing)="methods.handleTyping($event)" (focus)="methods.handleFocus($event)" (blur)="methods.handleBlur($event)" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow"></novo-chips>
-            <novo-row-chips [source]="control.config" [type]="control.config.type" [formControlName]="control.key" [placeholder]="control.placeholder" *ngIf="control.multiple && control.config.columns" [closeOnSelect]="control.closeOnSelect" (changed)="methods.modelChangeWithRaw($event)" (typing)="methods.handleTyping($event)" (focus)="methods.handleFocus($event)" (blur)="methods.handleBlur($event)" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow"></novo-row-chips>
+            <novo-picker [config]="control.config" [formControlName]="control.key" [placeholder]="control.placeholder" [parentScrollSelector]="control.parentScrollSelector" *ngIf="!control.multiple" (select)="methods.modelChange($event);" (changed)="methods.modelChangeWithRaw($event)" (typing)="methods.handleTyping($event)" (focus)="methods.handleFocus($event)" (blur)="methods.handleBlur($event)" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" [tooltipAutoPosition]="control?.tooltipAutoPosition"></novo-picker>
+            <novo-chips [source]="control.config" [type]="control.config.type" [formControlName]="control.key" [placeholder]="control.placeholder" *ngIf="control.multiple && !control.config.columns" [closeOnSelect]="control.closeOnSelect" (changed)="methods.modelChangeWithRaw($event)" (typing)="methods.handleTyping($event)" (focus)="methods.handleFocus($event)" (blur)="methods.handleBlur($event)" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" [tooltipAutoPosition]="control?.tooltipAutoPosition"></novo-chips>
+            <novo-row-chips [source]="control.config" [type]="control.config.type" [formControlName]="control.key" [placeholder]="control.placeholder" *ngIf="control.multiple && control.config.columns" [closeOnSelect]="control.closeOnSelect" (changed)="methods.modelChangeWithRaw($event)" (typing)="methods.handleTyping($event)" (focus)="methods.handleFocus($event)" (blur)="methods.handleBlur($event)" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" [tooltipAutoPosition]="control?.tooltipAutoPosition"></novo-row-chips>
           </div>
         </ng-template>
 
         <!--Novo Select-->
         <ng-template novoTemplate="select" let-control let-form="form" let-errors="errors" let-methods="methods">
           <div [formGroup]="form">
-            <novo-select [options]="control.options" [headerConfig]="control.headerConfig" [placeholder]="control.placeholder" [formControlName]="control.key" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" (onSelect)="methods.modelChange($event)"></novo-select>
+            <novo-select [options]="control.options" [headerConfig]="control.headerConfig" [placeholder]="control.placeholder" [formControlName]="control.key" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" [tooltipAutoPosition]="control?.tooltipAutoPosition" (onSelect)="methods.modelChange($event)"></novo-select>
           </div>
         </ng-template>
 
         <!--Radio-->
         <ng-template novoTemplate="radio" let-control let-form="form" let-errors="errors" let-methods="methods">
           <div [formGroup]="form" class="novo-control-input-container">
-            <novo-radio [vertical]="vertical" [name]="control.key" [formControlName]="control.key" *ngFor="let option of control.options" [value]="option.value" [label]="option.label" [checked]="option.value === form.value[control.key]" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" [button]="!!option.icon" [icon]="option.icon" [attr.data-automation-id]="control.key + '-' + (option?.label || option?.value)"></novo-radio>
+            <novo-radio [vertical]="vertical" [name]="control.key" [formControlName]="control.key" *ngFor="let option of control.options" [value]="option.value" [label]="option.label" [checked]="option.value === form.value[control.key]" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" [tooltipAutoPosition]="control?.tooltipAutoPosition" [button]="!!option.icon" [icon]="option.icon" [attr.data-automation-id]="control.key + '-' + (option?.label || option?.value)"></novo-radio>
           </div>
         </ng-template>
 
         <!--Time-->
         <ng-template novoTemplate="time" let-control let-form="form" let-errors="errors" let-methods="methods">
-          <div [formGroup]="form" class="novo-control-input-container" [tooltip]="control?.tooltip" [tooltipPosition]="control?.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow">
+          <div [formGroup]="form" class="novo-control-input-container" [tooltip]="control?.tooltip" [tooltipPosition]="control?.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" [tooltipAutoPosition]="control?.tooltipAutoPosition">
             <novo-time-picker-input [attr.id]="control.key" [name]="control.key" [formControlName]="control.key" [placeholder]="control.placeholder" [military]="control.military"></novo-time-picker-input>
           </div>
         </ng-template>
 
         <!--Date-->
         <ng-template novoTemplate="date" let-control let-form="form" let-errors="errors" let-methods="methods">
-          <div [formGroup]="form" class="novo-control-input-container" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow">
+          <div [formGroup]="form" class="novo-control-input-container" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" [tooltipAutoPosition]="control?.tooltipAutoPosition">
             <novo-date-picker-input [attr.id]="control.key" [name]="control.key" [formControlName]="control.key" [start]="control.startDate" [end]="control.endDate" [format]="control.dateFormat" [allowInvalidDate]="control.allowInvalidDate" [textMaskEnabled]="control.textMaskEnabled" [placeholder]="control.placeholder" (focusEvent)="methods.handleFocus($event)" (blurEvent)="methods.handleBlur($event)"></novo-date-picker-input>
           </div>
         </ng-template>
@@ -107,7 +107,7 @@ import { TextMaskModule } from 'angular2-text-mask';
 
         <!--Date and Time-->
         <ng-template novoTemplate="date-time" let-control let-form="form" let-errors="errors" let-methods="methods">
-          <div [formGroup]="form" class="novo-control-input-container" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow">
+          <div [formGroup]="form" class="novo-control-input-container" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" [tooltipAutoPosition]="control?.tooltipAutoPosition">
             <novo-date-time-picker-input [attr.id]="control.key" [name]="control.key" [formControlName]="control.key" [start]="control.startDate" [end]="control.endDate" [placeholder]="control.placeholder" [military]="control.military" (focusEvent)="methods.handleFocus($event)" (blurEvent)="methods.handleBlur($event)"></novo-date-time-picker-input>
           </div>
         </ng-template>
@@ -122,21 +122,21 @@ import { TextMaskModule } from 'angular2-text-mask';
         <!--Checkbox-->
         <ng-template novoTemplate="checkbox" let-control let-form="form" let-errors="errors" let-methods="methods">
           <div [formGroup]="form">
-            <novo-checkbox [formControlName]="control?.key" [name]="control?.key" [label]="control?.checkboxLabel" [tooltip]="control?.tooltip" [tooltipPosition]="control?.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" [layoutOptions]="control?.layoutOptions"></novo-checkbox>
+            <novo-checkbox [formControlName]="control?.key" [name]="control?.key" [label]="control?.checkboxLabel" [tooltip]="control?.tooltip" [tooltipPosition]="control?.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" [tooltipAutoPosition]="control?.tooltipAutoPosition" [layoutOptions]="control?.layoutOptions"></novo-checkbox>
           </div>
         </ng-template>
 
         <!--Checklist-->
         <ng-template novoTemplate="checklist" let-control let-form="form" let-errors="errors" let-methods="methods">
           <div [formGroup]="form">
-            <novo-check-list [formControlName]="control.key" [name]="control.key" [options]="control?.options" [tooltip]="control?.tooltip" [tooltipPosition]="control?.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" (onSelect)="methods.modelChange($event)"></novo-check-list>
+            <novo-check-list [formControlName]="control.key" [name]="control.key" [options]="control?.options" [tooltip]="control?.tooltip" [tooltipPosition]="control?.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" [tooltipAutoPosition]="control?.tooltipAutoPosition" (onSelect)="methods.modelChange($event)"></novo-check-list>
           </div>
         </ng-template>
 
         <!--QuickNote-->
         <ng-template novoTemplate="quick-note" let-control let-form="form" let-errors="errors" let-methods="methods">
           <div [formGroup]="form">
-            <novo-quick-note [formControlName]="control.key" [startupFocus]="control?.startupFocus" [placeholder]="control?.placeholder" [config]="control?.config" (change)="methods.modelChange($event)" [tooltip]="control?.tooltip" [tooltipPosition]="control?.tooltipPosition" [tooltipSize]="control?.tooltipSize" [removeTooltipArrow]="control?.removeTooltipArrow" [tooltipPreline]="control?.tooltipPreline"></novo-quick-note>
+            <novo-quick-note [formControlName]="control.key" [startupFocus]="control?.startupFocus" [placeholder]="control?.placeholder" [config]="control?.config" (change)="methods.modelChange($event)" [tooltip]="control?.tooltip" [tooltipPosition]="control?.tooltipPosition" [tooltipSize]="control?.tooltipSize" [removeTooltipArrow]="control?.removeTooltipArrow" [tooltipAutoPosition]="control?.tooltipAutoPosition" [tooltipPreline]="control?.tooltipPreline"></novo-quick-note>
           </div>
         </ng-template>
     `,

--- a/src/platform/elements/form/NovoFormControl.ts
+++ b/src/platform/elements/form/NovoFormControl.ts
@@ -21,6 +21,7 @@ export class NovoFormControl extends FormControl {
   tooltipSize?: string;
   tooltipPreline?: boolean;
   removeTooltipArrow?: boolean;
+  tooltipAutoPosition?: boolean;
   initialValue: any;
   valueHistory: any[] = [];
   validators: any;
@@ -82,6 +83,7 @@ export class NovoFormControl extends FormControl {
     this.tooltipSize = control.tooltipSize;
     this.tooltipPreline = control.tooltipPreline;
     this.removeTooltipArrow = control.removeTooltipArrow;
+    this.tooltipAutoPosition = control.tooltipAutoPosition;
     this.label = control.label;
     this.name = control.name;
     this.required = control.required;

--- a/src/platform/elements/form/controls/BaseControl.ts
+++ b/src/platform/elements/form/controls/BaseControl.ts
@@ -57,6 +57,7 @@ export interface NovoControlConfig {
   tooltipSize?: string;
   tooltipPreline?: boolean;
   removeTooltipArrow?: boolean;
+  tooltipAutoPosition?: boolean;
   layoutOptions?: {
     order?: string;
     download?: boolean;
@@ -131,6 +132,7 @@ export class BaseControl {
   tooltipSize?: string;
   tooltipPreline?: boolean;
   removeTooltipArrow?: boolean;
+  tooltipAutoPosition?: boolean;
   layoutOptions?: { order?: string; download?: boolean; labelStyle?: string; draggable?: boolean; iconStyle?: string };
   template?: any;
   customControlConfig?: any;
@@ -216,6 +218,7 @@ export class BaseControl {
       this.tooltipSize = config.tooltipSize;
       this.tooltipPreline = config.tooltipPreline;
       this.removeTooltipArrow = config.removeTooltipArrow;
+      this.tooltipAutoPosition = config.tooltipAutoPosition;
     }
     this.template = config.template;
     this.customControlConfig = config.customControlConfig;

--- a/src/platform/elements/table/Table.spec.ts
+++ b/src/platform/elements/table/Table.spec.ts
@@ -31,7 +31,7 @@ import { NovoLoadingElement } from '../loading/Loading';
 import { NovoItemElement, NovoListElement } from '../dropdown/Dropdown';
 import { NovoChipsElement, NovoChipElement } from '../chips/Chips';
 import { NovoDropdownElement } from '../dropdown/Dropdown';
-import { TooltipDirective } from '../tooltip/Tooltip';
+import { TooltipDirective } from '../tooltip/Tooltip.directive';
 import { NovoSelectElement } from '../select/Select';
 
 import { NovoLabelService } from '../../services/novo-label-service';
@@ -40,655 +40,652 @@ import { DateFormatService } from '../../services/date-format/DateFormat';
 import { OptionsService } from '../../services/options/OptionsService';
 
 describe('Elements: NovoTableElement', () => {
-    let fixture;
-    let component;
+  let fixture;
+  let component;
 
-    beforeEach(async(() => {
-        TestBed.configureTestingModule({
-            declarations: [
-                // Table:
-                NovoTableElement,
-                Pagination,
-                RowDetails,
-                TableCell,
-                TableFilter,
-                ThOrderable,
-                ThSortable,
-                NovoTableKeepFilterFocus,
-                NovoTableActionsElement,
-                NovoTableFooterElement,
-                NovoTableHeaderElement,
-                // Form:
-                NovoFormElement,
-                NovoControlElement,
-                NovoCheckboxElement,
-                NovoCheckListElement,
-                NovoAddressElement,
-                // Novo Elements
-                NovoDatePickerElement,
-                NovoToastElement,
-                NovoListElement,
-                NovoChipElement,
-                NovoLoadingElement,
-                NovoItemElement,
-                NovoChipsElement,
-                NovoDropdownElement,
-                TooltipDirective,
-                NovoSelectElement,
-                // NG2
-                FormGroupDirective,
-                FormControlName,
-            ],
-            imports: [
-                FormsModule,
-                //Vendor
-                TextMaskModule,
-                OverlayModule,
-                NovoOverlayModule
-            ],
-            providers: [
-                { provide: NovoLabelService, useClass: NovoLabelService },
-                { provide: FormUtils, useClass: FormUtils },
-                OptionsService,
-                NgControl,
-                FormBuilder,
-                DateFormatService
-            ],
-            schemas: [
-                CUSTOM_ELEMENTS_SCHEMA
-            ]
-        }).compileComponents();
-        fixture = TestBed.createComponent(NovoTableElement);
-        component = fixture.debugElement.componentInstance;
-    }));
-
-    it('should initialize with all of its defaults.', () => {
-        expect(component).toBeDefined();
-        component._rows = [];
-        component.mode = 'TEST';
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        // Table:
+        NovoTableElement,
+        Pagination,
+        RowDetails,
+        TableCell,
+        TableFilter,
+        ThOrderable,
+        ThSortable,
+        NovoTableKeepFilterFocus,
+        NovoTableActionsElement,
+        NovoTableFooterElement,
+        NovoTableHeaderElement,
+        // Form:
+        NovoFormElement,
+        NovoControlElement,
+        NovoCheckboxElement,
+        NovoCheckListElement,
+        NovoAddressElement,
+        // Novo Elements
+        NovoDatePickerElement,
+        NovoToastElement,
+        NovoListElement,
+        NovoChipElement,
+        NovoLoadingElement,
+        NovoItemElement,
+        NovoChipsElement,
+        NovoDropdownElement,
+        TooltipDirective,
+        NovoSelectElement,
         // NG2
-        expect(component.onRowClick).toBeDefined();
-        expect(component.onRowSelect).toBeDefined();
-        expect(component.onTableChange).toBeDefined();
-        // Vars
-        expect(component.activeId).toBeDefined();
-        expect(component.master).toBeDefined();
-        expect(component.indeterminate).toBeDefined();
-        expect(component.lastPage).toBeDefined();
-        expect(component.rows).toBeDefined();
-        // Setters
-        component.rows = [];
-        component.dataProvider = [];
-        // Getters
-        expect(component.dataProvider).toBeDefined();
-        expect(component.editing).toBeDefined();
-        expect(component.formValue).toBeDefined();
+        FormGroupDirective,
+        FormControlName,
+      ],
+      imports: [
+        FormsModule,
+        //Vendor
+        TextMaskModule,
+        OverlayModule,
+        NovoOverlayModule,
+      ],
+      providers: [
+        { provide: NovoLabelService, useClass: NovoLabelService },
+        { provide: FormUtils, useClass: FormUtils },
+        OptionsService,
+        NgControl,
+        FormBuilder,
+        DateFormatService,
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+    fixture = TestBed.createComponent(NovoTableElement);
+    component = fixture.debugElement.componentInstance;
+  }));
+
+  it('should initialize with all of its defaults.', () => {
+    expect(component).toBeDefined();
+    component._rows = [];
+    component.mode = 'TEST';
+    // NG2
+    expect(component.onRowClick).toBeDefined();
+    expect(component.onRowSelect).toBeDefined();
+    expect(component.onTableChange).toBeDefined();
+    // Vars
+    expect(component.activeId).toBeDefined();
+    expect(component.master).toBeDefined();
+    expect(component.indeterminate).toBeDefined();
+    expect(component.lastPage).toBeDefined();
+    expect(component.rows).toBeDefined();
+    // Setters
+    component.rows = [];
+    component.dataProvider = [];
+    // Getters
+    expect(component.dataProvider).toBeDefined();
+    expect(component.editing).toBeDefined();
+    expect(component.formValue).toBeDefined();
+  });
+
+  describe('Method: onDropdownToggled()', () => {
+    it('should be defined.', () => {
+      expect(component.onDropdownToggled).toBeDefined();
+      component.onDropdownToggled();
+    });
+  });
+
+  describe('Method: onPageChange()', () => {
+    it('should be defined.', () => {
+      expect(component.onPageChange).toBeDefined();
+      component.onPageChange();
+    });
+  });
+
+  describe('Method: getOptionDataAutomationId()', () => {
+    it('should be defined.', () => {
+      expect(component.getOptionDataAutomationId).toBeDefined();
+      component.getOptionDataAutomationId({ value: 2 });
+    });
+  });
+
+  describe('Method: setupColumnDefaults()', () => {
+    it('should be defined.', () => {
+      expect(component.setupColumnDefaults).toBeDefined();
+      component.columns = [{ type: 'misc' }];
+      component.setupColumnDefaults();
+    });
+  });
+
+  describe('Method: ngDoCheck()', () => {
+    it('should be defined.', () => {
+      expect(component.ngDoCheck).toBeDefined();
+      component.ngDoCheck();
+    });
+  });
+
+  describe('Method: getPageStart()', () => {
+    it('should be defined.', () => {
+      expect(component.getPageStart).toBeDefined();
+      component.getPageStart();
+    });
+  });
+
+  describe('Method: getPageEnd()', () => {
+    it('should be defined.', () => {
+      expect(component.getPageEnd).toBeDefined();
+    });
+  });
+
+  describe('Method: onFilterClick(column, filter)', () => {
+    beforeEach(() => {
+      component._dataProvider = {
+        edit: () => {},
+      };
+      component.columns = [
+        {
+          filtering: true,
+          name: 'date',
+          type: 'date',
+        },
+        {
+          filtering: true,
+          name: 'type',
+          options: ['Lead', 'Contact'],
+        },
+      ];
+      component.originalRows = [
+        {
+          id: 1,
+          date: new Date(),
+          type: 'Lead',
+        },
+        {
+          id: 2,
+          date: new Date(),
+          type: 'Contact',
+        },
+      ];
+      component.config = {
+        filtering: true,
+      };
     });
 
-
-    describe('Method: onDropdownToggled()', () => {
-        it('should be defined.', () => {
-            expect(component.onDropdownToggled).toBeDefined();
-            component.onDropdownToggled();
-        });
+    it('should allow multiple date selections if multiple=true/false', () => {
+      expect(component.onFilterClick).toBeDefined();
+      component.columns[0].multiple = true;
+      component.setupColumnDefaults();
+      // Select 4 rows
+      component.onFilterClick(component.columns[0], component.columns[0].options[0]);
+      component.onFilterClick(component.columns[0], component.columns[0].options[1]);
+      component.onFilterClick(component.columns[0], component.columns[0].options[2]);
+      component.onFilterClick(component.columns[0], component.columns[0].options[3]);
+      expect(component.columns[0].filter.length).toBe(4);
+      // deselect 4 rows
+      component.onFilterClick(component.columns[0], component.columns[0].options[0]);
+      component.onFilterClick(component.columns[0], component.columns[0].options[1]);
+      component.onFilterClick(component.columns[0], component.columns[0].options[2]);
+      component.onFilterClick(component.columns[0], component.columns[0].options[3]);
+      expect(component.columns[0].filter).toBe(null);
+      // set multiple to false and try and click 2 rows
+      component.columns[0].multiple = false;
+      component.onFilterClick(component.columns[0], component.columns[0].options[1]);
+      component.onFilterClick(component.columns[0], component.columns[0].options[2]);
+      expect(component.columns[0].filter.length).toBeUndefined();
+      expect(component.columns[0].filter).toBeTruthy();
     });
 
-    describe('Method: onPageChange()', () => {
-        it('should be defined.', () => {
-            expect(component.onPageChange).toBeDefined();
-            component.onPageChange();
-        });
+    it('should allow multiple text selections if multiple=true/false', () => {
+      expect(component.onFilterClick).toBeDefined();
+      component.columns[1].multiple = true;
+      component.setupColumnDefaults();
+      // Select 2 rows
+      component.onFilterClick(component.columns[1], component.columns[1].options[0]);
+      component.onFilterClick(component.columns[1], component.columns[1].options[1]);
+      expect(component.columns[1].filter.length).toBe(2);
+      // deselect 2 rows
+      component.onFilterClick(component.columns[1], component.columns[1].options[0]);
+      component.onFilterClick(component.columns[1], component.columns[1].options[1]);
+      expect(component.columns[1].filter).toBe(null);
+
+      // set multiple to false and try and click 2 rows
+      component.columns[1].multiple = false;
+      component.onFilterClick(component.columns[1], component.columns[1].options[0]);
+      component.onFilterClick(component.columns[1], component.columns[1].options[1]);
+      expect(component.columns[1].filter.length).toBe(7);
+      expect(component.columns[1].filter).toBeTruthy();
     });
 
-    describe('Method: getOptionDataAutomationId()', () => {
-        it('should be defined.', () => {
-            expect(component.getOptionDataAutomationId).toBeDefined();
-            component.getOptionDataAutomationId({ value: 2 });
-        });
+    it('should add range to options (11 total) if range is set', () => {
+      expect(component.onFilterClick).toBeDefined();
+      component.columns[0].range = true;
+      component.setupColumnDefaults();
+      expect(component.columns[0].options.length).toBe(11);
     });
 
-    describe('Method: setupColumnDefaults()', () => {
-        it('should be defined.', () => {
-            expect(component.setupColumnDefaults).toBeDefined();
-            component.columns = [
-                { type: 'misc' }
-            ];
-            component.setupColumnDefaults();
-        });
+    it('should add calenderShow if range is set', () => {
+      expect(component.onFilterClick).toBeDefined();
+      component.columns[0].range = true;
+      component.setupColumnDefaults();
+      component.onFilterClick(component.columns[0], component.columns[0].options[component.columns[0].options.length - 1]);
+      expect(component.columns[0].calenderShow).toBeTruthy();
+    });
+  });
+
+  describe('Method: onFilterClear(column)', () => {
+    it('should be defined.', () => {
+      expect(component.onFilterClear).toBeDefined();
+      component.onFilterClear({ filer: true, freetextFilter: true });
+    });
+  });
+
+  describe('Method: clearAllSortAndFilters()', () => {
+    it('should be defined.', () => {
+      expect(component.clearAllSortAndFilters).toBeDefined();
+      component.clearAllSortAndFilters();
+    });
+  });
+
+  xdescribe('Method: onFilterChange()', () => {
+    beforeEach(() => {
+      component.columns = [
+        {
+          filter: 'a',
+          filtering: true,
+          name: 'name',
+        },
+      ];
+      component.originalRows = [
+        {
+          id: 1,
+          name: 'Jane',
+        },
+        {
+          id: 2,
+          name: 'John',
+        },
+      ];
+      component.config = {
+        filtering: true,
+      };
     });
 
-    describe('Method: ngDoCheck()', () => {
-        it('should be defined.', () => {
-            expect(component.ngDoCheck).toBeDefined();
-            component.ngDoCheck();
-        });
+    it('should update the row data to reflect the active filters (string comparison).', () => {
+      expect(component.onFilterChange).toBeDefined();
+      component.onFilterChange();
+      expect(component.rows.length).toBe(1);
     });
 
-    describe('Method: getPageStart()', () => {
-        it('should be defined.', () => {
-            expect(component.getPageStart).toBeDefined();
-            component.getPageStart();
-        });
+    it('should update the row data to reflect the active filters (array comparison).', () => {
+      expect(component.onFilterChange).toBeDefined();
+      component.originalRows[0].name = ['Jane', 'Janet', 'Janice'];
+      component.originalRows[1].name = ['Jon', 'Joe', 'Jose'];
+      component.onFilterChange();
+      expect(component.rows.length).toBe(1);
     });
 
-    describe('Method: getPageEnd()', () => {
-        it('should be defined.', () => {
-            expect(component.getPageEnd).toBeDefined();
+    it('should update the row data to reflect the active filters (custom filter).', () => {
+      expect(component.onFilterChange).toBeDefined();
+      component.config.filtering = (filterValue, data) => {
+        let matches = [];
+        data.forEach((row) => {
+          if (row.name === 'John') {
+            matches.push(row);
+          }
         });
+        return matches;
+      };
+      component.onFilterChange();
+      expect(component.rows.length).toBe(1);
     });
 
-    describe('Method: onFilterClick(column, filter)', () => {
-        beforeEach(() => {
-            component._dataProvider = {
-                edit: () => { }
-            };
-            component.columns = [
-                {
-                    filtering: true,
-                    name: 'date',
-                    type: 'date'
-                },
-                {
-                    filtering: true,
-                    name: 'type',
-                    options: ['Lead', 'Contact']
-                }
-            ];
-            component.originalRows = [
-                {
-                    id: 1,
-                    date: new Date(),
-                    type: 'Lead'
-                },
-                {
-                    id: 2,
-                    date: new Date(),
-                    type: 'Contact'
-                }
-            ];
-            component.config = {
-                filtering: true
-            };
-        });
-
-        it('should allow multiple date selections if multiple=true/false', () => {
-            expect(component.onFilterClick).toBeDefined();
-            component.columns[0].multiple = true;
-            component.setupColumnDefaults();
-            // Select 4 rows
-            component.onFilterClick(component.columns[0], component.columns[0].options[0]);
-            component.onFilterClick(component.columns[0], component.columns[0].options[1]);
-            component.onFilterClick(component.columns[0], component.columns[0].options[2]);
-            component.onFilterClick(component.columns[0], component.columns[0].options[3]);
-            expect(component.columns[0].filter.length).toBe(4);
-            // deselect 4 rows
-            component.onFilterClick(component.columns[0], component.columns[0].options[0]);
-            component.onFilterClick(component.columns[0], component.columns[0].options[1]);
-            component.onFilterClick(component.columns[0], component.columns[0].options[2]);
-            component.onFilterClick(component.columns[0], component.columns[0].options[3]);
-            expect(component.columns[0].filter).toBe(null);
-            // set multiple to false and try and click 2 rows
-            component.columns[0].multiple = false;
-            component.onFilterClick(component.columns[0], component.columns[0].options[1]);
-            component.onFilterClick(component.columns[0], component.columns[0].options[2]);
-            expect(component.columns[0].filter.length).toBeUndefined();
-            expect(component.columns[0].filter).toBeTruthy();
-        });
-
-        it('should allow multiple text selections if multiple=true/false', () => {
-            expect(component.onFilterClick).toBeDefined();
-            component.columns[1].multiple = true;
-            component.setupColumnDefaults();
-            // Select 2 rows
-            component.onFilterClick(component.columns[1], component.columns[1].options[0]);
-            component.onFilterClick(component.columns[1], component.columns[1].options[1]);
-            expect(component.columns[1].filter.length).toBe(2);
-            // deselect 2 rows
-            component.onFilterClick(component.columns[1], component.columns[1].options[0]);
-            component.onFilterClick(component.columns[1], component.columns[1].options[1]);
-            expect(component.columns[1].filter).toBe(null);
-
-            // set multiple to false and try and click 2 rows
-            component.columns[1].multiple = false;
-            component.onFilterClick(component.columns[1], component.columns[1].options[0]);
-            component.onFilterClick(component.columns[1], component.columns[1].options[1]);
-            expect(component.columns[1].filter.length).toBe(7);
-            expect(component.columns[1].filter).toBeTruthy();
-        });
-
-        it('should add range to options (11 total) if range is set', () => {
-            expect(component.onFilterClick).toBeDefined();
-            component.columns[0].range = true;
-            component.setupColumnDefaults();
-            expect(component.columns[0].options.length).toBe(11);
-        });
-
-        it('should add calenderShow if range is set', () => {
-            expect(component.onFilterClick).toBeDefined();
-            component.columns[0].range = true;
-            component.setupColumnDefaults();
-            component.onFilterClick(component.columns[0], component.columns[0].options[component.columns[0].options.length - 1]);
-            expect(component.columns[0].calenderShow).toBeTruthy();
-        });
+    it('should update the row data to reflect the active filters (custom config filter).', () => {
+      expect(component.onFilterChange).toBeDefined();
+      let mockOption = { label: 'Today', min: -2, max: 2 };
+      component.columns = [
+        {
+          name: 'name',
+          type: 'date',
+          options: [mockOption],
+        },
+      ];
+      // Set dates
+      component.originalRows[0].name = new Date();
+      component.originalRows[1].name = new Date(1970, 3, 11, 13, 13);
+      // Set active filter
+      component.columns[0].filter = [mockOption];
+      component.onFilterChange();
+      expect(component.rows.length).toBe(1);
     });
 
-    describe('Method: onFilterClear(column)', () => {
-        it('should be defined.', () => {
-            expect(component.onFilterClear).toBeDefined();
-            component.onFilterClear({ filer: true, freetextFilter: true });
-        });
+    it('should update the row data to reflect the active filters (custom match function).', () => {
+      expect(component.onFilterChange).toBeDefined();
+      component.columns[0].match = (item, filter) => {
+        return item.match(new RegExp(filter, 'gi'));
+      };
+      component.onFilterChange();
+      expect(component.rows.length).toBe(1);
+    });
+  });
+
+  xdescribe('Method: isFilterActive(columnFilters, filter)', () => {
+    it('should return true when the filter is active and false when it is not.', () => {
+      expect(component.isFilterActive).toBeDefined();
+      let mockColumnFilters = {
+        filter: [],
+      };
+      let mockFilter = {
+        label: 'Filter',
+      };
+      // Using Filter Objects
+      expect(component.isFilterActive(mockColumnFilters, mockFilter)).toBeFalsy();
+      mockColumnFilters.filter.push(mockFilter);
+      expect(component.isFilterActive(mockColumnFilters, mockFilter)).toBeTruthy();
+      // Using strings
+      expect(component.isFilterActive({ filter: ['Filter'] }, 'Filter')).toBeTruthy();
+      expect(component.isFilterActive({ filter: ['Filter'] }, 'z')).toBeFalsy();
+    });
+  });
+
+  describe('Method: onSortChange(newSortColumn)', () => {
+    it('should be defined.', () => {
+      expect(component.onSortChange).toBeDefined();
+    });
+  });
+
+  describe('Method: fireTableChangeEvent()', () => {
+    it('should be defined.', () => {
+      expect(component.fireTableChangeEvent).toBeDefined();
+    });
+  });
+
+  describe('Method: findColumnIndex(value)', () => {
+    it('should be defined.', () => {
+      expect(component.findColumnIndex).toBeDefined();
+    });
+  });
+
+  describe('Method: onOrderChange(event)', () => {
+    it('should be defined.', () => {
+      expect(component.onOrderChange).toBeDefined();
+    });
+  });
+
+  describe('Method: selectPage()', () => {
+    it('should be defined.', () => {
+      expect(component.selectPage).toBeDefined();
+    });
+  });
+
+  describe('Method: selectAll()', () => {
+    it('should be defined.', () => {
+      expect(component.selectAll).toBeDefined();
+    });
+  });
+
+  describe('Method: rowSelectHandler()', () => {
+    it('should be defined.', () => {
+      expect(component.rowSelectHandler).toBeDefined();
+    });
+  });
+
+  describe('Method: emitSelected()', () => {
+    it('should be defined.', () => {
+      expect(component.emitSelected).toBeDefined();
+    });
+  });
+
+  describe('Method: rowClickHandler()', () => {
+    it('should be defined.', () => {
+      expect(component.rowClickHandler).toBeDefined();
+    });
+  });
+
+  describe('Method: getDefaultOptions()', () => {
+    it('should return a subset of options when the data dates cover a small range.', () => {
+      expect(component.getDefaultOptions).toBeDefined();
+      let mockOptions = component.getDefaultOptions();
+      expect(mockOptions.length).toBe(10);
+    });
+  });
+
+  describe('Method: onCalenderSelect(column, event)', () => {
+    it('should be defined.', () => {
+      expect(component.onCalenderSelect).toBeDefined();
+      component.onCalenderSelect(null, { startDate: new Date(), endDate: new Date() });
+    });
+  });
+
+  describe('Method: onFilterKeywords()', () => {
+    it('should be defined.', () => {
+      expect(component.onFilterKeywords).toBeDefined();
+      // component.onFilterKeywords();
+    });
+  });
+
+  describe('Method: setTableEdit()', () => {
+    beforeEach(() => {
+      component._dataProvider = {
+        edit: () => {},
+      };
+      component.columns = [
+        {
+          name: 'name',
+        },
+        {
+          name: 'id',
+        },
+      ];
+      component._rows = [
+        {
+          id: 1,
+          name: 'Jane',
+        },
+        {
+          id: 2,
+          name: 'John',
+        },
+      ];
     });
 
-    describe('Method: clearAllSortAndFilters()', () => {
-        it('should be defined.', () => {
-            expect(component.clearAllSortAndFilters).toBeDefined();
-            component.clearAllSortAndFilters();
-        });
+    it('should be defined.', () => {
+      expect(component.setTableEdit).toBeDefined();
     });
 
-    xdescribe('Method: onFilterChange()', () => {
-        beforeEach(() => {
-            component.columns = [
-                {
-                    filter: 'a',
-                    filtering: true,
-                    name: 'name'
-                }
-            ];
-            component.originalRows = [
-                {
-                    id: 1,
-                    name: 'Jane'
-                },
-                {
-                    id: 2,
-                    name: 'John'
-                }
-            ];
-            component.config = {
-                filtering: true
-            };
-        });
-
-        it('should update the row data to reflect the active filters (string comparison).', () => {
-            expect(component.onFilterChange).toBeDefined();
-            component.onFilterChange();
-            expect(component.rows.length).toBe(1);
-        });
-
-        it('should update the row data to reflect the active filters (array comparison).', () => {
-            expect(component.onFilterChange).toBeDefined();
-            component.originalRows[0].name = ['Jane', 'Janet', 'Janice'];
-            component.originalRows[1].name = ['Jon', 'Joe', 'Jose'];
-            component.onFilterChange();
-            expect(component.rows.length).toBe(1);
-        });
-
-        it('should update the row data to reflect the active filters (custom filter).', () => {
-            expect(component.onFilterChange).toBeDefined();
-            component.config.filtering = (filterValue, data) => {
-                let matches = [];
-                data.forEach(row => {
-                    if (row.name === 'John') {
-                        matches.push(row);
-                    }
-                });
-                return matches;
-            };
-            component.onFilterChange();
-            expect(component.rows.length).toBe(1);
-        });
-
-        it('should update the row data to reflect the active filters (custom config filter).', () => {
-            expect(component.onFilterChange).toBeDefined();
-            let mockOption = { label: 'Today', min: -2, max: 2 };
-            component.columns = [{
-                name: 'name',
-                type: 'date',
-                options: [mockOption]
-            }];
-            // Set dates
-            component.originalRows[0].name = new Date();
-            component.originalRows[1].name = new Date(1970, 3, 11, 13, 13);
-            // Set active filter
-            component.columns[0].filter = [mockOption];
-            component.onFilterChange();
-            expect(component.rows.length).toBe(1);
-        });
-
-        it('should update the row data to reflect the active filters (custom match function).', () => {
-            expect(component.onFilterChange).toBeDefined();
-            component.columns[0].match = (item, filter) => {
-                return item.match(new RegExp(filter, 'gi'));
-            };
-            component.onFilterChange();
-            expect(component.rows.length).toBe(1);
-        });
+    it('should set the table to edit mode', () => {
+      component.setTableEdit();
+      expect(component.mode).toBe(2);
     });
 
-    xdescribe('Method: isFilterActive(columnFilters, filter)', () => {
-        it('should return true when the filter is active and false when it is not.', () => {
-            expect(component.isFilterActive).toBeDefined();
-            let mockColumnFilters = {
-                filter: []
-            };
-            let mockFilter = {
-                label: 'Filter'
-            };
-            // Using Filter Objects
-            expect(component.isFilterActive(mockColumnFilters, mockFilter)).toBeFalsy();
-            mockColumnFilters.filter.push(mockFilter);
-            expect(component.isFilterActive(mockColumnFilters, mockFilter)).toBeTruthy();
-            // Using strings
-            expect(component.isFilterActive({ filter: ['Filter'] }, 'Filter')).toBeTruthy();
-            expect(component.isFilterActive({ filter: ['Filter'] }, 'z')).toBeFalsy();
-        });
+    it('should set columns with viewOnly to editing false', () => {
+      component.columns[0].viewOnly = true;
+      component.setTableEdit();
+      expect(component._rows).toEqual([
+        {
+          id: 1,
+          name: 'Jane',
+          _editing: {
+            id: true,
+            name: false,
+          },
+        },
+        {
+          id: 2,
+          name: 'John',
+          _editing: {
+            id: true,
+            name: false,
+          },
+        },
+      ]);
+    });
+  });
+
+  describe('Method: leaveEditMode()', () => {
+    beforeEach(() => {
+      component._dataProvider = {
+        undo: () => {},
+        commit: () => {},
+      };
+      component.columns = [
+        {
+          name: 'name',
+        },
+        {
+          name: 'id',
+        },
+      ];
+      component._rows = [
+        {
+          id: 1,
+          name: 'Jane',
+        },
+        {
+          id: 2,
+          name: 'John',
+        },
+      ];
     });
 
-    describe('Method: onSortChange(newSortColumn)', () => {
-        it('should be defined.', () => {
-            expect(component.onSortChange).toBeDefined();
-        });
+    it('should be defined.', () => {
+      expect(component.leaveEditMode).toBeDefined();
     });
 
-    describe('Method: fireTableChangeEvent()', () => {
-        it('should be defined.', () => {
-            expect(component.fireTableChangeEvent).toBeDefined();
-        });
+    it('should set the table to view mode', () => {
+      component.leaveEditMode();
+      expect(component.mode).toBe(1);
     });
 
-    describe('Method: findColumnIndex(value)', () => {
-        it('should be defined.', () => {
-            expect(component.findColumnIndex).toBeDefined();
-        });
+    it('should set the table colums editing to false', () => {
+      component.leaveEditMode();
+      expect(component._rows).toEqual([
+        {
+          id: 1,
+          name: 'Jane',
+          _editing: {
+            id: false,
+            name: false,
+          },
+        },
+        {
+          id: 2,
+          name: 'John',
+          _editing: {
+            id: false,
+            name: false,
+          },
+        },
+      ]);
+    });
+  });
+
+  describe('Method: addEditableRow()', () => {
+    it('should be defined.', () => {
+      expect(component.addEditableRow).toBeDefined();
+      // component.addEditableRow();
+    });
+  });
+
+  describe('Method: validateAndGetUpdatedData()', () => {
+    it('should be defined.', () => {
+      expect(component.validateAndGetUpdatedData).toBeDefined();
+      component.validateAndGetUpdatedData();
+    });
+  });
+
+  describe('Method: cancelEditing()', () => {
+    beforeEach(() => {
+      component._dataProvider = {
+        undo: () => {},
+        commit: () => {},
+      };
+    });
+    it('should be defined.', () => {
+      expect(component.cancelEditing).toBeDefined();
     });
 
-    describe('Method: onOrderChange(event)', () => {
-        it('should be defined.', () => {
-            expect(component.onOrderChange).toBeDefined();
-        });
+    it('should set the table to view mode', () => {
+      component.leaveEditMode();
+      expect(component.mode).toBe(1);
+    });
+  });
+
+  describe('Method: displayToastMessage()', () => {
+    it('should be defined.', () => {
+      expect(component.displayToastMessage).toBeDefined();
+      component.displayToastMessage();
+    });
+  });
+
+  describe('Method: hideToastMessage()', () => {
+    it('should be defined.', () => {
+      expect(component.hideToastMessage).toBeDefined();
+      component.hideToastMessage();
+    });
+  });
+
+  describe('Method: toggleLoading()', () => {
+    it('should be defined.', () => {
+      expect(component.toggleLoading).toBeDefined();
     });
 
-    describe('Method: selectPage()', () => {
-        it('should be defined.', () => {
-            expect(component.selectPage).toBeDefined();
-        });
+    it('should set loading to true', () => {
+      component.toggleLoading(true);
+      expect(component.loading).toBe(true);
     });
 
-    describe('Method: selectAll()', () => {
-        it('should be defined.', () => {
-            expect(component.selectAll).toBeDefined();
-        });
+    it('should set loading to false', () => {
+      component.toggleLoading(false);
+      expect(component.loading).toBe(false);
+    });
+  });
+
+  describe('Method: isColumnHidden()', () => {
+    it('should be defined.', () => {
+      expect(component.isColumnHidden).toBeDefined();
     });
 
-    describe('Method: rowSelectHandler()', () => {
-        it('should be defined.', () => {
-            expect(component.rowSelectHandler).toBeDefined();
-        });
+    it('should return true if column has hideColumnOnEdit and in editing mode', () => {
+      let column = { name: 'name', hideColumnOnEdit: true };
+      component.mode = 2;
+      expect(component.isColumnHidden(column)).toBe(true);
     });
 
-    describe('Method: emitSelected()', () => {
-        it('should be defined.', () => {
-            expect(component.emitSelected).toBeDefined();
-        });
+    it('should return false if column does not have hideColumnOnEdit and in editing mode', () => {
+      let column = { name: 'name' };
+      component.mode = 2;
+      expect(component.isColumnHidden(column)).toBe(false);
     });
 
-    describe('Method: rowClickHandler()', () => {
-        it('should be defined.', () => {
-            expect(component.rowClickHandler).toBeDefined();
-        });
+    it('should return false if column does not have hideColumnOnEdit and not in editing mode', () => {
+      let column = { name: 'name' };
+      component.mode = 1;
+      expect(component.isColumnHidden(column)).toBe(false);
     });
 
-    describe('Method: getDefaultOptions()', () => {
-        it('should return a subset of options when the data dates cover a small range.', () => {
-            expect(component.getDefaultOptions).toBeDefined();
-            let mockOptions = component.getDefaultOptions();
-            expect(mockOptions.length).toBe(10);
-        });
+    it('should return false if column has hideColumnOnEdit and not in editing mode', () => {
+      let column = { name: 'name', hideColumnOnEdit: true };
+      component.mode = 1;
+      expect(component.isColumnHidden(column)).toBe(false);
     });
 
-    describe('Method: onCalenderSelect(column, event)', () => {
-        it('should be defined.', () => {
-            expect(component.onCalenderSelect).toBeDefined();
-            component.onCalenderSelect(null, { startDate: new Date(), endDate: new Date() });
-        });
+    it('should return false if column has hideColumnOnView and in editing mode', () => {
+      let column = { name: 'name', hideColumnOnView: true };
+      component.mode = 2;
+      expect(component.isColumnHidden(column)).toBe(false);
     });
 
-    describe('Method: onFilterKeywords()', () => {
-        it('should be defined.', () => {
-            expect(component.onFilterKeywords).toBeDefined();
-            // component.onFilterKeywords();
-        });
+    it('should return false if column does not have hideColumnOnView and in editing mode', () => {
+      let column = { name: 'name' };
+      component.mode = 2;
+      expect(component.isColumnHidden(column)).toBe(false);
     });
 
-    describe('Method: setTableEdit()', () => {
-        beforeEach(() => {
-            component._dataProvider = {
-                edit: () => { }
-            };
-            component.columns = [
-                {
-                    name: 'name'
-                },
-                {
-                    name: 'id'
-                }
-            ];
-            component._rows = [
-                {
-                    id: 1,
-                    name: 'Jane'
-                },
-                {
-                    id: 2,
-                    name: 'John'
-                }
-            ];
-        });
-
-        it('should be defined.', () => {
-            expect(component.setTableEdit).toBeDefined();
-        });
-
-        it('should set the table to edit mode', () => {
-            component.setTableEdit();
-            expect(component.mode).toBe(2);
-        });
-
-        it('should set columns with viewOnly to editing false', () => {
-            component.columns[0].viewOnly = true;
-            component.setTableEdit();
-            expect(component._rows).toEqual([
-                {
-                    id: 1,
-                    name: 'Jane',
-                    _editing: {
-                        id: true,
-                        name: false
-                    }
-                },
-                {
-                    id: 2,
-                    name: 'John',
-                    _editing: {
-                        id: true,
-                        name: false
-                    }
-                }
-            ]);
-        });
+    it('should return false if column does not have hideColumnOnView and not in editing mode', () => {
+      let column = { name: 'name' };
+      component.mode = 1;
+      expect(component.isColumnHidden(column)).toBe(false);
     });
 
-    describe('Method: leaveEditMode()', () => {
-        beforeEach(() => {
-            component._dataProvider = {
-                undo: () => { },
-                commit: () => { }
-            };
-            component.columns = [
-                {
-                    name: 'name'
-                },
-                {
-                    name: 'id'
-                }
-            ];
-            component._rows = [
-                {
-                    id: 1,
-                    name: 'Jane'
-                },
-                {
-                    id: 2,
-                    name: 'John'
-                }
-            ];
-        });
-
-        it('should be defined.', () => {
-            expect(component.leaveEditMode).toBeDefined();
-        });
-
-        it('should set the table to view mode', () => {
-            component.leaveEditMode();
-            expect(component.mode).toBe(1);
-        });
-
-        it('should set the table colums editing to false', () => {
-            component.leaveEditMode();
-            expect(component._rows).toEqual([
-                {
-                    id: 1,
-                    name: 'Jane',
-                    _editing: {
-                        id: false,
-                        name: false
-                    }
-                },
-                {
-                    id: 2,
-                    name: 'John',
-                    _editing: {
-                        id: false,
-                        name: false
-                    }
-                }
-            ]);
-        });
+    it('should return false if column has hideColumnOnView and not in editing mode', () => {
+      let column = { name: 'name', hideColumnOnView: true };
+      component.mode = 1;
+      expect(component.isColumnHidden(column)).toBe(true);
     });
-
-    describe('Method: addEditableRow()', () => {
-        it('should be defined.', () => {
-            expect(component.addEditableRow).toBeDefined();
-            // component.addEditableRow();
-        });
-    });
-
-    describe('Method: validateAndGetUpdatedData()', () => {
-        it('should be defined.', () => {
-            expect(component.validateAndGetUpdatedData).toBeDefined();
-            component.validateAndGetUpdatedData();
-        });
-    });
-
-    describe('Method: cancelEditing()', () => {
-        beforeEach(() => {
-            component._dataProvider = {
-                undo: () => { },
-                commit: () => { }
-            };
-        });
-        it('should be defined.', () => {
-            expect(component.cancelEditing).toBeDefined();
-        });
-
-        it('should set the table to view mode', () => {
-            component.leaveEditMode();
-            expect(component.mode).toBe(1);
-        });
-    });
-
-    describe('Method: displayToastMessage()', () => {
-        it('should be defined.', () => {
-            expect(component.displayToastMessage).toBeDefined();
-            component.displayToastMessage();
-        });
-    });
-
-    describe('Method: hideToastMessage()', () => {
-        it('should be defined.', () => {
-            expect(component.hideToastMessage).toBeDefined();
-            component.hideToastMessage();
-        });
-    });
-
-    describe('Method: toggleLoading()', () => {
-        it('should be defined.', () => {
-            expect(component.toggleLoading).toBeDefined();
-        });
-
-        it('should set loading to true', () => {
-            component.toggleLoading(true);
-            expect(component.loading).toBe(true);
-        });
-
-        it('should set loading to false', () => {
-            component.toggleLoading(false);
-            expect(component.loading).toBe(false);
-        });
-    });
-
-    describe('Method: isColumnHidden()', () => {
-        it('should be defined.', () => {
-            expect(component.isColumnHidden).toBeDefined();
-        });
-
-        it('should return true if column has hideColumnOnEdit and in editing mode', () => {
-            let column = { name: 'name', hideColumnOnEdit: true };
-            component.mode = 2;
-            expect(component.isColumnHidden(column)).toBe(true);
-        });
-
-        it('should return false if column does not have hideColumnOnEdit and in editing mode', () => {
-            let column = { name: 'name' };
-            component.mode = 2;
-            expect(component.isColumnHidden(column)).toBe(false);
-        });
-
-        it('should return false if column does not have hideColumnOnEdit and not in editing mode', () => {
-            let column = { name: 'name' };
-            component.mode = 1;
-            expect(component.isColumnHidden(column)).toBe(false);
-        });
-
-        it('should return false if column has hideColumnOnEdit and not in editing mode', () => {
-            let column = { name: 'name', hideColumnOnEdit: true };
-            component.mode = 1;
-            expect(component.isColumnHidden(column)).toBe(false);
-        });
-
-        it('should return false if column has hideColumnOnView and in editing mode', () => {
-            let column = { name: 'name', hideColumnOnView: true };
-            component.mode = 2;
-            expect(component.isColumnHidden(column)).toBe(false);
-        });
-
-        it('should return false if column does not have hideColumnOnView and in editing mode', () => {
-            let column = { name: 'name' };
-            component.mode = 2;
-            expect(component.isColumnHidden(column)).toBe(false);
-        });
-
-        it('should return false if column does not have hideColumnOnView and not in editing mode', () => {
-            let column = { name: 'name' };
-            component.mode = 1;
-            expect(component.isColumnHidden(column)).toBe(false);
-        });
-
-        it('should return false if column has hideColumnOnView and not in editing mode', () => {
-            let column = { name: 'name', hideColumnOnView: true };
-            component.mode = 1;
-            expect(component.isColumnHidden(column)).toBe(true);
-        });
-    });
+  });
 });

--- a/src/platform/elements/tooltip/Tooltip.directive.ts
+++ b/src/platform/elements/tooltip/Tooltip.directive.ts
@@ -41,6 +41,8 @@ export class TooltipDirective implements OnDestroy, OnInit {
   preline: boolean;
   @Input('removeTooltipArrow')
   removeArrow: boolean = false;
+  @Input('tooltipAutoPosition')
+  autoPosition: boolean = false;
   private tooltipInstance: NovoTooltip | null;
   private portal: ComponentPortal<NovoTooltip>;
   private overlayRef: OverlayRef;
@@ -184,7 +186,7 @@ export class TooltipDirective implements OnDestroy, OnInit {
       .withOffsetX(offsetX)
       .withOffsetY(offsetY);
 
-    return this.withFallbackStrategy(strategy);
+    return this.autoPosition ? this.withFallbackStrategy(strategy) : strategy;
   }
   private withFallbackStrategy(strategy: ConnectedPositionStrategy): ConnectedPositionStrategy {
     strategy

--- a/src/platform/elements/tooltip/Tooltip.spec.ts
+++ b/src/platform/elements/tooltip/Tooltip.spec.ts
@@ -1,31 +1,30 @@
 // NG2
 import { Component } from '@angular/core';
 import { TestBed, async } from '@angular/core/testing';
+import { OverlayModule } from '@angular/cdk/overlay';
 // App
-import { TooltipDirective } from './Tooltip';
+import { TooltipDirective } from './Tooltip.directive';
 
 @Component({
-    selector: 'test-component',
-    template: `<div tooltip="test" tooltipPosition="right"></div>`
+  selector: 'test-component',
+  template: `<div tooltip="test" tooltipPosition="right"></div>`,
 })
 class TestComponent {}
 
 describe('Elements: TooltipDirective', () => {
-    let fixture;
-    let component;
+  let fixture;
+  let component;
 
-    beforeEach(async(() => {
-        TestBed.configureTestingModule({
-            declarations: [
-                TooltipDirective,
-                TestComponent
-            ]
-        }).compileComponents();
-        fixture = TestBed.createComponent(TestComponent);
-        component = fixture.debugElement.componentInstance;
-    }));
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [TooltipDirective, TestComponent],
+      imports: [OverlayModule],
+    }).compileComponents();
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.debugElement.componentInstance;
+  }));
 
-    it('should initialize with defaults', () => {
-        expect(component).toBeDefined();
-    });
+  it('should initialize with defaults', () => {
+    expect(component).toBeDefined();
+  });
 });


### PR DESCRIPTION
## **Description**

Interim change to restore full default functionality of tooltips until more research can be done in auto-positioning tooltips in novo.

#### **Verify that...**

- [x] Any related demos where added and `npm start` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**