### PR TITLE
Catching improper config

### DIFF
--- a/projects/novo-elements/src/elements/value/Render.ts
+++ b/projects/novo-elements/src/elements/value/Render.ts
@@ -282,7 +282,7 @@ export class RenderPipe implements PipeTransform {
         text = `${value.compensation ? `${value.compensation.code} - ` : ''} ${value.compensation ? value.compensation.name : ''}`;
         break;
       case 'Options':
-        text = this.options(value, args.options);
+        text = this.options(value, args.options, args);
         break;
       case 'ToMany':
         if (['Candidate', 'CorporateUser', 'Person'].indexOf(args.associatedEntity.entity) > -1) {
@@ -373,18 +373,25 @@ export class RenderPipe implements PipeTransform {
    * @param value - the value to find
    * @param list - list of options (label/value pairs)
    */
-  options(value: any, list: any): any {
+  options(value: any, list: any, args: any): any {
     if (!Array.isArray(value)) {
       value = [value];
     }
-    return value.map((item: any) => {
-      for (const option of list) {
-        if (option.value === item) {
-          return option.label;
+    try {
+      return value.map((item: any) => {
+        for (const option of list) {
+          if (option.value === item) {
+            return option.label;
+          }
         }
+        return item;
+      });
+    } catch (e) {
+      if (!args.optionsType) {
+        console.error(`WARNING: There are no options configured for the field: ${args.label}`);
       }
-      return item;
-    });
+      return value;
+    }
   }
 
   getNumberDecimalPlaces(value: any): any {


### PR DESCRIPTION
…ror, returing the value

## **Description**

If an inputType of 'SELECT' does not have an array of options, catch the error and pass a helpful error message.
If If an inputType of 'SELECT' is configured with and optionsType, don't throw the error & return the value
ex. customText5 is a Picker:People

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**