### PR TITLE
fix(control-group) style & input type fixes

### DIFF
--- a/projects/novo-elements/src/elements/form/ControlGroup.html
+++ b/projects/novo-elements/src/elements/form/ControlGroup.html
@@ -9,7 +9,7 @@
 <div class="novo-control-group-controls" [class.vertical]="vertical" [class.horizontal]="!vertical" [class.hidden]="collapsible && !toggled">
   <ng-template #defaultTemplate let-index="index" let-form="form" let-key="key">
     <div class="novo-control-group-control">
-      <div *ngFor="let c of controls" class="novo-control-container" [class.is-label]="c.controlType === 'read-only'" [style.max-width.px]="c.width">
+      <div *ngFor="let c of controls" class="novo-control-container {{c.key}}" [class.is-label]="c.controlType === 'read-only'" [style.max-width.px]="c.width">
         <novo-control [form]="(form?.controls)[key]['controls'][index]" [control]="c" [condensed]="!vertical || c.controlType === 'read-only'"></novo-control>
       </div>
       <div class="novo-control-container last" *ngIf="edit && !vertical">

--- a/projects/novo-elements/src/elements/form/ControlGroup.html
+++ b/projects/novo-elements/src/elements/form/ControlGroup.html
@@ -23,7 +23,7 @@
     <button [disabled]="!disabledArray[index].remove" type="button" *ngIf="remove && vertical" theme="icon" icon="delete-o" (click)="removeControl(index)" [attr.data-automation-id]="'novo-control-group-delete-' + key" index="-1"></button>
   </ng-template>
   <div class="novo-control-group-labels" *ngIf="!vertical && (form?.controls)[key] && (form?.controls)[key]['controls'].length !== 0">
-    <div class="novo-control-group-control-label" *ngFor="let label of controlLabels" [style.max-width.px]="label.width" [class.column-required]="label.required">
+    <div class="novo-control-group-control-label {{ label.key }}" *ngFor="let label of controlLabels" [style.max-width.px]="label.width" [class.column-required]="label.required">
       <span [attr.data-automation-id]="'novo-control-group-label-' + label.value">{{ label.value }}</span>
     </div>
     <div class="novo-control-group-control-label last" *ngIf="edit" [attr.data-automation-id]="'novo-control-group-edit-' + key"></div>

