### PR TITLE
feat(Currency): Allow Comma or Period as decimal for non-English users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # IDEs and editors
 /.idea
+novo-elements.iml
 .project
 .classpath
 .c9/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "novo-elements-projects",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4176,7 +4176,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
@@ -4609,7 +4609,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
@@ -5395,7 +5395,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -8367,7 +8367,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
@@ -12841,7 +12841,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {

--- a/projects/novo-elements/src/elements/form/Control.spec.ts
+++ b/projects/novo-elements/src/elements/form/Control.spec.ts
@@ -67,9 +67,8 @@ describe('Elements: NovoAutoSize', () => {
 describe('Test Localization', () => {
   let mockElement: ElementRef = new ElementRef(document.createElement('div'));
 
-  it('should set decimal seperator based on locale correctly', () => {
+  it('should set decimal separator based on locale correctly', () => {
     let component = new NovoControlElement(mockElement, null, null, null, null, null, 'fr-FR');
-    let decimalSeperator = component.getDecimalSeparator();
-    expect(decimalSeperator).toBe('.');
+    expect(component.decimalSeparator).toBe('.');
   });
 });

--- a/projects/novo-elements/src/elements/form/Control.ts
+++ b/projects/novo-elements/src/elements/form/Control.ts
@@ -211,7 +211,6 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
   templates: any = {};
   templateContext: any;
   loading: boolean = false;
-  decimalSeparator: string = '.';
 
   constructor(
     element: ElementRef,
@@ -276,7 +275,15 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
   }
 
   get showMessages(): boolean {
-    return this.showCount || !Helpers.isEmpty(this.form.controls[this.control.key].warning) || !Helpers.isEmpty(this.form.controls[this.control.key].description);
+    return (
+      this.showCount ||
+      !Helpers.isEmpty(this.form.controls[this.control.key].warning) ||
+      !Helpers.isEmpty(this.form.controls[this.control.key].description)
+    );
+  }
+
+  get decimalSeparator(): string {
+    return new Intl.NumberFormat(this.locale).format(1.2)[1];
   }
 
   ngAfterViewInit() {
@@ -409,13 +416,6 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
         }
       });
     }
-
-    this.decimalSeparator = this.getDecimalSeparator();
-  }
-
-  getDecimalSeparator(): string {
-    let result = new Intl.NumberFormat(this.locale).format(1.2)[1];
-    return result;
   }
 
   ngOnDestroy() {
@@ -628,18 +628,18 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
   restrictKeys(event) {
     const NUMBERS_ONLY = /[0-9\-]/;
     const NUMBERS_WITH_DECIMAL_DOT = /[0-9\.\-]/;
-    const NUMBERS_WITH_DECIMAL_COMMA = /[0-9\,\-]/;
+    const NUMBERS_WITH_DECIMAL_DOT_AND_COMMA = /[0-9\.\,\-]/;
     const UTILITY_KEYS = ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight', 'Tab'];
     let key = event.key;
 
-    // Types
+    // Numbers or numbers and decimal characters only
     if (this.form.controls[this.control.key].subType === 'number' && !(NUMBERS_ONLY.test(key) || UTILITY_KEYS.includes(key))) {
       event.preventDefault();
     } else if (
-      ~['currency', 'float', 'percentage'].indexOf(this.form.controls[this.control.key].subType) &&
+      ['currency', 'float', 'percentage'].includes(this.form.controls[this.control.key].subType) &&
       !(
         (this.decimalSeparator === '.' && NUMBERS_WITH_DECIMAL_DOT.test(key)) ||
-        (this.decimalSeparator === ',' && NUMBERS_WITH_DECIMAL_COMMA.test(key)) ||
+        (this.decimalSeparator === ',' && NUMBERS_WITH_DECIMAL_DOT_AND_COMMA.test(key)) ||
         UTILITY_KEYS.includes(key)
       )
     ) {


### PR DESCRIPTION
## **Description**

Added support for non-english locales to use commas and/or periods when entering a decimal separator character. This is required because some locales, like `fr_CA` (French Canadian) may need to switch between comma and period by switching between a French and English browser locale.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`