### PR TITLE
Use novo label service instead of built in angular date pipe

### DIFF
--- a/projects/novo-elements/src/elements/table/extras/date-cell/DateCell.ts
+++ b/projects/novo-elements/src/elements/table/extras/date-cell/DateCell.ts
@@ -2,16 +2,24 @@
 import { Component, Input } from '@angular/core';
 // APP
 import { BaseRenderer } from '../base-renderer/BaseRenderer';
+import { NovoLabelService } from '../../../../services/novo-label-service';
 
 @Component({
   selector: 'date-cell',
   template: `
         <div class="date-cell">
-            <label>{{ value | date }}</label>
+            <label>{{ getFormattedDate() }}</label>
         </div>
     `,
 })
 export class DateCell extends BaseRenderer {
   @Input()
   value: any;
+  constructor(public labels: NovoLabelService) {
+    super();
+  }
+
+  public getFormattedDate(): string {
+    return this.labels.formatDate(this.value);
+  }
 }


### PR DESCRIPTION
## **Description**

Dates throughout the rest of the app use NovoLabelService to format dates. If an app is extending NovoLabelService to change how dates are displayed, it currently doesn't affect date cells in tables.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**