### PR TITLE
set chomsky to default to 12hr clock

### DIFF
--- a/demo/assets/i18n/en-US.json
+++ b/demo/assets/i18n/en-US.json
@@ -5,6 +5,7 @@
   "long": "Today is {today:date:long}.",
   "timeLong": "Today is {today:date:timeLong}.",
   "formatToday": "Today is {today:date}.",
+  "militaryFormat": "For testing military time: {today:date:short}.",
   "alert": "You have {count:number} message.",
   "debt": "You owe: {balance:currency}",
   "html": "<b>I am HTML!</b>",

--- a/demo/assets/i18n/fr-FR.json
+++ b/demo/assets/i18n/fr-FR.json
@@ -5,6 +5,7 @@
   "long": "Aujourd hui est {today:date:long}.",
   "timeLong": "Aujourd hui est {today:date:timeLong}.",
   "formatToday": "Aujourd hui est {today:date}.",
+  "militaryFormat": "Pour tester le temps militaire: {today:date:short}.",
   "alert": "Vous avez {count:number} message.",
   "debt": "Vouz devez: {balance:currency}",
   "html": "<b>I am HTML!</b>",

--- a/demo/assets/i18n/ru-RU.json
+++ b/demo/assets/i18n/ru-RU.json
@@ -5,6 +5,7 @@
   "formatToday": "Сегодня {today:date}.",
   "long": "Сегодня {today:date:long}.",
   "timeLong": "Сегодня {today:date:timeLong}.",
+  "militaryFormat": "Для тестирования военного времени: {today:date:short}.",
   "alert": "У вас есть {count:number} сообщение.",
   "debt": "Вы должны: {balance:currency}",
   "html": "<b>I am HTML!</b>",

--- a/projects/chomsky/src/utils/chomsky.ts
+++ b/projects/chomsky/src/utils/chomsky.ts
@@ -22,6 +22,7 @@ export const FORMAT_DEFAULTS: IFormatDefaults = {
       year: 'numeric',
       hour: '2-digit',
       minute: '2-digit',
+      hour12: true,
     },
     medium: {
       // MMM DD, YYYY, HH:MM A - Feb 14, 2017, 1:17 PM
@@ -30,6 +31,7 @@ export const FORMAT_DEFAULTS: IFormatDefaults = {
       year: 'numeric',
       hour: '2-digit',
       minute: '2-digit',
+      hour12: true,
     },
     long: {
       // MMMM DD, YYYY, HH:MM A - Febuary 14, 2017, 1:17 PM
@@ -38,6 +40,7 @@ export const FORMAT_DEFAULTS: IFormatDefaults = {
       year: 'numeric',
       hour: '2-digit',
       minute: '2-digit',
+      hour12: true,
     },
     dateShort: {
       // DEFAULT: DD/MM/YYYY - 02/14/2017
@@ -61,12 +64,14 @@ export const FORMAT_DEFAULTS: IFormatDefaults = {
       // HH:MM A - 1:17 PM
       hour: '2-digit',
       minute: '2-digit',
+      hour12: true,
     },
     timeLong: {
       // HH:MM A Z - 1:17 PM CST
       hour: '2-digit',
       minute: '2-digit',
       timeZoneName: 'short',
+      hour12: true,
     },
   },
 };

--- a/projects/novo-examples/src/utils/chomsky/date-translations/date-translations-example.css
+++ b/projects/novo-examples/src/utils/chomsky/date-translations/date-translations-example.css
@@ -1,1 +1,4 @@
-/** No CSS for this example */
+.spacer {
+  width: 60px;
+  display: inline-block;
+}

--- a/projects/novo-examples/src/utils/chomsky/date-translations/date-translations-example.css
+++ b/projects/novo-examples/src/utils/chomsky/date-translations/date-translations-example.css
@@ -1,4 +1,4 @@
 .spacer {
-  width: 60px;
+  width: 8em;
   display: inline-block;
 }

--- a/projects/novo-examples/src/utils/chomsky/date-translations/date-translations-example.html
+++ b/projects/novo-examples/src/utils/chomsky/date-translations/date-translations-example.html
@@ -1,5 +1,7 @@
 
 <novo-tiles [options]="locales" [(ngModel)]="currentLocale" (onChange)="changeLanguage($event)"></novo-tiles>
+<span class="spacer"></span>
+<novo-tiles [options]="militaryTime" [(ngModel)]="useMilitaryTime" (onChange)="changeMilitaryTime($event)"></novo-tiles>
 
 <h4>Pipe</h4>
 <div class="panel panel-default">
@@ -8,6 +10,7 @@
         <p>{{ 'formatToday' | translate: { today: demoVariables.today } }}</p>
         <p>{{ 'long' | translate: { today: demoVariables.today } }}</p>
         <p>{{ 'timeLong' | translate: { today: demoVariables.today } }}</p>
+        <p>{{ 'militaryFormat' | translate: { today: demoVariables.timestamp } }}</p>
     </div>
 </div>
 
@@ -18,5 +21,6 @@
         <p [translate]="'formatToday'" [dynamicValues]="{ today: demoVariables.today }"></p>
         <p [translate]="'long'" [dynamicValues]="{ today: demoVariables.today }"></p>
         <p [translate]="'timeLong'" [dynamicValues]="{ today: demoVariables.today }"></p>
+        <p [translate]="'militaryFormat'" [dynamicValues]="{ today: demoVariables.timestamp }"></p>
     </div>
 </div>

--- a/projects/novo-examples/src/utils/chomsky/date-translations/date-translations-example.ts
+++ b/projects/novo-examples/src/utils/chomsky/date-translations/date-translations-example.ts
@@ -11,6 +11,7 @@ import { TranslateService } from 'chomsky';
 })
 export class DateTranslationsExample {
   public currentLocale: string = 'en-US';
+  public useMilitaryTime: boolean = false;
   public locales: Array<any> = [
     {
       label: 'en-US',
@@ -25,12 +26,23 @@ export class DateTranslationsExample {
       value: 'ru-RU',
     },
   ];
+  public militaryTime: Array<any> = [
+    {
+      label: '12 Hour',
+      value: false,
+    },
+    {
+      label: '24 Hour',
+      value: true,
+    },
+  ];
   public greeting: string = 'greeting';
   public demoVariables: any = {
     today: new Date(),
     name: 'Jane',
     balance: 9874.34,
     count: 1,
+    timestamp: 1506470400000,
   };
 
   public translateService: any = TranslateService;
@@ -47,5 +59,11 @@ export class DateTranslationsExample {
   changeLanguage(locale) {
     this.currentLocale = locale;
     TranslateService.use(locale);
+  }
+
+  changeMilitaryTime(useMilitaryTime) {
+    this.useMilitaryTime = useMilitaryTime;
+    TranslateService.forceDisplayTo24HourTime(useMilitaryTime);
+    this.changeLanguage('en-US');
   }
 }

--- a/projects/novo-examples/src/utils/chomsky/date-translations/date-translations-example.ts
+++ b/projects/novo-examples/src/utils/chomsky/date-translations/date-translations-example.ts
@@ -64,6 +64,6 @@ export class DateTranslationsExample {
   changeMilitaryTime(useMilitaryTime) {
     this.useMilitaryTime = useMilitaryTime;
     TranslateService.forceDisplayTo24HourTime(useMilitaryTime);
-    this.changeLanguage('en-US');
+    this.changeLanguage(this.currentLocale);
   }
 }


### PR DESCRIPTION
## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**