### PR TITLE
Fix(AddressControl & FieldInteractionAPI): Fix address disable state and promptUser data-automation-id

### DIFF
--- a/projects/novo-elements/src/elements/form/ControlTemplates.ts
+++ b/projects/novo-elements/src/elements/form/ControlTemplates.ts
@@ -115,7 +115,7 @@ import { NovoTemplateService } from '../../services/template/NovoTemplateService
         <!--Address-->
         <ng-template novoTemplate="address" let-control let-form="form" let-errors="errors" let-methods="methods">
           <div [formGroup]="form">
-            <novo-address [formControlName]="control.key" [config]="control?.config" (change)="methods.handleAddressChange($event)" (focus)="methods.handleFocus($event.event, $event.field)" (blur)="methods.handleBlur($event.event, $event.field)"  (validityChange)="methods.updateValidity()"></novo-address>
+            <novo-address [formControlName]="control.key" [config]="control?.config" [readOnly]="control?.readOnly" (change)="methods.handleAddressChange($event)" (focus)="methods.handleFocus($event.event, $event.field)" (blur)="methods.handleBlur($event.event, $event.field)"  (validityChange)="methods.updateValidity()"></novo-address>
           </div>
         </ng-template>
 

--- a/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
@@ -410,7 +410,7 @@ export class FieldInteractionApi {
   public promptUser(key: string, changes: string[]): Promise<boolean> {
     let showYes: boolean = true;
     (document.activeElement as any).blur();
-    return this.modalService.open(ControlPromptModal, { changes }).onClosed;
+    return this.modalService.open(ControlPromptModal, { changes: changes, key: key }).onClosed;
   }
 
   public setProperty(key: string, prop: string, value: any): void {

--- a/projects/novo-elements/src/elements/form/extras/address/Address.spec.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.spec.ts
@@ -572,5 +572,16 @@ describe('Elements: NovoAddressElement', () => {
       component.isInvalid('address1');
       expect(component.invalid.address1).toEqual(false);
     });
+    it('should render element disabled when containing control element set to readOnly', () => {
+      component.disabled = {};
+      component.readOnly = true;
+      component.fieldList.forEach((field: string) => {
+        expect(component.disabled[field]).toEqual(true);
+      });
+      component.readOnly = false;
+      component.fieldList.forEach((field: string) => {
+        expect(component.disabled[field]).toEqual(false);
+      });
+    });
   });
 });

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -85,6 +85,17 @@ export interface NovoAddressConfig {
 export class NovoAddressElement implements ControlValueAccessor, OnInit {
   @Input()
   config: NovoAddressConfig;
+  private _readOnly: boolean = false;
+  @Input()
+  set readOnly(readOnly: boolean) {
+    this._readOnly = readOnly;
+    this.fieldList.forEach((field: string) => {
+      this.disabled[field] = this.readOnly;
+    });
+  }
+  get readOnly(): boolean {
+    return this._readOnly;
+  }
   states: Array<any> = [];
   countries: Array<any> = getCountries();
   fieldList: Array<string> = ['address1', 'address2', 'city', 'state', 'zip', 'countryID'];
@@ -306,7 +317,7 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit {
         this.config.state.pickerConfig.defaultOptions = results;
         if (results.length) {
           this.tooltip.state = undefined;
-          this.disabled.state = false;
+          this.disabled.state = this._readOnly;
           this.setStateLabel(this.model);
         } else {
           this.disabled.state = true;


### PR DESCRIPTION
## **Description**

Fix FieldInteractionAPI promptUser function to pass data automation Id correctly. Update Address control to correctly update each address field's disabled state when the control is marked readOnly through field Interactions.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**