### PR TITLE
fixing mixed support warning in mobile builds

### DIFF
--- a/projects/novo-elements/src/elements/chips/Chips.scss
+++ b/projects/novo-elements/src/elements/chips/Chips.scss
@@ -344,7 +344,7 @@ novo-row-chip {
       }
       span {
         color: inherit;
-        align-items: start;
+        align-items: flex-start;
         display: flex;
         overflow: hidden;
         text-overflow: ellipsis;

--- a/projects/novo-elements/src/elements/popover/PopOver.scss
+++ b/projects/novo-elements/src/elements/popover/PopOver.scss
@@ -5,8 +5,8 @@
   letter-spacing: normal;
   line-break: auto;
   line-height: 1.428571429;
-  text-align: left; // Fallback for where `start` is not supported
-  text-align: start;
+  text-align: left; // Fallback for where `flex-start` is not supported
+  text-align: flex-start;
   text-decoration: none;
   text-shadow: none;
   text-transform: none;

--- a/projects/novo-elements/src/elements/toast/Toast.scss
+++ b/projects/novo-elements/src/elements/toast/Toast.scss
@@ -52,7 +52,7 @@ novo-toast.toast-container > .close-icon {
   justify-content: center;
   align-content: center;
   align-items: center;
-  align-self: start;
+  align-self: flex-start;
   cursor: pointer;
   i {
     display: flex;


### PR DESCRIPTION
## **Description**

Changed `start` to `flex-start` in 3 places to resolve mixed support warnings in mobile builds.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**