### PR TITLE
feat(picker): preserve empty results message on config for pickers

### DIFF
--- a/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
@@ -571,6 +571,7 @@ export class FieldInteractionApi {
       const format = ('format' in args && args.format) || pickerConfigFormat;
       return {
         options: this.createOptionsFunction(args, mapper, filteredOptionsCreator),
+        ...('emptyPickerMessage' in args && { emptyPickerMessage: args.emptyPickerMessage }),
         ...(format && { format }),
       };
     } else if ('options' in args && Array.isArray(args.options)) {

--- a/projects/novo-elements/src/elements/form/FieldInteractionApiTypes.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApiTypes.ts
@@ -1,9 +1,8 @@
-import { HttpClient } from '@angular/common/http';
-import { Observable, Subscription } from 'rxjs';
+import { Subscription } from 'rxjs';
 type OptionsFunctionConfig = {
   format?: string;
 } & (
-  | { where: string }
+  | { where: string; emptyPickerMessage?: string }
   | { optionsPromise: (query: string, http: CustomHttp) => Promise<unknown[]> }
   | { optionsUrl: string }
   | { optionsUrlBuilder: (query: string) => string });


### PR DESCRIPTION
…tions

## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**