### PR TITLE
feat(dropdowns) increased min-width for dropdowns

### DIFF
--- a/projects/novo-elements/src/elements/dropdown/Dropdown.scss
+++ b/projects/novo-elements/src/elements/dropdown/Dropdown.scss
@@ -18,7 +18,7 @@ novo-dropdown {
   list-style: none;
   margin: 0;
   padding: 0;
-  min-width: 180px;
+  min-width: 240px;
   margin-top: 5px;
   margin-bottom: 5px;
   box-shadow: $whiteframe-shadow-z3;

--- a/projects/novo-elements/src/elements/dropdown/Dropdown.scss
+++ b/projects/novo-elements/src/elements/dropdown/Dropdown.scss
@@ -18,7 +18,7 @@ novo-dropdown {
   list-style: none;
   margin: 0;
   padding: 0;
-  min-width: 240px;
+  min-width: 180px;
   margin-top: 5px;
   margin-bottom: 5px;
   box-shadow: $whiteframe-shadow-z3;
@@ -40,6 +40,7 @@ novo-dropdown {
       text-align: left;
       span {
         display: inline-block;
+        max-width: 240px;
       }
       a {
         color: inherit;


### PR DESCRIPTION
## **Description**

Increases the min-width for drowdown containers to accommodate longer statuses

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**

![image](https://user-images.githubusercontent.com/21197268/62079064-8eb72200-b213-11e9-8d7a-4101813d2526.png)
