### PR TITLE
BH-61571: Hide char count for field if not focused

### DIFF
--- a/projects/novo-elements/src/elements/form/Control.spec.ts
+++ b/projects/novo-elements/src/elements/form/Control.spec.ts
@@ -1,10 +1,21 @@
 // NG2
-import { Component, ElementRef } from '@angular/core';
-import { TestBed, async } from '@angular/core/testing';
+import {ChangeDetectorRef, Component, ElementRef, NO_ERRORS_SCHEMA} from '@angular/core';
+import {TestBed, async, ComponentFixture} from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 // App
 import { NovoAutoSize } from './Control';
 import { NovoControlElement } from './Control';
+import {NovoFormControl} from "./NovoFormControl";
+import {EntityPickerResult, FieldInteractionApi, NovoLabelService, NovoListElement, NovoTemplateService} from "../..";
+import {NovoLoadingElement} from "../loading/Loading";
+import {
+  NovoItemAvatarElement,
+  NovoItemContentElement,
+  NovoItemHeaderElement,
+  NovoItemTitleElement,
+  NovoListItemElement
+} from "../list/List";
+import {DateFormatService} from "../../services/date-format/DateFormat";
 
 @Component({
   selector: 'novo-auto-size-test-component',
@@ -70,5 +81,79 @@ describe('Test Localization', () => {
   it('should set decimal separator based on locale correctly', () => {
     let component = new NovoControlElement(mockElement, null, null, null, null, null, 'fr-FR');
     expect(component.decimalSeparator).toBe('.');
+  });
+});
+
+@Component({
+  template: `
+    <div></div>
+  `
+})
+class TestComponent {}
+describe("NovoControlElement", () => {
+  let component: NovoControlElement;
+  let fixture: ComponentFixture<NovoControlElement>;
+  beforeEach(() => {
+    const elementRefStub = {
+      nativeElement: { style: { height: {}, minHeight: {} }, scrollHeight: {} }
+    };
+    const changeDetectorRefStub = { markForCheck: () => ({}) };
+    const novoLabelServiceStub = { invalidIntegerInput: {} };
+    const dateFormatServiceStub = {};
+    const fieldInteractionApiStub = { form: {}, currentKey: {} };
+    const novoTemplateServiceStub = { getAll: () => ({}) };
+    TestBed.configureTestingModule({
+      declarations: [NovoAutoSize, TestComponent, NovoControlElement],
+      schemas: [NO_ERRORS_SCHEMA],
+      providers: [
+        NovoAutoSize,
+        { provide: ElementRef, useValue: elementRefStub },
+        { provide: ChangeDetectorRef, useValue: changeDetectorRefStub },
+        { provide: NovoLabelService, useValue: novoLabelServiceStub },
+        { provide: DateFormatService, useValue: dateFormatServiceStub },
+        { provide: FieldInteractionApi, useValue: fieldInteractionApiStub },
+        { provide: NovoTemplateService, useValue: novoTemplateServiceStub }
+      ]
+    });
+    fixture = TestBed.createComponent(NovoControlElement);
+    component = fixture.componentInstance;
+  });
+
+  it('should return false if the field has a MAX_LENGTH property but is not focused', () => {
+    // Arrange
+    component.control = {
+       key: 0,
+     };
+    component.form = {
+      controls: [{
+        maxLength: 1,
+      }],
+    };
+
+    // Act
+    let testBoolean = component.showCount;
+
+    // Assert
+    expect(testBoolean).toEqual(false);
+  });
+
+  it('should return true if the field has a MAX_LENGTH property but is not focused', () => {
+    // Arrange
+    component.control = {
+      key: 0,
+    };
+    component.form = {
+      controls: [{
+        maxLength: 1,
+      }],
+    };
+
+    (component as any)._focused = true;
+
+    // Act
+    let testBoolean = component.showCount;
+
+    // Assert
+    expect(testBoolean).toEqual(true);
   });
 });

--- a/projects/novo-elements/src/elements/form/Control.spec.ts
+++ b/projects/novo-elements/src/elements/form/Control.spec.ts
@@ -5,17 +5,8 @@ import { By } from '@angular/platform-browser';
 // App
 import { NovoAutoSize } from './Control';
 import { NovoControlElement } from './Control';
-import {NovoFormControl} from "./NovoFormControl";
-import {EntityPickerResult, FieldInteractionApi, NovoLabelService, NovoListElement, NovoTemplateService} from "../..";
-import {NovoLoadingElement} from "../loading/Loading";
-import {
-  NovoItemAvatarElement,
-  NovoItemContentElement,
-  NovoItemHeaderElement,
-  NovoItemTitleElement,
-  NovoListItemElement
-} from "../list/List";
-import {DateFormatService} from "../../services/date-format/DateFormat";
+import {FieldInteractionApi, NovoLabelService, NovoTemplateService} from '../..';
+import {DateFormatService} from '../../services/date-format/DateFormat';
 
 @Component({
   selector: 'novo-auto-size-test-component',
@@ -90,7 +81,7 @@ describe('Test Localization', () => {
   `
 })
 class TestComponent {}
-describe("NovoControlElement", () => {
+describe('NovoControlElement', () => {
   let component: NovoControlElement;
   let fixture: ComponentFixture<NovoControlElement>;
   beforeEach(() => {
@@ -137,23 +128,74 @@ describe("NovoControlElement", () => {
     expect(testBoolean).toEqual(false);
   });
 
-  it('should return true if the field has a MAX_LENGTH property but is not focused', () => {
+  it('should return true if the field has a MAX_LENGTH property and is focused', () => {
     // Arrange
     component.control = {
-      key: 0,
+      key: 'newField',
     };
     component.form = {
-      controls: [{
-        maxLength: 1,
-      }],
+      controls: {
+        newField: {
+          maxlength: 10,
+          controlType: 'textbox',
+        },
+      },
     };
 
-    (component as any)._focused = true;
+    // (component as any)._focused = true;
+    (component as any).handleFocus(new FocusEvent('input'));
 
     // Act
     let testBoolean = component.showCount;
 
     // Assert
     expect(testBoolean).toEqual(true);
+  });
+
+  it('should return false if the field does not have a MAX_LENGTH property and is focused', () => {
+    // Arrange
+    component.control = {
+      key: 'newField',
+    };
+    component.form = {
+      controls: {
+        newField: {
+          controlType: 'textbox',
+        },
+      },
+    };
+
+    // (component as any)._focused = true;
+    (component as any).handleFocus(new FocusEvent('input'));
+
+    // Act
+    let testBoolean = component.showCount;
+
+    // Assert
+    expect(testBoolean).toEqual(false);
+  });
+
+  it('should return false if the controlType of the field is not textbox, picker, or text-area', () => {
+    // Arrange
+    component.control = {
+      key: 'newField',
+    };
+    component.form = {
+      controls: {
+        newField: {
+          maxlength: 10,
+          controlType: 'test',
+        },
+      },
+    };
+
+    // (component as any)._focused = true;
+    (component as any).handleFocus(new FocusEvent('input'));
+
+    // Act
+    let testBoolean = component.showCount;
+
+    // Assert
+    expect(testBoolean).toEqual(false);
   });
 });

--- a/projects/novo-elements/src/elements/form/Control.ts
+++ b/projects/novo-elements/src/elements/form/Control.ts
@@ -267,7 +267,7 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
     const MAX_LENGTH_CONTROL_TYPES: string[] = ['textbox', 'picker', 'text-area'];
     let charCount: boolean =
       this.focused &&
-      this.form.controls[this.control.key].maxlength &&
+      !!this.form.controls[this.control.key].maxlength &&
       MAX_LENGTH_CONTROL_TYPES.includes(this.form.controls[this.control.key].controlType);
     return this._showCount || charCount;
   }

--- a/projects/novo-elements/src/elements/form/Control.ts
+++ b/projects/novo-elements/src/elements/form/Control.ts
@@ -266,10 +266,12 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
   get showCount() {
     let charCount: boolean =
       this.focused &&
-      ((this.form.controls[this.control.key].maxlength &&
-        (this.form.controls[this.control.key].controlType === 'text-area' ||
-          this.form.controls[this.control.key].controlType === 'textbox')) ||
-        (this.form.controls[this.control.key].maxlength && this.form.controls[this.control.key].controlType === 'picker'));
+      this.form.controls[this.control.key].maxlength &&
+      (
+        this.form.controls[this.control.key].controlType === 'text-area' ||
+        this.form.controls[this.control.key].controlType === 'textbox' ||
+        this.form.controls[this.control.key].controlType === 'picker'
+      );
     return this._showCount || charCount;
   }
 

--- a/projects/novo-elements/src/elements/form/Control.ts
+++ b/projects/novo-elements/src/elements/form/Control.ts
@@ -265,11 +265,11 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
 
   get showCount() {
     let charCount: boolean =
-      (this.form.controls[this.control.key].maxlength &&
-        this.focused &&
+      this.focused &&
+      ((this.form.controls[this.control.key].maxlength &&
         (this.form.controls[this.control.key].controlType === 'text-area' ||
           this.form.controls[this.control.key].controlType === 'textbox')) ||
-      (this.form.controls[this.control.key].maxlength && this.form.controls[this.control.key].controlType === 'picker');
+        (this.form.controls[this.control.key].maxlength && this.form.controls[this.control.key].controlType === 'picker'));
     return this._showCount || charCount;
   }
 

--- a/projects/novo-elements/src/elements/form/Control.ts
+++ b/projects/novo-elements/src/elements/form/Control.ts
@@ -264,14 +264,11 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
   }
 
   get showCount() {
+    const MAX_LENGTH_CONTROL_TYPES: string[] = ['textbox', 'picker', 'text-area'];
     let charCount: boolean =
       this.focused &&
       this.form.controls[this.control.key].maxlength &&
-      (
-        this.form.controls[this.control.key].controlType === 'text-area' ||
-        this.form.controls[this.control.key].controlType === 'textbox' ||
-        this.form.controls[this.control.key].controlType === 'picker'
-      );
+      MAX_LENGTH_CONTROL_TYPES.includes(this.form.controls[this.control.key].controlType);
     return this._showCount || charCount;
   }
 


### PR DESCRIPTION
## **Description**

Character counts for fields that use them should only ever display if the field is focused.

This small change in logic ensures that the focus state is checked before anything else.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**