### PR TITLE
fix(dataTable): Fix to show overflow ellipsis when width is explicitly passed into column

### DIFF
--- a/projects/novo-elements/src/elements/data-table/cells/data-table-cell.component.ts
+++ b/projects/novo-elements/src/elements/data-table/cells/data-table-cell.component.ts
@@ -65,7 +65,6 @@ export class NovoDataTableCell<T> extends CdkCell implements OnInit, OnDestroy {
 
   private calculateWidths(): void {
     if (this.column.width) {
-      this.renderer.setStyle(this.elementRef.nativeElement, 'min-width', `${this.column.width}px`);
       this.renderer.setStyle(this.elementRef.nativeElement, 'max-width', `${this.column.width}px`);
       this.renderer.setStyle(this.elementRef.nativeElement, 'width', `${this.column.width}px`);
     }


### PR DESCRIPTION
## **Description**

Fixed a small issue where we were failing to show the text ellipsis when the column was passed in a specific width. It seems like min-width messes up text-overflow.

**Before**
<img width="486" alt="before" src="https://user-images.githubusercontent.com/22011910/50106034-266f7f00-01f4-11e9-8ff1-4438d1d8efae.png">

**After**
<img width="479" alt="after" src="https://user-images.githubusercontent.com/22011910/50106037-28d1d900-01f4-11e9-87e2-6816b3561918.png">


#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**