### PR TITLE
fix examples import

### DIFF
--- a/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-basic/tabbed-group-picker-basic-example.ts
+++ b/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-basic/tabbed-group-picker-basic-example.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { TabbedGroupPickerTab, ChildTab } from 'dist/novo-elements/elements/tabbed-group-picker/TabbedGroupPicker';
+import { TabbedGroupPickerTab, ChildTab } from 'novo-elements';
 
 /**
  * @title Tabbed Group Picker - Basic Example

--- a/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-big-groups-example/tabbed-group-picker-big-groups-example.ts
+++ b/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-big-groups-example/tabbed-group-picker-big-groups-example.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { TabbedGroupPickerTab, ChildTab, ParentTab } from 'dist/novo-elements/elements/tabbed-group-picker/TabbedGroupPicker';
+import { TabbedGroupPickerTab, ChildTab, ParentTab } from 'novo-elements';
 
 /**
  * @title Tabbed Group Picker - Big Groups Example

--- a/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-groups-example/tabbed-group-picker-groups-example.ts
+++ b/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-groups-example/tabbed-group-picker-groups-example.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { TabbedGroupPickerTab, ChildTab, ParentTab } from 'dist/novo-elements/elements/tabbed-group-picker/TabbedGroupPicker';
+import { TabbedGroupPickerTab, ChildTab, ParentTab } from 'novo-elements';
 
 /**
  * @title Tabbed Group Picker - Groups Example

--- a/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-quick-select-example/tabbed-group-picker-quick-select-example.ts
+++ b/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-quick-select-example/tabbed-group-picker-quick-select-example.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { TabbedGroupPickerTab, ChildTab } from 'dist/novo-elements/elements/tabbed-group-picker/TabbedGroupPicker';
+import { TabbedGroupPickerTab, ChildTab } from 'novo-elements';
 
 /**
  * @title Tabbed Group Picker - Quick Select Example


### PR DESCRIPTION
## **Description**

novo-examples should refer to novo-elements using tsconfig>paths and not using 'dist/novo-elements' directly.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**