### PR TITLE
fix(package.json): Lock Typescript dependency to < 3.2.0 due to angular compiler issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "tsickle": "^0.34.0",
     "tslib": "^1.9.0",
     "tslint": "^5.11.0",
-    "typescript": "^3.1.6",
+    "typescript": "~3.1.6",
     "webpack": "^4.27.1"
   }
 }


### PR DESCRIPTION
## **Description**
Fix an Angular compiler error with Typescript > 3.2.0

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**