### PR TITLE
feat(FormUtils): Add support for workflow options

### DIFF
--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -356,7 +356,7 @@ export class NovoSelectElement implements OnInit, OnChanges, OnDestroy, ControlV
   writeValue(model: any): void {
     this.model = model;
     if (this.options) {
-      let item = this.filteredOptions.find((i) => i.value === model || i.value === model.id);
+      let item = this.filteredOptions.find((i) => i.value === model || (model && i.value === model.id));
       if (!item && !Helpers.isEmpty(model)) {
         item = {
           label: model,

--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -35,22 +35,38 @@ const SELECT_VALUE_ACCESSOR = {
   selector: 'novo-select',
   providers: [SELECT_VALUE_ACCESSOR],
   template: `
-    <div #dropdownElement (click)="togglePanel(); false" tabIndex="{{ disabled ? -1 : 0 }}" type="button" [class.empty]="empty">{{selected.label}}<i class="bhi-collapse"></i></div>
+    <div #dropdownElement (click)="togglePanel(); (false)" tabIndex="{{ disabled ? -1 : 0 }}" type="button" [class.empty]="empty">
+      {{ selected.label }}<i class="bhi-collapse"></i>
+    </div>
     <novo-overlay-template [parent]="element" position="center" (closing)="dropdown.nativeElement.focus()">
       <ul class="novo-select-list" tabIndex="-1" [class.header]="headerConfig" [class.active]="panelOpen">
         <ng-content></ng-content>
         <li *ngIf="headerConfig" class="select-header" [class.open]="header.open">
-          <button *ngIf="!header.open" (click)="toggleHeader($event); false" tabIndex="-1" type="button" class="header"><i class="bhi-add-thin"></i>&nbsp;{{headerConfig.label}}
+          <button *ngIf="!header.open" (click)="toggleHeader($event); (false)" tabIndex="-1" type="button" class="header">
+            <i class="bhi-add-thin"></i>&nbsp;{{ headerConfig.label }}
           </button>
-          <div *ngIf="header.open" [ngClass]="{active: header.open}">
-            <input autofocus type="text" [placeholder]="headerConfig.placeholder" [attr.id]="name" autocomplete="false" [(ngModel)]="header.value" [ngClass]="{invalid: !header.valid}" />
+          <div *ngIf="header.open" [ngClass]="{ active: header.open }">
+            <input
+              autofocus
+              type="text"
+              [placeholder]="headerConfig.placeholder"
+              [attr.id]="name"
+              autocomplete="false"
+              [(ngModel)]="header.value"
+              [ngClass]="{ invalid: !header.valid }"
+            />
             <footer>
-              <button (click)="toggleHeader($event, false)">{{labels.cancel}}</button>
-              <button (click)="saveHeader()" class="primary">{{labels.save}}</button>
+              <button (click)="toggleHeader($event, false)">{{ labels.cancel }}</button>
+              <button (click)="saveHeader()" class="primary">{{ labels.save }}</button>
             </footer>
           </div>
         </li>
-        <li *ngFor="let option of filteredOptions; let i = index" [ngClass]="{active: option.active}" (click)="setValueAndClose({value: option, index: i})" [attr.data-automation-value]="option.label">
+        <li
+          *ngFor="let option of filteredOptions; let i = index"
+          [ngClass]="{ active: option.active }"
+          (click)="setValueAndClose({ value: option, index: i })"
+          [attr.data-automation-value]="option.label"
+        >
           <span [innerHtml]="highlight(option.label, filterTerm)"></span>
           <i *ngIf="option.active" class="bhi-check"></i>
         </li>
@@ -340,7 +356,7 @@ export class NovoSelectElement implements OnInit, OnChanges, OnDestroy, ControlV
   writeValue(model: any): void {
     this.model = model;
     if (this.options) {
-      let item = this.filteredOptions.find((i) => i.value === model);
+      let item = this.filteredOptions.find((i) => i.value === model || i.value === model.id);
       if (!item && !Helpers.isEmpty(model)) {
         item = {
           label: model,

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
@@ -203,6 +203,9 @@ describe('Utils: FormUtils', () => {
       expect(formUtils.determineInputType).toBeDefined();
       expect(formUtils.determineInputType({ type: 'file' })).toBe('file');
     });
+    it('should return the type of WorkflowOptions correctly.', () => {
+      expect(formUtils.determineInputType({ dataSpecialization: 'WORKFLOW_OPTIONS' })).toBe('select');
+    });
     describe('TO_MANY field types', () => {
       const toManyField: FormField = {
         type: 'TO_MANY',
@@ -323,6 +326,13 @@ describe('Utils: FormUtils', () => {
       let result = formUtils.getControlForField({ type: 'editor-minimal' });
       expect(result instanceof EditorControl).toBeTruthy();
     });
+    it('should return the right component for WorkflowOptions and call getControlOptions with data', () => {
+      const field: { type: string } = { type: 'select' };
+      spyOn(formUtils, 'getControlOptions');
+      const result = formUtils.getControlForField(field, undefined, undefined, undefined, undefined, 'First');
+      expect(formUtils.getControlOptions).toHaveBeenCalledWith(field, undefined, undefined, 'First');
+      expect(result instanceof SelectControl).toBeTruthy();
+    });
     describe('with type: address', () => {
       it('should return the right component for address', () => {
         expect(formUtils.getControlForField).toBeDefined();
@@ -420,6 +430,35 @@ describe('Utils: FormUtils', () => {
       expect(fieldset[0].icon).toBe('bhi-certification');
       expect(fieldset[0].controls.length).toBe(1);
     });
+    it('should call getControlForField with data', () => {
+      let meta = {
+        entity: 'ENTITY_NAME',
+        label: 'ENTITY_LABEL',
+        fields: [
+          {
+            name: 'firstName',
+            type: 'text',
+            label: 'First Name',
+            required: true,
+            sortOrder: 10,
+            maxLength: 10,
+            description: 'First Name, Yo!',
+          },
+        ],
+        sectionHeaders: [
+          {
+            label: 'Header',
+            name: 'header',
+            sortOrder: 0,
+            enabled: true,
+            icon: 'bhi-certification',
+          },
+        ],
+      };
+      spyOn(formUtils, 'getControlForField').and.returnValue({});
+      formUtils.toFieldSets(meta, 'USD', {}, {}, {}, { firstName: 'First' });
+      expect(formUtils.getControlForField).toHaveBeenCalledWith(meta.fields[0], {}, {}, {}, undefined, 'First');
+    });
   });
 
   describe('Method: getControlOptions(field, http, config)', () => {
@@ -462,6 +501,17 @@ describe('Utils: FormUtils', () => {
     it('should return an array when options is an array', () => {
       expect(formUtils.getControlOptions).toBeDefined();
       let result = formUtils.getControlOptions({ dataSpecialization: 'DATETIME' });
+    });
+    it('should return an array when there are WorkflowOptions', () => {
+      const field: { workflowOptions: Object } = {
+        workflowOptions: {
+          '1': [{ value: '1', label: '1' }],
+          '2': [{ value: '2', label: '2' }],
+        },
+      };
+      const expected: Array<{ value: string; label: string }> = [{ value: '2', label: '2' }];
+      const result = formUtils.getControlOptions(field, undefined, undefined, { id: '2' });
+      expect(result).toEqual(expected);
     });
   });
 

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
@@ -513,6 +513,28 @@ describe('Utils: FormUtils', () => {
       const result = formUtils.getControlOptions(field, undefined, undefined, { id: '2' });
       expect(result).toEqual(expected);
     });
+    it('should add current option to array if current value is not there for WorkflowOptions', () => {
+      const field: { workflowOptions: Object } = {
+        workflowOptions: {
+          '1': [{ value: '1', label: 'one' }, { value: '3', label: 'three' }],
+          '2': [{ value: '2', label: 'two' }],
+        },
+      };
+      const expected: Array<{ value: string; label: string }> = [{ value: '1', label: 'one' }, { value: '3', label: 'three' }];
+      const result = formUtils.getControlOptions(field, undefined, undefined, { id: '1', label: 'one' });
+      expect(result).toEqual(expected);
+    });
+    it('should return an array when there are WorkflowOptions and value has no id', () => {
+      const field: { workflowOptions: Object } = {
+        workflowOptions: {
+          initial: [{ value: '1', label: '1' }],
+          '2': [{ value: '2', label: '2' }],
+        },
+      };
+      const expected: Array<{ value: string; label: string }> = [{ value: '1', label: '1' }];
+      const result = formUtils.getControlOptions(field, undefined, undefined, { label: '2' });
+      expect(result).toEqual(expected);
+    });
   });
 
   describe('Method: setInitialValues(controls, values, keepClean)', () => {

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -584,8 +584,7 @@ export class FormUtils {
       // TODO: (cont.) returns `tiles`
       return [{ value: false, label: this.labels.no }, { value: true, label: this.labels.yes }];
     } else if (field.workflowOptions && fieldData) {
-      const currentWorkflowOption: number | string = fieldData.id ? fieldData.id : 'initial';
-      return field.workflowOptions[currentWorkflowOption] || [];
+      return this.getWorkflowOptions(field.workflowOptions, fieldData);
     } else if (field.optionsUrl) {
       return this.optionsService.getOptionsConfig(http, field, config);
     } else if (Array.isArray(field.options) && field.type === 'chips') {
@@ -599,6 +598,25 @@ export class FormUtils {
       return field.options;
     }
     return null;
+  }
+
+  private getWorkflowOptions(
+    workflowOptions: { [key: string]: any },
+    fieldData: { [key: string]: any },
+  ): Array<{ value: string | number; label: string | number }> {
+    let currentValue: { value: string | number; label: string | number };
+    if (fieldData.id) {
+      currentValue = { value: fieldData.id, label: fieldData.label ? fieldData.label : fieldData.id };
+    }
+
+    const currentWorkflowOption: number | string = fieldData.id ? fieldData.id : 'initial';
+    let updateWorkflowOptions: Array<{ value: string | number; label: string | number }> = workflowOptions[currentWorkflowOption] || [];
+
+    if (currentValue && !updateWorkflowOptions.find((option) => option.value === currentValue.value)) {
+      updateWorkflowOptions.unshift(currentValue);
+    }
+
+    return updateWorkflowOptions;
   }
 
   setInitialValues(controls: Array<NovoControlConfig>, values: any, keepClean?: boolean, keyOverride?: string) {

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -126,6 +126,7 @@ export class FormUtils {
       HTML: 'editor',
       'HTML-MINIMAL': 'editor-minimal',
       YEAR: 'year',
+      WORKFLOW_OPTIONS: 'select',
     };
     let dataTypeToTypeMap = {
       Timestamp: 'date',
@@ -167,7 +168,9 @@ export class FormUtils {
         }
       }
     } else if (field.type === 'TO_ONE') {
-      if (this.hasAssociatedEntity(field)) {
+      if (field.dataSpecialization === 'WORKFLOW_OPTIONS') {
+        type = dataSpecializationTypeMap[field.dataSpecialization];
+      } else if (this.hasAssociatedEntity(field)) {
         type = 'entitypicker'; // TODO!
       } else {
         type = 'picker';
@@ -208,6 +211,7 @@ export class FormUtils {
     config: { token?: string; restUrl?: string; military?: boolean },
     overrides?: any,
     forTable: boolean = false,
+    fieldData?: any,
   ) {
     // TODO: if field.type overrides `determineInputType` we should use it in that method or use this method
     // TODO: (cont.) as the setter of the field argument
@@ -245,7 +249,7 @@ export class FormUtils {
       closeOnSelect: field.closeOnSelect,
     };
     // TODO: getControlOptions should always return the correct format
-    let optionsConfig = this.getControlOptions(field, http, config);
+    let optionsConfig = this.getControlOptions(field, http, config, fieldData);
     if (Array.isArray(optionsConfig) && !(type === 'chips' || type === 'picker')) {
       controlConfig.options = optionsConfig;
     } else if (Array.isArray(optionsConfig) && (type === 'chips' || type === 'picker')) {
@@ -410,7 +414,7 @@ export class FormUtils {
               if (!subfield.optionsUrl) {
                 subfield.optionsUrl = `options/${subfield.optionsType}`;
               }
-              controlConfig.config[subfield.name].pickerConfig = this.getControlOptions(subfield, http, config);
+              controlConfig.config[subfield.name].pickerConfig = this.getControlOptions(subfield, http, config, fieldData);
             }
           }
         }
@@ -472,7 +476,14 @@ export class FormUtils {
     return ret;
   }
 
-  toFieldSets(meta, currencyFormat, http, config: { token?: string; restUrl?: string; military?: boolean }, overrides?) {
+  toFieldSets(
+    meta,
+    currencyFormat,
+    http,
+    config: { token?: string; restUrl?: string; military?: boolean },
+    overrides?,
+    data?: { [key: string]: any },
+  ) {
     let fieldsets: Array<NovoFieldset> = [];
     let ranges = [];
     if (meta && meta.fields) {
@@ -539,7 +550,8 @@ export class FormUtils {
           (field.dataSpecialization !== 'SYSTEM' || ['address', 'billingAddress', 'secondaryAddress'].indexOf(field.name) !== -1) &&
           !field.readOnly
         ) {
-          let control = this.getControlForField(field, http, config, overrides);
+          const fieldData: any = data && data[field.name] ? data[field.name] : null;
+          let control = this.getControlForField(field, http, config, overrides, undefined, fieldData);
           // Set currency format
           if (control.subType === 'currency') {
             control.currencyFormat = currencyFormat;
@@ -565,12 +577,15 @@ export class FormUtils {
     }
   }
 
-  getControlOptions(field: any, http: any, config: { token?: string; restUrl?: string; military?: boolean }): any {
+  getControlOptions(field: any, http: any, config: { token?: string; restUrl?: string; military?: boolean }, fieldData?: any): any {
     // TODO: The token property of config is the only property used; just pass in `token: string`
     if (field.dataType === 'Boolean' && !field.options) {
       // TODO: dataType should only be determined by `determineInputType` which doesn't ever return 'Boolean' it
       // TODO: (cont.) returns `tiles`
       return [{ value: false, label: this.labels.no }, { value: true, label: this.labels.yes }];
+    } else if (field.workflowOptions && fieldData) {
+      const currentWorkflowOption: number | string = fieldData.id ? fieldData.id : 'initial';
+      return field.workflowOptions[currentWorkflowOption] || [];
     } else if (field.optionsUrl) {
       return this.optionsService.getOptionsConfig(http, field, config);
     } else if (Array.isArray(field.options) && field.type === 'chips') {

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -249,7 +249,7 @@ export class FormUtils {
       closeOnSelect: field.closeOnSelect,
     };
     // TODO: getControlOptions should always return the correct format
-    let optionsConfig = this.getControlOptions(field, http, config, fieldData);
+    const optionsConfig = this.getControlOptions(field, http, config, fieldData);
     if (Array.isArray(optionsConfig) && !(type === 'chips' || type === 'picker')) {
       controlConfig.options = optionsConfig;
     } else if (Array.isArray(optionsConfig) && (type === 'chips' || type === 'picker')) {


### PR DESCRIPTION
## **Description**

Updating FormUtils to allow support for workflow options.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**