### PR TITLE
Revert "Fix(AddressControl & FieldInteractionAPI): Fix address disabl…

### DIFF
--- a/projects/novo-elements/src/elements/form/ControlTemplates.ts
+++ b/projects/novo-elements/src/elements/form/ControlTemplates.ts
@@ -115,7 +115,7 @@ import { NovoTemplateService } from '../../services/template/NovoTemplateService
         <!--Address-->
         <ng-template novoTemplate="address" let-control let-form="form" let-errors="errors" let-methods="methods">
           <div [formGroup]="form">
-            <novo-address [formControlName]="control.key" [config]="control?.config" [readOnly]="control?.readOnly" (change)="methods.handleAddressChange($event)" (focus)="methods.handleFocus($event.event, $event.field)" (blur)="methods.handleBlur($event.event, $event.field)"  (validityChange)="methods.updateValidity()"></novo-address>
+            <novo-address [formControlName]="control.key" [config]="control?.config" (change)="methods.handleAddressChange($event)" (focus)="methods.handleFocus($event.event, $event.field)" (blur)="methods.handleBlur($event.event, $event.field)"  (validityChange)="methods.updateValidity()"></novo-address>
           </div>
         </ng-template>
 

--- a/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
@@ -410,7 +410,7 @@ export class FieldInteractionApi {
   public promptUser(key: string, changes: string[]): Promise<boolean> {
     let showYes: boolean = true;
     (document.activeElement as any).blur();
-    return this.modalService.open(ControlPromptModal, { changes: changes, key: key }).onClosed;
+    return this.modalService.open(ControlPromptModal, { changes }).onClosed;
   }
 
   public setProperty(key: string, prop: string, value: any): void {

--- a/projects/novo-elements/src/elements/form/extras/address/Address.spec.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.spec.ts
@@ -572,16 +572,5 @@ describe('Elements: NovoAddressElement', () => {
       component.isInvalid('address1');
       expect(component.invalid.address1).toEqual(false);
     });
-    it('should render element disabled when containing control element set to readOnly', () => {
-      component.disabled = {};
-      component.readOnly = true;
-      component.fieldList.forEach((field: string) => {
-        expect(component.disabled[field]).toEqual(true);
-      });
-      component.readOnly = false;
-      component.fieldList.forEach((field: string) => {
-        expect(component.disabled[field]).toEqual(false);
-      });
-    });
   });
 });

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -64,7 +64,7 @@ export interface NovoAddressConfig {
                 class="required-indicator"
                 [ngClass]="{'bhi-circle': !valid.state, 'bhi-check': valid.state}">
             </i>
-            <novo-picker [config]="config?.state?.pickerConfig" [placeholder]="config?.state?.label" (changed)="onStateChange($event)" autocomplete="shipping region" [(ngModel)]="model.state" [disablePickerInput]="disabled.state || !valid.countryID"></novo-picker>
+            <novo-picker [config]="config?.state?.pickerConfig" [placeholder]="config?.state?.label" (changed)="onStateChange($event)" autocomplete="shipping region" [(ngModel)]="model.state" [disablePickerInput]="disabled.state || config.readOnly"></novo-picker>
         </span>
         <span *ngIf="!config?.zip?.hidden" class="zip postal-code" [class.invalid]="invalid.zip" [class.focus]="focused.zip" [class.disabled]="disabled.zip">
             <i *ngIf="config.zip.required"
@@ -85,17 +85,6 @@ export interface NovoAddressConfig {
 export class NovoAddressElement implements ControlValueAccessor, OnInit {
   @Input()
   config: NovoAddressConfig;
-  private _readOnly: boolean = false;
-  @Input()
-  set readOnly(readOnly: boolean) {
-    this._readOnly = readOnly;
-    this.fieldList.forEach((field: string) => {
-      this.disabled[field] = this.readOnly;
-    });
-  }
-  get readOnly(): boolean {
-    return this._readOnly;
-  }
   states: Array<any> = [];
   countries: Array<any> = getCountries();
   fieldList: Array<string> = ['address1', 'address2', 'city', 'state', 'zip', 'countryID'];
@@ -317,7 +306,7 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit {
         this.config.state.pickerConfig.defaultOptions = results;
         if (results.length) {
           this.tooltip.state = undefined;
-          this.disabled.state = this._readOnly;
+          this.disabled.state = false;
           this.setStateLabel(this.model);
         } else {
           this.disabled.state = true;


### PR DESCRIPTION
…e state and promptUser data-automation-id (#849)"

This reverts commit aa4d215362e7fc71f299d8ee1e02f3e980d9bf24.

## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**