### PR TITLE
Support/3.11 fixes

### DIFF
--- a/projects/novo-elements/package.json
+++ b/projects/novo-elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "novo-elements",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "peerDependencies": {
     "@angular/animations": "^7.0.0",
     "@angular/cdk": "^7.0.0",

--- a/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
@@ -604,13 +604,7 @@ export class FieldInteractionApi {
     mapper?: (item: unknown) => unknown,
     filteredOptionsCreator?: (where?: string) => ((query: string, page?: number) => Promise<unknown[]>),
   ): ((query: string) => Promise<unknown[]>) => (query: string, page?: number) => {
-    if (filteredOptionsCreator) {
-      if ('where' in config) {
-        return filteredOptionsCreator(config.where)(query, page);
-      } else {
-        return filteredOptionsCreator()(query, page);
-      }
-    } else if ('optionsPromise' in config && config.optionsPromise) {
+    if ('optionsPromise' in config && config.optionsPromise) {
       return config.optionsPromise(query, new CustomHttpImpl(this.http));
     } else if (('optionsUrlBuilder' in config && config.optionsUrlBuilder) || ('optionsUrl' in config && config.optionsUrl)) {
       return new Promise((resolve, reject) => {
@@ -627,6 +621,12 @@ export class FieldInteractionApi {
           )
           .subscribe(resolve, reject);
       });
+    } else if (filteredOptionsCreator) {
+      if ('where' in config) {
+        return filteredOptionsCreator(config.where)(query, page);
+      } else {
+        return filteredOptionsCreator()(query, page);
+      }
     }
   };
 


### PR DESCRIPTION
## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**