### PR TITLE
feat(picker): Added maximum height to picker chips form control

### DIFF
--- a/projects/novo-elements/src/elements/chips/Chips.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.ts
@@ -79,7 +79,8 @@ export class NovoChipElement {
   selector: 'chips,novo-chips',
   providers: [CHIPS_VALUE_ACCESSOR],
   template: `
-        <novo-chip
+        <div class="novo-chip-container">
+          <novo-chip
             *ngFor="let item of _items | async"
             [type]="type || item?.value?.searchEntity"
             [class.selected]="item == selected"
@@ -88,7 +89,8 @@ export class NovoChipElement {
             (select)="select($event, item)"
             (deselect)="deselect($event, item)">
             {{ item.label }}
-        </novo-chip>
+          </novo-chip>
+        </div>
         <div class="chip-input-container">
             <novo-picker
                 clearValueOnSelect="true"


### PR DESCRIPTION
## **Description**
Adding a div to wrap the novo chips on multi-pickers for the purpose of limiting the maximum height in Novo.

No style changes in this branch.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**