### PR TITLE
Fix issue where novo data tables weren't showing results if they start filtered

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.source.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.source.ts
@@ -1,18 +1,19 @@
-import { ChangeDetectorRef } from '@angular/core';
+import {ChangeDetectorRef, OnDestroy} from '@angular/core';
 import { DataSource } from '@angular/cdk/table';
-import { Observable, merge, of } from 'rxjs';
+import {Observable, merge, of, Subscription} from 'rxjs';
 import { startWith, switchMap, map, catchError } from 'rxjs/operators';
 
 import { DataTableState } from './state/data-table-state.service';
 import { IDataTableService } from './interfaces';
 
-export class DataTableSource<T> extends DataSource<T> {
+export class DataTableSource<T> extends DataSource<T> implements OnDestroy {
   public total = 0;
   public currentTotal = 0;
   public current = 0;
   public loading = false;
   public pristine = true;
   public data: T[];
+  private connectSub: Subscription;
 
   private totalSet: boolean = false;
 
@@ -26,7 +27,7 @@ export class DataTableSource<T> extends DataSource<T> {
 
   constructor(private tableService: IDataTableService<T>, private state: DataTableState<T>, private ref: ChangeDetectorRef) {
     super();
-    this.connect().subscribe(() => {
+    this.connectSub = this.connect().subscribe(() => {
       if (!this.totalSet || this.currentTotal > this.total) {
         this.total = this.currentTotal;
         this.totalSet = true;
@@ -34,6 +35,10 @@ export class DataTableSource<T> extends DataSource<T> {
       this.loading = false;
       this.ref.markForCheck();
     });
+  }
+
+  ngOnDestroy(): void {
+    this.connectSub.unsubscribe();
   }
 
   public connect(): Observable<any> {

--- a/projects/novo-elements/src/elements/data-table/data-table.source.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.source.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectorRef } from '@angular/core';
 import { DataSource } from '@angular/cdk/table';
 import { Observable, merge, of } from 'rxjs';
-import { startWith, switchMap, map, catchError, distinctUntilChanged } from 'rxjs/operators';
+import { startWith, switchMap, map, catchError } from 'rxjs/operators';
 
 import { DataTableState } from './state/data-table-state.service';
 import { IDataTableService } from './interfaces';

--- a/projects/novo-elements/src/elements/data-table/data-table.source.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.source.ts
@@ -42,7 +42,9 @@ export class DataTableSource<T> extends DataSource<T> {
       startWith(null),
       switchMap(() => {
         this.pristine = false;
-        this.loading = true;
+          if (this.state.isForceRefresh || this.total === 0) {
+            this.loading = true;
+          }
         return this.tableService.getTableResults(
           this.state.sort,
           this.state.filter,
@@ -70,11 +72,11 @@ export class DataTableSource<T> extends DataSource<T> {
             this.state.dataLoaded.next();
           });
         });
+        this.loading = false;
         return data.results;
       }),
       catchError((err, caught) => {
         console.error(err, caught); // tslint: disable-line
-        this.loading = false;
         return of(null);
       }),
     );

--- a/projects/novo-elements/src/elements/data-table/data-table.source.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.source.ts
@@ -72,7 +72,6 @@ export class DataTableSource<T> extends DataSource<T> {
             this.state.dataLoaded.next();
           });
         });
-        this.loading = false;
         return data.results;
       }),
       catchError((err, caught) => {

--- a/projects/novo-elements/src/elements/data-table/data-table.source.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.source.ts
@@ -54,6 +54,7 @@ export class DataTableSource<T> extends DataSource<T> {
       }),
       map((data: { results: T[]; total: number }) => {
         if (this.state.isForceRefresh) {
+          this.totalSet = false;
           this.state.isForceRefresh = false;
         }
         this.currentTotal = data.total;


### PR DESCRIPTION
## **Description**

The data-table has a `total` property which was always set as the count of rows the first time data is returned for the table. This is not a safe assumption since because of things like sticky filters, the first time data is returned for a list may not be all of the data. In the case that the first time table data was returned was "0", data-tables were assuming there were no records.

If data-table gets more records than the `total` property is set to, the `total` property should be updated to the number of records received. This MR is also refactoring how and when the total and the `loading` property is being set, in order to avoid the `totallyEmpty` state pages from appearing during loading.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**

Old behavior:
![empty data table bug](https://user-images.githubusercontent.com/26778243/59784126-b9ff3680-928f-11e9-85dc-78b43efcaccb.gif)

New behavior:
![novo-elements pull request 991 video](https://user-images.githubusercontent.com/26778243/59784133-be2b5400-928f-11e9-93e2-fdfefd321fce.gif)
