### PR TITLE
Bh 61033 get start date from data or meta

### DIFF
--- a/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
@@ -627,4 +627,18 @@ describe('Utils: FormUtils', () => {
       expect(formUtils.isAddressEmpty(control)).toEqual(true);
     });
   });
+  describe('Method: getStartDate(data: any, meta: any): string | null', () => {
+    let data, meta;
+    beforeEach(() => {
+      data = { _metaOverrides: { effectiveDate: { allowedDateRange: { minDate: '2019-01-26' } } } };
+      meta = { fields: [{ name: 'effectiveDate', allowedDateRange: { minOffset: 1 } }] };
+    });
+    it('should be data override', () => {
+      expect(formUtils.getStartDate(data, meta)).toBe('2019-01-26');
+    });
+    it('should be data override', () => {
+      data._metaOverrides = null;
+      expect(formUtils.getStartDate(data, meta)).toBeDefined();
+    });
+  });
 });

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
@@ -457,7 +457,7 @@ describe('Utils: FormUtils', () => {
       };
       spyOn(formUtils, 'getControlForField').and.returnValue({});
       formUtils.toFieldSets(meta, 'USD', {}, {}, {}, { firstName: 'First' });
-      expect(formUtils.getControlForField).toHaveBeenCalledWith(meta.fields[0], {}, {}, {}, undefined, 'First');
+      expect(formUtils.getControlForField).toHaveBeenCalledWith(meta.fields[0], {}, {}, {}, undefined, 'First', meta);
     });
   });
 
@@ -628,17 +628,17 @@ describe('Utils: FormUtils', () => {
     });
   });
   describe('Method: getStartDate(data: any, meta: any): string | null', () => {
-    let data, meta;
+    let field, meta;
     beforeEach(() => {
-      data = { _metaOverrides: { effectiveDate: { allowedDateRange: { minDate: '2019-01-26' } } } };
+      field = { name: 'effectiveDate', _metaOverrides: { effectiveDate: { allowedDateRange: { minDate: '2019-01-26' } } } };
       meta = { fields: [{ name: 'effectiveDate', allowedDateRange: { minOffset: 1 } }] };
     });
     it('should be data override', () => {
-      expect(formUtils.getStartDate(data, meta)).toBe('2019-01-26');
+      expect(formUtils.getStartDate(field, meta)).toBeInstanceOf(Date);
     });
     it('should be data override', () => {
-      data._metaOverrides = null;
-      expect(formUtils.getStartDate(data, meta)).toBeDefined();
+      field._metaOverrides = null;
+      expect(formUtils.getStartDate(field, meta)).toBeDefined();
     });
   });
 });

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
@@ -457,7 +457,7 @@ describe('Utils: FormUtils', () => {
       };
       spyOn(formUtils, 'getControlForField').and.returnValue({});
       formUtils.toFieldSets(meta, 'USD', {}, {}, {}, { firstName: 'First' });
-      expect(formUtils.getControlForField).toHaveBeenCalledWith(meta.fields[0], {}, {}, {}, undefined, 'First', meta);
+      expect(formUtils.getControlForField).toHaveBeenCalledWith(meta.fields[0], {}, {}, {}, undefined, 'First');
     });
   });
 
