### PR TITLE
fix(data-table):  undo loading indicator logic changes

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.source.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.source.ts
@@ -1,6 +1,6 @@
-import {ChangeDetectorRef, OnDestroy} from '@angular/core';
+import { ChangeDetectorRef, OnDestroy } from '@angular/core';
 import { DataSource } from '@angular/cdk/table';
-import {Observable, merge, of, Subscription} from 'rxjs';
+import { Observable, merge, of, Subscription } from 'rxjs';
 import { startWith, switchMap, map, catchError } from 'rxjs/operators';
 
 import { DataTableState } from './state/data-table-state.service';
@@ -47,9 +47,7 @@ export class DataTableSource<T> extends DataSource<T> implements OnDestroy {
       startWith(null),
       switchMap(() => {
         this.pristine = false;
-          if (this.state.isForceRefresh || this.total === 0) {
-            this.loading = true;
-          }
+        this.loading = true;
         return this.tableService.getTableResults(
           this.state.sort,
           this.state.filter,
@@ -74,12 +72,14 @@ export class DataTableSource<T> extends DataSource<T> implements OnDestroy {
         setTimeout(() => {
           this.ref.markForCheck();
           setTimeout(() => {
+            this.loading = false;
             this.state.dataLoaded.next();
           });
         });
         return data.results;
       }),
       catchError((err, caught) => {
+        this.loading = false;
         console.error(err, caught); // tslint: disable-line
         return of(null);
       }),


### PR DESCRIPTION
## **Description**

The logic for when the loading indicator shows was changed.  This PR is changing it back. 

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**