### PR TITLE
Fix(Render) - SecondaryAddress and Billing Address render for verticl

### DIFF
--- a/projects/novo-elements/src/elements/value/Render.spec.ts
+++ b/projects/novo-elements/src/elements/value/Render.spec.ts
@@ -97,6 +97,34 @@ xdescribe('Render', () => {
       };
       expect(pipe.render(mockValue, mockArgs)).toBe(mockValue);
     });
+    it('should render an SecondaryAddress.', () => {
+      expect(pipe.render).toBeDefined();
+      let mockValue: any = {
+        address1: 'Derp',
+        address2: '264 Hess Rd',
+        city: 'Leola',
+        state: 'PA',
+        zip: '17540',
+      };
+      let mockArgs: any = {
+        type: 'SecondaryAddress',
+      };
+      expect(pipe.render(mockValue, mockArgs)).toBe(mockValue);
+    });
+    it('should render an BillingAddress.', () => {
+      expect(pipe.render).toBeDefined();
+      let mockValue: any = {
+        address1: 'Derp',
+        address2: '264 Hess Rd',
+        city: 'Leola',
+        state: 'PA',
+        zip: '17540',
+      };
+      let mockArgs: any = {
+        type: 'BillingAddress',
+      };
+      expect(pipe.render(mockValue, mockArgs)).toBe(mockValue);
+    });
     // TODO: DateTime
     // WILL BREAK THE NEXT DAY
     xit('should render a timestamp.', () => {

--- a/projects/novo-elements/src/elements/value/Render.ts
+++ b/projects/novo-elements/src/elements/value/Render.ts
@@ -200,6 +200,8 @@ export class RenderPipe implements PipeTransform {
       case 'Address':
       case 'Address1':
       case 'AddressWithoutCountry':
+      case 'SecondaryAddress':
+      case 'BillingAddress':
         let country: any = findByCountryId(Number(value.countryName));
         text = '';
         if (value.address1 || value.address2) {


### PR DESCRIPTION
## **Description**

Added support for SecondaryAddress and Billing Address display for Vertical Layout

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**