### PR TITLE
f/Multi-Column-Filter

### DIFF
--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
@@ -272,6 +272,7 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
       } else {
         this.filterActive = false;
         this.filter = undefined;
+        this.activeDateFilter = undefined;
         this.multiSelectedOptions = [];
       }
       changeDetectorRef.markForCheck();

--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
@@ -171,6 +171,9 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
   defaultSort: { id: string; value: string };
 
   @Input()
+  allowMultipleFilters: boolean = false;
+
+  @Input()
   resized: EventEmitter<IDataTableColumn<T>>;
   @Input()
   filterTemplate: TemplateRef<any>;
@@ -259,9 +262,13 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
         this.icon = 'sortable';
         this.sortActive = false;
       }
-      if (change.filter && change.filter.id === this.id) {
+
+      let tableFilter = Helpers.convertToArray(change.filter);
+      let thisFilter = tableFilter.find((filter) => filter && filter.id === this.id);
+
+      if (thisFilter) {
         this.filterActive = true;
-        this.filter = change.filter.value;
+        this.filter = thisFilter.value;
       } else {
         this.filterActive = false;
         this.filter = undefined;
@@ -421,7 +428,7 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
       if (actualFilter === '') {
         actualFilter = undefined;
       }
-      this._sort.filter(this.id, actualFilter, this.config.transforms.filter);
+      this._sort.filter(this.id, actualFilter, this.config.transforms.filter, this.allowMultipleFilters);
       this.changeDetectorRef.markForCheck();
     }, 300);
   }

