### PR TITLE
feat(RowChips): Add empty state message for disabled RowChips and RowChip delete functionality

### DIFF
--- a/projects/novo-elements/src/elements/chips/Chips.scss
+++ b/projects/novo-elements/src/elements/chips/Chips.scss
@@ -356,6 +356,10 @@ novo-row-chip {
       }
     }
   }
+  .novo-row-chips-empty-message {
+    font-style: italic;
+    color: $grey;
+  }
   novo-picker {
     max-width: 275px;
   }

--- a/projects/novo-elements/src/elements/chips/Chips.spec.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.spec.ts
@@ -115,6 +115,15 @@ describe('Elements: NovoChipsElement', () => {
       component.remove(null, item);
       expect(component.items.length).toBe(0);
     });
+    it('should remove an item wih valueFomatterFunc if provided', () => {
+      const itemFoo = { label: 'Foo', value: 'foo' };
+      const itemBar = { label: 'Bar', value: 'bar' };
+      component.source = { valueFormatter: (values) => `${values[0].label} (${values[0].value})` };
+      component.items = [itemFoo, itemBar];
+      component.remove(null, itemFoo);
+      expect(component.value).toBe('Bar (bar)');
+      expect(component.items.length).toEqual(1);
+    });
   });
 
   describe('Method: writeValue()', () => {

--- a/projects/novo-elements/src/elements/chips/Chips.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.ts
@@ -292,7 +292,7 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
     }
     this.items.splice(this.items.indexOf(item), 1);
     this.deselectAll();
-    this.value = this.items.map((i) => i.value);
+    this.value = this.source && this.source.valueFormatter ? this.source.valueFormatter(this.items) : this.items.map((i) => i.value);
     this.changed.emit({ value: this.value.length ? this.value : '', rawValue: this.items });
     this.onModelChange(this.value.length ? this.value : '');
     this._items.next(this.items);

--- a/projects/novo-elements/src/elements/chips/RowChips.ts
+++ b/projects/novo-elements/src/elements/chips/RowChips.ts
@@ -33,6 +33,7 @@ export class NovoRowChipElement extends NovoChipElement {
         <div class="novo-row-chips-columns" *ngIf="items.length > 0">
           <div class="column-label" *ngFor="let column of source.columns">{{ column.label }}</div>
         </div>
+        <div class="novo-row-chips-empty-message" *ngIf="source.emptyReadOnlyMessage && disablePickerInput && items.length === 0">{{source.emptyReadOnlyMessage}}</div>
         <novo-row-chip
           *ngFor="let item of _items | async"
           [type]="type || item?.value?.searchEntity"


### PR DESCRIPTION
## **Description**

Added param for user to specify an empty message for when no selections have been made and the input is disabled (the select input will be shown when enabled).

Also added value formatter support for deleting a row chip. Missed from [#845](https://github.com/bullhorn/novo-elements/pull/845)

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**