### PR TITLE
Revert "fix(picker): respect allow multiple false for picker fields (…

### DIFF
--- a/projects/novo-elements/src/elements/form/FormInterfaces.ts
+++ b/projects/novo-elements/src/elements/form/FormInterfaces.ts
@@ -19,15 +19,3 @@ export interface IFieldInteractionEvent {
   prop: string;
   value: any;
 }
-
-export interface FormField {
-  dataSpecialization: string;
-  inputType: string;
-  options: string;
-  multiValue: boolean;
-  dataType: string;
-  type: string;
-  associatedEntity?: { entity: string };
-  optionsUrl?: string;
-  optionsType?: string;
-}

--- a/projects/novo-elements/src/elements/form/controls/BaseControl.ts
+++ b/projects/novo-elements/src/elements/form/controls/BaseControl.ts
@@ -49,7 +49,6 @@ export interface NovoControlConfig {
   interactions?: Array<Object>;
   dataSpecialization?: string;
   dataType?: string;
-  metaType?: string;
   appendToBody?: boolean; // Deprecated
   parentScrollSelector?: string;
   description?: string;
@@ -107,7 +106,6 @@ export class BaseControl {
   encrypted: boolean;
   sortOrder: number;
   controlType: string;
-  metaType: string;
   placeholder: string;
   config: any;
   dirty: boolean;
@@ -182,7 +180,6 @@ export class BaseControl {
     this.encrypted = !!config.encrypted;
     this.sortOrder = config.sortOrder === undefined ? 1 : config.sortOrder;
     this.controlType = config.controlType || '';
-    this.metaType = config.metaType;
     this.placeholder = config.placeholder || '';
     this.config = config.config || null;
     this.dirty = !!config.value;

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
@@ -24,7 +24,6 @@ import { FormUtils } from './FormUtils';
 import { NovoFormControl } from '../../elements/form/NovoFormControl';
 import { NovoLabelService } from '../../services/novo-label-service';
 import { OptionsService } from '../../services/options/OptionsService';
-import { FormField } from '../../elements/form/FormTypes';
 
 /**
  * Creates a mock address
@@ -192,38 +191,6 @@ describe('Utils: FormUtils', () => {
     it('should return the type of file correctly.', () => {
       expect(formUtils.determineInputType).toBeDefined();
       expect(formUtils.determineInputType({ type: 'file' })).toBe('file');
-    });
-    describe('TO_MANY field types', () => {
-      const toManyField: FormField = {
-        type: 'TO_MANY',
-        multiValue: null,
-        dataType: 'fake',
-        options: 'fake',
-        inputType: 'fake',
-        dataSpecialization: 'fake',
-      };
-
-      describe('without associated field types', () => {
-        it('should return type \'picker\' if no \'Allow Multiple\' property', () => {
-          expect(formUtils.determineInputType({ ...toManyField, multiValue: false })).toBe('picker');
-        });
-        it('should return type \'chips\' with \'Allow Multiple\' property', () => {
-          expect(formUtils.determineInputType({ ...toManyField, multiValue: true })).toBe('chips');
-        });
-      });
-      describe('with associated entities', () => {
-        beforeEach(() => {
-          jest.spyOn(formUtils, 'hasAssociatedEntity').mockImplementation(() => true);
-        });
-        it('should return type \'entitypicker\' with no \'Allow Multiple\' property', () => {
-          const field: FormField = { ...toManyField, multiValue: false };
-          expect(formUtils.determineInputType(field)).toBe('entitypicker');
-        });
-        it('should return type \'entitychips\' with \'Allow Multiple\' property', () => {
-          const field: FormField = { ...toManyField, multiValue: true };
-          expect(formUtils.determineInputType(field)).toBe('entitychips');
-        });
-      });
     });
     xit('should throw an error when a type doesn\'t exist for the field.', () => {
       expect(formUtils.determineInputType).toBeDefined();

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -23,7 +23,7 @@ import {
 } from '../../elements/form/FormControls';
 import { EntityPickerResult, EntityPickerResults } from '../../elements/picker/extras/entity-picker-results/EntityPickerResults';
 import { Helpers } from '../Helpers';
-import { NovoFieldset, FormField } from '../../elements/form/FormInterfaces';
+import { NovoFieldset } from '../../elements/form/FormInterfaces';
 import { NovoFormControl, NovoFormGroup } from '../../elements/form/NovoFormControl';
 import { NovoLabelService } from '../../services/novo-label-service';
 import { OptionsService } from './../../services/options/OptionsService';
@@ -41,7 +41,7 @@ export class FormUtils {
     'Person',
     'Placement',
   ];
-  PICKER_TEXT_LIST: string[] = [
+  PICKER_TEST_LIST: string[] = [
     'CandidateText',
     'ClientText',
     'ClientContactText',
@@ -89,18 +89,20 @@ export class FormUtils {
   }
 
   /**
-   * @name hasAssociatedEntity
-   * @param field
-   */
-  hasAssociatedEntity(field: FormField): boolean {
-    return !!(field.associatedEntity && ~this.ASSOCIATED_ENTITY_LIST.indexOf(field.associatedEntity.entity));
-  }
-
-  /**
    * @name determineInputType
    * @param field
    */
-  determineInputType(field: FormField): string {
+  determineInputType(field: {
+    dataSpecialization: string;
+    inputType: string;
+    options: string;
+    multiValue: boolean;
+    dataType: string;
+    type: string;
+    associatedEntity?: any;
+    optionsUrl?: string;
+    optionsType?: string;
+  }): string {
     let type: string;
     let dataSpecializationTypeMap = {
       DATETIME: 'datetime',
@@ -137,27 +139,19 @@ export class FormUtils {
       Integer: 'number',
     };
     if (field.type === 'TO_MANY') {
-      if (this.hasAssociatedEntity(field)) {
-        if (field.multiValue === false) {
-          type = 'entitypicker';
-        } else {
-          type = 'entitychips';
-        }
+      if (field.associatedEntity && ~this.ASSOCIATED_ENTITY_LIST.indexOf(field.associatedEntity.entity)) {
+        type = 'entitychips'; // TODO!
       } else {
-        if (field.multiValue === false) {
-          type = 'picker';
-        } else {
-          type = 'chips';
-        }
+        type = 'chips';
       }
     } else if (field.type === 'TO_ONE') {
-      if (this.hasAssociatedEntity(field)) {
+      if (field.associatedEntity && ~this.ASSOCIATED_ENTITY_LIST.indexOf(field.associatedEntity.entity)) {
         type = 'entitypicker'; // TODO!
       } else {
         type = 'picker';
       }
     } else if (field.optionsUrl && field.inputType === 'SELECT') {
-      if (field.optionsType && ~this.PICKER_TEXT_LIST.indexOf(field.optionsType)) {
+      if (field.optionsType && ~this.PICKER_TEST_LIST.indexOf(field.optionsType)) {
         type = 'entitypicker'; // TODO!
       } else {
         type = 'picker';
@@ -198,7 +192,6 @@ export class FormUtils {
     let type: string = this.determineInputType(field) || field.type;
     let control: any;
     let controlConfig: NovoControlConfig = {
-      metaType: field.type,
       type: type,
       key: field.name,
       label: field.label,


### PR DESCRIPTION
…#846)"

This reverts commit 71241730d0f7c126e1359145801d64b08e0c5f64.

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE
Revert changes to FormUtils that forced TO_MANY fields to use picker instead of chips when allow multiple is disabled.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**