### PR TITLE
fix(form-utils) passing through layoutOptions

### DIFF
--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -238,6 +238,7 @@ export class FormUtils {
       optionsType: field.optionsType,
       multiple: field.multiValue,
       readOnly: !!field.disabled || !!field.readOnly,
+      disabled: field.disabled,
       maxlength: field.maxLength,
       interactions: field.interactions,
       dataSpecialization: field.dataSpecialization,

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -253,6 +253,7 @@ export class FormUtils {
       warning: field.warning,
       config: field.config || {},
       closeOnSelect: field.closeOnSelect,
+      layoutOptions: field.layoutOptions,
     };
     this.inferStartDate(controlConfig, field);
     // TODO: getControlOptions should always return the correct format


### PR DESCRIPTION
## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**