### PR TITLE
Epic embedded co

### DIFF
--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -661,7 +661,7 @@ export class FormUtils {
     if (field.name && field.name.startsWith('customObject') && field.associatedEntity && field.associatedEntity.label) {
       fieldsets.push({
         title: field.associatedEntity.label || field.label,
-        icon: field.icon || 'bh-card-expand',
+        icon: field.icon || 'bhi-card-expand',
         controls: [],
         isEmbedded: field.dataSpecialization && field.dataSpecialization.toLowerCase() === 'embedded',
         isInlineEmbedded: field.dataSpecialization && field.dataSpecialization.toLowerCase() === 'inline_embedded',

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -536,6 +536,8 @@ export class FormUtils {
               let control = this.createControl(embeddedField, data, http, config, overrides, currencyFormat);
               control = this.markControlAsEmbedded(control, field.dataSpecialization ? field.dataSpecialization.toLowerCase() : null);
               fieldsets[fieldsets.length - 1].controls.push(control);
+            } else if (this.isHeader(embeddedField)) {
+              this.insertHeaderToFieldsets(fieldsets, embeddedField);
             }
           });
         } else if (this.shouldCreateControl(field)) {
@@ -648,7 +650,11 @@ export class FormUtils {
   }
 
   private isHeader(field): boolean {
-    return !Helpers.isBlank(field) && field.hasOwnProperty('isSectionHeader') && field.isSectionHeader;
+    return (
+      !Helpers.isBlank(field) &&
+      ((field.hasOwnProperty('isSectionHeader') && field.isSectionHeader) ||
+        (field.dataSpecialization && field.dataSpecialization.toLowerCase() === 'section_header'))
+    );
   }
 
   private insertHeaderToFieldsets(fieldsets, field) {

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -658,23 +658,23 @@ export class FormUtils {
   }
 
   private insertHeaderToFieldsets(fieldsets, field) {
+    const constantProperties = {
+      controls: [],
+      isEmbedded: field.dataSpecialization && field.dataSpecialization.toLowerCase() === 'embedded',
+      isInlineEmbedded: field.dataSpecialization && field.dataSpecialization.toLowerCase() === 'inline_embedded',
+      key: field.name,
+    };
     if (field.name && field.name.startsWith('customObject') && field.associatedEntity && field.associatedEntity.label) {
       fieldsets.push({
         title: field.associatedEntity.label || field.label,
         icon: field.icon || 'bhi-card-expand',
-        controls: [],
-        isEmbedded: field.dataSpecialization && field.dataSpecialization.toLowerCase() === 'embedded',
-        isInlineEmbedded: field.dataSpecialization && field.dataSpecialization.toLowerCase() === 'inline_embedded',
-        key: field.name,
+        ...constantProperties,
       });
     } else {
       fieldsets.push({
         title: field.label,
         icon: field.icon || 'bhi-section',
-        controls: [],
-        isEmbedded: field.dataSpecialization && field.dataSpecialization.toLowerCase() === 'embedded',
-        isInlineEmbedded: field.dataSpecialization && field.dataSpecialization.toLowerCase() === 'inline_embedded',
-        key: field.name,
+        ...constantProperties,
       });
     }
   }

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -463,7 +463,7 @@ export class FormUtils {
 
     return (
       field.name !== 'id' &&
-      (['SYSTEM', 'SECTION_HEADER'].includes(field.dataSpecialization) ||
+      (!['SYSTEM', 'SECTION_HEADER'].includes(field.dataSpecialization) ||
         ['address', 'billingAddress', 'secondaryAddress'].includes(field.name)) &&
       !field.readOnly
     );

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -651,6 +651,15 @@ export class FormUtils {
   }
 
   private insertHeaderToFieldsets(fieldsets, field) {
+    if (field.name && field.name.startsWith('customObject') && field.associatedEntity) {
+      fieldsets.push({
+        title: field.associatedEntity.label || field.label,
+        icon: field.icon || 'bhi-section',
+        controls: [],
+        isEmbedded: field.dataSpecialization && field.dataSpecialization.toLowerCase() === 'embedded',
+        isInlineEmbedded: field.dataSpecialization && field.dataSpecialization.toLowerCase() === 'inline_embedded',
+      });
+    }
     fieldsets.push({
       title: field.label,
       icon: field.icon || 'bhi-section',

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -652,18 +652,25 @@ export class FormUtils {
   }
 
   private insertHeaderToFieldsets(fieldsets, field) {
-    const title =
-      field.name && field.name.startsWith('customObject') && field.associatedEntity && field.associatedEntity.label
-        ? field.associatedEntity.label
-        : field.label;
-    fieldsets.push({
-      title: title,
-      icon: field.icon || 'bhi-section',
-      controls: [],
-      isEmbedded: field.dataSpecialization && field.dataSpecialization.toLowerCase() === 'embedded',
-      isInlineEmbedded: field.dataSpecialization && field.dataSpecialization.toLowerCase() === 'inline_embedded',
-      key: field.name,
-    });
+    if (field.name && field.name.startsWith('customObject') && field.associatedEntity && field.associatedEntity.label) {
+      fieldsets.push({
+        title: field.associatedEntity.label || field.label,
+        icon: field.icon || 'bh-card-expand',
+        controls: [],
+        isEmbedded: field.dataSpecialization && field.dataSpecialization.toLowerCase() === 'embedded',
+        isInlineEmbedded: field.dataSpecialization && field.dataSpecialization.toLowerCase() === 'inline_embedded',
+        key: field.name,
+      });
+    } else {
+      fieldsets.push({
+        title: field.label,
+        icon: field.icon || 'bhi-section',
+        controls: [],
+        isEmbedded: field.dataSpecialization && field.dataSpecialization.toLowerCase() === 'embedded',
+        isInlineEmbedded: field.dataSpecialization && field.dataSpecialization.toLowerCase() === 'inline_embedded',
+        key: field.name,
+      });
+    }
   }
 
   private markControlAsEmbedded(control, dataSpecialization?: 'embedded' | 'inline_embedded') {

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -463,7 +463,8 @@ export class FormUtils {
 
     return (
       field.name !== 'id' &&
-      (field.dataSpecialization !== 'SYSTEM' || ['address', 'billingAddress', 'secondaryAddress'].indexOf(field.name) !== -1) &&
+      (['SYSTEM', 'SECTION_HEADER'].indexOf(field.dataSpecialization) === -1 ||
+        ['address', 'billingAddress', 'secondaryAddress'].indexOf(field.name) !== -1) &&
       !field.readOnly
     );
   }

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -652,17 +652,12 @@ export class FormUtils {
   }
 
   private insertHeaderToFieldsets(fieldsets, field) {
-    if (field.name && field.name.startsWith('customObject') && field.associatedEntity) {
-      fieldsets.push({
-        title: field.associatedEntity.label || field.label,
-        icon: field.icon || 'bhi-section',
-        controls: [],
-        isEmbedded: field.dataSpecialization && field.dataSpecialization.toLowerCase() === 'embedded',
-        isInlineEmbedded: field.dataSpecialization && field.dataSpecialization.toLowerCase() === 'inline_embedded',
-      });
-    }
+    const title =
+      field.name && field.name.startsWith('customObject') && field.associatedEntity && field.associatedEntity.label
+        ? field.associatedEntity.label
+        : field.label;
     fieldsets.push({
-      title: field.label,
+      title: title,
       icon: field.icon || 'bhi-section',
       controls: [],
       isEmbedded: field.dataSpecialization && field.dataSpecialization.toLowerCase() === 'embedded',

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -463,8 +463,8 @@ export class FormUtils {
 
     return (
       field.name !== 'id' &&
-      (['SYSTEM', 'SECTION_HEADER'].indexOf(field.dataSpecialization) === -1 ||
-        ['address', 'billingAddress', 'secondaryAddress'].indexOf(field.name) !== -1) &&
+      (['SYSTEM', 'SECTION_HEADER'].includes(field.dataSpecialization) ||
+        ['address', 'billingAddress', 'secondaryAddress'].includes(field.name)) &&
       !field.readOnly
     );
   }


### PR DESCRIPTION
## **Description**

This PR consists of a few small changes for making embedded custom objects work. These are specifically concerning section headers. With things as they were initially, section headers were rendering as editable text fields and with a generic label rather than the label they actually have configured. This corrects these problems coming through from the meta for embedded custom objects

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**