### PR TITLE
fix(FormUtils): Respect Allow Multiple false for to-many association fields

### DIFF
--- a/projects/novo-elements/src/elements/form/FormInterfaces.ts
+++ b/projects/novo-elements/src/elements/form/FormInterfaces.ts
@@ -19,3 +19,15 @@ export interface IFieldInteractionEvent {
   prop: string;
   value: any;
 }
+
+export interface FormField {
+  dataSpecialization: string;
+  inputType: string;
+  options: string;
+  multiValue: boolean;
+  dataType: string;
+  type: string;
+  associatedEntity?: { entity: string };
+  optionsUrl?: string;
+  optionsType?: string;
+}

--- a/projects/novo-elements/src/elements/form/controls/BaseControl.ts
+++ b/projects/novo-elements/src/elements/form/controls/BaseControl.ts
@@ -49,6 +49,7 @@ export interface NovoControlConfig {
   interactions?: Array<Object>;
   dataSpecialization?: string;
   dataType?: string;
+  metaType?: string;
   appendToBody?: boolean; // Deprecated
   parentScrollSelector?: string;
   description?: string;
@@ -106,6 +107,7 @@ export class BaseControl {
   encrypted: boolean;
   sortOrder: number;
   controlType: string;
+  metaType: string;
   placeholder: string;
   config: any;
   dirty: boolean;
@@ -180,6 +182,7 @@ export class BaseControl {
     this.encrypted = !!config.encrypted;
     this.sortOrder = config.sortOrder === undefined ? 1 : config.sortOrder;
     this.controlType = config.controlType || '';
+    this.metaType = config.metaType;
     this.placeholder = config.placeholder || '';
     this.config = config.config || null;
     this.dirty = !!config.value;

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
@@ -24,6 +24,7 @@ import { FormUtils } from './FormUtils';
 import { NovoFormControl } from '../../elements/form/NovoFormControl';
 import { NovoLabelService } from '../../services/novo-label-service';
 import { OptionsService } from '../../services/options/OptionsService';
+import { FormField } from '../../elements/form/FormTypes';
 
 /**
  * Creates a mock address
@@ -192,7 +193,39 @@ describe('Utils: FormUtils', () => {
       expect(formUtils.determineInputType).toBeDefined();
       expect(formUtils.determineInputType({ type: 'file' })).toBe('file');
     });
-    xit('should throw an error when a type doesn\'t exist for the field.', () => {
+    describe('TO_MANY field types', () => {
+      const toManyField: FormField = {
+        type: 'TO_MANY',
+        multiValue: null,
+        dataType: 'fake',
+        options: 'fake',
+        inputType: 'fake',
+        dataSpecialization: 'fake',
+      };
+
+      describe('without associated field types', () => {
+        it("should return type 'picker' if no 'Allow Multiple' property", () => {
+          expect(formUtils.determineInputType({ ...toManyField, multiValue: false })).toBe('picker');
+        });
+        it("should return type 'chips' with 'Allow Multiple' property", () => {
+          expect(formUtils.determineInputType({ ...toManyField, multiValue: true })).toBe('chips');
+        });
+      });
+      describe('with associated entities', () => {
+        beforeEach(() => {
+          jest.spyOn(formUtils, 'hasAssociatedEntity').mockImplementation(() => true);
+        });
+        it("should return type 'entitypicker' with no 'Allow Multiple' property", () => {
+          const field: FormField = { ...toManyField, multiValue: false };
+          expect(formUtils.determineInputType(field)).toBe('entitypicker');
+        });
+        it("should return type 'entitychips' with 'Allow Multiple' property", () => {
+          const field: FormField = { ...toManyField, multiValue: true };
+          expect(formUtils.determineInputType(field)).toBe('entitychips');
+        });
+      });
+    });
+    xit("should throw an error when a type doesn't exist for the field.", () => {
       expect(formUtils.determineInputType).toBeDefined();
       expect(() => {
         formUtils.determineInputType({});
@@ -384,7 +417,7 @@ describe('Utils: FormUtils', () => {
       expect(formUtils.getControlOptions).toBeDefined();
       formUtils.getControlOptions({ dataType: 'Boolean' });
     });
-    it('should return an object with a function that returns a promise when there\'s an optionsUrl', () => {
+    it("should return an object with a function that returns a promise when there's an optionsUrl", () => {
       expect(formUtils.getControlOptions).toBeDefined();
       let result = formUtils.getControlOptions({ optionsUrl: 'TEST' });
       expect(result.field).toBe('value');
@@ -394,7 +427,7 @@ describe('Utils: FormUtils', () => {
         expect(returnValue.length).toBe(0);
       });
     });
-    it('should return an object with a function that returns a promise when there\'s an optionsUrl that calls an API', () => {
+    it("should return an object with a function that returns a promise when there's an optionsUrl that calls an API", () => {
       expect(formUtils.getControlOptions).toBeDefined();
       let mockHttp = {
         get: () => {

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
@@ -417,7 +417,7 @@ describe('Utils: FormUtils', () => {
       expect(formUtils.getControlOptions).toBeDefined();
       formUtils.getControlOptions({ dataType: 'Boolean' });
     });
-    it("should return an object with a function that returns a promise when there's an optionsUrl", () => {
+    it('should return an object with a function that returns a promise when there is an optionsUrl', () => {
       expect(formUtils.getControlOptions).toBeDefined();
       let result = formUtils.getControlOptions({ optionsUrl: 'TEST' });
       expect(result.field).toBe('value');
@@ -427,7 +427,7 @@ describe('Utils: FormUtils', () => {
         expect(returnValue.length).toBe(0);
       });
     });
-    it("should return an object with a function that returns a promise when there's an optionsUrl that calls an API", () => {
+    it('should return an object with a function that returns a promise when there is an optionsUrl that calls an API', () => {
       expect(formUtils.getControlOptions).toBeDefined();
       let mockHttp = {
         get: () => {

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
@@ -24,7 +24,7 @@ import { FormUtils } from './FormUtils';
 import { NovoFormControl } from '../../elements/form/NovoFormControl';
 import { NovoLabelService } from '../../services/novo-label-service';
 import { OptionsService } from '../../services/options/OptionsService';
-import { FormField } from '../../elements/form/FormTypes';
+import { FormField } from '../../elements/form/FormInterfaces';
 
 /**
  * Creates a mock address
@@ -203,29 +203,29 @@ describe('Utils: FormUtils', () => {
         dataSpecialization: 'fake',
       };
 
-      describe('without associated field types', () => {
-        it("should return type 'picker' if no 'Allow Multiple' property", () => {
+      describe('without associated entity', () => {
+        it('when allow multiple is disabled should return picker', () => {
           expect(formUtils.determineInputType({ ...toManyField, multiValue: false })).toBe('picker');
         });
-        it("should return type 'chips' with 'Allow Multiple' property", () => {
+        it('when allow multiple is enabled should return chips', () => {
           expect(formUtils.determineInputType({ ...toManyField, multiValue: true })).toBe('chips');
         });
       });
-      describe('with associated entities', () => {
+      describe('with associated entity', () => {
         beforeEach(() => {
           jest.spyOn(formUtils, 'hasAssociatedEntity').mockImplementation(() => true);
         });
-        it("should return type 'entitypicker' with no 'Allow Multiple' property", () => {
+        it('when allow multiple is disabled should return entitypicker', () => {
           const field: FormField = { ...toManyField, multiValue: false };
           expect(formUtils.determineInputType(field)).toBe('entitypicker');
         });
-        it("should return type 'entitychips' with 'Allow Multiple' property", () => {
+        it('when allow multiple is enabled should return entitychips', () => {
           const field: FormField = { ...toManyField, multiValue: true };
           expect(formUtils.determineInputType(field)).toBe('entitychips');
         });
       });
     });
-    xit("should throw an error when a type doesn't exist for the field.", () => {
+    xit('should throw an error when a type does not exist for the field.', () => {
       expect(formUtils.determineInputType).toBeDefined();
       expect(() => {
         formUtils.determineInputType({});

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -23,7 +23,7 @@ import {
 } from '../../elements/form/FormControls';
 import { EntityPickerResult, EntityPickerResults } from '../../elements/picker/extras/entity-picker-results/EntityPickerResults';
 import { Helpers } from '../Helpers';
-import { NovoFieldset } from '../../elements/form/FormInterfaces';
+import { NovoFieldset, FormField } from '../../elements/form/FormInterfaces';
 import { NovoFormControl, NovoFormGroup } from '../../elements/form/NovoFormControl';
 import { NovoLabelService } from '../../services/novo-label-service';
 import { OptionsService } from './../../services/options/OptionsService';
@@ -41,7 +41,7 @@ export class FormUtils {
     'Person',
     'Placement',
   ];
-  PICKER_TEST_LIST: string[] = [
+  PICKER_TEXT_LIST: string[] = [
     'CandidateText',
     'ClientText',
     'ClientContactText',
@@ -89,20 +89,18 @@ export class FormUtils {
   }
 
   /**
+   * @name hasAssociatedEntity
+   * @param field
+   */
+  hasAssociatedEntity(field: FormField): boolean {
+    return !!(field.associatedEntity && ~this.ASSOCIATED_ENTITY_LIST.indexOf(field.associatedEntity.entity));
+  }
+
+  /**
    * @name determineInputType
    * @param field
    */
-  determineInputType(field: {
-    dataSpecialization: string;
-    inputType: string;
-    options: string;
-    multiValue: boolean;
-    dataType: string;
-    type: string;
-    associatedEntity?: any;
-    optionsUrl?: string;
-    optionsType?: string;
-  }): string {
+  determineInputType(field: FormField): string {
     let type: string;
     let dataSpecializationTypeMap = {
       DATETIME: 'datetime',
@@ -139,19 +137,27 @@ export class FormUtils {
       Integer: 'number',
     };
     if (field.type === 'TO_MANY') {
-      if (field.associatedEntity && ~this.ASSOCIATED_ENTITY_LIST.indexOf(field.associatedEntity.entity)) {
-        type = 'entitychips'; // TODO!
+      if (this.hasAssociatedEntity(field)) {
+        if (field.multiValue === false) {
+          type = 'entitypicker';
+        } else {
+          type = 'entitychips';
+        }
       } else {
-        type = 'chips';
+        if (field.multiValue === false) {
+          type = 'picker';
+        } else {
+          type = 'chips';
+        }
       }
     } else if (field.type === 'TO_ONE') {
-      if (field.associatedEntity && ~this.ASSOCIATED_ENTITY_LIST.indexOf(field.associatedEntity.entity)) {
+      if (this.hasAssociatedEntity(field)) {
         type = 'entitypicker'; // TODO!
       } else {
         type = 'picker';
       }
     } else if (field.optionsUrl && field.inputType === 'SELECT') {
-      if (field.optionsType && ~this.PICKER_TEST_LIST.indexOf(field.optionsType)) {
+      if (field.optionsType && ~this.PICKER_TEXT_LIST.indexOf(field.optionsType)) {
         type = 'entitypicker'; // TODO!
       } else {
         type = 'picker';
@@ -192,6 +198,7 @@ export class FormUtils {
     let type: string = this.determineInputType(field) || field.type;
     let control: any;
     let controlConfig: NovoControlConfig = {
+      metaType: field.type,
       type: type,
       key: field.name,
       label: field.label,


### PR DESCRIPTION
## **Description**

Update FormUtils to respect the "Allow Multiple" flag when it's configured to false for fields with to-many associations (by selecting type "picker"/"entitypicker" instead of "chips"/"entitychips").

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**