### PR TITLE
chore(data-table): refactor only execute code if there are any resizable columns

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -245,6 +245,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   name: string = 'novo-data-table';
   @Input()
   rowIdentifier: string = 'id';
+  // prettier-ignore
   @Input()
   trackByFn: Function = (index, item) => item.id
   @Input()
@@ -566,18 +567,17 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
           );
         },
       );
-      if (!resizableColumns || resizableColumns.length === 0) {
-        return;
+      if (resizableColumns && resizableColumns.length > 0) {
+        const lastResizableColumn: IDataTableColumn<T> = this.columns.find((column: IDataTableColumn<T>) => {
+          return column.id === resizableColumns[resizableColumns.length - 1];
+        });
+        lastResizableColumn.initialResizable = {
+          resizable: lastResizableColumn.resizable,
+          width: lastResizableColumn.width,
+        };
+        lastResizableColumn.width = undefined;
+        lastResizableColumn.resizable = false;
       }
-      const lastResizableColumn: IDataTableColumn<T> = this.columns.find((column: IDataTableColumn<T>) => {
-        return column.id === resizableColumns[resizableColumns.length - 1];
-      });
-      lastResizableColumn.initialResizable = {
-        resizable: lastResizableColumn.resizable,
-        width: lastResizableColumn.width,
-      };
-      lastResizableColumn.width = undefined;
-      lastResizableColumn.resizable = false;
     }
   }
 


### PR DESCRIPTION
## **Description**

Update data table code based on feedback and add a prettier ignore comment so prettier stops attempting to refactor against the linter

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**