### PR TITLE
fix(button): Only set icon on button if exists

### DIFF
--- a/projects/novo-elements/src/elements/button/Button.ts
+++ b/projects/novo-elements/src/elements/button/Button.ts
@@ -37,17 +37,15 @@ import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class NovoButtonElement {
-  @Input()
-  color: string;
-  @Input()
-  side: string = 'right';
-  @Input()
-  theme: string;
-  @Input()
-  loading: boolean;
+  @Input() color: string;
+  @Input() side: string = 'right';
+  @Input() theme: string;
+  @Input() loading: boolean;
   @Input()
   set icon(icon: string) {
-    this._icon = `bhi-${icon}`;
+    if (icon) {
+      this._icon = `bhi-${icon}`;
+    }
   }
   get icon(): string {
     return this._icon;


### PR DESCRIPTION
## **Description**

Fixed issue where we were setting an empty icon (bhi-undefined) on button causing it to look bad.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**