### PR TITLE
feat(Picker): Changing all entity id pickers to use full entity results

### DIFF
--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -41,15 +41,24 @@ export class FormUtils {
     'Person',
     'Placement',
   ];
-  PICKER_TEXT_LIST: string[] = [
+  ENTITY_PICKER_LIST: string[] = [
+    'Candidate',
     'CandidateText',
+    'Client',
     'ClientText',
+    'ClientContact',
     'ClientContactText',
+    'ClientCorporation',
     'ClientCorporationText',
+    'Lead',
     'LeadText',
+    'Opportunity',
     'OpportunityText',
+    'JobOrder',
     'JobOrderText',
+    'CorporateUser',
     'CorporateUserText',
+    'Person',
     'PersonText',
   ];
 
@@ -157,7 +166,7 @@ export class FormUtils {
         type = 'picker';
       }
     } else if (field.optionsUrl && field.inputType === 'SELECT') {
-      if (field.optionsType && ~this.PICKER_TEXT_LIST.indexOf(field.optionsType)) {
+      if (field.optionsType && ~this.ENTITY_PICKER_LIST.indexOf(field.optionsType)) {
         type = 'entitypicker'; // TODO!
       } else {
         type = 'picker';


### PR DESCRIPTION
## **Description**

Previously, entity pickers by ID did not return full entity picker results but entity pickers using text did. UX wanted both to show the entity results instead of the simple one line of text only results. Old behavior is on the left, new behavior is on the right.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**

![id-picker](https://user-images.githubusercontent.com/3843503/51838613-700bb900-22cc-11e9-9281-1175db583c8c.gif)
