### PR TITLE
feat(EntityPickerResults): Update Job, Placement, and Opportunity results to include ID

### DIFF
--- a/projects/novo-elements/src/elements/picker/extras/entity-picker-results/EntityPickerResults.spec.ts
+++ b/projects/novo-elements/src/elements/picker/extras/entity-picker-results/EntityPickerResults.spec.ts
@@ -85,9 +85,10 @@ describe('Elements: EntityPickerResult', () => {
     it('should return a correctly formatted name for Opportunity', () => {
       let input = {
         searchEntity: 'Opportunity',
-        title: 'Lead Bottlemaker',
+        id: 789,
+        title: 'Bottlemaking Opportunity',
       };
-      expect(component.getNameForResult(input)).toBe('Lead Bottlemaker');
+      expect(component.getNameForResult(input)).toBe('789 | Bottlemaking Opportunity');
     });
     it('should return a correctly formatted name for Lead', () => {
       let input = {
@@ -108,19 +109,52 @@ describe('Elements: EntityPickerResult', () => {
     it('should return a correctly formatted name for Job Order', () => {
       let input = {
         searchEntity: 'JobOrder',
+        id: 567,
         title: 'Mock Job Title',
       };
-      expect(component.getNameForResult(input)).toBe('Mock Job Title');
+      expect(component.getNameForResult(input)).toBe('567 | Mock Job Title');
     });
-    it('should return a correctly formatted name for Placement', () => {
+    it('when candidate and job are defined, should concatenate id, candidate name, and job title', () => {
       let input = {
         searchEntity: 'Placement',
+        id: 1234,
+        candidate: {
+          firstName: 'James',
+          lastName: 'Bond',
+        },
+        jobOrder: {
+          title: 'Gud Picker',
+        },
+      };
+      expect(component.getNameForResult(input)).toBe('1234 | James Bond - Gud Picker');
+    });
+    it('when candidate is undefined and job is defined, should concatenate id and job title', () => {
+      let input = {
+        searchEntity: 'Placement',
+        id: 1234,
+        jobOrder: {
+          title: 'Gud Picker',
+        },
+      };
+      expect(component.getNameForResult(input)).toBe('1234 | Gud Picker');
+    });
+    it('when candidate and job are undefined, should only return id', () => {
+      let input = {
+        searchEntity: 'Placement',
+        id: 1234,
+      };
+      expect(component.getNameForResult(input)).toBe('1234');
+    });
+    it('when candidate is defined and job is undefined, should concatenate id and candidate name', () => {
+      let input = {
+        searchEntity: 'Placement',
+        id: 1234,
         candidate: {
           firstName: 'James',
           lastName: 'Bond',
         },
       };
-      expect(component.getNameForResult(input)).toBe('James Bond');
+      expect(component.getNameForResult(input)).toBe('1234 | James Bond');
     });
     it('should return the name when present for an unknown entity', () => {
       let input = {

--- a/projects/novo-elements/src/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
@@ -159,14 +159,17 @@ export class EntityPickerResult {
           return `${result.name || ''}`.trim();
         case 'Opportunity':
         case 'JobOrder':
-          return `${result.title || ''}`.trim();
+          return `${result.id} | ${result.title || ''}`.trim();
         case 'Placement':
-          let label = '';
-          if (result.candidate) {
-            label = `${result.candidate.firstName} ${result.candidate.lastName}`.trim();
-          }
-          if (result.jobOrder) {
-            label = `${label} - ${result.jobOrder.title}`.trim();
+          let label = `${result.id}`;
+          if (result.candidate || result.jobOrder) {
+            if (result.candidate && result.jobOrder) {
+              label = `${label} | ${result.candidate.firstName} ${result.candidate.lastName} - ${result.jobOrder.title}`.trim();
+            } else if (result.jobOrder) {
+              label = `${label} | ${result.jobOrder.title}`.trim();
+            } else {
+              label = `${label} | ${result.candidate.firstName} ${result.candidate.lastName}`.trim();
+            }
           }
           return label;
         default:


### PR DESCRIPTION


## **Description**

Add ID for Job, Opportunity, and Placement picker results

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**