### PR TITLE
BH-61191 add Toast interface

### DIFF
--- a/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
@@ -7,7 +7,7 @@ import { map } from 'rxjs/operators';
 import { NovoFormControl } from './NovoFormControl';
 import { NovoControlConfig } from './FormControls';
 import { FormUtils } from '../../utils/form-utils/FormUtils';
-import { NovoToastService } from '../toast/ToastService';
+import { NovoToastService, ToastOptions } from '../toast/ToastService';
 import { NovoModalService } from '../modal/ModalService';
 import { ControlConfirmModal, ControlPromptModal } from './FieldInteractionModals';
 import { Helpers } from '../../utils/Helpers';
@@ -355,16 +355,7 @@ export class FieldInteractionApi {
     }
   }
 
-  public displayToast(toastConfig: {
-    message: string;
-    title?: string;
-    hideDelay?: number;
-    icon?: string;
-    theme?: string;
-    position?: string;
-    isCloseable?: boolean;
-    customClass?: string;
-  }): void {
+  displayToast(toastConfig: ToastOptions): void {
     if (this.toaster) {
       this.toaster.alert(toastConfig);
     }

--- a/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.ts
@@ -160,9 +160,7 @@ export class BasePickerResults {
             ) {
               this.isStatic = false;
               // Promises (ES6 or Deferred) are resolved whenever they resolve
-              options
-                .then(this.structureArray.bind(this))
-                .then(resolve, reject);
+              options.then(this.structureArray.bind(this)).then(resolve, reject);
             } else if (typeof options === 'function') {
               this.isStatic = false;
               // Promises (ES6 or Deferred) are resolved whenever they resolve
@@ -180,9 +178,7 @@ export class BasePickerResults {
               if (typeof this.config.defaultOptions === 'function') {
                 let defaultOptions = this.config.defaultOptions(term, ++this.page);
                 if (Object.getPrototypeOf(defaultOptions).hasOwnProperty('then')) {
-                  defaultOptions
-                    .then(this.structureArray.bind(this))
-                    .then(resolve, reject);
+                  defaultOptions.then(this.structureArray.bind(this)).then(resolve, reject);
                 } else {
                   resolve(this.structureArray(defaultOptions));
                 }
@@ -386,8 +382,8 @@ export class BasePickerResults {
       let preselectedFunc: Function = this.config.preselected;
       return (
         this.selected.findIndex((item) => {
-        return preselectedFunc(match, item);
-      }) !== -1
+          return preselectedFunc(match, item);
+        }) !== -1
       );
     }
     return (

--- a/projects/novo-elements/src/elements/toast/ToastService.ts
+++ b/projects/novo-elements/src/elements/toast/ToastService.ts
@@ -7,7 +7,7 @@ import { ComponentUtils } from '../../utils/component-utils/ComponentUtils';
 export interface ToastOptions {
   title?: string;
   message?: string;
-  icon?: 'bell' | 'check' | 'info' | 'warning' | 'remove' | 'caution' | 'times' | 'coffee';
+  icon?: 'bell' | 'check' | 'info' | 'warning' | 'remove' | 'caution' | 'times' | 'coffee' | 'danger' | string;
   theme?: 'default' | 'success' | 'info' | 'warning' | 'danger';
   hideDelay?: number;
   position?: 'fixedTop' | 'fixedBottom' | 'growlTopRight' | 'growlTopLeft' | 'growlBottomRight' | 'growlBottomLeft';

--- a/projects/novo-elements/src/elements/toast/ToastService.ts
+++ b/projects/novo-elements/src/elements/toast/ToastService.ts
@@ -4,23 +4,23 @@ import { Injectable } from '@angular/core';
 import { NovoToastElement } from './Toast';
 import { ComponentUtils } from '../../utils/component-utils/ComponentUtils';
 
+export interface ToastOptions {
+  title?: string;
+  message?: string;
+  icon?: 'bell' | 'check' | 'info' | 'warning' | 'remove' | 'caution' | 'times' | 'coffee';
+  theme?: 'default' | 'success' | 'info' | 'warning' | 'danger';
+  hideDelay?: number;
+  position?: 'fixedTop' | 'fixedBottom' | 'growlTopRight' | 'growlTopLeft' | 'growlBottomRight' | 'growlBottomLeft';
+  isCloseable?: boolean;
+  customClass?: string;
+}
+
 @Injectable()
 export class NovoToastService {
   _parentViewContainer: any;
   references: Array<any> = [];
-  themes: Array<string> = ['default', 'success', 'info', 'warning', 'danger'];
-  icons: any = {
-    default: 'bell',
-    success: 'check',
-    info: 'info',
-    warning: 'warning',
-    danger: 'remove',
-  };
-  defaults: any = {
-    hideDelay: 3500,
-    position: 'growlTopRight',
-    theme: 'default',
-  };
+  icons = { default: 'bell', success: 'check', info: 'info', warning: 'warning', danger: 'remove' };
+  defaults = { hideDelay: 3500, position: 'growlTopRight', theme: 'default' };
 
   constructor(private componentUtils: ComponentUtils) {}
 
@@ -28,7 +28,7 @@ export class NovoToastService {
     this._parentViewContainer = view;
   }
 
-  alert(options, toastElement: any = NovoToastElement) {
+  alert(options: ToastOptions, toastElement: any = NovoToastElement): Promise<any> {
     return new Promise((resolve) => {
       if (!this._parentViewContainer) {
         console.error(

--- a/projects/novo-elements/src/index.ts
+++ b/projects/novo-elements/src/index.ts
@@ -69,7 +69,7 @@ export { NovoTableElement, NovoTableConfig } from './elements/table/Table';
 export { NovoCalendarDateChangeElement } from './elements/calendar/common/CalendarDateChange';
 export { NovoTemplate } from './elements/common/novo-template/novo-template.directive';
 // Export all services
-export { NovoToastService } from './elements/toast/ToastService';
+export { NovoToastService, ToastOptions } from './elements/toast/ToastService';
 export { NovoModalService } from './elements/modal/ModalService';
 export { NovoLabelService } from './services/novo-label-service';
 export { NovoDragulaService } from './elements/dragula/DragulaService';


### PR DESCRIPTION
## **Description**

add an interface for the Toast options

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**