### PR TITLE
feat(helpers): Extended the logic of isNumber

### DIFF
--- a/projects/novo-elements/src/utils/Helpers.spec.ts
+++ b/projects/novo-elements/src/utils/Helpers.spec.ts
@@ -75,4 +75,19 @@ describe('Utils: Helpers', () => {
       expect(Helpers.getNextElementSibling(origin)).toEqual(null);
     });
   });
+
+  describe('Method: isNumber(val)', () => {
+    it('should return true', () => {
+      const numbers: any[] = [0, 1, 10.75, '25', '8.75', '5.', '.5', '0.10', '0'];
+      numbers.forEach((number) => {
+        expect(Helpers.isNumber(number)).toEqual(true);
+      });
+    });
+    it('should return false', () => {
+      const notNumbers: any[] = [NaN, undefined, null, '', [], {}, 'test', '.'];
+      notNumbers.forEach((notNumber) => {
+        expect(Helpers.isNumber(notNumber)).toBeFalsy();
+      });
+    });
+  });
 });

--- a/projects/novo-elements/src/utils/Helpers.ts
+++ b/projects/novo-elements/src/utils/Helpers.ts
@@ -83,8 +83,14 @@ export class Helpers {
     return typeof obj === 'string';
   }
 
-  static isNumber(obj: any) {
-    return obj && !isNaN(parseInt(obj, 10));
+  static isNumber(val: any) {
+    if (typeof val === 'number') {
+      return !isNaN(val);
+    } else if (typeof val === 'string') {
+      return val.length > 0 && val !== '.' && /^\d*\.?\d*$/.test(val);
+    } else {
+      return val && !isNaN(parseInt(val, 10));
+    }
   }
 
   /**

--- a/projects/novo-elements/src/utils/Helpers.ts
+++ b/projects/novo-elements/src/utils/Helpers.ts
@@ -84,13 +84,7 @@ export class Helpers {
   }
 
   static isNumber(val: any) {
-    if (typeof val === 'number') {
-      return !isNaN(val);
-    } else if (typeof val === 'string') {
-      return val.length > 0 && val !== '.' && /^\d*\.?\d*$/.test(val);
-    } else {
-      return val && !isNaN(parseInt(val, 10));
-    }
+    return !isNaN(parseFloat(val));
   }
 
   /**


### PR DESCRIPTION
## **Description**

I just extended the logic of `isNumber` to allow for floats as well.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**