### PR TITLE
Fix(RenderPipe) - allow options() to handle multiple values passed in an array

### DIFF
--- a/src/app/pages/elements/value/ValueDemo.ts
+++ b/src/app/pages/elements/value/ValueDemo.ts
@@ -13,6 +13,7 @@ let AssociatedValueDemoTpl = require('./templates/AssociatedValueDemo.html');
 let DateTimeValueDemoTpl = require('./templates/DateTimeValueDemo.html');
 let ExternalLinkValueDemoTpl = require('./templates/ExternalLinkValueDemo.html');
 let EntityListDemoTpl = require('./templates/EntityListDemo.html');
+let MultiOptionDemoTpl = require('./templates/MultiOptionDemo.html');
 const template = `
 <div class="container">
     <h1>Value/Details/Summary <small><a target="_blank" href="https://github.com/bullhorn/novo-elements/blob/master/src/elements/value">(source)</a></small></h1>
@@ -60,6 +61,10 @@ const template = `
     <p>Render entity lists</p>
     <div class="example value-demo">${EntityListDemoTpl}</div>
     <code-snippet [code]="EntityListDemoTpl"></code-snippet>
+    <h5>Multi Options</h5>
+    <p>Render multi option fields (Checkbox, radio, etc.) </p>
+    <div class="example value-demo">${MultiOptionDemoTpl}</div>
+    <code-snippet [code]="MultiOptionDemoTpl"></code-snippet>
 </div>
 `;
 
@@ -78,6 +83,7 @@ export class ValueDemoComponent {
   private AddressValueDemoTpl: string = AddressValueDemoTpl;
   private AssociatedValueDemoTpl: string = AssociatedValueDemoTpl;
   private EntityListDemoTpl: string = EntityListDemoTpl;
+  private MultiOptionDemoTpl: string = MultiOptionDemoTpl;
   private toggleCount: number = 0;
   private checked: boolean = true;
   simpleData = 1234567890;
@@ -221,6 +227,16 @@ export class ValueDemoComponent {
     associatedEntity: {
       entity: 'CorporateUser',
     },
+  };
+  multiOptionData = ['1', '3'];
+  multiOptionMeta = {
+    inputType: 'SELECT',
+    options: [
+      { label: 'New Lead', value: '1' },
+      { label: 'Old Lead', value: '2' },
+      { label: 'Active', value: '3' },
+      { label: 'Archived', value: '4' },
+    ],
   };
   increment() {
     this.toggleCount++;

--- a/src/app/pages/elements/value/templates/MultiOptionDemo.html
+++ b/src/app/pages/elements/value/templates/MultiOptionDemo.html
@@ -1,0 +1,1 @@
+<novo-value [data]="multiOptionData" [meta]="multiOptionMeta"></novo-value>

--- a/src/platform/elements/value/Render.spec.ts
+++ b/src/platform/elements/value/Render.spec.ts
@@ -438,6 +438,15 @@ xdescribe('Render', () => {
         it('should be defined.', () => {
             expect(pipe.options).toBeDefined();
         });
+        it('should return an array of corresponding labels for values passed', () => {
+            let values = ['1', '3'];
+            let list = [
+                { label: 'Archived', value: '1'},
+                { label: 'New Lead', value: '2' },
+                { label: 'Old Lead', value: '3' },
+            ];
+            expect(pipe.options(values, list)).toEqual(['Archived', 'Old Lead']);
+        });
     });
 
     describe('Function: getNumberDecimalPlaces(number)', () => {

--- a/src/platform/elements/value/Render.ts
+++ b/src/platform/elements/value/Render.ts
@@ -188,7 +188,7 @@ export class RenderPipe implements PipeTransform {
       type = 'Country';
     } else if (args.optionsType === 'SkillText') {
       type = 'SkillText';
-    } else if (args.options || args.inputType === 'SELECT') {
+    } else if (args.options || args.inputType === 'SELECT' || args.inputType === 'CHECKBOX') {
       type = 'Options';
     } else if (['MONEY', 'PERCENTAGE', 'HTML', 'SSN'].indexOf(args.dataSpecialization) > -1) {
       type = this.capitalize(args.dataSpecialization.toLowerCase());
@@ -375,16 +375,16 @@ export class RenderPipe implements PipeTransform {
    * @return {String}
    */
   options(value: any, list: any): any {
-    try {
-      for (const item of list) {
-        if (item.value === value) {
-          return item.label;
-        }
-      }
-    } catch (e) {
-      // do nothing
+    if (!Array.isArray(value)) {
+        value = [value];
     }
-    return value;
+    return value.map((item: any) => {
+        for (const option of list) {
+            if (option.value === item) {
+                return option.label;
+            }
+        }
+    });
   }
 
   getNumberDecimalPlaces(value: any): any {

--- a/src/platform/elements/value/Render.ts
+++ b/src/platform/elements/value/Render.ts
@@ -376,14 +376,15 @@ export class RenderPipe implements PipeTransform {
    */
   options(value: any, list: any): any {
     if (!Array.isArray(value)) {
-        value = [value];
+      value = [value];
     }
     return value.map((item: any) => {
-        for (const option of list) {
-            if (option.value === item) {
-                return option.label;
-            }
+      for (const option of list) {
+        if (option.value === item) {
+          return option.label;
         }
+      }
+      return item;
     });
   }
 

--- a/src/platform/elements/value/SimpleValueDemo.html
+++ b/src/platform/elements/value/SimpleValueDemo.html
@@ -1,1 +1,0 @@
-<novo-value [data]="simpleData" [meta]="simpleMeta" [theme]="simpleTheme"></novo-value>


### PR DESCRIPTION
… an array

## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**