### PR TITLE
allow controls to be forced hidden

### DIFF
--- a/projects/novo-elements/src/elements/form/DynamicForm.ts
+++ b/projects/novo-elements/src/elements/form/DynamicForm.ts
@@ -137,7 +137,9 @@ export class NovoDynamicFormElement implements OnChanges, OnInit, AfterContentIn
     if (this.allFieldsNotRequired && this.hideNonRequiredFields) {
       this.fieldsets.forEach((fieldset) => {
         fieldset.controls.forEach((control) => {
-          this.form.controls[control.key].hidden = false;
+          if (!control.forceHide) {
+            this.form.controls[control.key].hidden = false;
+          }
         });
       });
     }
@@ -156,7 +158,7 @@ export class NovoDynamicFormElement implements OnChanges, OnInit, AfterContentIn
     this.form.fieldsets.forEach((fieldset) => {
       fieldset.controls.forEach((control) => {
         const ctl = this.form.controls[control.key];
-        if (!this.fieldsAlreadyHidden.includes(control.key)) {
+        if (!this.fieldsAlreadyHidden.includes(control.key) && !ctl.forceHide) {
           ctl.hidden = false;
         }
       });
@@ -190,7 +192,7 @@ export class NovoDynamicFormElement implements OnChanges, OnInit, AfterContentIn
         }
 
         // Don't hide fields with errors
-        if (ctl.errors) {
+        if (ctl.errors && !ctl.forceHide) {
           ctl.hidden = false;
         }
       });

--- a/projects/novo-elements/src/elements/form/NovoFormControl.ts
+++ b/projects/novo-elements/src/elements/form/NovoFormControl.ts
@@ -9,6 +9,7 @@ import { IMaskOptions } from './Control';
 export class NovoFormControl extends FormControl {
   displayValueChanges: EventEmitter<any> = new EventEmitter<any>();
   hidden: boolean;
+  forceHide: boolean = false;
   encrypted: boolean;
   key: string;
   required: boolean;
@@ -73,6 +74,7 @@ export class NovoFormControl extends FormControl {
     this.label = control.label;
     this.readOnly = control.readOnly;
     this.hidden = control.hidden;
+    this.forceHide = control.forceHide;
     this.encrypted = control.encrypted;
     this.config = control.config;
     this.type = control.type;

--- a/projects/novo-elements/src/elements/form/controls/BaseControl.ts
+++ b/projects/novo-elements/src/elements/form/controls/BaseControl.ts
@@ -40,6 +40,7 @@ class ControlConfig {
   forceClear: EventEmitter<any>;
   headerConfig: any;
   hidden: boolean;
+  forceHide: boolean;
   interactions: Array<Object>;
   isEmpty?: Function;
   key: string;
@@ -113,6 +114,7 @@ export class BaseControl extends ControlConfig {
     this.name = config.name || '';
     this.required = !!config.required;
     this.hidden = !!config.hidden;
+    this.forceHide = !!config.forceHide;
     this.encrypted = !!config.encrypted;
     this.sortOrder = config.sortOrder === undefined ? 1 : config.sortOrder;
     this.controlType = config.controlType || '';

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -232,6 +232,7 @@ export class FormUtils {
       placeholder: field.hint || '',
       required: field.required || field.systemRequired,
       hidden: !field.required,
+      forceHide: !!field.forceHide,
       encrypted: this.isFieldEncrypted(field.name ? field.name.toString() : ''),
       value: field.value || field.defaultValue,
       sortOrder: field.sortOrder,

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -716,14 +716,18 @@ export class FormUtils {
 
   forceShowAllControls(controls: Array<NovoControlConfig>) {
     controls.forEach((control) => {
-      control.hidden = false;
+      if (!control.forceHide) {
+        control.hidden = false;
+      }
     });
   }
 
   forceShowAllControlsInFieldsets(fieldsets: Array<NovoFieldset>) {
     fieldsets.forEach((fieldset) => {
       fieldset.controls.forEach((control) => {
-        control.hidden = false;
+        if (!control.forceHide) {
+          control.hidden = false;
+        }
       });
     });
   }


### PR DESCRIPTION
## **Description**

Allowing Certain Controls to be forcibly hidden from the form

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**