### PR TITLE
fix(data-table): change z-index to be conditional for reverse compatibility.

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.component.scss
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.scss
@@ -404,7 +404,9 @@ novo-data-table {
     align-items: center;
     justify-content: center;
     color: $grey;
-    z-index: 5;
+    &.clickable-empty-state {
+      z-index: 5;
+    }
   }
   .novo-data-table-outside-container {
     display: flex;

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -145,6 +145,11 @@ import { StaticDataTableService } from './services/static-data-table.service';
         <div
           class="novo-data-table-no-results-container"
           [style.left.px]="scrollLeft"
+          [ngClass]="
+            dataSource?.currentlyEmpty && state.userFiltered && !dataSource?.loading && !loading && !dataSource.pristine
+              ? 'clickable-empty-state'
+              : ''
+          "
           *ngIf="dataSource?.currentlyEmpty && state.userFiltered && !dataSource?.loading && !loading && !dataSource.pristine"
         >
           <div class="novo-data-table-empty-message">
@@ -154,6 +159,11 @@ import { StaticDataTableService } from './services/static-data-table.service';
       </div>
       <div
         class="novo-data-table-empty-container"
+        [ngClass]="
+          dataSource?.totallyEmpty && !dataSource?.loading && !loading && !state.userFiltered && !dataSource.pristine
+            ? 'clickable-empty-state'
+            : ''
+        "
         *ngIf="dataSource?.totallyEmpty && !dataSource?.loading && !loading && !state.userFiltered && !dataSource.pristine"
       >
         <div class="novo-data-table-empty-message">
@@ -161,7 +171,7 @@ import { StaticDataTableService } from './services/static-data-table.service';
         </div>
       </div>
     </div>
-    <!-- DEFAULT CELL TEMPLATE -->
+    'emptyMessage'] || templates['
     <ng-template novoTemplate="textCellTemplate" let-row let-col="col">
       <span [style.width.px]="col?.width" [style.min-width.px]="col?.width" [style.max-width.px]="col?.width">{{
         row[col.id] | dataTableInterpolate: col
@@ -242,7 +252,7 @@ import { StaticDataTableService } from './services/static-data-table.service';
         <ng-container *ngTemplateOutlet="templates['expandedRow']; context: { $implicit: row }"></ng-container>
       </div>
     </ng-template>
-    <!-- CUSTOM CELLS PASSED IN -->
+    -detail-row" [@expand] style="o
     <ng-content></ng-content>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
## **Description**

#977 caused visual weirdness in novo.  This fix is to conditionally set z-index.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**