### PR TITLE
feat(pickers): enable FieldInteractionAPI to create filtered options calls for pickers, allow pickers to infinitely scroll with zero-length search term

### DIFF
--- a/projects/novo-elements/src/elements/form/FieldInteractionApi.spec.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApi.spec.ts
@@ -1,0 +1,105 @@
+import { async, TestBed, inject } from '@angular/core/testing';
+import { HttpClient, HttpHandler } from '@angular/common/http';
+
+import { FieldInteractionApi } from './FieldInteractionApi';
+import { NovoToastService } from '../toast/ToastService';
+import { NovoModalService } from '../modal/ModalService';
+import { FormUtils } from '../../utils/form-utils/FormUtils';
+import { NovoLabelService } from '../../services/novo-label-service';
+import { ComponentUtils } from '../../utils/component-utils/ComponentUtils';
+import { OptionsService } from '../../services/options/OptionsService';
+import { ModifyPickerConfigArgs, OptionsFunction } from './FieldInteractionApiTypes';
+import { of } from 'rxjs';
+import { of } from 'rxjs';
+
+describe('FieldInteractionApi', () => {
+  let service: FieldInteractionApi;
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: FieldInteractionApi,
+          useFactory: (toaster, modalService, formUtils, http, labels) => {
+            return new FieldInteractionApi(toaster, modalService, formUtils, http, labels);
+          },
+          deps: [NovoToastService, NovoModalService, FormUtils, HttpClient, NovoLabelService],
+        },
+        ComponentUtils,
+        OptionsService,
+        FormUtils,
+        HttpHandler,
+        NovoToastService,
+        NovoLabelService,
+        NovoModalService,
+        FormUtils,
+        HttpClient,
+      ],
+    });
+  }));
+
+  beforeEach(inject([FieldInteractionApi], (_service) => {
+    service = _service;
+  }));
+
+  describe('Function: getOptions', () => {
+    it('is defined', () => {
+      expect(service.getOptions).toBeDefined();
+    });
+    it('returns a new options call that calls optionsPromise', async (done) => {
+      const args: ModifyPickerConfigArgs = {
+        optionsPromise: async (str: string) => [],
+      };
+      const spy = spyOn(args, 'optionsPromise').and.returnValue(Promise.resolve([]));
+
+      const result = service.getOptions(args) as { options: OptionsFunction };
+      await result.options('asdf');
+
+      const [firstArg, secondArg] = spy.calls.mostRecent().args;
+      expect(firstArg).toEqual('asdf');
+      done();
+    });
+    it('calls optionsPromise if optionsUrl is also present', async (done) => {
+      const args: ModifyPickerConfigArgs = {
+        optionsPromise: async (str: string) => [],
+        optionsUrl: 'fake/url',
+      };
+      const spy = spyOn(args, 'optionsPromise').and.returnValue(Promise.resolve([]));
+
+      const result = service.getOptions(args) as { options: OptionsFunction };
+      await result.options('asdf');
+
+      expect(spy).toHaveBeenCalled();
+      done();
+    });
+    it('uses the optionsURLBuilder if included and no optionsPromise', async (done) => {
+      const args: ModifyPickerConfigArgs = {
+        optionsUrlBuilder: (query) => `asdf${query}`,
+        optionsUrl: 'fake/url',
+      };
+
+      const result = service.getOptions(args) as { options: OptionsFunction };
+      spyOn(result, 'options').and.callThrough();
+      const spy = spyOn((service as any).http, 'get').and.returnValue(of([]));
+      await result.options('asdf');
+      const [firstArg] = spy.calls.mostRecent().args;
+      expect(firstArg).toEqual('asdfasdf');
+      done();
+    });
+    it('passes down format if optionsUrl, optionsUrlBuilder, or optionsPromise is present', () => {
+      const args: ModifyPickerConfigArgs = {
+        optionsPromise: async (str: string) => [],
+        format: '$title',
+      };
+      const result = service.getOptions(args) as { options: OptionsFunction; format: string };
+      expect(result.format).toEqual('$title');
+    });
+    it('passes through options if no options function args are present', () => {
+      const args: ModifyPickerConfigArgs = {
+        options: ['asdf'],
+      };
+      const result = service.getOptions(args);
+      expect(result.options).toEqual(['asdf']);
+    });
+    it('uses the mapper if present', () => {});
+  });
+});

