### PR TITLE
Accept Custom Preselected Config

### DIFF
--- a/projects/novo-elements/src/elements/form/Control.spec.ts
+++ b/projects/novo-elements/src/elements/form/Control.spec.ts
@@ -1,10 +1,12 @@
 // NG2
-import { Component, ElementRef } from '@angular/core';
-import { TestBed, async } from '@angular/core/testing';
+import {ChangeDetectorRef, Component, ElementRef, NO_ERRORS_SCHEMA} from '@angular/core';
+import {TestBed, async, ComponentFixture} from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 // App
 import { NovoAutoSize } from './Control';
 import { NovoControlElement } from './Control';
+import {FieldInteractionApi, NovoLabelService, NovoTemplateService} from '../..';
+import {DateFormatService} from '../../services/date-format/DateFormat';
 
 @Component({
   selector: 'novo-auto-size-test-component',
@@ -70,5 +72,130 @@ describe('Test Localization', () => {
   it('should set decimal separator based on locale correctly', () => {
     let component = new NovoControlElement(mockElement, null, null, null, null, null, 'fr-FR');
     expect(component.decimalSeparator).toBe('.');
+  });
+});
+
+@Component({
+  template: `
+    <div></div>
+  `
+})
+class TestComponent {}
+describe('NovoControlElement', () => {
+  let component: NovoControlElement;
+  let fixture: ComponentFixture<NovoControlElement>;
+  beforeEach(() => {
+    const elementRefStub = {
+      nativeElement: { style: { height: {}, minHeight: {} }, scrollHeight: {} }
+    };
+    const changeDetectorRefStub = { markForCheck: () => ({}) };
+    const novoLabelServiceStub = { invalidIntegerInput: {} };
+    const dateFormatServiceStub = {};
+    const fieldInteractionApiStub = { form: {}, currentKey: {} };
+    const novoTemplateServiceStub = { getAll: () => ({}) };
+    TestBed.configureTestingModule({
+      declarations: [NovoAutoSize, TestComponent, NovoControlElement],
+      schemas: [NO_ERRORS_SCHEMA],
+      providers: [
+        NovoAutoSize,
+        { provide: ElementRef, useValue: elementRefStub },
+        { provide: ChangeDetectorRef, useValue: changeDetectorRefStub },
+        { provide: NovoLabelService, useValue: novoLabelServiceStub },
+        { provide: DateFormatService, useValue: dateFormatServiceStub },
+        { provide: FieldInteractionApi, useValue: fieldInteractionApiStub },
+        { provide: NovoTemplateService, useValue: novoTemplateServiceStub }
+      ]
+    });
+    fixture = TestBed.createComponent(NovoControlElement);
+    component = fixture.componentInstance;
+  });
+
+  it('should return false if the field has a MAX_LENGTH property but is not focused', () => {
+    // Arrange
+    component.control = {
+       key: 0,
+     };
+    component.form = {
+      controls: [{
+        maxLength: 1,
+      }],
+    };
+
+    // Act
+    let testBoolean = component.showCount;
+
+    // Assert
+    expect(testBoolean).toEqual(false);
+  });
+
+  it('should return true if the field has a MAX_LENGTH property and is focused', () => {
+    // Arrange
+    component.control = {
+      key: 'newField',
+    };
+    component.form = {
+      controls: {
+        newField: {
+          maxlength: 10,
+          controlType: 'textbox',
+        },
+      },
+    };
+
+    // (component as any)._focused = true;
+    (component as any).handleFocus(new FocusEvent('input'));
+
+    // Act
+    let testBoolean = component.showCount;
+
+    // Assert
+    expect(testBoolean).toEqual(true);
+  });
+
+  it('should return false if the field does not have a MAX_LENGTH property and is focused', () => {
+    // Arrange
+    component.control = {
+      key: 'newField',
+    };
+    component.form = {
+      controls: {
+        newField: {
+          controlType: 'textbox',
+        },
+      },
+    };
+
+    // (component as any)._focused = true;
+    (component as any).handleFocus(new FocusEvent('input'));
+
+    // Act
+    let testBoolean = component.showCount;
+
+    // Assert
+    expect(testBoolean).toEqual(false);
+  });
+
+  it('should return false if the controlType of the field is not textbox, picker, or text-area', () => {
+    // Arrange
+    component.control = {
+      key: 'newField',
+    };
+    component.form = {
+      controls: {
+        newField: {
+          maxlength: 10,
+          controlType: 'test',
+        },
+      },
+    };
+
+    // (component as any)._focused = true;
+    (component as any).handleFocus(new FocusEvent('input'));
+
+    // Act
+    let testBoolean = component.showCount;
+
+    // Assert
+    expect(testBoolean).toEqual(false);
   });
 });

--- a/projects/novo-elements/src/elements/form/Control.ts
+++ b/projects/novo-elements/src/elements/form/Control.ts
@@ -264,12 +264,11 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
   }
 
   get showCount() {
+    const MAX_LENGTH_CONTROL_TYPES: string[] = ['textbox', 'picker', 'text-area'];
     let charCount: boolean =
-      (this.form.controls[this.control.key].maxlength &&
-        this.focused &&
-        (this.form.controls[this.control.key].controlType === 'text-area' ||
-          this.form.controls[this.control.key].controlType === 'textbox')) ||
-      (this.form.controls[this.control.key].maxlength && this.form.controls[this.control.key].controlType === 'picker');
+      this.focused &&
+      !!this.form.controls[this.control.key].maxlength &&
+      MAX_LENGTH_CONTROL_TYPES.includes(this.form.controls[this.control.key].controlType);
     return this._showCount || charCount;
   }
 

--- a/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.spec.ts
+++ b/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.spec.ts
@@ -152,6 +152,11 @@ describe('Elements: BasePickerResults', () => {
   });
 
   describe('Method: preselected()', () => {
+    beforeAll(() => {
+      component.config = {
+        preselected: undefined,
+      };
+    });
     it('should be defined.', () => {
       expect(component.preselected).toBeDefined();
       // component.preselected();
@@ -170,6 +175,14 @@ describe('Elements: BasePickerResults', () => {
       component.selected = [{ id: 1, value: 'test0' }, { id: 2, value: 'test1' }];
       expect(component.preselected({ value: 'test0' })).toEqual(true);
       expect(component.preselected({ value: 'not a match' })).toEqual(false);
+    });
+    it('should use custom preselect when applicable', () => {
+      component.config.preselected = (match, item) => {
+        return match.testVal === item.testVal;
+      };
+      component.selected = [{ id: 1, testVal: 'test0' }, { id: 2, testVal: 'test1' }];
+      expect(component.preselected({ testVal: 'test0' })).toEqual(true);
+      expect(component.preselected({ testVal: 'not a match' })).toEqual(false);
     });
   });
 });

--- a/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.ts
@@ -382,6 +382,14 @@ export class BasePickerResults {
   }
 
   preselected(match) {
+    if (this.config.preselected) {
+      let preselectedFunc: Function = this.config.preselected;
+      return (
+        this.selected.findIndex((item) => {
+        return preselectedFunc(match, item);
+      }) !== -1
+      );
+    }
     return (
       this.selected.findIndex((item) => {
         let isPreselected = false;


### PR DESCRIPTION
## **Description**

Allow Picker results to accept a custom preselected function for determining whether a result has already been selected.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**