### PR TITLE
fix(ToastOptions): Add positive theme

### DIFF
--- a/projects/novo-elements/src/elements/toast/ToastService.ts
+++ b/projects/novo-elements/src/elements/toast/ToastService.ts
@@ -4,13 +4,17 @@ import { Injectable } from '@angular/core';
 import { NovoToastElement } from './Toast';
 import { ComponentUtils } from '../../utils/component-utils/ComponentUtils';
 
+export type ToastThemes = 'default' | 'success' | 'info' | 'warning' | 'danger' | 'positive' | string;
+export type ToastIcons = 'bell' | 'check' | 'info' | 'warning' | 'remove' | 'caution' | 'times' | 'coffee' | 'danger' | string;
+export type ToastPositions = 'fixedTop' | 'fixedBottom' | 'growlTopRight' | 'growlTopLeft' | 'growlBottomRight' | 'growlBottomLeft';
+
 export interface ToastOptions {
   title?: string;
   message?: string;
-  icon?: 'bell' | 'check' | 'info' | 'warning' | 'remove' | 'caution' | 'times' | 'coffee' | 'danger' | string;
-  theme?: 'default' | 'success' | 'info' | 'warning' | 'danger' | 'positive' | string;
+  icon?: ToastIcons;
+  theme?: ToastThemes;
   hideDelay?: number;
-  position?: 'fixedTop' | 'fixedBottom' | 'growlTopRight' | 'growlTopLeft' | 'growlBottomRight' | 'growlBottomLeft';
+  position?: ToastPositions;
   isCloseable?: boolean;
   customClass?: string;
 }


### PR DESCRIPTION
## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**