### PR TITLE
return time in parts for assembly

### DIFF
--- a/projects/chomsky/src/utils/chomsky.ts
+++ b/projects/chomsky/src/utils/chomsky.ts
@@ -209,7 +209,7 @@ export class Chomsky {
     return this.formats.formatDate(date, format);
   }
 
-  public formatTime(date: any, format?: string | Intl.DateTimeFormatOptions): any {
+  public formatTime(date: any, format?: string | Intl.DateTimeFormatOptions): string {
     return this.formats.formatTime(date, format);
   }
 

--- a/projects/chomsky/src/utils/chomsky.ts
+++ b/projects/chomsky/src/utils/chomsky.ts
@@ -209,6 +209,10 @@ export class Chomsky {
     return this.formats.formatDate(date, format);
   }
 
+  public formatTime(date: any, format?: string | Intl.DateTimeFormatOptions): any {
+    return this.formats.formatTime(date, format);
+  }
+
   public formatCurrency(value: any, format?: string | Intl.NumberFormatOptions): string {
     return this.formats.formatCurrency(value, format);
   }

--- a/projects/chomsky/src/utils/formats.spec.ts
+++ b/projects/chomsky/src/utils/formats.spec.ts
@@ -1,0 +1,38 @@
+import { Formats} from './formats';
+
+describe('Formats', () => {
+
+  let formats;
+
+  beforeEach(() => {
+    formats = new Formats();
+  });
+
+  describe('Function: formatTime()', () => {
+    it('should return time in a string format', () => {
+      const date = new Date();
+      const options = {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: true,
+      };
+
+      const timeResult = formats.formatTime(date, options);
+      const resultType = typeof timeResult;
+      expect(resultType).toEqual('string');
+    });
+    it('should return time formatted to the locale', () => {
+      const date = new Date();
+      const options = {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: true,
+      };
+
+      formats.setLocale('en-US');
+      const timeResult: string = formats.formatTime(date, options);
+      const result = timeResult.includes('AM') || timeResult.includes('PM')
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/projects/chomsky/src/utils/formats.spec.ts
+++ b/projects/chomsky/src/utils/formats.spec.ts
@@ -31,7 +31,7 @@ describe('Formats', () => {
 
       formats.setLocale('en-US');
       const timeResult: string = formats.formatTime(date, options);
-      const result = timeResult.includes('AM') || timeResult.includes('PM')
+      const result = timeResult.includes('AM') || timeResult.includes('PM');
       expect(result).toBe(true);
     });
   });

--- a/projects/chomsky/src/utils/formats.ts
+++ b/projects/chomsky/src/utils/formats.ts
@@ -82,7 +82,7 @@ export class Formats {
   }
 
   public formatTime(value: any, format?: string | Intl.DateTimeFormatOptions): string {
-    const _value = value === null || value === undefined || value === '' ? new Date() : new Date(value);
+    const _value = (value === null || value === undefined || value === '') ? new Date() : new Date(value);
     let options: Intl.DateTimeFormatOptions = this.getDateOptions(format);
     let timeParts: { [p: string]: string } = Intl.DateTimeFormat([this.locale, 'en-US'], options).formatToParts(_value).reduce((obj, part) => {
       obj[part.type] = part.value;

--- a/projects/chomsky/src/utils/formats.ts
+++ b/projects/chomsky/src/utils/formats.ts
@@ -1,5 +1,6 @@
 import { mergeDeep } from './object-assign-deep';
 import { currencyOverridesMap } from './currency-overrides';
+import DateTimeFormatPart = Intl.DateTimeFormatPart;
 
 // Interface for defaults
 export interface IFormatDefaults {
@@ -86,8 +87,10 @@ export class Formats {
     if (this.use24HourTime) {
       options.hour12 = false;
     }
-    let timeResult: { [type: string]: string }[] =  Intl.DateTimeFormat([this.locale, 'en-US'], options).formatToParts(_value).map(part => ({[part.type]: part.value}));
-    const timeParts = Object.assign({}, ...timeResult);
+    let timeParts: { [type: string]: string } =  Intl.DateTimeFormat([this.locale, 'en-US'], options).formatToParts(_value).reduce((obj, part) => {
+      obj[part.type] = part.value
+      return obj;
+    }, {});
     const dayPeriod = timeParts.dayPeriod ? timeParts.dayPeriod : '';
     return `${timeParts.hour}:${timeParts.minute}${dayPeriod}`;
   }

--- a/projects/chomsky/src/utils/formats.ts
+++ b/projects/chomsky/src/utils/formats.ts
@@ -1,6 +1,5 @@
 import { mergeDeep } from './object-assign-deep';
 import { currencyOverridesMap } from './currency-overrides';
-import DateTimeFormatPart = Intl.DateTimeFormatPart;
 
 // Interface for defaults
 export interface IFormatDefaults {
@@ -85,12 +84,12 @@ export class Formats {
   public formatTime(value: any, format?: string | Intl.DateTimeFormatOptions): string {
     const _value = value === null || value === undefined || value === '' ? new Date() : new Date(value);
     let options: Intl.DateTimeFormatOptions = this.getDateOptions(format);
-    let timeParts: { [type: string]: string } =  Intl.DateTimeFormat([this.locale, 'en-US'], options).formatToParts(_value).reduce((obj, part) => {
-      obj[part.type] = part.value
+    let timeParts: { [p: string]: string } = Intl.DateTimeFormat([this.locale, 'en-US'], options).formatToParts(_value).reduce((obj, part) => {
+      obj[part.type] = part.value;
       return obj;
     }, {});
-    const dayPeriod = timeParts.dayPeriod ? timeParts.dayPeriod : '';
-    return `${timeParts.hour}:${timeParts.minute}${dayPeriod}`;
+    const dayperiod = timeParts.dayperiod ? timeParts.dayperiod : '';
+    return `${timeParts.hour}:${timeParts.minute}${dayperiod}`;
   }
 
   public format(value: string, format?: string): string {

--- a/projects/chomsky/src/utils/formats.ts
+++ b/projects/chomsky/src/utils/formats.ts
@@ -76,6 +76,22 @@ export class Formats {
     return new Intl.DateTimeFormat([this.locale, 'en-US'], options).format(_value);
   }
 
+  public formatTime(value: any, format?: string | Intl.DateTimeFormatOptions): string {
+    const _value = value === null || value === undefined || value === '' ? new Date() : new Date(value);
+    const shortHands = mergeDeep({}, this.defaults.date);
+    let options: Intl.DateTimeFormatOptions = typeof format === 'string' ? shortHands[format] : format;
+    if (!options || Object.keys(options).length === 0) {
+      options = shortHands.dateShort;
+    }
+    if (this.use24HourTime) {
+      options.hour12 = false;
+    }
+    let timeResult: { [type: string]: string }[] =  Intl.DateTimeFormat([this.locale, 'en-US'], options).formatToParts(_value).map(part => ({[part.type]: part.value}));
+    const timeParts = Object.assign({}, ...timeResult);
+    const dayPeriod = timeParts.dayPeriod ? timeParts.dayPeriod : '';
+    return `${timeParts.hour}:${timeParts.minute}${dayPeriod}`;
+  }
+
   public format(value: string, format?: string): string {
     if (!value) {
       return value;

--- a/projects/chomsky/src/utils/formats.ts
+++ b/projects/chomsky/src/utils/formats.ts
@@ -64,8 +64,7 @@ export class Formats {
       : currencyValue;
   }
 
-  public formatDate(value: any, format?: string | Intl.DateTimeFormatOptions): string {
-    const _value = value === null || value === undefined || value === '' ? new Date() : new Date(value);
+  public getDateOptions(format) {
     const shortHands = mergeDeep({}, this.defaults.date);
     let options: Intl.DateTimeFormatOptions = typeof format === 'string' ? shortHands[format] : format;
     if (!options || Object.keys(options).length === 0) {
@@ -74,19 +73,18 @@ export class Formats {
     if (this.use24HourTime) {
       options.hour12 = false;
     }
+    return options;
+  }
+
+  public formatDate(value: any, format?: string | Intl.DateTimeFormatOptions): string {
+    const _value = value === null || value === undefined || value === '' ? new Date() : new Date(value);
+    let options: Intl.DateTimeFormatOptions = this.getDateOptions(format);
     return new Intl.DateTimeFormat([this.locale, 'en-US'], options).format(_value);
   }
 
   public formatTime(value: any, format?: string | Intl.DateTimeFormatOptions): string {
     const _value = value === null || value === undefined || value === '' ? new Date() : new Date(value);
-    const shortHands = mergeDeep({}, this.defaults.date);
-    let options: Intl.DateTimeFormatOptions = typeof format === 'string' ? shortHands[format] : format;
-    if (!options || Object.keys(options).length === 0) {
-      options = shortHands.dateShort;
-    }
-    if (this.use24HourTime) {
-      options.hour12 = false;
-    }
+    let options: Intl.DateTimeFormatOptions = this.getDateOptions(format);
     let timeParts: { [type: string]: string } =  Intl.DateTimeFormat([this.locale, 'en-US'], options).formatToParts(_value).reduce((obj, part) => {
       obj[part.type] = part.value
       return obj;

--- a/projects/novo-elements/src/elements/time-picker/TimePickerInput.ts
+++ b/projects/novo-elements/src/elements/time-picker/TimePickerInput.ts
@@ -80,7 +80,7 @@ export class NovoTimePickerInputElement implements OnInit, ControlValueAccessor 
   ngOnInit(): void {
     this.placeholder = this.military ? this.labels.timeFormatPlaceholder24Hour : this.labels.timeFormatPlaceholderAM;
     this.maskOptions = {
-      mask: this.military ? [/\d/, /\d/, ':', /\d/, /\d/] : [/\d/, /\d/, ':', /\d/, /\d/, ' ', /[aApP]/, /[mM]/],
+      mask: this.military ? [/\d/, /\d/, ':', /\d/, /\d/] : [/\d/, /\d/, ':', /\d/, /\d/, ' ', /[aApP上下]/, /[mM午]/],
       pipe: this.military ? createAutoCorrectedDatePipe('HH:MM') : createAutoCorrectedDatePipe('mm:MM'),
       keepCharPositions: false,
       guide: true,

--- a/projects/novo-elements/src/elements/time-picker/TimePickerInput.ts
+++ b/projects/novo-elements/src/elements/time-picker/TimePickerInput.ts
@@ -196,7 +196,7 @@ export class NovoTimePickerInputElement implements OnInit, ControlValueAccessor 
     if (!value) {
       return '';
     }
-    let format = this.labels.formatDateWithFormat(value, {
+    let format = this.labels.formatTimeWithFormat(value, {
       hour: '2-digit',
       minute: '2-digit',
       hour12: !this.military,

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -154,11 +154,11 @@ export class NovoLabelService {
       return value;
     }
     let timeParts: { [type: string]: string } =  Intl.DateTimeFormat(this.userLocale, format).formatToParts(date).reduce((obj, part) => {
-      obj[part.type] = part.value
+      obj[part.type] = part.value;
       return obj;
     }, {});
-    const dayPeriod = timeParts.dayPeriod ? timeParts.dayPeriod : '';
-    return `${timeParts.hour}:${timeParts.minute}${dayPeriod}`;
+    const dayperiod = timeParts.dayperiod ? timeParts.dayperiod : '';
+    return `${timeParts.hour}:${timeParts.minute}${dayperiod}`;
   }
 
   getWeekdays(): string[] {

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -1,5 +1,12 @@
 // NG2
 import { Injectable, Inject, Optional, LOCALE_ID } from '@angular/core';
+import DateTimeFormatPart = Intl.DateTimeFormatPart;
+
+interface TimeFormatParts {
+  hour: string;
+  minute: string;
+  dayPeriod?: string;
+}
 
 @Injectable()
 export class NovoLabelService {
@@ -139,6 +146,17 @@ export class NovoLabelService {
       return value;
     }
     return new Intl.DateTimeFormat(this.userLocale, format).format(date);
+  }
+
+  formatTimeWithFormat(value: any, format: Intl.DateTimeFormatOptions): string {
+    let date = value instanceof Date ? value : new Date(value);
+    if (date.getTime() !== date.getTime()) {
+      return value;
+    }
+    let timeResult: { [type: string]: string }[] =  Intl.DateTimeFormat(this.userLocale, format).formatToParts(date).map((part) => ({ [part.type]: part.value }));
+    const timeParts = Object.assign({}, ...timeResult);
+    const dayPeriod = timeParts.dayPeriod ? timeParts.dayPeriod : '';
+    return `${timeParts.hour}:${timeParts.minute}${dayPeriod}`;
   }
 
   getWeekdays(): string[] {

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -153,8 +153,10 @@ export class NovoLabelService {
     if (date.getTime() !== date.getTime()) {
       return value;
     }
-    let timeResult: { [type: string]: string }[] =  Intl.DateTimeFormat(this.userLocale, format).formatToParts(date).map((part) => ({ [part.type]: part.value }));
-    const timeParts = Object.assign({}, ...timeResult);
+    let timeParts: { [type: string]: string } =  Intl.DateTimeFormat(this.userLocale, format).formatToParts(date).reduce((obj, part) => {
+      obj[part.type] = part.value
+      return obj;
+    }, {});
     const dayPeriod = timeParts.dayPeriod ? timeParts.dayPeriod : '';
     return `${timeParts.hour}:${timeParts.minute}${dayPeriod}`;
   }


### PR DESCRIPTION
## **Description**

The change I make are returning formatted time results in parts for consistency between locale formats

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**