### PR TITLE
Feat(Picker): Allow Picker to display title property as label.

### DIFF
--- a/projects/novo-elements/src/elements/picker/Picker.spec.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.spec.ts
@@ -145,6 +145,10 @@ describe('Elements: NovoPickerElement', () => {
       component.writeValue({ name: 'NAME' });
       expect(component.term).toEqual('NAME');
     });
+    it('should use title for a complex object if present.', () => {
+      component.writeValue({ title: 'TITLE' });
+      expect(component.term).toEqual('TITLE');
+    });
     it('should use getLabels for a number if present.', fakeAsync(() => {
       component.config = {
         getLabels: () =>

--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -370,6 +370,8 @@ export class NovoPickerElement implements OnInit {
           }
           this.ref.markForCheck();
         });
+      } else if (value && value.title) {
+        this.term = value.title;
       } else {
         this.term = value || '';
       }


### PR DESCRIPTION
## **Description**

Add support for a picker to display the title property of an object if it is present.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**