### PR TITLE
fix(data-table): novo-data-table empty state is unclickable

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.component.scss
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.scss
@@ -388,7 +388,6 @@ novo-data-table {
   }
   .novo-data-table-empty-container {
     padding-top: 0;
-    z-index: 5;
   }
   .novo-data-table-no-results-container {
     position: absolute;
@@ -405,6 +404,7 @@ novo-data-table {
     align-items: center;
     justify-content: center;
     color: $grey;
+    z-index: 5;
   }
   .novo-data-table-outside-container {
     display: flex;

--- a/projects/novo-elements/src/elements/data-table/data-table.component.scss
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.scss
@@ -388,6 +388,7 @@ novo-data-table {
   }
   .novo-data-table-empty-container {
     padding-top: 0;
+    z-index: 5;
   }
   .novo-data-table-no-results-container {
     position: absolute;


### PR DESCRIPTION
## **Description**

Fixing an issue from #947 where an outer element made empty state links unclickable.

Empty state on data-table should be clickable for elements such as buttons or links.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**