@@ -628,17 +628,22 @@ describe('Utils: FormUtils', () => {
     });
   });
   describe('Method: getStartDate(data: any, meta: any): string | null', () => {
-    let field, meta;
-    beforeEach(() => {
-      field = { name: 'effectiveDate', _metaOverrides: { effectiveDate: { allowedDateRange: { minDate: '2019-01-26' } } } };
-      meta = { fields: [{ name: 'effectiveDate', allowedDateRange: { minOffset: 1 } }] };
+    it('should use minDate', () => {
+      const field = { allowedDateRange: { minDate: '2019-01-26' } };
+      const startDate = formUtils.getStartDate(field);
+      expect(startDate).toBeInstanceOf(Date);
     });
-    it('should be data override', () => {
-      expect(formUtils.getStartDate(field, meta)).toBeInstanceOf(Date);
+    it('should use minOffset', () => {
+      const field = { allowedDateRange: { minOffset: 1 } };
+      const startDate = formUtils.getStartDate(field);
+      expect(startDate).toBeInstanceOf(Date);
     });
-    it('should be data override', () => {
-      field._metaOverrides = null;
-      expect(formUtils.getStartDate(field, meta)).toBeDefined();
+  });
+  describe('Method: getControlValue()', () => {
+    it('should return Date', () => {
+      const field = { dataType: 'Date', allowedDateRange: { minOffset: 1 } };
+      const startDate = formUtils.getControlValue(field);
+      expect(startDate).toBeInstanceOf(Date);
     });
   });
 });

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
@@ -639,10 +639,10 @@ describe('Utils: FormUtils', () => {
       expect(startDate).toBeInstanceOf(Date);
     });
   });
-  describe('Method: getControlValue()', () => {
+  describe('Method: inferStartDate()', () => {
     it('should return Date', () => {
       const field = { dataType: 'Date', allowedDateRange: { minOffset: 1 } };
-      const startDate = formUtils.getControlValue(field);
+      const startDate = formUtils.inferStartDate({}, field);
       expect(startDate).toBeInstanceOf(Date);
     });
   });

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -717,9 +717,9 @@ export class FormUtils {
 
   private getStartDateFromRange(dateRange: { minDate: string; minOffset: number }): Date {
     if (dateRange.minDate) {
-      return new Date(dateRange.minDate);
+      return dateFns.parse(dateRange.minDate);
     } else if (dateRange.minOffset) {
-      return dateFns.addDays(new Date(), dateRange.minOffset - 1);
+      return dateFns.addDays(dateFns.startOfToday(), dateRange.minOffset);
     }
   }
 

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -219,7 +219,7 @@ export class FormUtils {
     // TODO: (cont.) as the setter of the field argument
     let type: string = this.determineInputType(field) || field.type;
     let control: any;
-    const controlConfig: NovoControlConfig = {
+    let controlConfig: NovoControlConfig = {
       metaType: field.type,
       type: type,
       key: field.name,
@@ -228,7 +228,7 @@ export class FormUtils {
       required: field.required || field.systemRequired,
       hidden: !field.required,
       encrypted: this.isFieldEncrypted(field.name ? field.name.toString() : ''),
-      value: this.getControlValue(field, meta),
+      value: this.getControlValue(field),
       sortOrder: field.sortOrder,
       associatedEntity: field.associatedEntity,
       optionsType: field.optionsType,
@@ -251,7 +251,7 @@ export class FormUtils {
       closeOnSelect: field.closeOnSelect,
     };
     if (field.dataType === 'Date') {
-      controlConfig.startDate = this.getStartDate(field, meta);
+      controlConfig.startDate = this.getStartDate(field);
     }
     // TODO: getControlOptions should always return the correct format
     const optionsConfig = this.getControlOptions(field, http, config, fieldData);
@@ -456,7 +456,7 @@ export class FormUtils {
           (field.dataSpecialization !== 'SYSTEM' || ['address', 'billingAddress', 'secondaryAddress'].indexOf(field.name) !== -1) &&
           !field.readOnly
         ) {
-          const control = this.getControlForField(field, http, config, overrides, forTable, undefined, meta);
+          let control = this.getControlForField(field, http, config, overrides, forTable, undefined);
           // Set currency format
           if (control.subType === 'currency') {
             control.currencyFormat = currencyFormat;
@@ -556,12 +556,12 @@ export class FormUtils {
           !field.readOnly
         ) {
           const fieldData: any = data && data[field.name] ? data[field.name] : null;
-          const control = this.getControlForField(field, http, config, overrides, undefined, fieldData, meta);
+          let control = this.getControlForField(field, http, config, overrides, undefined, fieldData);
           // Set currency format
           if (control.subType === 'currency') {
             control.currencyFormat = currencyFormat;
           }
-          const location = ranges.find((item) => {
+          let location = ranges.find((item) => {
             return (item.min <= field.sortOrder && field.sortOrder <= item.max) || (item.min <= field.sortOrder && item.min === item.max);
           });
           if (location) {
@@ -729,24 +729,19 @@ export class FormUtils {
   /**
    * Get the min start date of a Date base on data or meta.
    */
-  private getStartDate(field: any, meta: any): Date | null {
+  private getStartDate(field: any): Date | null {
     if (field.allowedDateRange) {
       return this.getStartDateFromRange(field.allowedDateRange);
-    } else {
-      const fields: any = meta.fields.filter((f) => f.name === 'effectiveDate');
-      if (fields && fields.length && fields[0].allowedDateRange) {
-        return this.getStartDateFromRange(fields[0].allowedDateRange);
-      }
     }
     // there is no restriction on the start date
     return null;
   }
 
-  private getControlValue(field, meta) {
+  private getControlValue(field) {
     if (field.value || field.defaultValue) {
       return field.value || field.defaultValue;
     } else if (field.dataType === 'Date') {
-      const startDate = this.getStartDate(field, meta);
+      const startDate = this.getStartDate(field);
       if (!startDate || this.isBeforeToday(startDate)) {
         return Date.now();
       } else {

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -213,7 +213,6 @@ export class FormUtils {
     overrides?: any,
     forTable: boolean = false,
     fieldData?: any,
-    meta?: any,
   ) {
     // TODO: if field.type overrides `determineInputType` we should use it in that method or use this method
     // TODO: (cont.) as the setter of the field argument
@@ -456,7 +455,7 @@ export class FormUtils {
           (field.dataSpecialization !== 'SYSTEM' || ['address', 'billingAddress', 'secondaryAddress'].indexOf(field.name) !== -1) &&
           !field.readOnly
         ) {
-          let control = this.getControlForField(field, http, config, overrides, forTable, undefined);
+          let control = this.getControlForField(field, http, config, overrides, forTable);
           // Set currency format
           if (control.subType === 'currency') {
             control.currencyFormat = currencyFormat;

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -740,18 +740,7 @@ export class FormUtils {
       if (startDate) {
         controlConfig.startDate = startDate;
       }
-      if (!controlConfig.value) {
-        if (!startDate || this.isBeforeToday(startDate)) {
-          controlConfig.value = Date.now();
-        } else {
-          controlConfig.value = dateFns.addDays(startDate, 1);
-        }
-      }
       return startDate;
     }
-  }
-
-  private isBeforeToday(startDate: Date): boolean {
-    return startDate.setHours(0, 0, 0, 0) < new Date().setHours(0, 0, 0, 0);
   }
 }

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -714,7 +714,7 @@ export class FormUtils {
     return valid;
   }
 
-  private getStartDateFromRange(dateRange: { minDate; minOffset }) {
+  private getStartDateFromRange(dateRange: { minDate; minOffset }): string {
     if (dateRange.minDate) {
       return dateRange.minDate;
     }
@@ -728,13 +728,12 @@ export class FormUtils {
    * @param data entity data
    * @param meta entity meta
    */
-  public getStartDate(data: any, meta: any) {
+  public getStartDate(data: any, meta: any): string | null {
     // edit or create a new version of a EDE
     if (data._metaOverrides && data._metaOverrides.effectiveDate.allowedDateRange) {
       const dateRange = data._metaOverrides.effectiveDate.allowedDateRange;
       return this.getStartDateFromRange(dateRange);
     }
-
     // create a new EDE
     if (!data._metaOverrides) {
       const fields: any = meta.fields.filter((f) => f.name === 'effectiveDate');
@@ -742,6 +741,7 @@ export class FormUtils {
         return this.getStartDateFromRange(fields[0].allowedDateRange);
       }
     }
+    // there is no restriction on the start date
     return null;
   }
 }

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -1,5 +1,6 @@
 // NG
 import { Injectable } from '@angular/core';
+import * as dateFns from 'date-fns';
 // App
 import {
   AddressControl,
@@ -711,5 +712,36 @@ export class FormUtils {
       });
     }
     return valid;
+  }
+
+  private getStartDateFromRange(dateRange: { minDate; minOffset }) {
+    if (dateRange.minDate) {
+      return dateRange.minDate;
+    }
+    if (dateRange.minOffset) {
+      return dateFns.format(dateFns.addDays(new Date(), dateRange.minOffset), 'YYYY-MM-DD');
+    }
+  }
+
+  /**
+   * Get the min start date of a EDE base on data or meta.
+   * @param data entity data
+   * @param meta entity meta
+   */
+  public getStartDate(data: any, meta: any) {
+    // edit or create a new version of a EDE
+    if (data._metaOverrides && data._metaOverrides.effectiveDate.allowedDateRange) {
+      const dateRange = data._metaOverrides.effectiveDate.allowedDateRange;
+      return this.getStartDateFromRange(dateRange);
+    }
+
+    // create a new EDE
+    if (!data._metaOverrides) {
+      const fields: any = meta.fields.filter((f) => f.name === 'effectiveDate');
+      if (fields && fields.length && fields[0].allowedDateRange) {
+        return this.getStartDateFromRange(fields[0].allowedDateRange);
+      }
+    }
+    return null;
   }
 }

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -724,7 +724,7 @@ export class FormUtils {
   }
 
   /**
-   * Get the min start date of a Date base on data or meta.
+   * Get the min start date of a Date base on field data.
    */
   private getStartDate(field: any): Date | null {
     if (field.allowedDateRange) {

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -227,7 +227,7 @@ export class FormUtils {
       required: field.required || field.systemRequired,
       hidden: !field.required,
       encrypted: this.isFieldEncrypted(field.name ? field.name.toString() : ''),
-      value: this.getControlValue(field),
+      value: field.value || field.defaultValue,
       sortOrder: field.sortOrder,
       associatedEntity: field.associatedEntity,
       optionsType: field.optionsType,
@@ -249,9 +249,7 @@ export class FormUtils {
       config: field.config || {},
       closeOnSelect: field.closeOnSelect,
     };
-    if (field.dataType === 'Date') {
-      controlConfig.startDate = this.getStartDate(field);
-    }
+    this.inferStartDate(controlConfig, field);
     // TODO: getControlOptions should always return the correct format
     const optionsConfig = this.getControlOptions(field, http, config, fieldData);
     if (Array.isArray(optionsConfig) && !(type === 'chips' || type === 'picker')) {
@@ -736,16 +734,20 @@ export class FormUtils {
     return null;
   }
 
-  private getControlValue(field) {
-    if (field.value || field.defaultValue) {
-      return field.value || field.defaultValue;
-    } else if (field.dataType === 'Date') {
+  private inferStartDate(controlConfig, field) {
+    if (field.dataType === 'Date') {
       const startDate = this.getStartDate(field);
-      if (!startDate || this.isBeforeToday(startDate)) {
-        return Date.now();
-      } else {
-        return dateFns.addDays(startDate, 1);
+      if (startDate) {
+        controlConfig.startDate = startDate;
       }
+      if (!controlConfig.value) {
+        if (!startDate || this.isBeforeToday(startDate)) {
+          controlConfig.value = Date.now();
+        } else {
+          controlConfig.value = dateFns.addDays(startDate, 1);
+        }
+      }
+      return startDate;
     }
   }
 


### PR DESCRIPTION
## **Description**

get the minimum start date of an effective date entity (EDE Locations, Billing Profiles or Invoice Terms) from data or meta.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**