### PR TITLE
BH-61377 - Add filter box for filtering multi-select columns

### DIFF
--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
@@ -31,6 +31,7 @@ import { NovoDropdownElement } from '../../dropdown/Dropdown';
 import { NovoLabelService } from '../../../services/novo-label-service';
 import { DataTableState } from '../state/data-table-state.service';
 import { Helpers } from '../../../utils/Helpers';
+import { KeyCodes } from '../../../utils/key-codes/KeyCodes';
 
 @Component({
   selector: '[novo-data-table-cell-config]',
@@ -114,9 +115,21 @@ import { Helpers } from '../../../utils/Helpers';
             </item>
           </list>
           <list *ngSwitchCase="'multi-select'">
+            <div class="dropdown-list-filter" (keydown)="multiSelectOptionFilterHandleKeydown($event)">
+              <item class="filter-search" keepOpen="true">
+                <input
+                  [(ngModel)]="optionFilter"
+                  (ngModelChange)="multiSelectOptionFilter($event)"
+                  #optionFilterInput
+                  data-automation-id="novo-data-table-multi-select-option-filter-input"
+                />
+                <i class="bhi-search"></i> <span class="error-text" [hidden]="!error">{{ labels.selectFilterOptions }}</span>
+              </item>
+            </div>
             <div class="dropdown-list-options">
               <item
                 *ngFor="let option of config.filterConfig.options"
+                [hidden]="multiSelectOptionIsHidden(option)"
                 (click)="toggleSelection(option)"
                 [attr.data-automation-id]="'novo-data-table-filter-' + (option?.label || option)"
                 [keepOpen]="true"
@@ -128,6 +141,7 @@ import { Helpers } from '../../../utils/Helpers';
                 ></i>
               </item>
             </div>
+            <p class="filter-null-results" [hidden]="multiSelectOptionEmptyState()">{{ labels.pickerEmpty }}</p>
           </list>
           <list *ngSwitchCase="'custom'">
             <item class="filter-search" keepOpen="true">
@@ -166,6 +180,8 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
   filterInput: ElementRef;
   @ViewChild(NovoDropdownElement)
   dropdown: NovoDropdownElement;
+  @ViewChild('optionFilterInput')
+  optionFilterInput: ElementRef;
 
   @Input()
   defaultSort: { id: string; value: string };
@@ -239,6 +255,10 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
   };
   public multiSelect: boolean = false;
   public multiSelectedOptions: Array<any> = [];
+  private multiSelectedOptionIsHidden: Array<{ option: string | IDataTableColumnFilterOption; hidden: boolean }> = [];
+  private multiSelectHighlightedOption: number = 0;
+  public optionFilter: string = '';
+  public error: boolean = false;
   private subscriptions: Subscription[] = [];
   private _column: IDataTableColumn<T>;
 
@@ -283,6 +303,19 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
     this.multiSelect = this.config.filterConfig && this.config.filterConfig.type ? this.config.filterConfig.type === 'multi-select' : false;
     if (this.multiSelect) {
       this.multiSelectedOptions = this.filter ? [...this.filter] : [];
+      if (typeof this.config.filterConfig.options[1] === 'string') {
+        (this.config.filterConfig.options as string[]).forEach(
+          (option: string): void => {
+            this.multiSelectedOptionIsHidden.push({ option: option, hidden: false });
+          },
+        );
+      } else {
+        (this.config.filterConfig.options as IDataTableColumnFilterOption[]).forEach(
+          (option: IDataTableColumnFilterOption): void => {
+            this.multiSelectedOptionIsHidden.push({ option: option, hidden: false });
+          },
+        );
+      }
     }
   }
 
@@ -307,9 +340,17 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
     const optionValue = option.value ? option.value : option;
 
     let optionIndex = this.multiSelectedOptions.findIndex((item) => this.optionPresentCheck(item, optionValue));
-
+    this.error = false;
     if (optionIndex > -1) {
       this.multiSelectedOptions.splice(optionIndex, 1);
+      if (
+        this.optionFilter &&
+        !this.getOptionText(option)
+          .toLowerCase()
+          .startsWith(this.optionFilter.toLowerCase())
+      ) {
+        this.multiSelectedOptionIsHidden[this.multiSelectedOptionIsHidden.findIndex((record) => record.option === option)].hidden = true;
+      }
     } else {
       this.multiSelectedOptions.push(optionValue);
     }
