### PR TITLE
feat(AppBridge): App Bridge Fixes

### DIFF
--- a/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
+++ b/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
@@ -715,7 +715,6 @@ export class DevAppBridge extends AppBridge {
    * @param packet any - packet of data to send with the event
    */
   public httpGET(relativeURL: string): Promise<any> {
-    // TODO: Unwrap the response
     return this.http.get(`${this.baseURL}/${relativeURL}`, { withCredentials: true }).toPromise();
   }
 
@@ -724,7 +723,6 @@ export class DevAppBridge extends AppBridge {
    * @param packet any - packet of data to send with the event
    */
   public httpPOST(relativeURL: string, postData: any): Promise<any> {
-    // TODO: Unwrap the response
     return this.http.post(`${this.baseURL}/${relativeURL}`, postData, { withCredentials: true }).toPromise();
   }
 
@@ -733,7 +731,6 @@ export class DevAppBridge extends AppBridge {
    * @param packet any - packet of data to send with the event
    */
   public httpPUT(relativeURL: string, putData: any): Promise<any> {
-    // TODO: Unwrap the response
     return this.http.put(`${this.baseURL}/${relativeURL}`, putData, { withCredentials: true }).toPromise();
   }
 
@@ -742,7 +739,6 @@ export class DevAppBridge extends AppBridge {
    * @param packet any - packet of data to send with the event
    */
   public httpDELETE(relativeURL: string): Promise<any> {
-    // TODO: Unwrap the response
     return this.http.delete(`${this.baseURL}/${relativeURL}`, { withCredentials: true }).toPromise();
   }
 

--- a/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
+++ b/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
@@ -715,6 +715,7 @@ export class DevAppBridge extends AppBridge {
    * @param packet any - packet of data to send with the event
    */
   public httpGET(relativeURL: string): Promise<any> {
+    // TODO: Unwrap the response
     return this.http.get(`${this.baseURL}/${relativeURL}`, { withCredentials: true }).toPromise();
   }
 
@@ -723,6 +724,7 @@ export class DevAppBridge extends AppBridge {
    * @param packet any - packet of data to send with the event
    */
   public httpPOST(relativeURL: string, postData: any): Promise<any> {
+    // TODO: Unwrap the response
     return this.http.post(`${this.baseURL}/${relativeURL}`, postData, { withCredentials: true }).toPromise();
   }
 
@@ -731,6 +733,7 @@ export class DevAppBridge extends AppBridge {
    * @param packet any - packet of data to send with the event
    */
   public httpPUT(relativeURL: string, putData: any): Promise<any> {
+    // TODO: Unwrap the response
     return this.http.put(`${this.baseURL}/${relativeURL}`, putData, { withCredentials: true }).toPromise();
   }
 
@@ -739,6 +742,7 @@ export class DevAppBridge extends AppBridge {
    * @param packet any - packet of data to send with the event
    */
   public httpDELETE(relativeURL: string): Promise<any> {
+    // TODO: Unwrap the response
     return this.http.delete(`${this.baseURL}/${relativeURL}`, { withCredentials: true }).toPromise();
   }
 

--- a/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
+++ b/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
@@ -542,7 +542,7 @@ export class AppBridge {
           })
           .catch((err) => {
             this._trace(`${MESSAGE_TYPES.REGISTER} - FAILED - (no parent)`, err);
-            resolve(null);
+            reject(null);
           });
       }
     });

--- a/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
+++ b/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
@@ -14,7 +14,11 @@ export enum AppBridgeHandler {
   CALLBACK,
 }
 
-export type NovoApps = 'record' | 'add' | 'fast-add' | 'custom';
+// record       - an individual entity record
+// add/fast-add - the add page for a new record
+// custom       - custom action that opens the url provided in data.url
+// preview      - the preview slideout available only in Novo
+export type NovoApps = 'record' | 'add' | 'fast-add' | 'custom' | 'preview';
 
 export interface IAppBridgeOpenEvent {
   type: NovoApps;

--- a/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
+++ b/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
@@ -542,7 +542,7 @@ export class AppBridge {
           })
           .catch((err) => {
             this._trace(`${MESSAGE_TYPES.REGISTER} - FAILED - (no parent)`, err);
-            reject(null);
+            reject(err);
           });
       }
     });


### PR DESCRIPTION
## **Description**

Fixing the AppBridge registration call to send back reject() when it fails, instead of the same response as when it succeeds. Also, adding type for preview slideout (Novo Only) and fixing the response of the DevAppBridge to not wrap the rest return in a second data object. 

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`
