### PR TITLE
Update the default text on Picker field overlays

### DIFF
--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -243,7 +243,7 @@ export class NovoPickerElement implements OnInit {
     this.onModelChange(this._value);
 
     if (wipeTerm) {
-      this.term = null;
+      this.term = '';
       this.hideResults();
     }
     this.ref.markForCheck();

--- a/projects/novo-elements/src/elements/picker/extras/checklist-picker-results/ChecklistPickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/checklist-picker-results/ChecklistPickerResults.ts
@@ -18,25 +18,33 @@ import { from, Observable } from 'rxjs';
     class: 'active picker-results',
   },
   template: `
-        <novo-loading theme="line" *ngIf="isLoading && !matches.length"></novo-loading>
-        <ul *ngIf="matches.length > 0">
-            <span *ngFor="let section of matches; let i = index">
-                <li class="header caption" *ngIf="section.data.length > 0">{{ section.label || section.type }}</li>
-                <li
-                    *ngFor="let match of section.data; let i = index" [ngClass]="{checked: match.checked}"
-                    (click)="selectMatch($event, match)"
-                    [class.active]="match === activeMatch"
-                    (mouseenter)="selectActive(match)">
-                    <label>
-                        <i [ngClass]="{'bhi-checkbox-empty': !match.checked, 'bhi-checkbox-filled': match.checked, 'bhi-checkbox-indeterminate': match.indeterminate }"></i>
-                        {{match.label}}
-                    </label>
-                </li>
-            </span>
-        </ul>
-        <p class="picker-error" *ngIf="hasError">{{ labels.pickerError }}</p>
-        <p class="picker-null-results" *ngIf="!isLoading && !matches.length && !hasError">{{ labels.pickerEmpty }}</p>
-    `,
+    <novo-loading theme="line" *ngIf="isLoading && !matches.length"></novo-loading>
+    <ul *ngIf="matches.length > 0">
+      <span *ngFor="let section of matches; let i = index">
+        <li class="header caption" *ngIf="section.data.length > 0">{{ section.label || section.type }}</li>
+        <li
+          *ngFor="let match of section.data; let i = index"
+          [ngClass]="{ checked: match.checked }"
+          (click)="selectMatch($event, match)"
+          [class.active]="match === activeMatch"
+          (mouseenter)="selectActive(match)"
+        >
+          <label>
+            <i
+              [ngClass]="{
+                'bhi-checkbox-empty': !match.checked,
+                'bhi-checkbox-filled': match.checked,
+                'bhi-checkbox-indeterminate': match.indeterminate
+              }"
+            ></i>
+            {{ match.label }}
+          </label>
+        </li>
+      </span>
+    </ul>
+    <p class="picker-error" *ngIf="hasError">{{ labels.pickerError }}</p>
+    <p class="picker-null-results" *ngIf="!isLoading && !matches.length && !hasError && term !== ''">{{ labels.resultsEmpty }}</p>
+  `,
 })
 export class ChecklistPickerResults extends BasePickerResults {
   filteredMatches: any;

--- a/projects/novo-elements/src/elements/picker/extras/checklist-picker-results/ChecklistPickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/checklist-picker-results/ChecklistPickerResults.ts
@@ -43,7 +43,7 @@ import { from, Observable } from 'rxjs';
       </span>
     </ul>
     <p class="picker-error" *ngIf="hasError">{{ labels.pickerError }}</p>
-    <p class="picker-null-results" *ngIf="!isLoading && !matches.length && !hasError && term !== ''">{{ labels.resultsEmpty }}</p>
+    <p class="picker-null-results" *ngIf="!isLoading && !matches.length && !hasError && term !== ''">{{ labels.pickerEmpty }}</p>
   `,
 })
 export class ChecklistPickerResults extends BasePickerResults {

--- a/projects/novo-elements/src/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
@@ -191,7 +191,7 @@ export class EntityPickerResult {
       <novo-loading theme="line" *ngIf="isLoading && matches.length > 0"></novo-loading>
     </novo-list>
     <p class="picker-error" *ngIf="hasError">{{ labels.pickerError }}</p>
-    <p class="picker-null-results" *ngIf="hasNonErrorMessage && term !== ''">{{ labels.resultsEmpty }}</p>
+    <p class="picker-null-results" *ngIf="hasNonErrorMessage && term !== ''">{{ labels.pickerEmpty }}</p>
     <p class="picker-null-results" *ngIf="hasNonErrorMessage && term === ''">{{ labels.pickerTextFieldEmpty }}</p>
   `,
 })

--- a/projects/novo-elements/src/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
@@ -8,74 +8,68 @@ import { NovoLabelService } from '../../../../services/novo-label-service';
 @Component({
   selector: 'entity-picker-result',
   template: `
-        <novo-list-item *ngIf="match.data">
-            <item-header>
-                <item-avatar [icon]="getIconForResult(match.data)"></item-avatar>
-                <item-title>
-                    <span [innerHtml]="highlight(getNameForResult(match.data), term)"></span>
-                </item-title>
-            </item-header>
-            <item-content direction="horizontal">
-                <!-- COMPANY 1 -->
-                <p class="company" *ngIf="match.data.companyName || match.data?.clientCorporation?.name">
-                    <i class="bhi-company"></i>
-                    <span [innerHtml]="highlight(match.data.companyName || match.data?.clientCorporation?.name, term)"></span>
-                </p>
-                <!-- CLIENT CONTACT -->
-                <p class="contact" *ngIf="match.data?.clientContact?.firstName">
-                    <i class="bhi-person contact person"></i>
-                    <span [innerHtml]="highlight(match.data.clientContact.firstName + ' ' + match.data.clientContact.lastName, term)"></span>
-                </p>
-                <!-- CANDIDATE -->
-                <p class="candidate" *ngIf="match.data.candidate && match.data.searchEntity === 'Placement'">
-                    <i class="bhi-candidate"></i>
-                    <span [innerHtml]="highlight((match.data.candidate.firstName + ' ' + match.data.candidate.lastName), term)"></span>
-                </p>
-                <!-- START & END DATE -->
-                <p class="start-date" *ngIf="match.data.dateBegin && match.data.searchEntity === 'Placement'">
-                    <i class="bhi-calendar"></i>
-                    <span [innerHtml]="renderTimestamp(match.data.dateBegin) + ' - ' + renderTimestamp(match.data.dateEnd)"></span>
-                </p>
-                <!-- EMAIL -->
-                <p class="email" *ngIf="match.data.email">
-                    <i class="bhi-email"></i>
-                    <span [innerHtml]="highlight(match.data.email, term)"></span>
-                </p>
-                <!-- PHONE -->
-                <p class="phone" *ngIf="match.data.phone">
-                    <i class="bhi-phone"></i>
-                    <span [innerHtml]="highlight(match.data.phone, term)"></span>
-                </p>
-                <!-- ADDRESS -->
-                <p class="location" *ngIf="match.data.address && (match.data.address.city || match.data.address.state)">
-                    <i class="bhi-location"></i>
-                    <span *ngIf="match.data.address.city" [innerHtml]="highlight(match.data.address.city, term)"></span>
-                    <span *ngIf="match.data.address.city && match.data.address.state">, </span>
-                    <span *ngIf="match.data.address.state" [innerHtml]="highlight(match.data.address.state, term)"></span>
-                </p>
-                <!-- STATUS -->
-                <p class="status" *ngIf="match.data.status">
-                    <i class="bhi-info"></i>
-                    <span [innerHtml]="highlight(match.data.status, term)"></span>
-                </p>
-                <!-- OWNER -->
-                <p class="owner" *ngIf="match.data.owner && match.data.owner.name && match.data.searchEntity === 'Candidate'">
-                    <i class="bhi-person"></i>
-                    <span [innerHtml]="highlight(match.data.owner.name, term)"></span>
-                </p>
-                <!-- PRIMARY DEPARTMENT -->
-                <p class="primary-department" *ngIf="match.data.primaryDepartment && match.data.primaryDepartment.name && match.data.searchEntity === 'CorporateUser'">
-                    <i class="bhi-department"></i>
-                    <span [innerHtml]="highlight(match.data.primaryDepartment.name, term)"></span>
-                </p>
-                <!-- OCCUPATION -->
-                <p class="occupation" *ngIf="match.data.occupation && match.data.searchEntity === 'CorporateUser'">
-                    <i class="bhi-occupation"></i>
-                    <span [innerHtml]="highlight(match.data.occupation, term)"></span>
-                </p>
-            </item-content>
-        </novo-list-item>
-    `,
+    <novo-list-item *ngIf="match.data">
+      <item-header>
+        <item-avatar [icon]="getIconForResult(match.data)"></item-avatar>
+        <item-title> <span [innerHtml]="highlight(getNameForResult(match.data), term)"></span> </item-title>
+      </item-header>
+      <item-content direction="horizontal">
+        <!-- COMPANY 1 -->
+        <p class="company" *ngIf="match.data.companyName || match.data?.clientCorporation?.name">
+          <i class="bhi-company"></i>
+          <span [innerHtml]="highlight(match.data.companyName || match.data?.clientCorporation?.name, term)"></span>
+        </p>
+        <!-- CLIENT CONTACT -->
+        <p class="contact" *ngIf="match.data?.clientContact?.firstName">
+          <i class="bhi-person contact person"></i>
+          <span [innerHtml]="highlight(match.data.clientContact.firstName + ' ' + match.data.clientContact.lastName, term)"></span>
+        </p>
+        <!-- CANDIDATE -->
+        <p class="candidate" *ngIf="match.data.candidate && match.data.searchEntity === 'Placement'">
+          <i class="bhi-candidate"></i>
+          <span [innerHtml]="highlight(match.data.candidate.firstName + ' ' + match.data.candidate.lastName, term)"></span>
+        </p>
+        <!-- START & END DATE -->
+        <p class="start-date" *ngIf="match.data.dateBegin && match.data.searchEntity === 'Placement'">
+          <i class="bhi-calendar"></i>
+          <span [innerHtml]="renderTimestamp(match.data.dateBegin) + ' - ' + renderTimestamp(match.data.dateEnd)"></span>
+        </p>
+        <!-- EMAIL -->
+        <p class="email" *ngIf="match.data.email">
+          <i class="bhi-email"></i> <span [innerHtml]="highlight(match.data.email, term)"></span>
+        </p>
+        <!-- PHONE -->
+        <p class="phone" *ngIf="match.data.phone">
+          <i class="bhi-phone"></i> <span [innerHtml]="highlight(match.data.phone, term)"></span>
+        </p>
+        <!-- ADDRESS -->
+        <p class="location" *ngIf="match.data.address && (match.data.address.city || match.data.address.state)">
+          <i class="bhi-location"></i> <span *ngIf="match.data.address.city" [innerHtml]="highlight(match.data.address.city, term)"></span>
+          <span *ngIf="match.data.address.city && match.data.address.state">, </span>
+          <span *ngIf="match.data.address.state" [innerHtml]="highlight(match.data.address.state, term)"></span>
+        </p>
+        <!-- STATUS -->
+        <p class="status" *ngIf="match.data.status">
+          <i class="bhi-info"></i> <span [innerHtml]="highlight(match.data.status, term)"></span>
+        </p>
+        <!-- OWNER -->
+        <p class="owner" *ngIf="match.data.owner && match.data.owner.name && match.data.searchEntity === 'Candidate'">
+          <i class="bhi-person"></i> <span [innerHtml]="highlight(match.data.owner.name, term)"></span>
+        </p>
+        <!-- PRIMARY DEPARTMENT -->
+        <p
+          class="primary-department"
+          *ngIf="match.data.primaryDepartment && match.data.primaryDepartment.name && match.data.searchEntity === 'CorporateUser'"
+        >
+          <i class="bhi-department"></i> <span [innerHtml]="highlight(match.data.primaryDepartment.name, term)"></span>
+        </p>
+        <!-- OCCUPATION -->
+        <p class="occupation" *ngIf="match.data.occupation && match.data.searchEntity === 'CorporateUser'">
+          <i class="bhi-occupation"></i> <span [innerHtml]="highlight(match.data.occupation, term)"></span>
+        </p>
+      </item-content>
+    </novo-list-item>
+  `,
 })
 export class EntityPickerResult {
   @Input()
@@ -183,26 +177,33 @@ export class EntityPickerResult {
 @Component({
   selector: 'entity-picker-results',
   template: `
-        <novo-list *ngIf="matches.length > 0" direction="vertical">
-            <entity-picker-result *ngFor="let match of matches"
-                    [match]="match"
-                    [term]="term"
-                    (click)="selectMatch($event, match)"
-                    [ngClass]="{active: isActive(match)}"
-                    (mouseenter)="selectActive(match)"
-                    [class.disabled]="preselected(match)">
-            </entity-picker-result>
-            <novo-loading theme="line" *ngIf="isLoading && matches.length > 0"></novo-loading>
-        </novo-list>
-        <p class="picker-error" *ngIf="hasError">{{ labels.pickerError }}</p>
-        <p class="picker-null-results" *ngIf="!isLoading && !matches.length && !hasError">{{ labels.pickerEmpty }}</p>
-    `,
+    <novo-list *ngIf="matches.length > 0" direction="vertical">
+      <entity-picker-result
+        *ngFor="let match of matches"
+        [match]="match"
+        [term]="term"
+        (click)="selectMatch($event, match)"
+        [ngClass]="{ active: isActive(match) }"
+        (mouseenter)="selectActive(match)"
+        [class.disabled]="preselected(match)"
+      >
+      </entity-picker-result>
+      <novo-loading theme="line" *ngIf="isLoading && matches.length > 0"></novo-loading>
+    </novo-list>
+    <p class="picker-error" *ngIf="hasError">{{ labels.pickerError }}</p>
+    <p class="picker-null-results" *ngIf="hasNonErrorMessage && term !== ''">{{ labels.resultsEmpty }}</p>
+    <p class="picker-null-results" *ngIf="hasNonErrorMessage && term === ''">{{ labels.pickerTextFieldEmpty }}</p>
+  `,
 })
 export class EntityPickerResults extends BasePickerResults {
   @Output()
   select: EventEmitter<any> = new EventEmitter();
   constructor(element: ElementRef, public labels: NovoLabelService, ref: ChangeDetectorRef) {
     super(element, ref);
+  }
+
+  get hasNonErrorMessage() {
+    return !this.isLoading && !this.matches.length && !this.hasError;
   }
 
   getListElement() {

--- a/projects/novo-elements/src/elements/picker/extras/picker-results/PickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/picker-results/PickerResults.ts
@@ -24,7 +24,7 @@ import { BasePickerResults } from '../base-picker-results/BasePickerResults';
     </novo-list>
     <div class="picker-loader" *ngIf="isLoading && matches.length === 0"><novo-loading theme="line"></novo-loading></div>
     <p class="picker-error" *ngIf="hasError">{{ labels.pickerError }}</p>
-    <p class="picker-null-results" *ngIf="hasNonErrorMessage && term !== ''">{{ labels.resultsEmpty }}</p>
+    <p class="picker-null-results" *ngIf="hasNonErrorMessage && term !== ''">{{ labels.pickerEmpty }}</p>
     <p class="picker-null-results" *ngIf="hasNonErrorMessage && term === ''">{{ labels.pickerTextFieldEmpty }}</p>
   `,
 })

--- a/projects/novo-elements/src/elements/picker/extras/picker-results/PickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/picker-results/PickerResults.ts
@@ -10,29 +10,31 @@ import { BasePickerResults } from '../base-picker-results/BasePickerResults';
     class: 'active',
   },
   template: `
-        <novo-list *ngIf="matches.length > 0" direction="vertical">
-            <novo-list-item
-                *ngFor="let match of matches"
-                (click)="selectMatch($event)"
-                [class.active]="match === activeMatch"
-                (mouseenter)="selectActive(match)"
-                [class.disabled]="preselected(match)">
-                <item-content>
-                    <span [innerHtml]="highlight(match.label, term)"></span>
-                </item-content>
-            </novo-list-item>
-            <novo-loading *ngIf="isLoading && matches.length > 0" theme="line"></novo-loading>
-        </novo-list>
-        <div class="picker-loader" *ngIf="isLoading && matches.length === 0">
-            <novo-loading theme="line"></novo-loading>
-        </div>
-        <p class="picker-error" *ngIf="hasError">{{ labels.pickerError }}</p>
-        <p class="picker-null-results" *ngIf="!isLoading && !matches.length && !hasError">{{ labels.pickerEmpty }}</p>
-    `,
+    <novo-list *ngIf="matches.length > 0" direction="vertical">
+      <novo-list-item
+        *ngFor="let match of matches"
+        (click)="selectMatch($event)"
+        [class.active]="match === activeMatch"
+        (mouseenter)="selectActive(match)"
+        [class.disabled]="preselected(match)"
+      >
+        <item-content> <span [innerHtml]="highlight(match.label, term)"></span> </item-content>
+      </novo-list-item>
+      <novo-loading *ngIf="isLoading && matches.length > 0" theme="line"></novo-loading>
+    </novo-list>
+    <div class="picker-loader" *ngIf="isLoading && matches.length === 0"><novo-loading theme="line"></novo-loading></div>
+    <p class="picker-error" *ngIf="hasError">{{ labels.pickerError }}</p>
+    <p class="picker-null-results" *ngIf="hasNonErrorMessage && term !== ''">{{ labels.resultsEmpty }}</p>
+    <p class="picker-null-results" *ngIf="hasNonErrorMessage && term === ''">{{ labels.pickerTextFieldEmpty }}</p>
+  `,
 })
 export class PickerResults extends BasePickerResults {
   constructor(element: ElementRef, public labels: NovoLabelService, ref: ChangeDetectorRef) {
     super(element, ref);
+  }
+
+  get hasNonErrorMessage() {
+    return !this.isLoading && !this.matches.length && !this.hasError;
   }
 
   getListElement() {

--- a/projects/novo-elements/src/elements/picker/extras/skills-picker-results/SkillsSpecialtyPickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/skills-picker-results/SkillsSpecialtyPickerResults.ts
@@ -30,7 +30,7 @@ import { NovoLabelService } from '../../../../services/novo-label-service';
       <novo-loading theme="line" *ngIf="isLoading && matches.length > 0"></novo-loading>
     </novo-list>
     <p class="picker-error" *ngIf="hasError">{{ labels.pickerError }}</p>
-    <p class="picker-null" *ngIf="!isLoading && !matches.length && !hasError">{{ labels.resultsEmpty }}</p>
+    <p class="picker-null" *ngIf="!isLoading && !matches.length && !hasError">{{ labels.pickerEmpty }}</p>
   `,
 })
 export class SkillsSpecialtyPickerResults extends BasePickerResults {

--- a/projects/novo-elements/src/elements/picker/extras/skills-picker-results/SkillsSpecialtyPickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/skills-picker-results/SkillsSpecialtyPickerResults.ts
@@ -7,29 +7,31 @@ import { NovoLabelService } from '../../../../services/novo-label-service';
 @Component({
   selector: 'skill-specialty-picker-results',
   template: `
-        <section class="picker-loading" *ngIf="isLoading && !matches?.length">
-            <novo-loading theme="line"></novo-loading>
-        </section>
-        <novo-list *ngIf="matches.length > 0" direction="vertical">
-            <novo-list-item
-                *ngFor="let match of matches"
-                (click)="selectMatch($event)"
-                [class.active]="match === activeMatch"
-                (mouseenter)="selectActive(match)"
-                [class.disabled]="preselected(match)">
-                <item-content>
-                    <h6><span [innerHtml]="highlight(match.label, term)"></span></h6>
-                    <div class="category">
-                        <i class="bhi-category-tags"></i><span [innerHtml]="highlight(match.data.categories || match.data.parentCategory.name, term)"></span>
-                    </div>
-                </item-content>
-            </novo-list-item>
-            <novo-list-item *ngIf="limitedTo"><div>{{labels.showingXofXResults(limit, total)}}</div></novo-list-item>
-            <novo-loading theme="line" *ngIf="isLoading && matches.length > 0"></novo-loading>
-        </novo-list>
-        <p class="picker-error" *ngIf="hasError">{{ labels.pickerError }}</p>
-        <p class="picker-null" *ngIf="!isLoading && !matches.length && !hasError">{{ labels.pickerEmpty }}</p>
-    `,
+    <section class="picker-loading" *ngIf="isLoading && !matches?.length"><novo-loading theme="line"></novo-loading></section>
+    <novo-list *ngIf="matches.length > 0" direction="vertical">
+      <novo-list-item
+        *ngFor="let match of matches"
+        (click)="selectMatch($event)"
+        [class.active]="match === activeMatch"
+        (mouseenter)="selectActive(match)"
+        [class.disabled]="preselected(match)"
+      >
+        <item-content>
+          <h6><span [innerHtml]="highlight(match.label, term)"></span></h6>
+          <div class="category">
+            <i class="bhi-category-tags"></i
+            ><span [innerHtml]="highlight(match.data.categories || match.data.parentCategory.name, term)"></span>
+          </div>
+        </item-content>
+      </novo-list-item>
+      <novo-list-item *ngIf="limitedTo"
+        ><div>{{ labels.showingXofXResults(limit, total) }}</div></novo-list-item
+      >
+      <novo-loading theme="line" *ngIf="isLoading && matches.length > 0"></novo-loading>
+    </novo-list>
+    <p class="picker-error" *ngIf="hasError">{{ labels.pickerError }}</p>
+    <p class="picker-null" *ngIf="!isLoading && !matches.length && !hasError">{{ labels.resultsEmpty }}</p>
+  `,
 })
 export class SkillsSpecialtyPickerResults extends BasePickerResults {
   @HostBinding('class.active')

--- a/projects/novo-elements/src/services/novo-label-service.spec.ts
+++ b/projects/novo-elements/src/services/novo-label-service.spec.ts
@@ -12,7 +12,8 @@ describe('Service: NovoLabelService', () => {
     expect(service.noMatchingRecordsMessage).toBeDefined();
     expect(service.erroredTableMessage).toBeDefined();
     expect(service.pickerError).toBeDefined();
-    expect(service.pickerEmpty).toBeDefined();
+    expect(service.pickerTextFieldEmpty).toBeDefined();
+    expect(service.resultsEmpty).toBeDefined();
     expect(service.quickNoteError).toBeDefined();
     expect(service.quickNoteEmpty).toBeDefined();
     expect(service.required).toBeDefined();

--- a/projects/novo-elements/src/services/novo-label-service.spec.ts
+++ b/projects/novo-elements/src/services/novo-label-service.spec.ts
@@ -13,7 +13,7 @@ describe('Service: NovoLabelService', () => {
     expect(service.erroredTableMessage).toBeDefined();
     expect(service.pickerError).toBeDefined();
     expect(service.pickerTextFieldEmpty).toBeDefined();
-    expect(service.resultsEmpty).toBeDefined();
+    expect(service.pickerEmpty).toBeDefined();
     expect(service.quickNoteError).toBeDefined();
     expect(service.quickNoteEmpty).toBeDefined();
     expect(service.required).toBeDefined();

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -12,7 +12,8 @@ export class NovoLabelService {
   noMatchingRecordsMessage = 'No Matching Records';
   erroredTableMessage = 'Oops! An error occurred.';
   pickerError = 'Oops! An error occurred.';
-  pickerEmpty = 'No results to display...';
+  pickerTextFieldEmpty = 'Begin typing to see results.';
+  resultsEmpty = 'No results to display...';
   quickNoteError = 'Oops! An error occurred.';
   quickNoteEmpty = 'No results to display...';
   required = 'Required';

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -13,7 +13,7 @@ export class NovoLabelService {
   erroredTableMessage = 'Oops! An error occurred.';
   pickerError = 'Oops! An error occurred.';
   pickerTextFieldEmpty = 'Begin typing to see results.';
-  resultsEmpty = 'No results to display...';
+  pickerEmpty = 'No results to display...';
   quickNoteError = 'Oops! An error occurred.';
   quickNoteEmpty = 'No results to display...';
   required = 'Required';


### PR DESCRIPTION
## **Description**

I changed the default text on picker overlays so that users are not confused by the message, "No results to display..." as they focus on the field.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**