### PR TITLE
feat(formUtils): add remove controls function to form utils

### DIFF
--- a/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
@@ -104,6 +104,16 @@ describe('Utils: FormUtils', () => {
     });
   });
 
+  describe('Method: removeControls(formGroup, controls)', () => {
+    it('should remove controls from a form group.', () => {
+      expect(formUtils.removeControls).toBeDefined();
+      let formGroup: FormGroup = formUtils.toFormGroup([{ key: 'Test' }, { key: 'Test2' }]);
+      formUtils.removeControls(formGroup, [{ key: 'Test2' }]);
+      // Can't use `.Test2` because the formGroup isn't returned
+      expect(formGroup.controls['Test2']).not.toBeDefined();
+    });
+  });
+
   describe('Method: toFormGroupFromFieldset(fieldsets)', () => {
     it('should create FormGroups from a collection of FieldSets that contain controls.', () => {
       expect(formUtils.toFormGroup).toBeDefined();

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -86,6 +86,12 @@ export class FormUtils {
     });
   }
 
+  removeControls(formGroup: NovoFormGroup, controls: Array<NovoControlConfig>): void {
+    controls.forEach((control) => {
+      formGroup.removeControl(control.key);
+    });
+  }
+
   /**
    * @name toFormGroupFromFieldset
    * @param fieldsets


### PR DESCRIPTION
## **Description**

Add function to remove controls from form group.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**