### PR TITLE
ReflectiveInjector is deprecated

### DIFF
--- a/projects/novo-elements/src/elements/chips/Chips.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.ts
@@ -21,12 +21,11 @@ const CHIPS_VALUE_ACCESSOR = {
 @Component({
   selector: 'chip,novo-chip',
   template: `
-        <span (click)="onSelect($event)" (mouseenter)="onSelect($event)" (mouseleave)="onDeselect($event)" [ngClass]="_type">
-            <i *ngIf="_type" class="bhi-circle"></i>
-            <span><ng-content></ng-content></span>
-        </span>
-        <i class="bhi-close" *ngIf="!disabled" (click)="onRemove($event)"></i>
-    `,
+    <span (click)="onSelect($event)" (mouseenter)="onSelect($event)" (mouseleave)="onDeselect($event)" [ngClass]="_type">
+      <i *ngIf="_type" class="bhi-circle"></i> <span><ng-content></ng-content></span>
+    </span>
+    <i class="bhi-close" *ngIf="!disabled" (click)="onRemove($event)"></i>
+  `,
 })
 export class NovoChipElement {
   @Input()
@@ -79,41 +78,43 @@ export class NovoChipElement {
   selector: 'chips,novo-chips',
   providers: [CHIPS_VALUE_ACCESSOR],
   template: `
-        <div class="novo-chip-container">
-          <novo-chip
-              *ngFor="let item of _items | async"
-              [type]="type || item?.value?.searchEntity"
-              [class.selected]="item == selected"
-              [disabled]="disablePickerInput"
-              (remove)="remove($event, item)"
-              (select)="select($event, item)"
-              (deselect)="deselect($event, item)">
-              {{ item.label }}
-          </novo-chip>
-        </div>
-        <div class="chip-input-container" *ngIf="!maxlength || (maxlength && items.length < maxlength)">
-            <novo-picker
-                clearValueOnSelect="true"
-                [closeOnSelect]="closeOnSelect"
-                [config]="source"
-                [disablePickerInput]="disablePickerInput"
-                [placeholder]="placeholder"
-                [(ngModel)]="itemToAdd"
-                (select)="add($event)"
-                (keydown)="onKeyDown($event)"
-                (focus)="onFocus($event)"
-                (typing)="onTyping($event)"
-                (blur)="onTouched($event)"
-                [selected]="items"
-                [overrideElement]="element">
-            </novo-picker>
-        </div>
-        <div class="preview-container">
-            <span #preview></span>
-        </div>
-        <i class="bhi-search" [class.has-value]="items.length" *ngIf="!disablePickerInput"></i>
-        <label class="clear-all" *ngIf="items.length && !disablePickerInput" (click)="clearValue()">{{ labels.clearAll }} <i class="bhi-times"></i></label>
-   `,
+    <div class="novo-chip-container">
+      <novo-chip
+        *ngFor="let item of (_items | async)"
+        [type]="type || item?.value?.searchEntity"
+        [class.selected]="item == selected"
+        [disabled]="disablePickerInput"
+        (remove)="remove($event, item)"
+        (select)="select($event, item)"
+        (deselect)="deselect($event, item)"
+      >
+        {{ item.label }}
+      </novo-chip>
+    </div>
+    <div class="chip-input-container" *ngIf="!maxlength || (maxlength && items.length < maxlength)">
+      <novo-picker
+        clearValueOnSelect="true"
+        [closeOnSelect]="closeOnSelect"
+        [config]="source"
+        [disablePickerInput]="disablePickerInput"
+        [placeholder]="placeholder"
+        [(ngModel)]="itemToAdd"
+        (select)="add($event)"
+        (keydown)="onKeyDown($event)"
+        (focus)="onFocus($event)"
+        (typing)="onTyping($event)"
+        (blur)="onTouched($event)"
+        [selected]="items"
+        [overrideElement]="element"
+      >
+      </novo-picker>
+    </div>
+    <div class="preview-container"><span #preview></span></div>
+    <i class="bhi-search" [class.has-value]="items.length" *ngIf="!disablePickerInput"></i>
+    <label class="clear-all" *ngIf="items.length && !disablePickerInput" (click)="clearValue()"
+      >{{ labels.clearAll }} <i class="bhi-times"></i
+    ></label>
+  `,
   host: {
     '[class.with-value]': 'items.length > 0',
     '[class.disabled]': 'disablePickerInput',
@@ -352,7 +353,7 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
   showPreview() {
     if (this.source.previewTemplate) {
       if (!this.popup) {
-        this.popup = this.componentUtils.appendNextToLocation(this.source.previewTemplate, this.preview);
+        this.popup = this.componentUtils.append(this.source.previewTemplate, this.preview);
       }
       this.popup.instance.match = this.selected;
     }

--- a/projects/novo-elements/src/elements/modal/Modal.ts
+++ b/projects/novo-elements/src/elements/modal/Modal.ts
@@ -60,7 +60,7 @@ export class NovoModalContainerElement implements AfterViewInit {
 
   ngAfterViewInit() {
     setTimeout(() => {
-      this.modalRef.contentRef = this.componentUtils.appendNextToLocation(this.modalRef.component, this.container);
+      this.modalRef.contentRef = this.componentUtils.append(this.modalRef.component, this.container);
     });
   }
 }
@@ -68,12 +68,10 @@ export class NovoModalContainerElement implements AfterViewInit {
 @Component({
   selector: 'novo-modal',
   template: `
-        <ng-content select="header"></ng-content>
-        <ng-content select="section"></ng-content>
-        <footer>
-            <ng-content select="button"></ng-content>
-        </footer>
-    `,
+    <ng-content select="header"></ng-content>
+    <ng-content select="section"></ng-content>
+    <footer><ng-content select="button"></ng-content></footer>
+  `,
 })
 export class NovoModalElement {
   constructor(private modalRef: NovoModalRef) {}
@@ -86,20 +84,16 @@ export class NovoModalElement {
 @Component({
   selector: 'novo-notification',
   template: `
-        <button class="modal-close" theme="icon" icon="times" (click)="close()"></button>
-        <header>
-            <ng-content select="label"></ng-content>
-        </header>
-        <section class="notification-body">
-            <i class="indicator" [ngClass]="iconType" *ngIf="iconType"></i>
-            <ng-content select="h1"></ng-content>
-            <ng-content select="h2"></ng-content>
-            <ng-content select="p"></ng-content>
-        </section>
-        <footer>
-            <ng-content select="button"></ng-content>
-        </footer>
-    `,
+    <button class="modal-close" theme="icon" icon="times" (click)="close()"></button>
+    <header><ng-content select="label"></ng-content></header>
+    <section class="notification-body">
+      <i class="indicator" [ngClass]="iconType" *ngIf="iconType"></i>
+      <ng-content select="h1"></ng-content>
+      <ng-content select="h2"></ng-content>
+      <ng-content select="p"></ng-content>
+    </section>
+    <footer><ng-content select="button"></ng-content></footer>
+  `,
 })
 export class NovoModalNotificationElement implements OnInit {
   @Input()

--- a/projects/novo-elements/src/elements/modal/ModalService.ts
+++ b/projects/novo-elements/src/elements/modal/ModalService.ts
@@ -1,20 +1,20 @@
 // NG2
-import { Injectable, ReflectiveInjector } from '@angular/core';
+import { Injectable, ViewContainerRef, StaticProvider, Type } from '@angular/core';
 // APP
 import { NovoModalRef, NovoModalParams, NovoModalContainerElement } from './Modal';
 import { ComponentUtils } from './../../utils/component-utils/ComponentUtils';
 
 @Injectable()
 export class NovoModalService {
-  _parentViewContainer: any = null;
+  _parentViewContainer: ViewContainerRef;
 
   constructor(private componentUtils: ComponentUtils) {}
 
-  set parentViewContainer(view) {
+  set parentViewContainer(view: ViewContainerRef) {
     this._parentViewContainer = view;
   }
 
-  open(component, scope = {}) {
+  open<T>(component: Type<T>, scope = {}) {
     if (!this._parentViewContainer) {
       console.error(
         'No parent view container specified for the ModalService. Set it inside your main application. \nthis.modalService.parentViewContainer = view (ViewContainerRef)',
@@ -26,8 +26,8 @@ export class NovoModalService {
     modal.component = component;
     modal.open();
 
-    let bindings = ReflectiveInjector.resolve([{ provide: NovoModalRef, useValue: modal }, { provide: NovoModalParams, useValue: scope }]);
-    modal.containerRef = this.componentUtils.appendNextToLocation(NovoModalContainerElement, this._parentViewContainer, bindings);
+    const providers: StaticProvider[] = [{ provide: NovoModalRef, useValue: modal }, { provide: NovoModalParams, useValue: scope }];
+    modal.containerRef = this.componentUtils.append(NovoModalContainerElement, this._parentViewContainer, providers);
     return modal;
   }
 }

--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -272,7 +272,7 @@ export class NovoPickerElement implements OnInit {
       this.popup.instance.autoSelectFirstOption = this.autoSelectFirstOption;
       this.ref.markForCheck();
     } else {
-      this.popup = this.componentUtils.appendNextToLocation(this.resultsComponent, this.results);
+      this.popup = this.componentUtils.append(this.resultsComponent, this.results);
       this.popup.instance.parent = this;
       this.popup.instance.config = this.config;
       this.popup.instance.term = this.term;

--- a/projects/novo-elements/src/elements/quick-note/QuickNote.spec.ts
+++ b/projects/novo-elements/src/elements/quick-note/QuickNote.spec.ts
@@ -74,6 +74,10 @@ describe('Elements: QuickNoteElement', () => {
       fakeResultsDropdown.visible = true;
       return fakeResultsDropdown;
     }
+    append() {
+      fakeResultsDropdown.visible = true;
+      return fakeResultsDropdown;
+    }
   }
 
   beforeEach(() => {

--- a/projects/novo-elements/src/elements/quick-note/QuickNote.ts
+++ b/projects/novo-elements/src/elements/quick-note/QuickNote.ts
@@ -33,11 +33,8 @@ declare var CKEDITOR: any;
   selector: 'novo-quick-note',
   providers: [QUICK_NOTE_VALUE_ACCESSOR],
   template: `
-        <div class="quick-note-wrapper" #wrapper>
-            <textarea #host></textarea>
-            <span #results></span>
-        </div>
-    `,
+    <div class="quick-note-wrapper" #wrapper><textarea #host></textarea> <span #results></span></div>
+  `,
 })
 export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy, AfterViewInit {
   @ViewChild('wrapper')
@@ -341,7 +338,7 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
           };
         } else {
           // Create the results DOM element
-          this.quickNoteResults = this.componentUtils.appendNextToLocation(this.resultsComponent, this.results);
+          this.quickNoteResults = this.componentUtils.append(this.resultsComponent, this.results);
           this.quickNoteResults.instance.parent = this;
           this.quickNoteResults.instance.config = this.config;
           this.quickNoteResults.instance.term = {

--- a/projects/novo-elements/src/elements/table/extras/row-details/RowDetails.ts
+++ b/projects/novo-elements/src/elements/table/extras/row-details/RowDetails.ts
@@ -7,9 +7,8 @@ import { ComponentUtils } from './../../../../utils/component-utils/ComponentUti
 @Component({
   selector: 'novo-row-details',
   template: `
-        <span #container></span>
-        <span>{{value}}</span>
-    `,
+    <span #container></span> <span>{{ value }}</span>
+  `,
 })
 export class RowDetails implements OnInit {
   @ViewChild('container', { read: ViewContainerRef })
@@ -27,8 +26,8 @@ export class RowDetails implements OnInit {
   ngOnInit() {
     if (this.renderer) {
       if (this.renderer.prototype instanceof BaseRenderer) {
-        let componentRef = this.componentUtils.appendNextToLocation(this.renderer, this.container);
-        componentRef.instance.data = this.data;
+        let componentRef = this.componentUtils.append(this.renderer, this.container);
+        componentRef.instance['data'] = this.data;
       } else {
         this.value = this.renderer(this.data);
       }

--- a/projects/novo-elements/src/elements/table/extras/table-cell/TableCell.ts
+++ b/projects/novo-elements/src/elements/table/extras/table-cell/TableCell.ts
@@ -10,13 +10,12 @@ import { ComponentUtils } from './../../../../utils/component-utils/ComponentUti
 @Component({
   selector: 'novo-table-cell',
   template: `
-        <div [ngSwitch]="column._type">
-            <span #container></span>
-            <date-cell *ngSwitchCase="'date'" [value]="value"></date-cell>
-            <a *ngSwitchCase="'link'" (click)="onClick($event);">{{ value }}</a>
-            <span *ngSwitchDefault>{{ value }}</span>
-        </div>
-    `,
+    <div [ngSwitch]="column._type">
+      <span #container></span>
+      <date-cell *ngSwitchCase="'date'" [value]="value"></date-cell>
+      <a *ngSwitchCase="'link'" (click)="onClick($event)">{{ value }}</a> <span *ngSwitchDefault>{{ value }}</span>
+    </div>
+  `,
 })
 export class TableCell implements OnInit, OnDestroy {
   @ViewChild('container', { read: ViewContainerRef })
@@ -44,10 +43,10 @@ export class TableCell implements OnInit, OnDestroy {
     if (this.column.renderer) {
       if (this.column.renderer.prototype instanceof BaseRenderer) {
         this.column._type = 'custom';
-        let componentRef = this.componentUtils.appendNextToLocation(this.column.renderer, this.container);
-        componentRef.instance.meta = this.column;
-        componentRef.instance.data = this.row;
-        componentRef.instance.value = this.form && this.hasEditor ? this.form.value[this.column.name] : this.row[this.column.name];
+        let componentRef = this.componentUtils.append(this.column.renderer, this.container);
+        componentRef.instance['meta'] = this.column;
+        componentRef.instance['data'] = this.row;
+        componentRef.instance['value'] = this.form && this.hasEditor ? this.form.value[this.column.name] : this.row[this.column.name];
         // TODO - save ref to this and update in the valueChanges below!!
       } else {
         // TODO - wtf to do here?

--- a/projects/novo-elements/src/elements/toast/ToastService.ts
+++ b/projects/novo-elements/src/elements/toast/ToastService.ts
@@ -36,7 +36,7 @@ export class NovoToastService {
         );
         return;
       }
-      let toast = this.componentUtils.appendNextToLocation(toastElement, this._parentViewContainer);
+      const toast = this.componentUtils.append(toastElement, this._parentViewContainer);
       this.references.push(toast);
       this.handleAlert(toast.instance, options);
       resolve(toast);

--- a/projects/novo-elements/src/utils/component-utils/ComponentUtils.spec.ts
+++ b/projects/novo-elements/src/utils/component-utils/ComponentUtils.spec.ts
@@ -1,14 +1,20 @@
 // APP
 import { ComponentUtils } from './ComponentUtils';
+import { ViewContainerRef, ComponentFactoryResolver } from '@angular/core';
+import { async, TestBed } from '@angular/core/testing';
 
 describe('Utils: ComponentUtils', () => {
-  let service;
+  let service: ComponentUtils;
 
-  beforeEach(() => {
-    service = new ComponentUtils(null);
-  });
+  beforeAll(async(() => {
+    const resolve = { resolveComponentFactory: ({}) => {} };
+    service = new ComponentUtils(resolve as ComponentFactoryResolver);
+  }));
 
-  it('should be defined.', () => {
-    expect(service).toBeDefined();
+  it('function append() should call location.createComponent', () => {
+    spyOn(service.componentFactoryResolver, 'resolveComponentFactory');
+    const location = { createComponent: () => {} };
+    service.append(ComponentUtils, location as any);
+    expect(service.componentFactoryResolver.resolveComponentFactory).toHaveBeenCalled();
   });
 });

--- a/projects/novo-elements/src/utils/component-utils/ComponentUtils.ts
+++ b/projects/novo-elements/src/utils/component-utils/ComponentUtils.ts
@@ -7,16 +7,17 @@ import {
   ReflectiveInjector,
   ViewContainerRef,
   ResolvedReflectiveProvider,
+  StaticProvider,
+  Type,
 } from '@angular/core';
 
 @Injectable()
 export class ComponentUtils {
-  componentFactoryResolver: ComponentFactoryResolver;
+  constructor(private componentFactoryResolver: ComponentFactoryResolver) {}
 
-  constructor(componentFactoryResolver: ComponentFactoryResolver) {
-    this.componentFactoryResolver = componentFactoryResolver;
-  }
-
+  /**
+   * @deprecated since version 3.7. Use append() instead.
+   */
   appendNextToLocation(ComponentClass, location: ViewContainerRef, providers?: ResolvedReflectiveProvider[]): ComponentRef<any> {
     let componentFactory = this.componentFactoryResolver.resolveComponentFactory(ComponentClass);
     let parentInjector = location.parentInjector;
@@ -27,6 +28,9 @@ export class ComponentUtils {
     return location.createComponent(componentFactory, location.length, childInjector);
   }
 
+  /**
+   * @deprecated since version 3.7. Use append() instead.
+   */
   appendTopOfLocation(ComponentClass, location: ViewContainerRef, providers?: ResolvedReflectiveProvider[]): ComponentRef<any> {
     let componentFactory = this.componentFactoryResolver.resolveComponentFactory(ComponentClass);
     let parentInjector = location.parentInjector;
@@ -35,5 +39,11 @@ export class ComponentUtils {
       childInjector = ReflectiveInjector.fromResolvedProviders(providers, parentInjector);
     }
     return location.createComponent(componentFactory, 0, childInjector);
+  }
+
+  append<T>(ComponentClass: Type<T>, location: ViewContainerRef, providers?: StaticProvider[]): ComponentRef<T> {
+    const componentFactory = this.componentFactoryResolver.resolveComponentFactory(ComponentClass);
+    const parent = location.injector;
+    return location.createComponent(componentFactory, location.length, Injector.create({ providers, parent }));
   }
 }

--- a/projects/novo-elements/src/utils/component-utils/ComponentUtils.ts
+++ b/projects/novo-elements/src/utils/component-utils/ComponentUtils.ts
@@ -13,10 +13,10 @@ import {
 
 @Injectable()
 export class ComponentUtils {
-  constructor(private componentFactoryResolver: ComponentFactoryResolver) {}
+  constructor(public componentFactoryResolver: ComponentFactoryResolver) {}
 
   /**
-   * @deprecated since version 3.7. Use append() instead.
+   * @deprecated use append() instead.
    */
   appendNextToLocation(ComponentClass, location: ViewContainerRef, providers?: ResolvedReflectiveProvider[]): ComponentRef<any> {
     let componentFactory = this.componentFactoryResolver.resolveComponentFactory(ComponentClass);
@@ -29,7 +29,7 @@ export class ComponentUtils {
   }
 
   /**
-   * @deprecated since version 3.7. Use append() instead.
+   * @deprecated
    */
   appendTopOfLocation(ComponentClass, location: ViewContainerRef, providers?: ResolvedReflectiveProvider[]): ComponentRef<any> {
     let componentFactory = this.componentFactoryResolver.resolveComponentFactory(ComponentClass);


### PR DESCRIPTION
## **Description**

ReflectiveInjectors have been deprecated since Angular 5 in favor of StaticProvider. This pull request marks methods using reflectiveInjectors as @deprecated and implement the new way of doing it.

The goal is to make projects depending of novo-elements aware of the future changes in the API and give them the time to change their code.

It impacts Modal, Picker, Table (the deprecated one), Quick Note, Toast, Chips.

Modal, Picker, Table are straightforward to test.

Quick note can be tested when tagging in the text editor (enter a word starting with # or @ for example)

Toast can be tested for example on the Design > Colors page of the demo by clicking on the colors. Or on the basic Card example by clicking on the refresh button.

The code for Chips is triggered every time the mouse goes over a Chip. It is not used in any example in novo-elememts or in novo’s code.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**