### PR TITLE
set loading to false after getting results

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.source.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.source.ts
@@ -47,7 +47,7 @@ export class DataTableSource<T> extends DataSource<T> implements OnDestroy {
       startWith(null),
       switchMap(() => {
         this.pristine = false;
-          if (this.state.isForceRefresh || this.total === 0) {
+          if (this.state.isForceRefresh) {
             this.loading = true;
           }
         return this.tableService.getTableResults(


### PR DESCRIPTION
## **Description**

Set Loading to False when results are received from connect()

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**