### PR TITLE
feat(data-table): modified how fixed header is applied to column headers

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.component.scss
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.scss
@@ -74,6 +74,12 @@ cdk-table {
   z-index: 1;
 }
 
+.novo-data-table-header-row.fixed-header,
+.novo-data-table-header-cell.fixed-header {
+  position: sticky;
+  top: 0;
+}
+
 .novo-data-table-row,
 .novo-data-table-header-row {
   display: flex;

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -114,6 +114,7 @@ import { StaticDataTableService } from './services/static-data-table.service';
               [class.empty]="column?.type === 'action' && !column?.label"
               [class.button-header-cell]="column?.type === 'expand' || (column?.type === 'action' && !column?.action?.options)"
               [class.dropdown-header-cell]="column?.type === 'action' && column?.action?.options"
+              [class.fixed-header]="fixedHeader"
             ></novo-data-table-header-cell>
             <novo-data-table-cell
               *cdkCellDef="let row"
@@ -128,6 +129,7 @@ import { StaticDataTableService } from './services/static-data-table.service';
           </ng-container>
           <novo-data-table-header-row
             *cdkHeaderRowDef="displayedColumns"
+            [fixedHeader]="fixedHeader"
             data-automation-id="novo-data-table-header-row"
           ></novo-data-table-header-row>
           <novo-data-table-row
@@ -697,13 +699,6 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
     let left: number = target.scrollLeft;
     if (left !== this.scrollLeft) {
       this.scrollLeft = target.scrollLeft;
-    }
-    if (this.fixedHeader) {
-      const top: number = target.scrollTop;
-      const header: any = target.querySelector('cdk-table > novo-data-table-header-row');
-      if (header) {
-        header.style.transform = `translateY(${top}px)`;
-      }
     }
     this.ref.markForCheck();
   }

--- a/projects/novo-elements/src/elements/data-table/rows/data-table-header-row.component.ts
+++ b/projects/novo-elements/src/elements/data-table/rows/data-table-header-row.component.ts
@@ -9,6 +9,9 @@ import { CdkHeaderRow, CDK_ROW_TEMPLATE } from '@angular/cdk/table';
 export class NovoDataTableHeaderRow extends CdkHeaderRow {
   @HostBinding('class')
   public rowClass = 'novo-data-table-header-row';
+  @HostBinding('class.fixed-header')
+  @Input()
+  public fixedHeader: boolean = false;
   @HostBinding('attr.role')
   public role = 'row';
 }


### PR DESCRIPTION
## **Description**

The column headers bounce when there are a large number of records within the data set (items per page = 500) that is being scrolled. The problem is related to it being triggered from the scroll bar scroll event. This changeset changes the approach to CSS instead of the listener.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**