--- a/projects/novo-elements/src/elements/form/ControlGroup.html
+++ b/projects/novo-elements/src/elements/form/ControlGroup.html
@@ -1,0 +1,46 @@
+<h6 class="novo-section-header" *ngIf="label">
+  <span (click)="toggle($event)" [class.clickable]="collapsible">
+    <i *ngIf="icon && !collapsible" [ngClass]="icon" [attr.data-automation-id]="'novo-control-group-icon-' + key"></i>
+    <i *ngIf="collapsible" class="bhi-next" [class.toggled]="toggled" [attr.data-automation-id]="'novo-control-group-collapse-' + key"></i>
+    <span [attr.data-automation-id]="'novo-control-group-label-' + key">{{ label }}</span>
+  </span>
+  <label class="novo-control-group-description" *ngIf="description" [attr.data-automation-id]="'novo-control-group-description-' + key">{{ description }}</label>
+</h6>
+<div class="novo-control-group-controls" [class.vertical]="vertical" [class.horizontal]="!vertical" [class.hidden]="collapsible && !toggled">
+  <ng-template #defaultTemplate let-index="index" let-form="form" let-key="key">
+    <div class="novo-control-group-control">
+      <div *ngFor="let c of controls" class="novo-control-container" [class.is-label]="c.controlType === 'read-only'" [style.max-width.px]="c.width">
+        <novo-control [form]="(form?.controls)[key]['controls'][index]" [control]="c" [condensed]="!vertical || c.controlType === 'read-only'"></novo-control>
+      </div>
+      <div class="novo-control-container last" *ngIf="edit && !vertical">
+        <button [disabled]="!disabledArray[index].edit" type="button" *ngIf="edit && !vertical" theme="icon" icon="edit" (click)="editControl(index)" [attr.data-automation-id]="'novo-control-group-edit-' + key" index="-1"></button>
+      </div>
+      <div class="novo-control-container last" *ngIf="remove && !vertical">
+        <button [disabled]="!disabledArray[index].remove" type="button" *ngIf="remove && !vertical" theme="icon" icon="delete-o" (click)="removeControl(index)" [attr.data-automation-id]="'novo-control-group-delete-' + key" index="-1"></button>
+      </div>
+    </div>
+    <button [disabled]="!disabledArray[index].edit" type="button" *ngIf="edit && vertical" theme="icon" icon="edit" (click)="editControl(index)" [attr.data-automation-id]="'novo-control-group-edit-' + key" index="-1"></button>
+    <button [disabled]="!disabledArray[index].remove" type="button" *ngIf="remove && vertical" theme="icon" icon="delete-o" (click)="removeControl(index)" [attr.data-automation-id]="'novo-control-group-delete-' + key" index="-1"></button>
+  </ng-template>
+  <div class="novo-control-group-labels" *ngIf="!vertical && (form?.controls)[key] && (form?.controls)[key]['controls'].length !== 0">
+    <div class="novo-control-group-control-label" *ngFor="let label of controlLabels" [style.max-width.px]="label.width" [class.column-required]="label.required">
+      <span [attr.data-automation-id]="'novo-control-group-label-' + label.value">{{ label.value }}</span>
+    </div>
+    <div class="novo-control-group-control-label last" *ngIf="edit" [attr.data-automation-id]="'novo-control-group-edit-' + key"></div>
+    <div class="novo-control-group-control-label last" *ngIf="remove" [attr.data-automation-id]="'novo-control-group-delete-' + key"></div>
+  </div>
+  <ng-container *ngIf="(form?.controls)[key]">
+    <div class="novo-control-group-row" *ngFor="let control of (form?.controls)[key]['controls']; let index = index">
+      <ng-template [ngTemplateOutlet]="rowTemplate || defaultTemplate" [ngTemplateOutletContext]="{ form: form, index: index, key: key, controls: controls }">
+      </ng-template>
+    </div>
+  </ng-container>
+  <div class="novo-control-group-empty" *ngIf="(form?.controls)[key] && (form?.controls)[key]['controls'].length === 0" [attr.data-automation-id]="'novo-control-group-empty-' + key">
+    {{ emptyMessage }}
+  </div>
+  <p *ngIf="add">
+    <button type="button" theme="dialogue" icon="add-thin" (click)="addNewControl()" [attr.data-automation-id]="'novo-control-group-bottom-add-' + key" index="-1">
+      {{ add?.label }}
+    </button>
+  </p>
+</div>

