### PR TITLE
date local format

### DIFF
--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -662,7 +662,7 @@ export class FormUtils {
         continue;
       }
 
-      if (control.dataType === 'Date' && typeof value === 'string') {
+      if (control.dataType === 'Date' && typeof value === 'string' && control.optionsType !== 'skipConversion') {
         value = dateFns.startOfDay(value);
       }
 

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -64,7 +64,7 @@ export class FormUtils {
     'Placement',
   ];
 
-  constructor(public labels: NovoLabelService, public optionsService: OptionsService) { }
+  constructor(public labels: NovoLabelService, public optionsService: OptionsService) {}
 
   toFormGroup(controls: Array<any>): NovoFormGroup {
     let group: any = {};
@@ -268,7 +268,7 @@ export class FormUtils {
     } else if (optionsConfig) {
       controlConfig.config = {
         ...optionsConfig,
-        ...controlConfig && controlConfig.config,
+        ...(controlConfig && controlConfig.config),
       };
     }
 
@@ -635,8 +635,8 @@ export class FormUtils {
 
   setInitialValues(controls: Array<NovoControlConfig>, values: any, keepClean?: boolean, keyOverride?: string) {
     for (let i = 0; i < controls.length; i++) {
-      let control = controls[i];
-      let key = keyOverride ? control.key.replace(keyOverride, '') : control.key;
+      const control = controls[i];
+      const key = keyOverride ? control.key.replace(keyOverride, '') : control.key;
       let value = values[key];
 
       if (Helpers.isBlank(value)) {
@@ -660,6 +660,10 @@ export class FormUtils {
 
       if (Object.keys(value).length === 0 && value.constructor === Object) {
         continue;
+      }
+
+      if (control.dataType === 'Date' && typeof value === 'string') {
+        value = dateFns.startOfDay(value);
       }
 
       control.value = value;


### PR DESCRIPTION
## **Description**

A string date is not at a local GMT zone so it can show a different date on a novo date picker.

For example '2019-06-24' will be seen as '2019-06-24' in GMT 0 so '2019-06-23' on the Est coast. 

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**