### PR TITLE
BH-64754: Add for new novo version

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.pipes.spec.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.pipes.spec.ts
@@ -1,7 +1,5 @@
 // APP
-import {DateTableDateTimeRendererPipe} from "./data-table.pipes";
-import {async, inject, TestBed} from "@angular/core/testing";
-import {IDataTableColumn, NovoLabelService} from "../..";
+import {DateTableDateTimeRendererPipe} from './data-table.pipes';
 
 class MockNovoLabelService {
   formatDateShort(val) {}

--- a/projects/novo-elements/src/elements/data-table/data-table.pipes.spec.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.pipes.spec.ts
@@ -1,0 +1,49 @@
+// APP
+import {DateTableDateTimeRendererPipe} from "./data-table.pipes";
+import {async, inject, TestBed} from "@angular/core/testing";
+import {IDataTableColumn, NovoLabelService} from "../..";
+
+class MockNovoLabelService {
+  formatDateShort(val) {}
+}
+
+describe('Pipe: DateTableDateTimeRendererPipe', () => {
+  let labels;
+  let pipe;
+
+  beforeEach(() => {
+    labels = new MockNovoLabelService();
+    pipe = new DateTableDateTimeRendererPipe(labels);
+  });
+
+  describe('When rendering strings', () => {
+    it('should make a call to the novo-label service if the value is not null', () => {
+      // Arrange
+      spyOn(pipe.labels, 'formatDateShort')
+      const testVal = 1234567890;
+      const testColumn = {
+        label: 'Test',
+        id: 'test',
+        type: 'datetime',
+      };
+      // Act
+      pipe.transform(testVal, testColumn);
+      // Assert
+      expect(pipe.labels.formatDateShort).toHaveBeenCalled();
+    });
+    it('should return an empty string if the value is null', () => {
+      // Arrange
+      spyOn(pipe.labels, 'formatDateShort')
+      const testVal = null;
+      const testColumn = {
+        label: 'Test',
+        id: 'test',
+        type: 'datetime',
+      };
+      // Act
+      const testString = pipe.transform(testVal, testColumn);
+      // Assert
+      expect(testString).toEqual('');
+    });
+  });
+});

--- a/projects/novo-elements/src/elements/data-table/data-table.pipes.spec.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.pipes.spec.ts
@@ -17,7 +17,7 @@ describe('Pipe: DateTableDateTimeRendererPipe', () => {
   describe('When rendering strings', () => {
     it('should make a call to the novo-label service if the value is not null', () => {
       // Arrange
-      spyOn(pipe.labels, 'formatDateShort')
+      spyOn(pipe.labels, 'formatDateShort');
       const testVal = 1234567890;
       const testColumn = {
         label: 'Test',
@@ -31,7 +31,7 @@ describe('Pipe: DateTableDateTimeRendererPipe', () => {
     });
     it('should return an empty string if the value is null', () => {
       // Arrange
-      spyOn(pipe.labels, 'formatDateShort')
+      spyOn(pipe.labels, 'formatDateShort');
       const testVal = null;
       const testColumn = {
         label: 'Test',

--- a/projects/novo-elements/src/elements/data-table/data-table.pipes.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.pipes.ts
@@ -46,7 +46,8 @@ export class DateTableDateTimeRendererPipe<T> implements PipeTransform {
   constructor(private labels: NovoLabelService) {}
   transform(value: any, column: IDataTableColumn<T>): string {
     if (!Helpers.isEmpty(value)) {
-      return column.format ? value : this.labels.formatDate(interpolateCell<T>(value, column));
+      let val = interpolateCell<T>(value, column);
+      return this.labels.formatDateShort(val);
     }
     return '';
   }


### PR DESCRIPTION
## **Description**

This will make sure the hotfix applied in 3.16.1 will also publish to the new version of novo in the 3.17.0 release.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`