### PR TITLE
country name fix

### DIFF
--- a/projects/novo-elements/src/elements/form/extras/address/Address.spec.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.spec.ts
@@ -584,4 +584,12 @@ describe('Elements: NovoAddressElement', () => {
       });
     });
   });
+  describe('Method: get default country config', () => {
+    it('maps the countries global into a list of value/label objects', async () => {
+      const result = await component['getDefaultCountryConfig']()['options']();
+
+      expect(result.length > 0).toBe(true);
+      expect(result.every((country) => 'value' in country && 'label' in country && Object.keys(country).length === 2)).toBe(true);
+    });
+  });
 });

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -430,7 +430,7 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit {
           if (query) {
             countries = countries.filter((country) => new RegExp(`${query}`, 'gi').test(country.name));
           }
-          return resolve(countries.map(country => { return { value: country.id, label: country.name }}));
+          return resolve(countries.map((country) => ({ value: country.id, label: country.name })));
         });
       },
       getLabels: (countryID) => {

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -2,7 +2,7 @@
 import { Component, forwardRef, Input, OnInit, ChangeDetectionStrategy, EventEmitter, Output } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 // APP
-import { getCountries, getStates, findByCountryId } from '../../../../utils/countries/Countries';
+import { getCountries, getStates, findByCountryId, COUNTRIES } from '../../../../utils/countries/Countries';
 import { NovoLabelService } from '../../../../services/novo-label-service';
 import { Helpers } from '../../../../utils/Helpers';
 
@@ -78,7 +78,7 @@ export interface NovoAddressConfig {
                 class="required-indicator"
                 [ngClass]="{'bhi-circle': !valid.countryID, 'bhi-check': valid.countryID}">
             </i>
-            <novo-picker [config]="config?.countryID?.pickerConfig" [placeholder]="config.countryID.label" (changed)="onCountryChange($event)" autocomplete="shipping country" [(ngModel)]="model.countryName" [disablePickerInput]="disabled.countryID"></novo-picker>
+            <novo-picker [config]="config?.countryID?.pickerConfig" [placeholder]="config.countryID.label" (changed)="onCountryChange($event)" autocomplete="shipping country" [(ngModel)]="model.countryID" [disablePickerInput]="disabled.countryID"></novo-picker>
         </span>
     `,
 })
@@ -426,11 +426,11 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit {
       format: '$label',
       options: (query: string = '') => {
         return new Promise((resolve: any) => {
-          let countries: any = getCountries();
+          let countries: any = COUNTRIES;
           if (query) {
             countries = countries.filter((country) => new RegExp(`${query}`, 'gi').test(country.name));
           }
-          return resolve(countries);
+          return resolve(countries.map(country => { return { value: country.id, label: country.name }}));
         });
       },
       getLabels: (countryID) => {

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -38,49 +38,149 @@ export interface NovoAddressConfig {
   selector: 'novo-address',
   providers: [ADDRESS_VALUE_ACCESSOR],
   template: `
-        <span *ngIf="!config?.address1?.hidden" class="street-address" [class.invalid]="invalid.address1" [class.focus]="focused.address1" [class.disabled]="disabled.address1">
-            <i *ngIf="config.address1.required"
-                class="required-indicator address1"
-                [ngClass]="{'bhi-circle': !valid.address1, 'bhi-check': valid.address1}">
-            </i>
-            <input [class.maxlength-error]="invalidMaxlength.address1" type="text" id="address1" name="address1" [placeholder]="config.address1.label" [maxlength]="config?.address1?.maxlength" autocomplete="shipping street-address address-line-1" [(ngModel)]="model.address1" (ngModelChange)="updateControl()" (focus)="isFocused($event, 'address1')" (blur)="isBlurred($event, 'address1')" (input)="onInput($event, 'address1')"/>
-        </span>
-        <span *ngIf="!config?.address2?.hidden" class="apt suite" [class.invalid]="invalid.address2" [class.focus]="focused.address2" [class.disabled]="disabled.address2">
-            <i *ngIf="config.address2.required"
-                class="required-indicator address2"
-                [ngClass]="{'bhi-circle': !valid.address2, 'bhi-check': valid.address2}">
-            </i>
-            <input [class.maxlength-error]="invalidMaxlength.address2" type="text" id="address2" name="address2" [placeholder]="config.address2.label" [maxlength]="config?.address2?.maxlength" autocomplete="shipping address-line-2" [(ngModel)]="model.address2" (ngModelChange)="updateControl()" (focus)="isFocused($event, 'address2')" (blur)="isBlurred($event, 'address2')" (input)="onInput($event, 'address2')"/>
-        </span>
-        <span *ngIf="!config?.city?.hidden" class="city locality" [class.invalid]="invalid.city" [class.focus]="focused.city" [class.disabled]="disabled.city">
-            <i *ngIf="config.city.required"
-                class="required-indicator"
-                [ngClass]="{'bhi-circle': !valid.city, 'bhi-check': valid.city}">
-            </i>
-            <input [class.maxlength-error]="invalidMaxlength.city" type="text" id="city" name="city" [placeholder]="config.city.label" autocomplete="shipping city locality" [maxlength]="config?.city?.maxlength" [(ngModel)]="model.city" (ngModelChange)="updateControl()" (focus)="isFocused($event, 'city')" (blur)="isBlurred($event, 'city')" (input)="onInput($event, 'city')"/>
-        </span>
-        <span *ngIf="!config?.state?.hidden" class="state region" [class.invalid]="invalid.state" [class.focus]="focused.state" [class.disabled]="disabled.state"  [tooltip]="tooltip.state">
-            <i *ngIf="config.state.required"
-                class="required-indicator"
-                [ngClass]="{'bhi-circle': !valid.state, 'bhi-check': valid.state}">
-            </i>
-            <novo-picker [config]="config?.state?.pickerConfig" [placeholder]="config?.state?.label" (changed)="onStateChange($event)" autocomplete="shipping region" [(ngModel)]="model.state" [disablePickerInput]="disabled.state"></novo-picker>
-        </span>
-        <span *ngIf="!config?.zip?.hidden" class="zip postal-code" [class.invalid]="invalid.zip" [class.focus]="focused.zip" [class.disabled]="disabled.zip">
-            <i *ngIf="config.zip.required"
-                class="required-indicator"
-                [ngClass]="{'bhi-circle': !valid.zip, 'bhi-check': valid.zip}">
-            </i>
-            <input [class.maxlength-error]="invalidMaxlength.zip" type="text" id="zip" name="zip" [placeholder]="config.zip.label" autocomplete="shipping postal-code" [maxlength]="config?.zip?.maxlength" [(ngModel)]="model.zip" (ngModelChange)="updateControl()" (focus)="isFocused($event, 'zip')" (blur)="isBlurred($event, 'zip')" (input)="onInput($event, 'zip')" />
-        </span>
-        <span *ngIf="!config?.countryID?.hidden" class="country-name" [class.invalid]="invalid.countryID" [class.focus]="focused.countryID" [class.disabled]="disabled.countryID">
-            <i *ngIf="config.countryID.required"
-                class="required-indicator"
-                [ngClass]="{'bhi-circle': !valid.countryID, 'bhi-check': valid.countryID}">
-            </i>
-            <novo-picker [config]="config?.countryID?.pickerConfig" [placeholder]="config.countryID.label" (changed)="onCountryChange($event)" autocomplete="shipping country" [(ngModel)]="model.countryID" [disablePickerInput]="disabled.countryID"></novo-picker>
-        </span>
-    `,
+    <span
+      *ngIf="!config?.address1?.hidden"
+      class="street-address"
+      [class.invalid]="invalid.address1"
+      [class.focus]="focused.address1"
+      [class.disabled]="disabled.address1"
+    >
+      <i
+        *ngIf="config.address1.required"
+        class="required-indicator address1"
+        [ngClass]="{ 'bhi-circle': !valid.address1, 'bhi-check': valid.address1 }"
+      >
+      </i>
+      <input
+        [class.maxlength-error]="invalidMaxlength.address1"
+        type="text"
+        id="address1"
+        name="address1"
+        [placeholder]="config.address1.label"
+        [maxlength]="config?.address1?.maxlength"
+        autocomplete="shipping street-address address-line-1"
+        [(ngModel)]="model.address1"
+        (ngModelChange)="updateControl()"
+        (focus)="isFocused($event, 'address1')"
+        (blur)="isBlurred($event, 'address1')"
+        (input)="onInput($event, 'address1')"
+      />
+    </span>
+    <span
+      *ngIf="!config?.address2?.hidden"
+      class="apt suite"
+      [class.invalid]="invalid.address2"
+      [class.focus]="focused.address2"
+      [class.disabled]="disabled.address2"
+    >
+      <i
+        *ngIf="config.address2.required"
+        class="required-indicator address2"
+        [ngClass]="{ 'bhi-circle': !valid.address2, 'bhi-check': valid.address2 }"
+      >
+      </i>
+      <input
+        [class.maxlength-error]="invalidMaxlength.address2"
+        type="text"
+        id="address2"
+        name="address2"
+        [placeholder]="config.address2.label"
+        [maxlength]="config?.address2?.maxlength"
+        autocomplete="shipping address-line-2"
+        [(ngModel)]="model.address2"
+        (ngModelChange)="updateControl()"
+        (focus)="isFocused($event, 'address2')"
+        (blur)="isBlurred($event, 'address2')"
+        (input)="onInput($event, 'address2')"
+      />
+    </span>
+    <span
+      *ngIf="!config?.city?.hidden"
+      class="city locality"
+      [class.invalid]="invalid.city"
+      [class.focus]="focused.city"
+      [class.disabled]="disabled.city"
+    >
+      <i *ngIf="config.city.required" class="required-indicator" [ngClass]="{ 'bhi-circle': !valid.city, 'bhi-check': valid.city }"> </i>
+      <input
+        [class.maxlength-error]="invalidMaxlength.city"
+        type="text"
+        id="city"
+        name="city"
+        [placeholder]="config.city.label"
+        autocomplete="shipping city locality"
+        [maxlength]="config?.city?.maxlength"
+        [(ngModel)]="model.city"
+        (ngModelChange)="updateControl()"
+        (focus)="isFocused($event, 'city')"
+        (blur)="isBlurred($event, 'city')"
+        (input)="onInput($event, 'city')"
+      />
+    </span>
+    <span
+      *ngIf="!config?.state?.hidden"
+      class="state region"
+      [class.invalid]="invalid.state"
+      [class.focus]="focused.state"
+      [class.disabled]="disabled.state"
+      [tooltip]="tooltip.state"
+    >
+      <i *ngIf="config.state.required" class="required-indicator" [ngClass]="{ 'bhi-circle': !valid.state, 'bhi-check': valid.state }"> </i>
+      <novo-picker
+        [config]="config?.state?.pickerConfig"
+        [placeholder]="config?.state?.label"
+        (changed)="onStateChange($event)"
+        autocomplete="shipping region"
+        [(ngModel)]="model.state"
+        [disablePickerInput]="disabled.state"
+      ></novo-picker>
+    </span>
+    <span
+      *ngIf="!config?.zip?.hidden"
+      class="zip postal-code"
+      [class.invalid]="invalid.zip"
+      [class.focus]="focused.zip"
+      [class.disabled]="disabled.zip"
+    >
+      <i *ngIf="config.zip.required" class="required-indicator" [ngClass]="{ 'bhi-circle': !valid.zip, 'bhi-check': valid.zip }"> </i>
+      <input
+        [class.maxlength-error]="invalidMaxlength.zip"
+        type="text"
+        id="zip"
+        name="zip"
+        [placeholder]="config.zip.label"
+        autocomplete="shipping postal-code"
+        [maxlength]="config?.zip?.maxlength"
+        [(ngModel)]="model.zip"
+        (ngModelChange)="updateControl()"
+        (focus)="isFocused($event, 'zip')"
+        (blur)="isBlurred($event, 'zip')"
+        (input)="onInput($event, 'zip')"
+      />
+    </span>
+    <span
+      *ngIf="!config?.countryID?.hidden"
+      class="country-name"
+      [class.invalid]="invalid.countryID"
+      [class.focus]="focused.countryID"
+      [class.disabled]="disabled.countryID"
+    >
+      <i
+        *ngIf="config.countryID.required"
+        class="required-indicator"
+        [ngClass]="{ 'bhi-circle': !valid.countryID, 'bhi-check': valid.countryID }"
+      >
+      </i>
+      <novo-picker
+        [config]="config?.countryID?.pickerConfig"
+        [placeholder]="config.countryID.label"
+        (changed)="onCountryChange($event)"
+        autocomplete="shipping country"
+        [(ngModel)]="model.countryID"
+        [disablePickerInput]="disabled.countryID"
+      ></novo-picker>
+    </span>
+  `,
 })
 export class NovoAddressElement implements ControlValueAccessor, OnInit {
   @Input()
@@ -425,8 +525,8 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit {
       field: 'value',
       format: '$label',
       options: (query: string = '') => {
-        return new Promise((resolve: any) => {
-          let countries: any = COUNTRIES;
+        return new Promise((resolve) => {
+          let countries = COUNTRIES;
           if (query) {
             countries = countries.filter((country) => new RegExp(`${query}`, 'gi').test(country.name));
           }

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -474,11 +474,7 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit {
             if (promise.then) {
               promise.then((result: any) => {
                 loadingCountries = false;
-                if (typeof result === 'string') {
-                  countryName = result;
-                } else {
-                  countryName = Helpers.interpolateWithFallback(this.config.countryID.pickerConfig.format, result);
-                }
+                countryName = Helpers.interpolateWithFallback(this.config.countryID.pickerConfig.format, result);
                 this.model = Object.assign(model, { countryName });
                 this.updateStates();
               });
@@ -540,7 +536,7 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit {
         return new Promise((resolve: any) => {
           let country: any = findByCountryId(countryID);
           if (country) {
-            resolve(country.name);
+            resolve({ value: country.id, label: country.name });
           } else {
             resolve('');
           }

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -2,7 +2,7 @@
 import { Component, forwardRef, Input, OnInit, ChangeDetectionStrategy, EventEmitter, Output } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 // APP
-import { getCountries, getStates, findByCountryId, COUNTRIES } from '../../../../utils/countries/Countries';
+import { getStates, findByCountryId, COUNTRIES } from '../../../../utils/countries/Countries';
 import { NovoLabelService } from '../../../../services/novo-label-service';
 import { Helpers } from '../../../../utils/Helpers';
 
@@ -176,7 +176,7 @@ export interface NovoAddressConfig {
         [placeholder]="config.countryID.label"
         (changed)="onCountryChange($event)"
         autocomplete="shipping country"
-        [(ngModel)]="model.countryID"
+        [(ngModel)]="model.countryName"
         [disablePickerInput]="disabled.countryID"
       ></novo-picker>
     </span>
@@ -200,7 +200,6 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit {
     return this._readOnly;
   }
   states: Array<any> = [];
-  countries: Array<any> = getCountries();
   fieldList: Array<string> = ['address1', 'address2', 'city', 'state', 'zip', 'countryID'];
   model: any;
   onModelChange: Function = () => {};
@@ -475,7 +474,11 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit {
             if (promise.then) {
               promise.then((result: any) => {
                 loadingCountries = false;
-                countryName = Helpers.interpolateWithFallback(this.config.countryID.pickerConfig.format, result);
+                if (typeof result === 'string') {
+                  countryName = result;
+                } else {
+                  countryName = Helpers.interpolateWithFallback(this.config.countryID.pickerConfig.format, result);
+                }
                 this.model = Object.assign(model, { countryName });
                 this.updateStates();
               });

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -176,7 +176,7 @@ export interface NovoAddressConfig {
         [placeholder]="config.countryID.label"
         (changed)="onCountryChange($event)"
         autocomplete="shipping country"
-        [(ngModel)]="model.countryName"
+        [(ngModel)]="model.countryID"
         [disablePickerInput]="disabled.countryID"
       ></novo-picker>
     </span>

--- a/projects/novo-examples/src/form-controls/form/address-control/address-control-example.ts
+++ b/projects/novo-examples/src/form-controls/form/address-control/address-control-example.ts
@@ -82,9 +82,10 @@ export class AddressControlExample {
       value: {
         address1: '321 Summer Street',
         address2: '11 Washington Street',
+        city: 'Chicago',
+        state: 'California',
+        zip: 95133,
         countryID: 1,
-        countryName: 'United States',
-        countryCode: 'US',
       },
     });
     this.secondaryAddressControl = new AddressControl({

--- a/projects/novo-examples/src/form-controls/form/address-control/address-control-example.ts
+++ b/projects/novo-examples/src/form-controls/form/address-control/address-control-example.ts
@@ -124,7 +124,14 @@ export class AddressControlExample {
               return Promise.resolve(this.getCountryOptions(query));
             },
             getLabels: (value: number) => {
-              return Promise.resolve(findByCountryId(value));
+              return new Promise((resolve: any) => {
+                let country: any = findByCountryId(value);
+                if (country) {
+                  resolve({ value: country.id, label: country.name });
+                } else {
+                  resolve('');
+                }
+              });
             },
           },
         },
@@ -138,7 +145,7 @@ export class AddressControlExample {
       value: {
         address1: '123 Summer Street',
         address2: '10 Washington Street and stuff',
-        countryID: 1,
+        countryID: 2359,
       },
     });
     this.addressFormControls = [this.addressControl, this.secondaryAddressControl];


### PR DESCRIPTION
## **Description**
Fixed the countryID to not be set to the countryName in default config
Fixes issue: #988

Duplicate of https://github.com/bullhorn/novo-elements/pull/1010. Rebase caused a lot of false file changes, so cherry-picked changes over on to new feature branch.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation` - BBO doesn't use NE address component

##### **Screenshots**