### PR TITLE
fix(picker): Keep getLabels function from picker config when updated …

### DIFF
--- a/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
@@ -545,13 +545,14 @@ export class FieldInteractionApi {
   public mutatePickerConfig(key: string, args: ModifyPickerConfigArgs, mapper?: (item: unknown) => unknown): void {
     let control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
-      const { minSearchLength, enableInfiniteScroll, filteredOptionsCreator, format } = control.config;
+      const { minSearchLength, enableInfiniteScroll, filteredOptionsCreator, format, getLabels } = control.config;
       const optionsConfig = this.getOptionsConfig(args, mapper, filteredOptionsCreator, format);
 
       const newConfig: NovoControlConfig['config'] = {
         ...(Number.isInteger(minSearchLength) && { minSearchLength }),
         ...(enableInfiniteScroll && { enableInfiniteScroll }),
         ...(filteredOptionsCreator && { filteredOptionsCreator }),
+        ...(getLabels && { getLabels }),
         ...(optionsConfig && optionsConfig),
         resultsTemplate: control.config.resultsTemplate,
       };


### PR DESCRIPTION
…via field interaction

## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**