### PR TITLE
Fix data table sticky filter empty state bug

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.source.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.source.ts
@@ -49,6 +49,8 @@ export class DataTableSource<T> extends DataSource<T> {
           this.total = data.total;
           this.totalSet = true;
           this.state.isForceRefresh = false;
+        } else if (data.total > this.total) {
+          this.total = data.total;
         }
         this.currentTotal = data.total;
         this.current = data.results.length;


### PR DESCRIPTION
## **Description**

Given that a user 1) filters a novo-data-table that has sticky filters so that there are no results, 2) navigates away, and 3) returns (so that the filter with empty results is applied on load)

When the user clears the filter so that non-empty data is returned

Then the table reloads with the expected results.

Previous undesired behavior: the table loads with an empty state message.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**