### PR TITLE
fix(demo): remove angular-cli json file and add it in typescript

### DIFF
--- a/demo/assets/stackblitz/.angular-cli.json
+++ b/demo/assets/stackblitz/.angular-cli.json
@@ -1,7 +1,0 @@
-{
-  "apps": [
-    {
-      "styles": ["styles.scss"]
-    }
-  ]
-}

--- a/projects/novo-examples/src/_shared/stackblitz/stackblitz-writer.ts
+++ b/projects/novo-examples/src/_shared/stackblitz/stackblitz-writer.ts
@@ -9,7 +9,7 @@ const COPYRIGHT = `Copyright 2018 Bullhorn Inc. All Rights Reserved.
     can be found in the LICENSE file at http://angular.io/license`;
 
 const TEMPLATE_PATH = './assets/stackblitz/';
-const TEMPLATE_FILES = ['index.html', 'styles.scss', 'polyfills.ts', '.angular-cli.json', 'main.ts'];
+const TEMPLATE_FILES = ['index.html', 'styles.scss', 'polyfills.ts', 'main.ts'];
 
 const TAGS: string[] = ['angular', 'bullhon', 'novo-elements', 'example'];
 const angularVersion = '^7.2.0';
@@ -97,6 +97,11 @@ export class StackblitzWriter {
       exampleContents.push(
         Promise.resolve(
           this._addFileToForm(form, data, decodeURIComponent(data.source.cssSource), `app/${data.selectorName}.css`, TEMPLATE_PATH),
+        ),
+      );
+      exampleContents.push(
+        Promise.resolve(
+          this._addFileToForm(form, data, JSON.stringify({ apps: [{ styles: ['styles.scss'] }] }), `.angular-cli.json`, TEMPLATE_PATH),
         ),
       );
 


### PR DESCRIPTION
## **Description**
Follow on from #928 

Github pages doesn't seem to agree with the .angular-cli.json file.  I removed dependency of the json file and added it via javascript. removes the requirement of server side requests
#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works
