### PR TITLE
chore(build): split path by forwardslashes instead of backslashes when generating routes

### DIFF
--- a/tools/examples-routes.ts
+++ b/tools/examples-routes.ts
@@ -143,12 +143,12 @@ function parsePageMetadata(filePath: string, sourceContent: string): PageMetadat
     title: convertToSentence(fileName),
     section: path
       .dirname(filePath)
-      .split(path.sep)
+      .split('/') // Platform specific File separator doesn't apply
       .slice(-2, -1)[0],
     template: markup,
     route: path
       .dirname(filePath)
-      .split(path.sep)
+      .split('/')
       .slice(3)
       .join('/'),
   };


### PR DESCRIPTION
## **Description**
 fixes #865
On Windows, the build doesn't generate routes correctly.  This small change is to help generate them as expected. 

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**