### PR TITLE
fix(datepicker): handle dates stored as strings properly

### DIFF
--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -56,32 +56,21 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
   /** View -> model callback called when autocomplete has been touched */
   _onTouched = () => {};
 
-  @Input()
-  name: string;
-  @Input()
-  start: Date;
-  @Input()
-  end: Date;
-  @Input()
-  placeholder: string;
-  @Input()
-  maskOptions: any;
-  @Input()
-  format: string;
-  @Input()
-  textMaskEnabled: boolean = true;
-  @Input()
-  allowInvalidDate: boolean = false;
+  @Input() name: string;
+  @Input() start: Date;
+  @Input() end: Date;
+  @Input() placeholder: string;
+  @Input() maskOptions: any;
+  @Input() format: string;
+  @Input() textMaskEnabled: boolean = true;
+  @Input() allowInvalidDate: boolean = false;
   @HostBinding('class.disabled')
   @Input()
   disabled: boolean = false;
-  @Output()
-  blurEvent: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
-  @Output()
-  focusEvent: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
+  @Output() blurEvent: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
+  @Output() focusEvent: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
   /** Element for the panel containing the autocomplete options. */
-  @ViewChild(NovoOverlayTemplateComponent)
-  overlay: NovoOverlayTemplateComponent;
+  @ViewChild(NovoOverlayTemplateComponent) overlay: NovoOverlayTemplateComponent;
 
   constructor(
     public element: ElementRef,
@@ -233,6 +222,10 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
     try {
       if (!value) {
         return '';
+      }
+      // Handle dates stored as string values
+      if (/\d{4}-\d{2}-\d{2}/.test(value)) {
+        return value;
       }
       if (this.userDefinedFormat && dateFns.isValid(value)) {
         return dateFns.format(value, this.format);


### PR DESCRIPTION
## **Description**

Handle dates that are stored as strings in (YYYY-MM-DD format) so that they do not get incorrectly converted.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**