### PR TITLE
fix(dataTable): Change to allow data table search to show

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.component.scss
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.scss
@@ -317,7 +317,6 @@ novo-data-table {
     }
     > novo-search {
       padding-right: 10px;
-      display: none;
       @media (min-width: $breakpoint) {
         display: flex;
       }


### PR DESCRIPTION
## **Description**

The data table search is hidden behind an *ngIf, but there was styling left to always hide it.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**