### PR TITLE
Change how dirty flag is being calculated

### DIFF
--- a/projects/novo-elements/src/elements/form/controls/BaseControl.spec.ts
+++ b/projects/novo-elements/src/elements/form/controls/BaseControl.spec.ts
@@ -157,15 +157,6 @@ describe('Control: BaseControl', () => {
   describe('Integer field', () => {
     it('non-zero default value should be marked dirty', () => {
       control = new BaseControl('BaseControl', {
-        validators: ['TEST_VALIDATORS'],
-        key: 'TEST_KEY',
-        label: 'TEST_LABEL',
-        required: true,
-        hidden: false,
-        encrypted: true,
-        sortOrder: 2,
-        placeholder: 'TEST_PLACEHOLDER',
-        config: { test: 'TEST_CONFIG' },
         dataType: 'Integer',
         value: 2,
       });
@@ -173,17 +164,43 @@ describe('Control: BaseControl', () => {
     });
     it('zero default value should be marked dirty', () => {
       control = new BaseControl('BaseControl', {
-        validators: ['TEST_VALIDATORS'],
-        key: 'TEST_KEY',
-        label: 'TEST_LABEL',
-        required: true,
-        hidden: false,
-        encrypted: true,
-        sortOrder: 2,
-        placeholder: 'TEST_PLACEHOLDER',
-        config: { test: 'TEST_CONFIG' },
         dataType: 'Integer',
         value: 0,
+      });
+      expect(control.dirty).toBe(true);
+    });
+    it('string default value should be marked dirty', () => {
+      control = new BaseControl('BaseControl', {
+        dataType: 'String',
+        value: 'remote work',
+      });
+      expect(control.dirty).toBe(true);
+    });
+    it('string default value should be marked dirty', () => {
+      control = new BaseControl('BaseControl', {
+        dataType: 'Boolean',
+        value: false,
+      });
+      expect(control.dirty).toBe(false);
+    });
+    it('string default value should be marked dirty', () => {
+      control = new BaseControl('BaseControl', {
+        dataType: 'Boolean',
+        value: true,
+      });
+      expect(control.dirty).toBe(true);
+    });
+    it('string default value should be marked dirty', () => {
+      control = new BaseControl('BaseControl', {
+        dataType: 'Double',
+        value: 12.34,
+      });
+      expect(control.dirty).toBe(true);
+    });
+    it('string default value should be marked dirty', () => {
+      control = new BaseControl('BaseControl', {
+        dataType: 'Timestamp',
+        value: '10-04-19 12:00:17',
       });
       expect(control.dirty).toBe(true);
     });

--- a/projects/novo-elements/src/elements/form/controls/BaseControl.spec.ts
+++ b/projects/novo-elements/src/elements/form/controls/BaseControl.spec.ts
@@ -154,55 +154,89 @@ describe('Control: BaseControl', () => {
     });
   });
 
-  describe('Integer field', () => {
-    it('non-zero default value should be marked dirty', () => {
+  describe('Dirty flag tests', () => {
+    it('non-zero value should be marked dirty', () => {
       control = new BaseControl('BaseControl', {
         dataType: 'Integer',
         value: 2,
       });
       expect(control.dirty).toBe(true);
     });
-    it('zero default value should be marked dirty', () => {
+    it('zero value should be marked dirty', () => {
       control = new BaseControl('BaseControl', {
         dataType: 'Integer',
         value: 0,
       });
       expect(control.dirty).toBe(true);
     });
-    it('string default value should be marked dirty', () => {
+    it('string value should be marked dirty', () => {
       control = new BaseControl('BaseControl', {
         dataType: 'String',
         value: 'remote work',
       });
       expect(control.dirty).toBe(true);
     });
-    it('string default value should be marked dirty', () => {
+    it('empty string value should be marked dirty', () => {
+      control = new BaseControl('BaseControl', {
+        dataType: 'String',
+        value: '',
+      });
+      expect(control.dirty).toBe(true);
+    });
+    it('boolean value should be marked dirty', () => {
       control = new BaseControl('BaseControl', {
         dataType: 'Boolean',
         value: false,
       });
-      expect(control.dirty).toBe(false);
+      expect(control.dirty).toBe(true);
     });
-    it('string default value should be marked dirty', () => {
+    it('boolean value should be marked dirty', () => {
       control = new BaseControl('BaseControl', {
         dataType: 'Boolean',
         value: true,
       });
       expect(control.dirty).toBe(true);
     });
-    it('string default value should be marked dirty', () => {
+    it('double value should be marked dirty', () => {
       control = new BaseControl('BaseControl', {
         dataType: 'Double',
         value: 12.34,
       });
       expect(control.dirty).toBe(true);
     });
-    it('string default value should be marked dirty', () => {
+    it('zero double value should be marked dirty', () => {
+      control = new BaseControl('BaseControl', {
+        dataType: 'Double',
+        value: 0.0,
+      });
+      expect(control.dirty).toBe(true);
+    });
+    it('timestamp value should be marked dirty', () => {
       control = new BaseControl('BaseControl', {
         dataType: 'Timestamp',
         value: '10-04-19 12:00:17',
       });
       expect(control.dirty).toBe(true);
+    });
+    it('undefined value should not be marked dirty', () => {
+      control = new BaseControl('BaseControl', {
+        dataType: 'String',
+      });
+      expect(control.dirty).toBe(false);
+    });
+    it('null string value should not be marked dirty', () => {
+      control = new BaseControl('BaseControl', {
+        dataType: 'String',
+        value: null,
+      });
+      expect(control.dirty).toBe(false);
+    });
+    it('null boolean should not be marked dirty', () => {
+      control = new BaseControl('BaseControl', {
+        dataType: 'Boolean',
+        value: null,
+      });
+      expect(control.dirty).toBe(false);
     });
   });
 });

--- a/projects/novo-elements/src/elements/form/controls/BaseControl.spec.ts
+++ b/projects/novo-elements/src/elements/form/controls/BaseControl.spec.ts
@@ -153,4 +153,39 @@ describe('Control: BaseControl', () => {
       expect(control.maskOptions).toEqual({ mask: ['TEST_MASK_OPTIONS'], keepCharPositions: false, guide: true });
     });
   });
+
+  describe('Integer field', () => {
+    it('non-zero default value should be marked dirty', () => {
+      control = new BaseControl('BaseControl', {
+        validators: ['TEST_VALIDATORS'],
+        key: 'TEST_KEY',
+        label: 'TEST_LABEL',
+        required: true,
+        hidden: false,
+        encrypted: true,
+        sortOrder: 2,
+        placeholder: 'TEST_PLACEHOLDER',
+        config: { test: 'TEST_CONFIG' },
+        dataType: 'Integer',
+        value: 2,
+      });
+      expect(control.dirty).toBe(true);
+    });
+    it('zero default value should be marked dirty', () => {
+      control = new BaseControl('BaseControl', {
+        validators: ['TEST_VALIDATORS'],
+        key: 'TEST_KEY',
+        label: 'TEST_LABEL',
+        required: true,
+        hidden: false,
+        encrypted: true,
+        sortOrder: 2,
+        placeholder: 'TEST_PLACEHOLDER',
+        config: { test: 'TEST_CONFIG' },
+        dataType: 'Integer',
+        value: 0,
+      });
+      expect(control.dirty).toBe(true);
+    });
+  });
 });

--- a/projects/novo-elements/src/elements/form/controls/BaseControl.ts
+++ b/projects/novo-elements/src/elements/form/controls/BaseControl.ts
@@ -121,7 +121,7 @@ export class BaseControl extends ControlConfig {
     this.metaType = config.metaType;
     this.placeholder = config.placeholder || '';
     this.config = config.config || null;
-    this.dirty = !!config.value;
+    this.dirty = !!(config.value || (config.dataType === 'Integer' && config.value !== null));
     this.multiple = !!config.multiple;
     this.headerConfig = config.headerConfig || null;
     this.currencyFormat = config.currencyFormat || null;

--- a/projects/novo-elements/src/elements/form/controls/BaseControl.ts
+++ b/projects/novo-elements/src/elements/form/controls/BaseControl.ts
@@ -121,7 +121,7 @@ export class BaseControl extends ControlConfig {
     this.metaType = config.metaType;
     this.placeholder = config.placeholder || '';
     this.config = config.config || null;
-    this.dirty = !!config.value || (config.dataType === 'Integer' && config.value !== null);
+    this.dirty = !!(config.value !== undefined && config.value !== null);
     this.multiple = !!config.multiple;
     this.headerConfig = config.headerConfig || null;
     this.currencyFormat = config.currencyFormat || null;

--- a/projects/novo-elements/src/elements/form/controls/BaseControl.ts
+++ b/projects/novo-elements/src/elements/form/controls/BaseControl.ts
@@ -121,7 +121,7 @@ export class BaseControl extends ControlConfig {
     this.metaType = config.metaType;
     this.placeholder = config.placeholder || '';
     this.config = config.config || null;
-    this.dirty = !!(config.value || (config.dataType === 'Integer' && config.value !== null));
+    this.dirty = !!config.value || (config.dataType === 'Integer' && config.value !== null);
     this.multiple = !!config.multiple;
     this.headerConfig = config.headerConfig || null;
     this.currencyFormat = config.currencyFormat || null;


### PR DESCRIPTION
## **Description**

Fixed bug where some fields don't calculate dirty flag properly, specifically booleans set to false, and integers set to 0

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**