### PR TITLE
feat(picker): Added container div to picker chips form control

### DIFF
--- a/projects/novo-elements/src/elements/chips/Chips.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.ts
@@ -79,16 +79,18 @@ export class NovoChipElement {
   selector: 'chips,novo-chips',
   providers: [CHIPS_VALUE_ACCESSOR],
   template: `
-        <novo-chip
-            *ngFor="let item of _items | async"
-            [type]="type || item?.value?.searchEntity"
-            [class.selected]="item == selected"
-            [disabled]="disablePickerInput"
-            (remove)="remove($event, item)"
-            (select)="select($event, item)"
-            (deselect)="deselect($event, item)">
-            {{ item.label }}
-        </novo-chip>
+        <div class="novo-chip-container">
+          <novo-chip
+              *ngFor="let item of _items | async"
+              [type]="type || item?.value?.searchEntity"
+              [class.selected]="item == selected"
+              [disabled]="disablePickerInput"
+              (remove)="remove($event, item)"
+              (select)="select($event, item)"
+              (deselect)="deselect($event, item)">
+              {{ item.label }}
+          </novo-chip>
+        </div>
         <div class="chip-input-container" *ngIf="!maxlength || (maxlength && items.length < maxlength)">
             <novo-picker
                 clearValueOnSelect="true"


### PR DESCRIPTION
## **Description**

Added back a container Div that was removed by a later commit

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**