--- a/projects/novo-elements/src/elements/form/ControlGroup.scss
+++ b/projects/novo-elements/src/elements/form/ControlGroup.scss
@@ -81,6 +81,9 @@ novo-control-group {
       display: flex;
       padding: 0 0 1em;
       > .novo-control-group-control-label {
+        &:nth-child(1).column-required {
+          margin-left: 23px;
+        }
         flex: 1;
         > span {
           color: #9e9e9e;

--- a/projects/novo-elements/src/elements/form/ControlGroup.spec.ts
+++ b/projects/novo-elements/src/elements/form/ControlGroup.spec.ts
@@ -1,0 +1,117 @@
+// NG2
+import { ChangeDetectorRef } from '@angular/core';
+import { TestBed, async } from '@angular/core/testing';
+import { FormBuilder, FormArray } from '@angular/forms';
+// App
+// App
+import { NovoControlGroup } from './ControlGroup';
+import { NovoFormModule } from './Form.module';
+import { FormUtils } from './../../utils/form-utils/FormUtils';
+import { NovoLabelService } from '../../services/novo-label-service';
+import { OptionsService } from '../../services/options/OptionsService';
+
+describe('Elements: NovoControlGroup', () => {
+  let fixture;
+  let component;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [NovoFormModule],
+      providers: [FormUtils, FormBuilder, ChangeDetectorRef, NovoLabelService, OptionsService],
+    }).compileComponents();
+    fixture = TestBed.createComponent(NovoControlGroup);
+    component = fixture.debugElement.componentInstance;
+    // Mock @Input
+    component.form = {
+      value: 'TEST',
+      valid: false,
+      getRawValue: () => {
+        return 'TEST';
+      },
+    };
+    component.add = true;
+    component.edit = true;
+    component.remove = true;
+    component.canRemove = () => true;
+    component.canEdit = () => true;
+    component.onAdd = () => {};
+    component.controls = [
+      {
+        key: 'test1',
+        controlType: 'textbox',
+        type: 'number',
+        subtype: 'percentage',
+      },
+    ];
+    component.initialValue = [
+      {
+        test1: '34',
+      },
+    ];
+    component.key = 'test';
+  }));
+
+  it('should initialize correctly', () => {
+    expect(component).toBeTruthy();
+    component.ngAfterContentInit();
+    expect(component.key).toBe('test');
+  });
+
+  describe('Function: public resetAddRemove(): void', () => {
+    beforeEach(() => {
+      spyOn(component, 'checkCanEdit').and.returnValue(true);
+      spyOn(component, 'checkCanRemove').and.returnValue(true);
+    });
+    it('should not error if disabledArray is empty', () => {
+      component.resetAddRemove();
+      expect(component.disabledArray.length).toEqual(0);
+    });
+    it('should execute when disabledArray is not empty', () => {
+      component.disabledArray = [
+        {
+          edit: false,
+          remove: false,
+        },
+      ];
+      component.resetAddRemove();
+      expect(component.disabledArray[0].edit).toEqual(true);
+      expect(component.disabledArray[0].remove).toEqual(true);
+    });
+  });
+  describe('Function: public removeControl(index: number, emitEvent: boolean = true): void', () => {
+    beforeEach(() => {
+      spyOn(component, 'resetAddRemove');
+      spyOn(component.ref, 'markForCheck');
+      spyOn(component.onRemove, 'emit');
+      component.currentIndex = 3;
+      component.disabledArray = [{ edit: true, remove: false }, { edit: false, remove: false }, { edit: true, remove: true }];
+      component.form = {
+        controls: {
+          one: {
+            controls: [{ key: 'name' }, { key: 'name2' }, { key: 'name3' }],
+            at: () => {
+              return { value: 1 };
+            },
+            removeAt: () => {},
+          },
+        },
+      };
+      component.key = 'one';
+      spyOn(component.form.controls.one, 'removeAt').and.callFake(() => {
+        component.form.controls.one.controls = [{ key: 'name' }, { key: 'name2' }];
+      });
+    });
+    it('should remove control row', () => {
+      component.removeControl(1);
+      expect(component.form.controls.one.controls.length).toEqual(2);
+    });
+    it('should update disabledArray', () => {
+      component.removeControl(1);
+      expect(component.disabledArray).toEqual([{ edit: true, remove: false }, { edit: true, remove: true }]);
+    });
+    it('should update currentIndex', () => {
+      component.removeControl(1);
+      expect(component.currentIndex).toEqual(2);
+    });
+  });
+});

--- a/projects/novo-elements/src/elements/form/ControlGroup.spec.ts
+++ b/projects/novo-elements/src/elements/form/ControlGroup.spec.ts
@@ -3,7 +3,6 @@ import { ChangeDetectorRef } from '@angular/core';
 import { TestBed, async } from '@angular/core/testing';
 import { FormBuilder, FormArray } from '@angular/forms';
 // App
-// App
 import { NovoControlGroup } from './ControlGroup';
 import { NovoFormModule } from './Form.module';
 import { FormUtils } from './../../utils/form-utils/FormUtils';

