### PR TITLE
BH-61236 field hidden when error message

### DIFF
--- a/projects/novo-elements/src/elements/form/DynamicForm.ts
+++ b/projects/novo-elements/src/elements/form/DynamicForm.ts
@@ -91,6 +91,7 @@ export class NovoDynamicFormElement implements OnChanges, OnInit, AfterContentIn
   autoFocusFirstField: boolean = false;
   @ContentChildren(NovoTemplate)
   customTemplates: QueryList<NovoTemplate>;
+  @Input() fieldsToToggleHidden: string[];
 
   allFieldsRequired = false;
   allFieldsNotRequired = false;
@@ -154,7 +155,10 @@ export class NovoDynamicFormElement implements OnChanges, OnInit, AfterContentIn
   public showAllFields(): void {
     this.form.fieldsets.forEach((fieldset) => {
       fieldset.controls.forEach((control) => {
-        this.form.controls[control.key].hidden = false;
+        const ctl = this.form.controls[control.key];
+        if (!this.fieldsToToggleHidden.includes(control.key) || !ctl.isHiddenByLogic) {
+          ctl.hidden = false;
+        }
       });
     });
     this.showingAllFields = true;

--- a/projects/novo-elements/src/elements/form/DynamicForm.ts
+++ b/projects/novo-elements/src/elements/form/DynamicForm.ts
@@ -169,29 +169,29 @@ export class NovoDynamicFormElement implements OnChanges, OnInit, AfterContentIn
     this.fieldsAlreadyHidden = [];
     this.form.fieldsets.forEach((fieldset) => {
       fieldset.controls.forEach((control) => {
-        const formControl = this.form.controls[control.key];
+        const ctl = this.form.controls[control.key];
 
-        if (formControl.hidden) {
+        if (ctl.hidden) {
           this.fieldsAlreadyHidden.push(control.key);
         }
 
         // Hide any non-required fields
         if (!control.required) {
-          formControl.hidden = true;
+          ctl.hidden = true;
         }
 
         // Hide required fields that have been successfully filled out
         if (
           hideRequiredWithValue &&
           !Helpers.isBlank(this.form.value[control.key]) &&
-          (!control.isEmpty || (control.isEmpty && control.isEmpty(formControl)))
+          (!control.isEmpty || (control.isEmpty && control.isEmpty(ctl)))
         ) {
-          formControl.hidden = true;
+          ctl.hidden = true;
         }
 
         // Don't hide fields with errors
-        if (formControl.errors) {
-          formControl.hidden = false;
+        if (ctl.errors) {
+          ctl.hidden = false;
         }
       });
     });

--- a/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
@@ -243,11 +243,6 @@ export class FieldInteractionApi {
     }
   }
 
-  public isHiddenByLogic(key: string, value: boolean): void {
-    const control = this.getControl(key);
-    control.isHiddenByLogic = value;
-  }
-
   public disable(
     key: string,
     options?: {

--- a/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
@@ -243,6 +243,11 @@ export class FieldInteractionApi {
     }
   }
 
+  public isHiddenByLogic(key: string, value: boolean): void {
+    const control = this.getControl(key);
+    control.isHiddenByLogic = value;
+  }
+
   public disable(
     key: string,
     options?: {

--- a/projects/novo-elements/src/elements/form/NovoFormControl.ts
+++ b/projects/novo-elements/src/elements/form/NovoFormControl.ts
@@ -1,9 +1,8 @@
 // NG2
-import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { FormControl, Validators } from '@angular/forms';
 import { EventEmitter } from '@angular/core';
 // APP
 import { NovoControlConfig } from './FormControls';
-import { IFieldInteractionEvent } from './FormInterfaces';
 import { notify } from '../../utils/notifier/notifier.util';
 import { IMaskOptions } from './Control';
 
@@ -62,6 +61,7 @@ export class NovoFormControl extends FormControl {
   checkboxLabel?: string;
   restrictFieldInteractions?: boolean;
   warning?: string;
+  isHiddenByLogic = false; // if a control is hidden because not releavant (email address in billing profile)
   private historyTimeout: any;
 
   constructor(value: any, control: NovoControlConfig) {

--- a/projects/novo-elements/src/elements/form/NovoFormControl.ts
+++ b/projects/novo-elements/src/elements/form/NovoFormControl.ts
@@ -61,7 +61,6 @@ export class NovoFormControl extends FormControl {
   checkboxLabel?: string;
   restrictFieldInteractions?: boolean;
   warning?: string;
-  isHiddenByLogic = false; // if a control is hidden because not releavant (email address in billing profile)
   private historyTimeout: any;
 
   constructor(value: any, control: NovoControlConfig) {


### PR DESCRIPTION
## **Description**

Fields can be hidden in a form because an other fields. Those hidden fields should stay hidden if the user go back and forth in the error page.

#### **Verify that...**

- [*] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [*] `npm run lint` passes
- [*] `npm test` passes and code coverage is increased
- [*] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**