### PR TITLE
Store filter and sort state

### DIFF
--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
@@ -251,24 +251,7 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
     @Optional() public _sort: NovoDataTableSortFilter<T>,
     @Optional() public _cdkColumnDef: CdkColumnDef,
   ) {
-    this._rerenderSubscription = state.updates.subscribe((change: IDataTableChangeEvent) => {
-      if (change.sort && change.sort.id === this.id) {
-        this.icon = `sort-${change.sort.value}`;
-        this.sortActive = true;
-      } else {
-        this.icon = 'sortable';
-        this.sortActive = false;
-      }
-      if (change.filter && change.filter.id === this.id) {
-        this.filterActive = true;
-        this.filter = change.filter.value;
-      } else {
-        this.filterActive = false;
-        this.filter = undefined;
-        this.multiSelectedOptions = [];
-      }
-      changeDetectorRef.markForCheck();
-    });
+    this._rerenderSubscription = state.updates.subscribe((change: IDataTableChangeEvent) => this.checkSortFilterState(change));
   }
 
   public ngOnInit(): void {
@@ -284,6 +267,7 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
     if (this.multiSelect) {
       this.multiSelectedOptions = this.filter ? [...this.filter] : [];
     }
+    this.checkSortFilterState({ filter: this.state.filter, sort: this.state.sort });
   }
 
   public ngOnDestroy(): void {
@@ -291,6 +275,25 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
     this.subscriptions.forEach((subscription: Subscription) => {
       subscription.unsubscribe();
     });
+  }
+
+  public checkSortFilterState(sortFilterState: IDataTableChangeEvent): void {
+    if (sortFilterState.sort && sortFilterState.sort.id === this.id) {
+      this.icon = `sort-${sortFilterState.sort.value}`;
+      this.sortActive = true;
+    } else {
+      this.icon = 'sortable';
+      this.sortActive = false;
+    }
+    if (sortFilterState.filter && sortFilterState.filter.id === this.id) {
+      this.filterActive = true;
+      this.filter = sortFilterState.filter.value;
+    } else {
+      this.filterActive = false;
+      this.filter = undefined;
+      this.multiSelectedOptions = [];
+    }
+    this.changeDetectorRef.markForCheck();
   }
 
   public isSelected(option, optionsList) {

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -14,6 +14,8 @@ import {
   TemplateRef,
   ElementRef,
   Output,
+  OnInit,
+  AfterViewInit,
 } from '@angular/core';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { Subscription } from 'rxjs';
@@ -243,7 +245,7 @@ import { StaticDataTableService } from './services/static-data-table.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [DataTableState],
 })
-export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
+export class NovoDataTable<T> implements AfterContentInit, AfterViewInit, OnDestroy {
   @HostBinding('class.global-search-hidden')
   globalSearchHiddenClassToggle: boolean = false;
 
@@ -458,6 +460,10 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
     if (this.resetSubscription) {
       this.resetSubscription.unsubscribe();
     }
+  }
+
+  public ngAfterViewInit(): void {
+    this.state.getInitialFilterSortState(this.name);
   }
 
   public ngAfterContentInit(): void {

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -245,7 +245,7 @@ import { StaticDataTableService } from './services/static-data-table.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [DataTableState],
 })
-export class NovoDataTable<T> implements AfterContentInit, AfterViewInit, OnDestroy {
+export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   @HostBinding('class.global-search-hidden')
   globalSearchHiddenClassToggle: boolean = false;
 
@@ -462,10 +462,6 @@ export class NovoDataTable<T> implements AfterContentInit, AfterViewInit, OnDest
     }
   }
 
-  public ngAfterViewInit(): void {
-    this.state.getInitialFilterSortState(this.name);
-  }
-
   public ngAfterContentInit(): void {
     if (this.displayedColumns && this.displayedColumns.length) {
       this.expandable = this.displayedColumns.includes('expand');
@@ -498,6 +494,8 @@ export class NovoDataTable<T> implements AfterContentInit, AfterViewInit, OnDest
     }
     this.state.page = this.paginationOptions ? this.paginationOptions.page : undefined;
     this.state.pageSize = this.paginationOptions ? this.paginationOptions.pageSize : undefined;
+
+    this.state.getInitialFilterSortState(this.name);
 
     // Scrolling inside table
     (this.novoDataTableContainer.nativeElement as Element).addEventListener('scroll', this.scrollListenerHandler);

--- a/projects/novo-elements/src/elements/data-table/sort-filter/sort-filter.directive.ts
+++ b/projects/novo-elements/src/elements/data-table/sort-filter/sort-filter.directive.ts
@@ -19,14 +19,20 @@ export class NovoDataTableSortFilter<T> {
     this.state.filter = filter;
     this.state.reset(false, true);
     this.state.updates.next({ filter: filter, sort: this.state.sort });
+    if (this.state.tableName) {
+      this.state.setState();
+    }
     this.state.onSortFilterChange();
   }
 
-  public sort(id: string, value: string, transform: Function): void {
+  public sort(id: string, value: string, transform: Function, tableName: string = null): void {
     let sort = { id, value, transform };
     this.state.sort = sort;
     this.state.reset(false, true);
     this.state.updates.next({ sort: sort, filter: this.state.filter });
+    if (this.state.tableName) {
+      this.state.setState();
+    }
     this.state.onSortFilterChange();
   }
 }

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
@@ -11,6 +11,7 @@ export class DataTableState<T> {
   public expandSource = new Subject();
   public dataLoaded = new Subject();
 
+  tableName: string;
   sort: { id: string; value: string } = undefined;
   filter: { id: string; value: string | string[] } = undefined;
   page: number = 0;
@@ -40,6 +41,7 @@ export class DataTableState<T> {
     this.page = 0;
     this.selectedRows.clear();
     this.resetSource.next();
+    this.setState();
     if (fireUpdate) {
       this.updates.emit({
         sort: this.sort,
@@ -54,6 +56,7 @@ export class DataTableState<T> {
     this.page = 0;
     this.selectedRows.clear();
     this.resetSource.next();
+    this.setState();
     if (fireUpdate) {
       this.updates.emit({
         sort: this.sort,
@@ -69,6 +72,7 @@ export class DataTableState<T> {
     this.page = 0;
     this.selectedRows.clear();
     this.resetSource.next();
+    this.setState();
     if (fireUpdate) {
       this.updates.emit({
         sort: this.sort,
@@ -92,5 +96,27 @@ export class DataTableState<T> {
 
   public onSortFilterChange(): void {
     this.sortFilterSource.next();
+  }
+
+  public setState(): void {
+    if (this.tableName) {
+      const stickyState = {
+        filter: this.filter,
+        sort: this.sort,
+        globalSearch: this.globalSearch,
+      };
+      window.localStorage.setItem(this.tableName, JSON.stringify(stickyState));
+    }
+  }
+
+  public getInitialFilterSortState(name: string) {
+    this.tableName = name;
+    const stickyState = JSON.parse(window.localStorage.getItem(name));
+    if (stickyState !== null && stickyState !== undefined) {
+      this.filter = stickyState.filter;
+      this.sort = stickyState.sort;
+      this.globalSearch = stickyState.globalSearch;
+      this.reset(true, true);
+    }
   }
 }

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
@@ -116,7 +116,6 @@ export class DataTableState<T> {
       this.filter = stickyState.filter;
       this.sort = stickyState.sort;
       this.globalSearch = stickyState.globalSearch;
-      this.reset(true, true);
     }
   }
 }


### PR DESCRIPTION
## **Description**

Persist the filters a user has selected into local storage

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**