--- a/projects/novo-elements/src/elements/form/FieldInteractionApi.spec.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApi.spec.ts
@@ -70,7 +70,7 @@ describe('FieldInteractionApi', () => {
       expect(spy).toHaveBeenCalled();
       done();
     });
-    it('uses the optionsURLBuilder if included and no optionsPromise', async (done) => {
+    it('uses the optionsURLBuilder if included and not optionsUrl', async (done) => {
       const args: ModifyPickerConfigArgs = {
         optionsUrlBuilder: (query) => `asdf${query}`,
         optionsUrl: 'fake/url',

--- a/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
@@ -533,7 +533,16 @@ export class FieldInteractionApi {
     }
   }
 
-  public modifyPickerConfig(key: string, args: ModifyPickerConfigArgs, mapper?: any): void {
+  public modifyPickerConfig(
+    key: string,
+    config: { format?: string; optionsUrl?: string; optionsUrlBuilder?: Function; optionsPromise?: any; options?: any[] },
+    mapper?: any,
+  ): void {
+    // call another public method to avoid a breaking change but still enable stricter types
+    this.mutatePickerConfig(key, config as ModifyPickerConfigArgs, mapper);
+  }
+
+  public mutatePickerConfig(key: string, args: ModifyPickerConfigArgs, mapper?: (item: unknown) => unknown): void {
     let control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       const { minSearchLength, enableInfiniteScroll, filteredOptionsCreator, format } = control.config;

--- a/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
@@ -536,8 +536,8 @@ export class FieldInteractionApi {
   public modifyPickerConfig(key: string, args: ModifyPickerConfigArgs, mapper?: any): void {
     let control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
-      const { minSearchLength, enableInfiniteScroll, filteredOptionsCreator } = control.config;
-      const optionsConfig = this.getOptionsConfig(args, mapper, filteredOptionsCreator);
+      const { minSearchLength, enableInfiniteScroll, filteredOptionsCreator, format } = control.config;
+      const optionsConfig = this.getOptionsConfig(args, mapper, filteredOptionsCreator, format);
 
       const newConfig: NovoControlConfig['config'] = {
         ...(Number.isInteger(minSearchLength) && { minSearchLength }),
@@ -555,9 +555,10 @@ export class FieldInteractionApi {
     args: ModifyPickerConfigArgs,
     mapper?: (item: unknown) => unknown,
     filteredOptionsCreator?: (where: string) => (query: string) => Promise<unknown[]>,
+    pickerConfigFormat?: string,
   ): undefined | { options: unknown[] } | { options: OptionsFunction; format?: string } => {
     if (filteredOptionsCreator || 'optionsUrl' in args || 'optionsUrlBuilder' in args || 'optionsPromise' in args) {
-      const format = 'format' in args && args.format;
+      const format = ('format' in args && args.format) || pickerConfigFormat;
       return {
         options: this.createOptionsFunction(args, mapper, filteredOptionsCreator),
         ...(format && { format }),

--- a/projects/novo-elements/src/elements/form/FieldInteractionApiTypes.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApiTypes.ts
@@ -1,0 +1,19 @@
+export type ModifyPickerConfigArgs = {
+  format?: string;
+} & (
+  | (
+      | {
+          options?: unknown[];
+        }
+      | {
+          optionsPromise?: (query: string, http: unknown) => Promise<unknown[]>;
+        })
+  | (
+      | {
+          optionsUrl: string;
+        }
+      | {
+          optionsUrlBuilder: (query: string) => string;
+        }));
+
+export type OptionsFunction = (query: string) => Promise<unknown[]>;

--- a/projects/novo-elements/src/elements/form/FieldInteractionApiTypes.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApiTypes.ts
@@ -1,19 +1,29 @@
-export type ModifyPickerConfigArgs = {
+import { HttpClient } from '@angular/common/http';
+import { Observable, Subscription } from 'rxjs';
+type OptionsFunctionConfig = {
   format?: string;
 } & (
-  | (
-      | {
-          options?: unknown[];
-        }
-      | {
-          optionsPromise?: (query: string, http: unknown) => Promise<unknown[]>;
-        })
-  | (
-      | {
-          optionsUrl: string;
-        }
-      | {
-          optionsUrlBuilder: (query: string) => string;
-        }));
+  | { where: string }
+  | { optionsPromise: (query: string, http: CustomHttp) => Promise<unknown[]> }
+  | { optionsUrl: string }
+  | { optionsUrlBuilder: (query: string) => string });
+
+export type ModifyPickerConfigArgs =
+  | {
+      options: unknown[];
+    }
+  | OptionsFunctionConfig;
 
 export type OptionsFunction = (query: string) => Promise<unknown[]>;
+
+export interface CustomHttp<T = any> {
+  url: string;
+  options: any;
+  mapFn: (o: unknown) => T;
+
+  get(url: string, options?: any): CustomHttp;
+
+  map(mapFn: (o: unknown) => T): CustomHttp;
+
+  subscribe(resolve: any, reject?: any): Subscription;
+}

--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -24,6 +24,7 @@ import { ComponentUtils } from '../../utils/component-utils/ComponentUtils';
 import { Helpers } from '../../utils/Helpers';
 import { NovoOverlayTemplateComponent } from '../overlay/Overlay';
 import { notify } from '../../utils/notifier/notifier.util';
+import { NovoControlConfig } from '../form/FormControls';
 
 // Value accessor for the component (supports ngModel)
 const PICKER_VALUE_ACCESSOR = {
@@ -81,7 +82,7 @@ export class NovoPickerElement implements OnInit {
   results: ViewContainerRef;
 
   @Input()
-  config: any;
+  config: NovoControlConfig['config'];
   @Input()
   placeholder: string;
   @Input()
@@ -191,10 +192,10 @@ export class NovoPickerElement implements OnInit {
     return this.container && this.container.panelOpen;
   }
 
-  private show(term?: string, resetPage?: boolean): void {
+  private show(term?: string): void {
     this.openPanel();
     // Show the results inside
-    this.showResults(term, resetPage);
+    this.showResults(term);
   }
 
   onKeyDown(event: KeyboardEvent) {
@@ -259,17 +260,16 @@ export class NovoPickerElement implements OnInit {
    */
   onFocus(event) {
     if (!this.panelOpen) {
-      this.show(this.term || '', true);
+      this.show();
     }
     this.focus.emit(event);
   }
 
   // Creates an instance of the results (called popup) and adds all the bindings to that instance.
-  showResults(term?: any, resetPage?: boolean) {
+  showResults(term?: any) {
     // Update Matches
     if (this.popup) {
       // Update existing list or create the DOM element
-      this.popup.instance.page = resetPage ? 0 : this.popup.instance.page;
       this.popup.instance.config = this.config;
       this.popup.instance.term = this.term;
       this.popup.instance.selected = this.selected;

--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -191,10 +191,10 @@ export class NovoPickerElement implements OnInit {
     return this.container && this.container.panelOpen;
   }
 
-  private show(term?: string): void {
+  private show(term?: string, resetPage?: boolean): void {
     this.openPanel();
     // Show the results inside
-    this.showResults(term);
+    this.showResults(term, resetPage);
   }
 
   onKeyDown(event: KeyboardEvent) {
@@ -259,16 +259,17 @@ export class NovoPickerElement implements OnInit {
    */
   onFocus(event) {
     if (!this.panelOpen) {
-      this.show();
+      this.show(this.term || '', true);
     }
     this.focus.emit(event);
   }
 
   // Creates an instance of the results (called popup) and adds all the bindings to that instance.
-  showResults(term?: any) {
+  showResults(term?: any, resetPage?: boolean) {
     // Update Matches
     if (this.popup) {
       // Update existing list or create the DOM element
+      this.popup.instance.page = resetPage ? 0 : this.popup.instance.page;
       this.popup.instance.config = this.config;
       this.popup.instance.term = this.term;
       this.popup.instance.selected = this.selected;

--- a/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.ts
@@ -16,8 +16,7 @@ import { NovoControlConfig } from '../../../form/controls/BaseControl';
 export class BasePickerResults {
   _term: string = '';
   selected: Array<any> = [];
-  @Input()
-  matches: any = [];
+  @Input() matches: any = [];
   hasError: boolean = false;
   isLoading: boolean = false;
   isStatic: boolean = true;
@@ -30,7 +29,7 @@ export class BasePickerResults {
   lastPage: boolean = false;
   autoSelectFirstOption: boolean = true;
   overlay: OverlayRef;
-  optionsCallHasChanged: boolean = false;
+  optionsFunctionHasChanged: boolean = false;
   private selectingMatches: boolean = false;
   private scrollHandler: any;
 
@@ -70,7 +69,7 @@ export class BasePickerResults {
     if (this.shouldSearch(value)) {
       this._term = value;
       this.page = 0;
-      this.optionsCallHasChanged = false;
+      this.optionsFunctionHasChanged = false;
       this.matches = [];
       this.processSearch(true);
     } else {
@@ -80,7 +79,7 @@ export class BasePickerResults {
 
   set config(value: NovoControlConfig['config']) {
     if (this.config && this.config.options !== value.options) {
-      this.optionsCallHasChanged = true; // reset page so that new options call is used to search
+      this.optionsFunctionHasChanged = true; // reset page so that new options call is used to search
     }
     this._config = value;
   }
@@ -93,7 +92,7 @@ export class BasePickerResults {
     const termHasChanged = value !== this._term;
     const optionsNotYetCalled = this.page === 0;
 
-    return termHasChanged || optionsNotYetCalled || this.optionsCallHasChanged;
+    return termHasChanged || optionsNotYetCalled || this.optionsFunctionHasChanged;
   }
 
   addScrollListener(): void {

--- a/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.ts
@@ -79,7 +79,13 @@ export class BasePickerResults {
   shouldSearch(value: unknown): boolean {
     const termHasChanged = value !== this._term;
     const optionsNotYetCalled = this.page === 0;
-    const optionsCalledOnEmptyStringSearch = !termHasChanged && this.page > 0 && value === '';
+    // problem here is that BasePickerResults has no way to know that this.config.options has changed
+    // out from under it due to field interactions
+    // so selecting a client corp, clicking in (and searching) on Billing Profile, then selecting a diff client corp
+    // then clicking back into Billing Profile, will mean that results for previous client corp show up
+    // *until search term changes*
+    // AFAIK there is no way to discern this state only using page, value, and term
+    const optionsCalledOnEmptyStringSearch = this.page === 0 && value === '';
 
     return termHasChanged || optionsNotYetCalled || optionsCalledOnEmptyStringSearch;
   }

--- a/tslint.json
+++ b/tslint.json
@@ -25,7 +25,7 @@
       true,
       "spaces"
     ],
-    "interface-over-type-literal": true,
+    "interface-over-type-literal": false,
     "label-position": true,
     "member-access": false,
     // "member-ordering": [

--- a/tslint.json
+++ b/tslint.json
@@ -88,7 +88,8 @@
     // "radix": true,
     "semicolon": [
       true,
-      "always"
+      "always",
+      "ignore-bound-class-methods"
     ],
     "triple-equals": [
       true,


### PR DESCRIPTION
## **Description**

FieldInteractionAPI's `modifyPickerConfig` can now create picker `options` functions (which are called in `BasePickerResults.search`) by calling an optional `filteredOptionsCreator` function that exists on picker configs. This allows pickers' own configs to determine how the picker is allowed to be changed, rather than having field interactions violate encapsulation.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**