--- a/projects/novo-elements/src/elements/form/ControlGroup.ts
+++ b/projects/novo-elements/src/elements/form/ControlGroup.ts
@@ -124,7 +124,7 @@ export class NovoControlGroup implements AfterContentInit, OnChanges {
   @Output()
   public onAdd: EventEmitter<any> = new EventEmitter<any>();
 
-  public controlLabels: { value: string; width: number }[] = [];
+  public controlLabels: { value: string; width: number, required: boolean; key: string; }[] = [];
   public toggled: boolean = false;
   public disabledArray: { edit: boolean; remove: boolean }[] = [];
 
@@ -163,6 +163,7 @@ export class NovoControlGroup implements AfterContentInit, OnChanges {
           value: control.label,
           width: control.width,
           required: control.required,
+          key: control.key,
         };
       });
       this.ref.markForCheck();

--- a/projects/novo-elements/src/elements/form/ControlGroup.ts
+++ b/projects/novo-elements/src/elements/form/ControlGroup.ts
@@ -27,134 +27,14 @@ export interface NovoControlGroupAddConfig {
   label: string;
 }
 
+export interface NovoControlGroupRowConfig {
+  edit: boolean;
+  remove: boolean;
+}
+
 @Component({
   selector: 'novo-control-group',
-  template: `
-    <h6 class="novo-section-header" *ngIf="label">
-      <span (click)="toggle($event)" [class.clickable]="collapsible">
-        <i *ngIf="icon && !collapsible" [ngClass]="icon" [attr.data-automation-id]="'novo-control-group-icon-' + key"></i>
-        <i
-          *ngIf="collapsible"
-          class="bhi-next"
-          [class.toggled]="toggled"
-          [attr.data-automation-id]="'novo-control-group-collapse-' + key"
-        ></i>
-        <span [attr.data-automation-id]="'novo-control-group-label-' + key">{{ label }}</span>
-      </span>
-      <label
-        class="novo-control-group-description"
-        *ngIf="description"
-        [attr.data-automation-id]="'novo-control-group-description-' + key"
-        >{{ description }}</label
-      >
-    </h6>
-    <div
-      class="novo-control-group-controls"
-      [class.vertical]="vertical"
-      [class.horizontal]="!vertical"
-      [class.hidden]="collapsible && !toggled"
-    >
-      <ng-template #defaultTemplate let-index="index" let-form="form" let-key="key">
-        <div class="novo-control-group-control">
-          <div
-            *ngFor="let c of controls"
-            class="novo-control-container"
-            [class.is-label]="c.controlType === 'read-only'"
-            [style.max-width.px]="c.width"
-          >
-            <novo-control
-              [form]="(form?.controls)[key]['controls'][index]"
-              [control]="c"
-              [condensed]="!vertical || c.controlType === 'read-only'"
-            ></novo-control>
-          </div>
-          <div class="novo-control-container last" *ngIf="edit && !vertical">
-            <button
-              [disabled]="!disabledArray[index].edit"
-              type="button"
-              *ngIf="edit && !vertical"
-              theme="icon"
-              icon="edit"
-              (click)="editControl(index)"
-              [attr.data-automation-id]="'novo-control-group-edit-' + key"
-              index="-1"
-            ></button>
-          </div>
-          <div class="novo-control-container last" *ngIf="remove && !vertical">
-            <button
-              [disabled]="!disabledArray[index].remove"
-              type="button"
-              *ngIf="remove && !vertical"
-              theme="icon"
-              icon="delete-o"
-              (click)="removeControl(index)"
-              [attr.data-automation-id]="'novo-control-group-delete-' + key"
-              index="-1"
-            ></button>
-          </div>
-        </div>
-        <button
-          [disabled]="!disabledArray[index].edit"
-          type="button"
-          *ngIf="edit && vertical"
-          theme="icon"
-          icon="edit"
-          (click)="editControl(index)"
-          [attr.data-automation-id]="'novo-control-group-edit-' + key"
-          index="-1"
-        ></button>
-        <button
-          [disabled]="!disabledArray[index].remove"
-          type="button"
-          *ngIf="remove && vertical"
-          theme="icon"
-          icon="delete-o"
-          (click)="removeControl(index)"
-          [attr.data-automation-id]="'novo-control-group-delete-' + key"
-          index="-1"
-        ></button>
-      </ng-template>
-      <div class="novo-control-group-labels" *ngIf="!vertical && (form?.controls)[key] && (form?.controls)[key]['controls'].length !== 0">
-        <div class="novo-control-group-control-label" *ngFor="let label of controlLabels" [style.max-width.px]="label.width">
-          <span [attr.data-automation-id]="'novo-control-group-label-' + label.value">{{ label.value }}</span>
-        </div>
-        <div class="novo-control-group-control-label last" *ngIf="edit" [attr.data-automation-id]="'novo-control-group-edit-' + key"></div>
-        <div
-          class="novo-control-group-control-label last"
-          *ngIf="remove"
-          [attr.data-automation-id]="'novo-control-group-delete-' + key"
-        ></div>
-      </div>
-      <ng-container *ngIf="(form?.controls)[key]">
-        <div class="novo-control-group-row" *ngFor="let control of (form?.controls)[key]['controls']; let index = index">
-          <ng-template
-            [ngTemplateOutlet]="rowTemplate || defaultTemplate"
-            [ngTemplateOutletContext]="{ form: form, index: index, key: key, controls: controls }"
-          >
-          </ng-template>
-        </div>
-      </ng-container>
-      <div
-        class="novo-control-group-empty"
-        *ngIf="(form?.controls)[key] && (form?.controls)[key]['controls'].length === 0"
-        [attr.data-automation-id]="'novo-control-group-empty-' + key"
-      >
-        {{ emptyMessage }}
-      </div>
-      <p *ngIf="add">
-        <button
-          type="button"
-          theme="dialogue"
-          icon="add-thin"
-          (click)="addNewControl()"
-          [attr.data-automation-id]="'novo-control-group-bottom-add-' + key"
-          index="-1"
-        >
-          {{ add?.label }}
-        </button>
-      </p>
-    </div>
-  `,
+  templateUrl: './ControlGroup.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class NovoControlGroup implements AfterContentInit, OnChanges {
@@ -282,6 +162,7 @@ export class NovoControlGroup implements AfterContentInit, OnChanges {
         return {
           value: control.label,
           width: control.width,
+          required: control.required,
         };
       });
       this.ref.markForCheck();
@@ -289,7 +170,7 @@ export class NovoControlGroup implements AfterContentInit, OnChanges {
   }
 
   private resetAddRemove(): void {
-    this.disabledArray.forEach((item: { edit: boolean; remove: boolean }, idx: number) => {
+    this.disabledArray.forEach((item: NovoControlGroupRowConfig, idx: number) => {
       item.edit = this.checkCanEdit(idx);
       item.remove = this.checkCanRemove(idx);
     });
@@ -330,7 +211,7 @@ export class NovoControlGroup implements AfterContentInit, OnChanges {
       this.onRemove.emit({ value: control.at(index).value, index: index });
     }
     control.removeAt(index);
-    this.disabledArray = this.disabledArray.filter((value: {edit: boolean; remove: boolean}, idx: number) => idx !== index);
+    this.disabledArray = this.disabledArray.filter((value: NovoControlGroupRowConfig, idx: number) => idx !== index);
     this.resetAddRemove();
     this.currentIndex--;
     this.ref.markForCheck();

--- a/projects/novo-elements/src/elements/form/ControlGroup.ts
+++ b/projects/novo-elements/src/elements/form/ControlGroup.ts
@@ -124,7 +124,7 @@ export class NovoControlGroup implements AfterContentInit, OnChanges {
   @Output()
   public onAdd: EventEmitter<any> = new EventEmitter<any>();
 
-  public controlLabels: { value: string; width: number, required: boolean; key: string; }[] = [];
+  public controlLabels: { value: string; width: number; required: boolean; key: string }[] = [];
   public toggled: boolean = false;
   public disabledArray: { edit: boolean; remove: boolean }[] = [];
 
@@ -170,7 +170,7 @@ export class NovoControlGroup implements AfterContentInit, OnChanges {
     }
   }
 
-  private resetAddRemove(): void {
+  public resetAddRemove(): void {
     this.disabledArray.forEach((item: NovoControlGroupRowConfig, idx: number) => {
       item.edit = this.checkCanEdit(idx);
       item.remove = this.checkCanRemove(idx);

--- a/projects/novo-elements/src/elements/form/ControlGroup.ts
+++ b/projects/novo-elements/src/elements/form/ControlGroup.ts
@@ -288,6 +288,13 @@ export class NovoControlGroup implements AfterContentInit, OnChanges {
     }
   }
 
+  private resetAddRemove(): void {
+    this.disabledArray.forEach((item: { edit: boolean; remove: boolean }, idx: number) => {
+      item.edit = this.checkCanEdit(idx);
+      item.remove = this.checkCanRemove(idx);
+    });
+  }
+
   public addNewControl(value?: {}): void {
     const control: FormArray = <FormArray>this.form.controls[this.key];
     const newCtrl: NovoFormGroup = this.buildControl(value);
@@ -297,9 +304,10 @@ export class NovoControlGroup implements AfterContentInit, OnChanges {
       this.form.addControl(this.key, this.fb.array([newCtrl]));
     }
     this.disabledArray.push({
-      edit: this.checkCanEdit(this.currentIndex),
-      remove: this.checkCanRemove(this.currentIndex),
+      edit: true,
+      remove: true,
     });
+    this.resetAddRemove();
     if (!value) {
       this.onAdd.emit();
     }
@@ -322,6 +330,8 @@ export class NovoControlGroup implements AfterContentInit, OnChanges {
       this.onRemove.emit({ value: control.at(index).value, index: index });
     }
     control.removeAt(index);
+    this.disabledArray = this.disabledArray.filter((value: {edit: boolean; remove: boolean}, idx: number) => idx !== index);
+    this.resetAddRemove();
     this.currentIndex--;
     this.ref.markForCheck();
   }

--- a/projects/novo-elements/src/elements/form/controls/BaseControl.ts
+++ b/projects/novo-elements/src/elements/form/controls/BaseControl.ts
@@ -114,6 +114,8 @@ export class BaseControl extends ControlConfig {
     this.encrypted = !!config.encrypted;
     this.sortOrder = config.sortOrder === undefined ? 1 : config.sortOrder;
     this.controlType = config.controlType || '';
+    this.type = config.type;
+    this.subType = config.subType;
     this.metaType = config.metaType;
     this.placeholder = config.placeholder || '';
     this.config = config.config || null;

--- a/projects/novo-elements/src/utils/Helpers.spec.ts
+++ b/projects/novo-elements/src/utils/Helpers.spec.ts
@@ -89,5 +89,11 @@ describe('Utils: Helpers', () => {
         expect(Helpers.isNumber(notNumber)).toBeFalsy();
       });
     });
+    it('should return true for negative numbers', () => {
+      const numbers: any[] = ['-10', '-2145'];
+      numbers.forEach((number) => {
+        expect(Helpers.isNumber(number, true)).toBeTruthy();
+      });
+    });
   });
 });

--- a/projects/novo-elements/src/utils/Helpers.ts
+++ b/projects/novo-elements/src/utils/Helpers.ts
@@ -83,9 +83,10 @@ export class Helpers {
     return typeof obj === 'string';
   }
 
-  static isNumber(val: any) {
+  static isNumber(val: any, includeNegatives: boolean = false) {
+    const numberRegex = includeNegatives ? /^-{0,1}\d*\.?\d*$/ : /^\d*\.?\d*$/;
     if (typeof val === 'string') {
-      return val.length > 0 && val !== '.' && /^\d*\.?\d*$/.test(val);
+      return val.length > 0 && val !== '.' && numberRegex.test(val);
     } else {
       return !isNaN(parseFloat(val));
     }


### PR DESCRIPTION
## **Description**

- base-control: copying over subtype and type
- resetting edit/remove checks on every add and remove of controls
- fixed styles for required columns
- added the control key as a class to the label column
#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**