### PR TITLE
Angular injector refactor

### DIFF
--- a/projects/novo-elements/src/elements/chips/Chips.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.ts
@@ -352,7 +352,7 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
   showPreview() {
     if (this.source.previewTemplate) {
       if (!this.popup) {
-        this.popup = this.componentUtils.appendNextToLocation(this.source.previewTemplate, this.preview);
+        this.popup = this.componentUtils.append(this.source.previewTemplate, this.preview);
       }
       this.popup.instance.match = this.selected;
     }

--- a/projects/novo-elements/src/elements/modal/Modal.ts
+++ b/projects/novo-elements/src/elements/modal/Modal.ts
@@ -60,7 +60,7 @@ export class NovoModalContainerElement implements AfterViewInit {
 
   ngAfterViewInit() {
     setTimeout(() => {
-      this.modalRef.contentRef = this.componentUtils.appendNextToLocation(this.modalRef.component, this.container);
+      this.modalRef.contentRef = this.componentUtils.append(this.modalRef.component, this.container);
     });
   }
 }
@@ -68,12 +68,10 @@ export class NovoModalContainerElement implements AfterViewInit {
 @Component({
   selector: 'novo-modal',
   template: `
-        <ng-content select="header"></ng-content>
-        <ng-content select="section"></ng-content>
-        <footer>
-            <ng-content select="button"></ng-content>
-        </footer>
-    `,
+    <ng-content select="header"></ng-content>
+    <ng-content select="section"></ng-content>
+    <footer><ng-content select="button"></ng-content></footer>
+  `,
 })
 export class NovoModalElement {
   constructor(private modalRef: NovoModalRef) {}
@@ -86,20 +84,16 @@ export class NovoModalElement {
 @Component({
   selector: 'novo-notification',
   template: `
-        <button class="modal-close" theme="icon" icon="times" (click)="close()"></button>
-        <header>
-            <ng-content select="label"></ng-content>
-        </header>
-        <section class="notification-body">
-            <i class="indicator" [ngClass]="iconType" *ngIf="iconType"></i>
-            <ng-content select="h1"></ng-content>
-            <ng-content select="h2"></ng-content>
-            <ng-content select="p"></ng-content>
-        </section>
-        <footer>
-            <ng-content select="button"></ng-content>
-        </footer>
-    `,
+    <button class="modal-close" theme="icon" icon="times" (click)="close()"></button>
+    <header><ng-content select="label"></ng-content></header>
+    <section class="notification-body">
+      <i class="indicator" [ngClass]="iconType" *ngIf="iconType"></i>
+      <ng-content select="h1"></ng-content>
+      <ng-content select="h2"></ng-content>
+      <ng-content select="p"></ng-content>
+    </section>
+    <footer><ng-content select="button"></ng-content></footer>
+  `,
 })
 export class NovoModalNotificationElement implements OnInit {
   @Input()

--- a/projects/novo-elements/src/elements/modal/ModalService.ts
+++ b/projects/novo-elements/src/elements/modal/ModalService.ts
@@ -14,7 +14,8 @@ export class NovoModalService {
     this._parentViewContainer = view;
   }
 
-  open<T>(component: Type<T>, scope = {}) {
+  // open<T>(component: Type<T>, scope = {}) {
+  open(component, scope = {}) {
     if (!this._parentViewContainer) {
       console.error(
         'No parent view container specified for the ModalService. Set it inside your main application. \nthis.modalService.parentViewContainer = view (ViewContainerRef)',

--- a/projects/novo-elements/src/elements/modal/ModalService.ts
+++ b/projects/novo-elements/src/elements/modal/ModalService.ts
@@ -14,13 +14,9 @@ export class NovoModalService {
     this._parentViewContainer = view;
   }
 
-  // open<T>(component: Type<T>, scope = {}) {
-  open(component, scope = {}) {
+  open<T>(component: Type<T>, scope = {}): NovoModalRef {
     if (!this._parentViewContainer) {
-      console.error(
-        'No parent view container specified for the ModalService. Set it inside your main application. \nthis.modalService.parentViewContainer = view (ViewContainerRef)',
-      );
-      return null;
+      throw new Error('No parent view container specified for the ModalService. Set it inside your main application. \nthis.modalService.parentViewContainer = view (ViewContainerRef)');
     }
 
     const modal = new NovoModalRef();

--- a/projects/novo-elements/src/elements/modal/ModalService.ts
+++ b/projects/novo-elements/src/elements/modal/ModalService.ts
@@ -1,20 +1,20 @@
 // NG2
-import { Injectable, ReflectiveInjector } from '@angular/core';
+import { Injectable, ViewContainerRef, StaticProvider, Type } from '@angular/core';
 // APP
 import { NovoModalRef, NovoModalParams, NovoModalContainerElement } from './Modal';
 import { ComponentUtils } from './../../utils/component-utils/ComponentUtils';
 
 @Injectable()
 export class NovoModalService {
-  _parentViewContainer: any = null;
+  _parentViewContainer: ViewContainerRef;
 
   constructor(private componentUtils: ComponentUtils) {}
 
-  set parentViewContainer(view) {
+  set parentViewContainer(view: ViewContainerRef) {
     this._parentViewContainer = view;
   }
 
-  open(component, scope = {}) {
+  open<T>(component: Type<T>, scope = {}) {
     if (!this._parentViewContainer) {
       console.error(
         'No parent view container specified for the ModalService. Set it inside your main application. \nthis.modalService.parentViewContainer = view (ViewContainerRef)',
@@ -26,8 +26,8 @@ export class NovoModalService {
     modal.component = component;
     modal.open();
 
-    let bindings = ReflectiveInjector.resolve([{ provide: NovoModalRef, useValue: modal }, { provide: NovoModalParams, useValue: scope }]);
-    modal.containerRef = this.componentUtils.appendNextToLocation(NovoModalContainerElement, this._parentViewContainer, bindings);
+    const providers: StaticProvider[] = [{ provide: NovoModalRef, useValue: modal }, { provide: NovoModalParams, useValue: scope }];
+    modal.containerRef = this.componentUtils.append(NovoModalContainerElement, this._parentViewContainer, providers);
     return modal;
   }
 }

--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -276,7 +276,7 @@ export class NovoPickerElement implements OnInit {
       this.popup.instance.autoSelectFirstOption = this.autoSelectFirstOption;
       this.ref.markForCheck();
     } else {
-      this.popup = this.componentUtils.appendNextToLocation(this.resultsComponent, this.results);
+      this.popup = this.componentUtils.append(this.resultsComponent, this.results);
       this.popup.instance.parent = this;
       this.popup.instance.config = this.config;
       this.popup.instance.term = this.term;

--- a/projects/novo-elements/src/elements/quick-note/QuickNote.spec.ts
+++ b/projects/novo-elements/src/elements/quick-note/QuickNote.spec.ts
@@ -74,6 +74,10 @@ describe('Elements: QuickNoteElement', () => {
       fakeResultsDropdown.visible = true;
       return fakeResultsDropdown;
     }
+    append() {
+      fakeResultsDropdown.visible = true;
+      return fakeResultsDropdown;
+    }
   }
 
   beforeEach(() => {

--- a/projects/novo-elements/src/elements/quick-note/QuickNote.ts
+++ b/projects/novo-elements/src/elements/quick-note/QuickNote.ts
@@ -341,7 +341,7 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
           };
         } else {
           // Create the results DOM element
-          this.quickNoteResults = this.componentUtils.appendNextToLocation(this.resultsComponent, this.results);
+          this.quickNoteResults = this.componentUtils.append(this.resultsComponent, this.results);
           this.quickNoteResults.instance.parent = this;
           this.quickNoteResults.instance.config = this.config;
           this.quickNoteResults.instance.term = {

--- a/projects/novo-elements/src/elements/table/extras/row-details/RowDetails.ts
+++ b/projects/novo-elements/src/elements/table/extras/row-details/RowDetails.ts
@@ -27,8 +27,8 @@ export class RowDetails implements OnInit {
   ngOnInit() {
     if (this.renderer) {
       if (this.renderer.prototype instanceof BaseRenderer) {
-        let componentRef = this.componentUtils.appendNextToLocation(this.renderer, this.container);
-        componentRef.instance.data = this.data;
+        const componentRef = this.componentUtils.append(this.renderer, this.container);
+        componentRef.instance['data'] = this.data;
       } else {
         this.value = this.renderer(this.data);
       }

--- a/projects/novo-elements/src/elements/table/extras/table-cell/TableCell.ts
+++ b/projects/novo-elements/src/elements/table/extras/table-cell/TableCell.ts
@@ -44,7 +44,7 @@ export class TableCell implements OnInit, OnDestroy {
     if (this.column.renderer) {
       if (this.column.renderer.prototype instanceof BaseRenderer) {
         this.column._type = 'custom';
-        let componentRef = this.componentUtils.appendNextToLocation(this.column.renderer, this.container);
+        const componentRef = this.componentUtils.append(this.column.renderer, this.container) as any;
         componentRef.instance.meta = this.column;
         componentRef.instance.data = this.row;
         componentRef.instance.value = this.form && this.hasEditor ? this.form.value[this.column.name] : this.row[this.column.name];

--- a/projects/novo-elements/src/elements/toast/ToastService.ts
+++ b/projects/novo-elements/src/elements/toast/ToastService.ts
@@ -36,7 +36,7 @@ export class NovoToastService {
         );
         return;
       }
-      let toast = this.componentUtils.appendNextToLocation(toastElement, this._parentViewContainer);
+      const toast = this.componentUtils.append(toastElement, this._parentViewContainer);
       this.references.push(toast);
       this.handleAlert(toast.instance, options);
       resolve(toast);

--- a/projects/novo-elements/src/utils/component-utils/ComponentUtils.spec.ts
+++ b/projects/novo-elements/src/utils/component-utils/ComponentUtils.spec.ts
@@ -1,14 +1,20 @@
 // APP
 import { ComponentUtils } from './ComponentUtils';
+import { ComponentFactoryResolver } from '@angular/core';
+import { async } from '@angular/core/testing';
 
 describe('Utils: ComponentUtils', () => {
-  let service;
+  let service: ComponentUtils;
 
-  beforeEach(() => {
-    service = new ComponentUtils(null);
-  });
+  beforeAll(async(() => {
+    const resolve = { resolveComponentFactory: ({}) => {} };
+    service = new ComponentUtils(resolve as ComponentFactoryResolver);
+  }));
 
-  it('should be defined.', () => {
-    expect(service).toBeDefined();
+  it('function append() should call location.createComponent', () => {
+    spyOn(service.componentFactoryResolver, 'resolveComponentFactory');
+    const location = { createComponent: () => {} };
+    service.append(ComponentUtils, location as any);
+    expect(service.componentFactoryResolver.resolveComponentFactory).toHaveBeenCalled();
   });
 });

--- a/projects/novo-elements/src/utils/component-utils/ComponentUtils.ts
+++ b/projects/novo-elements/src/utils/component-utils/ComponentUtils.ts
@@ -7,16 +7,17 @@ import {
   ReflectiveInjector,
   ViewContainerRef,
   ResolvedReflectiveProvider,
+  StaticProvider,
+  Type,
 } from '@angular/core';
 
 @Injectable()
 export class ComponentUtils {
-  componentFactoryResolver: ComponentFactoryResolver;
+  constructor(public componentFactoryResolver: ComponentFactoryResolver) {}
 
-  constructor(componentFactoryResolver: ComponentFactoryResolver) {
-    this.componentFactoryResolver = componentFactoryResolver;
-  }
-
+  /**
+   * @deprecated use append() instead.
+   */
   appendNextToLocation(ComponentClass, location: ViewContainerRef, providers?: ResolvedReflectiveProvider[]): ComponentRef<any> {
     let componentFactory = this.componentFactoryResolver.resolveComponentFactory(ComponentClass);
     let parentInjector = location.parentInjector;
@@ -27,6 +28,9 @@ export class ComponentUtils {
     return location.createComponent(componentFactory, location.length, childInjector);
   }
 
+  /**
+   * @deprecated
+   */
   appendTopOfLocation(ComponentClass, location: ViewContainerRef, providers?: ResolvedReflectiveProvider[]): ComponentRef<any> {
     let componentFactory = this.componentFactoryResolver.resolveComponentFactory(ComponentClass);
     let parentInjector = location.parentInjector;
@@ -35,5 +39,12 @@ export class ComponentUtils {
       childInjector = ReflectiveInjector.fromResolvedProviders(providers, parentInjector);
     }
     return location.createComponent(componentFactory, 0, childInjector);
+  }
+
+  append<T>(ComponentClass: Type<T>, location: ViewContainerRef, providers?: StaticProvider[], onTop?: boolean): ComponentRef<T> {
+    const componentFactory = this.componentFactoryResolver.resolveComponentFactory(ComponentClass);
+    const parent = location.injector;
+    const index = onTop ? 0 : location.length;
+    return location.createComponent(componentFactory, index, Injector.create({ providers, parent }));
   }
 }


### PR DESCRIPTION
## **Description**

ReflectiveInjectors have been deprecated since Angular 5 in favor of StaticProvider.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**