--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
@@ -311,7 +311,7 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
   }
 
   public toggleSelection(option) {
-    const optionValue = option.value ? option.value : option;
+    const optionValue = option.hasOwnProperty('value') ? option.value : option;
 
     let optionIndex = this.multiSelectedOptions.findIndex((item) => this.optionPresentCheck(item, optionValue));
 

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -109,6 +109,7 @@ import { StaticDataTableService } from './services/static-data-table.service';
               [novo-data-table-cell-config]="column"
               [resized]="resized"
               [defaultSort]="defaultSort"
+              [allowMultipleFilters]="allowMultipleFilters"
               [class.empty]="column?.type === 'action' && !column?.label"
               [class.button-header-cell]="column?.type === 'expand' || (column?.type === 'action' && !column?.action?.options)"
               [class.dropdown-header-cell]="column?.type === 'action' && column?.action?.options"
@@ -290,6 +291,8 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   defaultSort: { id: string; value: string };
   @Input()
   name: string = 'novo-data-table';
+  @Input()
+  allowMultipleFilters: boolean = false;
   @Input()
   rowIdentifier: string = 'id';
   @Input()

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -94,7 +94,7 @@ export interface IDataTableSortFilter {
 
 export interface IDataTableChangeEvent {
   sort?: { id: string; value: string };
-  filter?: { id: string; value: string | string[] };
+  filter?: IDataTableFilter | IDataTableFilter[];
   page?: number;
   pageSize?: number;
   globalSearch?: string;
@@ -110,10 +110,16 @@ export interface IDataTablePaginationEvent {
   length: number;
 }
 
+export interface IDataTableFilter {
+  id: string;
+  value: string | string[];
+  transform?: Function;
+}
+
 export interface IDataTableService<T> {
   getTableResults(
     sort: { id: string; value: string; transform?: Function },
-    filter: { id: string; value: string | string[]; transform?: Function },
+    filter: IDataTableFilter | IDataTableFilter[],
     page: number,
     pageSize: number,
     globalSearch?: string,

--- a/projects/novo-elements/src/elements/data-table/services/remote-data-table.service.ts
+++ b/projects/novo-elements/src/elements/data-table/services/remote-data-table.service.ts
@@ -1,11 +1,11 @@
 import { Observable } from 'rxjs';
 
-import { IDataTableService } from '../interfaces';
+import { IDataTableFilter, IDataTableService } from '../interfaces';
 
 export abstract class RemoteDataTableService<T> implements IDataTableService<T> {
   abstract getTableResults(
     sort: { id: string; value: string; transform?: Function },
-    filter: { id: string; value: string; transform?: Function },
+    filter: IDataTableFilter | IDataTableFilter[],
     page: number,
     pageSize: number,
     globalSearch?: string,

--- a/projects/novo-elements/src/elements/data-table/services/static-data-table.service.spec.ts
+++ b/projects/novo-elements/src/elements/data-table/services/static-data-table.service.spec.ts
@@ -1,0 +1,40 @@
+// NG2
+import { TestBed, async } from '@angular/core/testing';
+// APP
+import { StaticDataTableService } from './static-data-table.service';
+import * as dateFns from 'date-fns';
+
+describe('StaticDataTableService', () => {
+  let service;
+
+  beforeEach(async(() => {
+    let staticDataSet1 = [];
+    for (let i = 0; i < 100; i++) {
+      let day = dateFns.subDays(new Date(), i);
+      let rando = Math.floor(Math.random() * 5);
+      staticDataSet1.push({
+        id: i,
+        date: day,
+        status: `Status ${rando}`,
+      });
+    }
+    service = new StaticDataTableService([...staticDataSet1]);
+  }));
+
+  it('should initialize correctly.', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('method: filterData', () => {
+    it('should filter data when passed a value', () => {
+      let results = service.filterData(service.currentData, { id: 'id', value: 5 });
+      let resultsAreFiltered = results.every((x) => x.id.toString().includes('5'));
+      expect(resultsAreFiltered).toBe(true);
+    });
+    it('should filter data when passed an array of values', () => {
+      let results = service.filterData(service.currentData, { id: 'status', value: [1, 5] });
+      let resultsAreFiltered = results.every((x) => x.status.includes(['1', '5']));
+      expect(resultsAreFiltered).toBe(true);
+    });
+  });
+});

--- a/projects/novo-elements/src/elements/data-table/services/static-data-table.service.ts
+++ b/projects/novo-elements/src/elements/data-table/services/static-data-table.service.ts
@@ -1,6 +1,6 @@
 import { Observable, of } from 'rxjs';
 
-import { IDataTableService } from '../interfaces';
+import { IDataTableFilter, IDataTableService } from '../interfaces';
 import { Helpers } from '../../../utils/Helpers';
 
 export class StaticDataTableService<T> implements IDataTableService<T> {
@@ -12,7 +12,7 @@ export class StaticDataTableService<T> implements IDataTableService<T> {
 
   public getTableResults(
     sort: { id: string; value: string; transform?: Function },
-    filter: { id: string; value: string; transform?: Function },
+    filter: IDataTableFilter | IDataTableFilter[],
     page: number = 0,
     pageSize: number,
     globalSearch?: string,
@@ -28,9 +28,16 @@ export class StaticDataTableService<T> implements IDataTableService<T> {
         total = this.currentData.length;
       }
       if (filter) {
-        let value = Helpers.isString(filter.value) ? filter.value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : filter.value;
-        this.currentData = this.currentData.filter(Helpers.filterByField(filter.id, value));
-        total = this.currentData.length;
+        let filters = Helpers.convertToArray(filter);
+        filters.forEach((aFilter) => {
+          let values = Helpers.convertToArray(aFilter.value);
+          values.forEach((aValue) => {
+            aValue = Helpers.isString(aValue) ? aValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : aValue;
+
+            this.currentData = this.currentData.filter(Helpers.filterByField(aFilter.id, aValue));
+            total = this.currentData.length;
+          });
+        });
       }
       if (sort) {
         this.currentData = this.currentData.sort(Helpers.sortByField(sort.id, sort.value === 'desc'));

--- a/projects/novo-elements/src/elements/data-table/services/static-data-table.service.ts
+++ b/projects/novo-elements/src/elements/data-table/services/static-data-table.service.ts
@@ -30,13 +30,16 @@ export class StaticDataTableService<T> implements IDataTableService<T> {
       if (filter) {
         let filters = Helpers.convertToArray(filter);
         filters.forEach((aFilter) => {
-          let values = Helpers.convertToArray(aFilter.value);
-          values.forEach((aValue) => {
-            aValue = Helpers.isString(aValue) ? aValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : aValue;
-
-            this.currentData = this.currentData.filter(Helpers.filterByField(aFilter.id, aValue));
-            total = this.currentData.length;
-          });
+          if (Array.isArray(aFilter.value)) {
+            let values = Helpers.convertToArray(aFilter.value).map((aValue) => {
+              return Helpers.cleanIfString(aValue);
+            });
+            this.currentData = this.currentData.filter(Helpers.filterByField(aFilter.id, values));
+          } else {
+            let value = Helpers.cleanIfString(aFilter.value);
+            this.currentData = this.currentData.filter(Helpers.filterByField(aFilter.id, value));
+          }
+          total = this.currentData.length;
         });
       }
       if (sort) {

--- a/projects/novo-elements/src/elements/data-table/services/static-data-table.service.ts
+++ b/projects/novo-elements/src/elements/data-table/services/static-data-table.service.ts
@@ -28,19 +28,8 @@ export class StaticDataTableService<T> implements IDataTableService<T> {
         total = this.currentData.length;
       }
       if (filter) {
-        let filters = Helpers.convertToArray(filter);
-        filters.forEach((aFilter) => {
-          if (Array.isArray(aFilter.value)) {
-            let values = Helpers.convertToArray(aFilter.value).map((aValue) => {
-              return Helpers.cleanIfString(aValue);
-            });
-            this.currentData = this.currentData.filter(Helpers.filterByField(aFilter.id, values));
-          } else {
-            let value = Helpers.cleanIfString(aFilter.value);
-            this.currentData = this.currentData.filter(Helpers.filterByField(aFilter.id, value));
-          }
-          total = this.currentData.length;
-        });
+        this.currentData = this.filterData(this.currentData, filter);
+        total = this.currentData.length;
       }
       if (sort) {
         this.currentData = this.currentData.sort(Helpers.sortByField(sort.id, sort.value === 'desc'));
@@ -54,5 +43,21 @@ export class StaticDataTableService<T> implements IDataTableService<T> {
       }
     }
     return of({ results: this.currentData, total: total });
+  }
+
+  public filterData(currentData: T[], filter: IDataTableFilter | IDataTableFilter[]): T[] {
+    let filters = Helpers.convertToArray(filter);
+    filters.forEach((aFilter) => {
+      if (Array.isArray(aFilter.value)) {
+        let values = Helpers.convertToArray(aFilter.value).map((aValue) => {
+          return Helpers.cleanIfString(aValue);
+        });
+        currentData = currentData.filter(Helpers.filterByField(aFilter.id, values));
+      } else {
+        let value = Helpers.cleanIfString(aFilter.value);
+        currentData = currentData.filter(Helpers.filterByField(aFilter.id, value));
+      }
+    });
+    return currentData;
   }
 }

--- a/projects/novo-elements/src/elements/data-table/services/static-data-table.service.ts
+++ b/projects/novo-elements/src/elements/data-table/services/static-data-table.service.ts
@@ -49,12 +49,10 @@ export class StaticDataTableService<T> implements IDataTableService<T> {
     let filters = Helpers.convertToArray(filter);
     filters.forEach((aFilter) => {
       if (Array.isArray(aFilter.value)) {
-        let values = Helpers.convertToArray(aFilter.value).map((aValue) => {
-          return Helpers.cleanIfString(aValue);
-        });
+        let values = Helpers.convertToArray(aFilter.value).map(Helpers.escapeString);
         currentData = currentData.filter(Helpers.filterByField(aFilter.id, values));
       } else {
-        let value = Helpers.cleanIfString(aFilter.value);
+        let value = Helpers.escapeString(aFilter.value);
         currentData = currentData.filter(Helpers.filterByField(aFilter.id, value));
       }
     });

--- a/projects/novo-elements/src/elements/data-table/sort-filter/sort-filter.directive.spec.ts
+++ b/projects/novo-elements/src/elements/data-table/sort-filter/sort-filter.directive.spec.ts
@@ -2,11 +2,60 @@ import { NovoDataTableSortFilter } from './sort-filter.directive';
 import { DataTableState } from '../state/data-table-state.service';
 
 describe('Directive: sort-filter', () => {
-  describe('Function: makeFilter', () => {
-    let directive: NovoDataTableSortFilter<{}> = new NovoDataTableSortFilter(new DataTableState());
-    it('works', () => {
-      const result = directive['makeFilter'](true, [{}], 'whelp', 5, () => {});
-      expect(result).toBeDefined();
+  describe('Function: filter', () => {
+    let testState: DataTableState<{}> = new DataTableState();
+    let directive: NovoDataTableSortFilter<{}> = new NovoDataTableSortFilter(testState);
+
+    it('should set state filter to results', () => {
+      directive.filter('test', 'test', undefined);
+      expect(testState.filter).toEqual({ id: 'test', transform: undefined, value: 'test' });
+    });
+
+    it('should set state filter to undefined is value is blank', () => {
+      directive.filter('test', null, undefined);
+      expect(testState.filter).toEqual(undefined);
+    });
+  });
+
+  describe('Function: sort', () => {
+    let testState: DataTableState<{}> = new DataTableState();
+    let directive: NovoDataTableSortFilter<{}> = new NovoDataTableSortFilter(testState);
+
+    it('should set state sort to results', () => {
+      directive.sort('test', 'test', undefined);
+      expect(testState.sort).toEqual({ id: 'test', transform: undefined, value: 'test' });
+    });
+  });
+
+  describe('Function: resolveMultiFilter', () => {
+    let testState: DataTableState<{}> = new DataTableState();
+    let directive: NovoDataTableSortFilter<{}> = new NovoDataTableSortFilter(testState);
+
+    it('should return an array of results', () => {
+      testState.filter = { id: 'test', transform: undefined, value: 'test' };
+      let result = directive.resolveMultiFilter('test2', 'also a test', undefined);
+      let expected = [{ id: 'test', transform: undefined, value: 'test' }, { id: 'test2', transform: undefined, value: 'also a test' }];
+      expect(result).toEqual(expected);
+    });
+
+    it('should replace a result if id already exists', () => {
+      testState.filter = { id: 'test', transform: undefined, value: 'test' };
+      let result = directive.resolveMultiFilter('test', 'replacement test', undefined);
+      let expected = [{ id: 'test', transform: undefined, value: 'replacement test' }];
+      expect(result).toEqual(expected);
+    });
+
+    it('should remove a result if passed value is blank', () => {
+      testState.filter = [{ id: 'test', transform: undefined, value: 'test' }, { id: 'test2', transform: undefined, value: 'also a test' }];
+      let result = directive.resolveMultiFilter('test2', null, undefined);
+      let expected = [{ id: 'test', transform: undefined, value: 'test' }];
+      expect(result).toEqual(expected);
+    });
+
+    it('should return undefined rather than an empty array', () => {
+      testState.filter = [{ id: 'test2', transform: undefined, value: 'also a test' }];
+      let result = directive.resolveMultiFilter('test2', null, undefined);
+      expect(result).toEqual(undefined);
     });
   });
 });

--- a/projects/novo-elements/src/elements/data-table/sort-filter/sort-filter.directive.spec.ts
+++ b/projects/novo-elements/src/elements/data-table/sort-filter/sort-filter.directive.spec.ts
@@ -1,0 +1,12 @@
+import { NovoDataTableSortFilter } from './sort-filter.directive';
+import { DataTableState } from '../state/data-table-state.service';
+
+describe('Directive: sort-filter', () => {
+  describe('Function: makeFilter', () => {
+    let directive: NovoDataTableSortFilter<{}> = new NovoDataTableSortFilter(new DataTableState());
+    it('works', () => {
+      const result = directive['makeFilter'](true, [{}], 'whelp', 5, () => {});
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/projects/novo-elements/src/elements/data-table/sort-filter/sort-filter.directive.ts
+++ b/projects/novo-elements/src/elements/data-table/sort-filter/sort-filter.directive.ts
@@ -13,20 +13,7 @@ export class NovoDataTableSortFilter<T> {
     let filter;
 
     if (allowMultipleFilters) {
-      filter = Helpers.convertToArray(this.state.filter);
-
-      let filterIndex = filter.findIndex((aFilter) => aFilter && aFilter.id === id);
-      if (filterIndex > -1) {
-        filter.splice(filterIndex, 1);
-      }
-
-      if (!Helpers.isBlank(value)) {
-        filter = [...filter, { id, value, transform }];
-      }
-
-      if (filter.length < 1) {
-        filter = undefined;
-      }
+      filter = this.resolveMultiFilter(id, value, transform);
     } else {
       if (!Helpers.isBlank(value)) {
         filter = { id, value, transform };
@@ -47,5 +34,26 @@ export class NovoDataTableSortFilter<T> {
     this.state.reset(false, true);
     this.state.updates.next({ sort: sort, filter: this.state.filter });
     this.state.onSortFilterChange();
+  }
+
+  public resolveMultiFilter(id: string, value: any, transform: Function) {
+    let filter;
+
+    filter = Helpers.convertToArray(this.state.filter);
+
+    let filterIndex = filter.findIndex((aFilter) => aFilter && aFilter.id === id);
+    if (filterIndex > -1) {
+      filter.splice(filterIndex, 1);
+    }
+
+    if (!Helpers.isBlank(value)) {
+      filter = [...filter, { id, value, transform }];
+    }
+
+    if (filter.length < 1) {
+      filter = undefined;
+    }
+
+    return filter;
   }
 }

--- a/projects/novo-elements/src/elements/data-table/sort-filter/sort-filter.directive.ts
+++ b/projects/novo-elements/src/elements/data-table/sort-filter/sort-filter.directive.ts
@@ -13,15 +13,15 @@ export class NovoDataTableSortFilter<T> {
     let filter;
 
     if (allowMultipleFilters) {
-      let currentFilters = Helpers.convertToArray(this.state.filter);
+      filter = Helpers.convertToArray(this.state.filter);
 
-      let filterIndex = currentFilters.findIndex((aFilter) => aFilter && aFilter.id === id);
+      let filterIndex = filter.findIndex((aFilter) => aFilter && aFilter.id === id);
       if (filterIndex > -1) {
-        currentFilters.splice(filterIndex, 1);
+        filter.splice(filterIndex, 1);
       }
 
       if (!Helpers.isBlank(value)) {
-        filter = currentFilters.length > 0 ? [...currentFilters, { id, value, transform }] : [{ id, value, transform }];
+        filter = [...filter, { id, value, transform }];
       }
 
       if (filter.length < 1) {

--- a/projects/novo-elements/src/elements/data-table/sort-filter/sort-filter.directive.ts
+++ b/projects/novo-elements/src/elements/data-table/sort-filter/sort-filter.directive.ts
@@ -9,13 +9,32 @@ import { Helpers } from '../../../utils/Helpers';
 export class NovoDataTableSortFilter<T> {
   constructor(private state: DataTableState<T>) {}
 
-  public filter(id: string, value: any, transform: Function): void {
+  public filter(id: string, value: any, transform: Function, allowMultipleFilters: boolean = false): void {
     let filter;
-    if (!Helpers.isBlank(value)) {
-      filter = { id, value, transform };
+
+    if (allowMultipleFilters) {
+      this.state.filter = Helpers.convertToArray(this.state.filter);
+
+      let filterIndex = this.state.filter.findIndex((aFilter) => aFilter && aFilter.id === id);
+      if (filterIndex > -1) {
+        this.state.filter.splice(filterIndex, 1);
+      }
+
+      if (!Helpers.isBlank(value)) {
+        filter = this.state.filter.length > 0 ? [...this.state.filter, { id, value, transform }] : [{ id, value, transform }];
+      }
+
+      if (filter.length < 1) {
+        filter = undefined;
+      }
     } else {
-      filter = undefined;
+      if (!Helpers.isBlank(value)) {
+        filter = { id, value, transform };
+      } else {
+        filter = undefined;
+      }
     }
+
     this.state.filter = filter;
     this.state.reset(false, true);
     this.state.updates.next({ filter: filter, sort: this.state.sort });

--- a/projects/novo-elements/src/elements/data-table/sort-filter/sort-filter.directive.ts
+++ b/projects/novo-elements/src/elements/data-table/sort-filter/sort-filter.directive.ts
@@ -13,15 +13,15 @@ export class NovoDataTableSortFilter<T> {
     let filter;
 
     if (allowMultipleFilters) {
-      this.state.filter = Helpers.convertToArray(this.state.filter);
+      let currentFilters = Helpers.convertToArray(this.state.filter);
 
-      let filterIndex = this.state.filter.findIndex((aFilter) => aFilter && aFilter.id === id);
+      let filterIndex = currentFilters.findIndex((aFilter) => aFilter && aFilter.id === id);
       if (filterIndex > -1) {
-        this.state.filter.splice(filterIndex, 1);
+        currentFilters.splice(filterIndex, 1);
       }
 
       if (!Helpers.isBlank(value)) {
-        filter = this.state.filter.length > 0 ? [...this.state.filter, { id, value, transform }] : [{ id, value, transform }];
+        filter = currentFilters.length > 0 ? [...currentFilters, { id, value, transform }] : [{ id, value, transform }];
       }
 
       if (filter.length < 1) {

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from '@angular/core';
 import { Subject } from 'rxjs';
 
-import { IDataTableChangeEvent } from '../interfaces';
+import { IDataTableChangeEvent, IDataTableFilter } from '../interfaces';
 
 export class DataTableState<T> {
   public selectionSource = new Subject();
@@ -12,7 +12,7 @@ export class DataTableState<T> {
   public dataLoaded = new Subject();
 
   sort: { id: string; value: string } = undefined;
-  filter: { id: string; value: string | string[] } = undefined;
+  filter: IDataTableFilter | IDataTableFilter[] = undefined;
   page: number = 0;
   pageSize: number = undefined;
   globalSearch: string = undefined;

--- a/projects/novo-elements/src/utils/Helpers.ts
+++ b/projects/novo-elements/src/utils/Helpers.ts
@@ -83,6 +83,13 @@ export class Helpers {
     return typeof obj === 'string';
   }
 
+  static cleanIfString(obj: any): any {
+    if (Helpers.isString(obj)) {
+      return obj.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+    return obj;
+  }
+
   static isNumber(val: any, includeNegatives: boolean = false) {
     const numberRegex = includeNegatives ? /^-{0,1}\d*\.?\d*$/ : /^\d*\.?\d*$/;
     if (typeof val === 'string') {

--- a/projects/novo-elements/src/utils/Helpers.ts
+++ b/projects/novo-elements/src/utils/Helpers.ts
@@ -83,7 +83,7 @@ export class Helpers {
     return typeof obj === 'string';
   }
 
-  static cleanIfString(obj: any): any {
+  static escapeString(obj: any): any {
     if (Helpers.isString(obj)) {
       return obj.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     }
@@ -127,7 +127,7 @@ export class Helpers {
     return obj instanceof Date;
   }
 
-  static convertToArray(obj: any): any[] {
+  static convertToArray(obj: undefined | Object | Object[]): any[] {
     if (obj === undefined) {
       return [];
     } else if (!Array.isArray(obj)) {

--- a/projects/novo-elements/src/utils/Helpers.ts
+++ b/projects/novo-elements/src/utils/Helpers.ts
@@ -120,6 +120,15 @@ export class Helpers {
     return obj instanceof Date;
   }
 
+  static convertToArray(obj: any): any[] {
+    if (obj === undefined) {
+      return [];
+    } else if (!Array.isArray(obj)) {
+      return [obj];
+    }
+    return obj;
+  }
+
   static sortByField(fields: any, reverse = false) {
     return (previous: any, current: any) => {
       if (Helpers.isFunction(fields)) {

--- a/projects/novo-examples/src/components/data-table/data-table-remote/data-table-remote-example.html
+++ b/projects/novo-examples/src/components/data-table/data-table-remote/data-table-remote-example.html
@@ -1,5 +1,6 @@
 <novo-data-table [dataTableService]="remoteService"
                  [columns]="sharedColumns"
+                 [allowMultipleFilters]="true"
                  [hideGlobalSearch]="!globalSearchEnabled"
                  [displayedColumns]="sharedDisplayColumns"
                  [paginationOptions]="widePaginationOptions"

--- a/projects/novo-examples/src/components/data-table/data-table-rows/data-table-rows-example.html
+++ b/projects/novo-examples/src/components/data-table/data-table-rows/data-table-rows-example.html
@@ -13,6 +13,7 @@
 <div class="fixedWindowSize">
 <novo-data-table [rows]="basicRows"
                  [columns]="sharedColumns"
+                 [allowMultipleFilters]="true"
                  [hideGlobalSearch]="!globalSearchEnabled"
                  [displayedColumns]="sharedDisplayColumns"
                  [paginationOptions]="sharedPaginationOptions"

--- a/projects/novo-examples/src/components/data-table/data-table-service/data-table-service-example.html
+++ b/projects/novo-examples/src/components/data-table/data-table-service/data-table-service-example.html
@@ -1,5 +1,6 @@
 <novo-data-table [dataTableService]="basicService"
                  [columns]="sharedColumns"
+                 [allowMultipleFilters]="true"
                  [hideGlobalSearch]="!globalSearchEnabled"
                  [displayedColumns]="sharedDisplayColumns"
                  [paginationOptions]="sharedPaginationOptions">


### PR DESCRIPTION
## **Description**

Added config to allow the data-tables to be sorted on more than one column at once.

Simply pass an attribute of [allowMultipleFilters]="true" in the Novo-Data-Table config.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**
![multi-column-filtering](https://user-images.githubusercontent.com/21197268/57092963-49e22480-6cd2-11e9-9d2e-7f5cbefafc75.png)
