### PR TITLE
feat(Picker): Enabling custom optionsPromise to use infinite scroll

### DIFF
--- a/projects/novo-elements/src/elements/form/FieldInteractionApi.spec.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApi.spec.ts
@@ -50,18 +50,18 @@ describe('FieldInteractionApi', () => {
     it('adds properties to a picker config without deleting any', () => {
       service.form.controls.doughnuts.config = { oldProperty: 'old!' };
 
-      service.addPropertiesToPickerConfig('doughnuts', {newProperty: 'new!'});
+      service.addPropertiesToPickerConfig('doughnuts', { newProperty: 'new!' });
 
       expect(setProperty).toBeCalledWith('doughnuts', 'config', { newProperty: 'new!', oldProperty: 'old!' });
-      expect(triggerEvent).toBeCalledWith({controlKey: 'doughnuts', prop: 'pickerConfig', value: {newProperty: 'new!'} });
+      expect(triggerEvent).toBeCalledWith({ controlKey: 'doughnuts', prop: 'pickerConfig', value: { newProperty: 'new!' } });
     });
     it('overrides pre-existing properties', () => {
-      service.form.controls.doughnuts.config = { oldProperty: 'old!'};
+      service.form.controls.doughnuts.config = { oldProperty: 'old!' };
 
-      service.addPropertiesToPickerConfig('doughnuts', {oldProperty: 'new!'});
+      service.addPropertiesToPickerConfig('doughnuts', { oldProperty: 'new!' });
 
-      expect(setProperty).toBeCalledWith('doughnuts', 'config', {oldProperty: 'new!'});
-      expect(triggerEvent).toBeCalledWith({controlKey: 'doughnuts', prop: 'pickerConfig', value: {oldProperty: 'new!'} });
+      expect(setProperty).toBeCalledWith('doughnuts', 'config', { oldProperty: 'new!' });
+      expect(triggerEvent).toBeCalledWith({ controlKey: 'doughnuts', prop: 'pickerConfig', value: { oldProperty: 'new!' } });
     });
     it('does not allow picker modifications if restrictFieldInteractions is true for that control', () => {
       service.form = { controls: { doughnuts: { restrictFieldInteractions: true } } };
@@ -96,11 +96,13 @@ describe('FieldInteractionApi', () => {
         optionsUrl: 'fake/url',
       };
       const spy = spyOn(args, 'optionsPromise').and.returnValue(Promise.resolve([]));
+      const query = 'Novo Elem';
+      const page = 9;
 
       const result = service.getOptionsConfig(args) as { options: OptionsFunction };
-      await result.options('asdf');
+      await result.options(query, page);
 
-      expect(spy).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledWith(query, jasmine.any(Object), page);
       done();
     });
     it('uses the optionsURLBuilder if included and not optionsUrl', async (done) => {

--- a/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
@@ -597,7 +597,7 @@ export class FieldInteractionApi {
     filteredOptionsCreator?: (where?: string) => ((query: string, page?: number) => Promise<unknown[]>),
   ): ((query: string) => Promise<unknown[]>) => (query: string, page?: number) => {
     if ('optionsPromise' in config && config.optionsPromise) {
-      return config.optionsPromise(query, new CustomHttpImpl(this.http));
+      return config.optionsPromise(query, new CustomHttpImpl(this.http), page);
     } else if (('optionsUrlBuilder' in config && config.optionsUrlBuilder) || ('optionsUrl' in config && config.optionsUrl)) {
       return new Promise((resolve, reject) => {
         const url = 'optionsUrlBuilder' in config ? config.optionsUrlBuilder(query) : `${config.optionsUrl}?filter=${query || ''}`;

--- a/projects/novo-elements/src/elements/form/FieldInteractionApiTypes.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApiTypes.ts
@@ -3,7 +3,7 @@ type OptionsFunctionConfig = {
   format?: string;
 } & (
   | { where: string; emptyPickerMessage?: string }
-  | { optionsPromise: (query: string, http: CustomHttp, page: number) => Promise<unknown[]> }
+  | { optionsPromise: (query: string, http: CustomHttp, page?: number) => Promise<unknown[]> }
   | { optionsUrl: string }
   | { optionsUrlBuilder: (query: string) => string });
 
@@ -13,7 +13,7 @@ export type ModifyPickerConfigArgs =
     }
   | OptionsFunctionConfig;
 
-export type OptionsFunction = (query: string) => Promise<unknown[]>;
+export type OptionsFunction = (query: string, page?: number) => Promise<unknown[]>;
 
 export interface CustomHttp<T = any> {
   url: string;

--- a/projects/novo-elements/src/elements/form/FieldInteractionApiTypes.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApiTypes.ts
@@ -3,7 +3,7 @@ type OptionsFunctionConfig = {
   format?: string;
 } & (
   | { where: string; emptyPickerMessage?: string }
-  | { optionsPromise: (query: string, http: CustomHttp) => Promise<unknown[]> }
+  | { optionsPromise: (query: string, http: CustomHttp, page: number) => Promise<unknown[]> }
   | { optionsUrl: string }
   | { optionsUrlBuilder: (query: string) => string });
 


### PR DESCRIPTION
## **Description**

Adding a page parameter to the existing optionsPromise field interaction for custom picker options in order to enable optionsPromise to implement paging when constructing a third party service for options generation.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`
