### PR TITLE
stop execution if there are not any re-sizable columns

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -246,7 +246,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   @Input()
   rowIdentifier: string = 'id';
   @Input()
-  trackByFn: Function = (index, item) => item.id
+  trackByFn: Function = (index, item) => item.id;
   @Input()
   templates: { [key: string]: TemplateRef<any> } = {};
   @Input()
@@ -566,6 +566,9 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
           );
         },
       );
+      if (!resizableColumns || resizableColumns.length === 0) {
+        return;
+      }
       const lastResizableColumn: IDataTableColumn<T> = this.columns.find((column: IDataTableColumn<T>) => {
         return column.id === resizableColumns[resizableColumns.length - 1];
       });

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -246,7 +246,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   @Input()
   rowIdentifier: string = 'id';
   @Input()
-  trackByFn: Function = (index, item) => item.id;
+  trackByFn: Function = (index, item) => item.id
   @Input()
   templates: { [key: string]: TemplateRef<any> } = {};
   @Input()


### PR DESCRIPTION
## **Description**

This fixes the demo for data-tables

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [x] Run `BBO Automation`