@@ -326,12 +367,75 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
   public cancel(): void {
     this.multiSelectedOptions = this.filter ? [...this.filter] : [];
     this.dropdown.closePanel();
+    this.clearOptionFilter();
   }
 
   public filterMultiSelect(): void {
-    let actualFilter = this.multiSelectedOptions.length > 0 ? [...this.multiSelectedOptions] : undefined;
-    this.filterData(actualFilter);
-    this.dropdown.closePanel();
+    if ((this.multiSelectedOptions.length === 0 && !this.filter) || this.multiSelectedOptions === this.filter) {
+      this.multiSelectOptionEmptyState() ? (this.error = true) : null;
+    } else {
+      this.clearOptionFilter();
+      let actualFilter = this.multiSelectedOptions.length > 0 ? [...this.multiSelectedOptions] : undefined;
+      this.filterData(actualFilter);
+      this.dropdown.closePanel();
+    }
+  }
+
+  public multiSelectOptionFilter(optionFilter: string) {
+    this.multiSelectedOptionIsHidden.forEach((record) => {
+      if (
+        this.getOptionText(record.option)
+          .toLowerCase()
+          .startsWith(optionFilter.toLowerCase()) ||
+        this.isSelected(record.option, this.multiSelectedOptions)
+      ) {
+        record.hidden = false;
+      } else {
+        record.hidden = true;
+      }
+    });
+    this.multiSelectHighlightedOption = 0;
+  }
+
+  public multiSelectOptionIsHidden(option: string | IDataTableColumnFilterOption): boolean {
+    return this.multiSelectedOptionIsHidden.find((record) => record.option === option).hidden;
+  }
+
+  public multiSelectOptionEmptyState(): boolean {
+    return this.multiSelectedOptionIsHidden.some((record) => !record.hidden);
+  }
+
+  private getOptionText(option: string | IDataTableColumnFilterOption): string {
+    if (typeof option === 'string') {
+      return option as string;
+    } else {
+      const opt = option as IDataTableColumnFilterOption;
+      return opt.label && opt.value ? opt.label : opt.value;
+    }
+  }
+
+  public multiSelectOptionFilterHandleKeydown(event: KeyboardEvent) {
+    if (this.dropdown.panelOpen && event.keyCode === KeyCodes.ESC) {
+      // escape = clear text box and close
+      Helpers.swallowEvent(event);
+      this.clearOptionFilter();
+      this.dropdown.closePanel();
+    } else if (event.keyCode === KeyCodes.ENTER) {
+      Helpers.swallowEvent(event);
+      this.filterMultiSelect();
+    } else {
+      this.error = false;
+    }
+  }
+
+  private clearOptionFilter() {
+    this.error = false;
+    if (this.optionFilter.length > 0) {
+      this.optionFilter = '';
+      this.multiSelectedOptionIsHidden.forEach((record) => {
+        record.hidden = false;
+      });
+    }
   }
 
   public startResize(mouseDownEvent: MouseEvent): void {
@@ -371,6 +475,18 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
   public focusInput(): void {
     if (this.filterInput && this.filterInput.nativeElement) {
       setTimeout(() => this.filterInput.nativeElement.focus(), 0);
+    }
+    if (this.multiSelect && this.dropdown) {
+      this.dropdown.onKeyDown = (event: KeyboardEvent): void => {
+        if (
+          (event.keyCode >= 65 && event.keyCode <= 90) ||
+          (event.keyCode >= 96 && event.keyCode <= 105) ||
+          (event.keyCode >= 48 && event.keyCode <= 57)
+        ) {
+          this.optionFilterInput.nativeElement.focus();
+        }
+        this.multiSelectOptionFilterHandleKeydown(event);
+      };
     }
   }
 
@@ -431,6 +547,7 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
     this.multiSelectedOptions = [];
     this.activeDateFilter = undefined;
     this.filterData(undefined);
+    this.clearOptionFilter();
   }
 
   private getNextSortDirection(direction: string): string {

--- a/projects/novo-elements/src/elements/data-table/data-table.component.scss
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.scss
@@ -613,7 +613,7 @@ novo-data-table-pagination {
     }
   }
   .dropdown-list-options {
-    max-height: 400px;
+    max-height: 347px;
     overflow-y: auto;
     overflow-x: hidden;
   }
@@ -681,6 +681,9 @@ novo-data-table-pagination {
         &:focus {
           outline: none;
           border-bottom: 2px solid $ocean;
+          ~ i.bhi-search {
+            color: $ocean;
+          }
         }
       }
     }
@@ -715,5 +718,25 @@ novo-data-table-pagination {
         }
       }
     }
+  }
+  i.bhi-search {
+    color: inherit;
+    position: relative;
+    left: 196px;
+    top: -25px;
+  }
+  span.error-text {
+    color: $negative;
+    position: relative;
+    left: 10px;
+    top: -17px;
+    font-size: x-small;
+  }
+  .filter-null-results {
+    background-color: $white;
+    text-align: center;
+    color: darken($light, 15%);
+    background: transparent;
+    font-weight: 500;
   }
 }

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -93,6 +93,7 @@ export class NovoLabelService {
   selectCountryFirst = 'Please select a country before selecting a state';
   invalidIntegerInput = 'Special characters are not allowed for';
   maxRecordsReached = 'Sorry, you have reached the maximum number of records allowed for this field';
+  selectFilterOptions = 'Please select one or more filter options below.';
 
   constructor(
     @Optional()


### PR DESCRIPTION
## **Description**

In data-table on multi-select columns, there is now a text box to search for options within the options list.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**

![image](https://user-images.githubusercontent.com/26778243/57107870-30a39d00-6cff-11e9-92cc-399cfea2d4d3.png)
