### PR TITLE
State picker assign value

### DIFF
--- a/projects/novo-elements/src/elements/chips/Chips.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.ts
@@ -222,7 +222,12 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
       if (noLabels.length > 0 && this.source && this.source.getLabels && typeof this.source.getLabels === 'function') {
         this.source.getLabels(noLabels).then((result) => {
           for (let value of result) {
-            if (value.hasOwnProperty('label')) {
+            if (value.hasOwnProperty('label') && this.source.useGetLabels) {
+              this.items.push({
+                value: value.value,
+                label: value.label,
+              });
+            } else if (value.hasOwnProperty('label')) {
               this.items.push({
                 value,
                 label: value.label,


### PR DESCRIPTION
## **Description**

Made a change in chips.ts that will allow state picker values to have their value attribute assigned to the incoming value, rather than entire incoming result.

#### **Verify that...**

- [/] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [/] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**