### PR TITLE
fix(Editor): Fix the creation logic of CKEditor element within dynamic forms

### DIFF
--- a/projects/novo-elements/src/elements/ckeditor/CKEditor.spec.ts
+++ b/projects/novo-elements/src/elements/ckeditor/CKEditor.spec.ts
@@ -43,11 +43,11 @@ describe('Elements: NovoCKEditorElement', () => {
       expect(component.ckeditorInit).toHaveBeenCalledWith({ test: true });
     });
 
-    it('should set with passed config', () => {
-      jest.spyOn(component, 'getBaseConfig').mockReturnValue({ test: false });
-      component.config = { test: true };
+    it('should use the passed in config to overwrite and add to base config', () => {
+      jest.spyOn(component, 'getBaseConfig').mockReturnValue({ base: true, default: false });
+      component.config = { default: true, another: true };
       component.ngAfterViewInit();
-      expect(component.ckeditorInit).toHaveBeenCalledWith({ test: true });
+      expect(component.ckeditorInit).toHaveBeenCalledWith({ base: true, default: true, another: true });
     });
   });
 

--- a/projects/novo-elements/src/elements/ckeditor/CKEditor.ts
+++ b/projects/novo-elements/src/elements/ckeditor/CKEditor.ts
@@ -86,7 +86,7 @@ export class NovoCKEditorElement implements OnDestroy, AfterViewInit, ControlVal
   }
 
   ngAfterViewInit() {
-    let config = this.config || this.getBaseConfig();
+    let config = Object.assign(this.getBaseConfig(), this.config);
     if (this.startupFocus) {
       config.startupFocus = true;
     }
@@ -155,7 +155,7 @@ export class NovoCKEditorElement implements OnDestroy, AfterViewInit, ControlVal
     });
   }
 
-  getBaseConfig() {
+  getBaseConfig(): { [key: string]: any } {
     const baseConfig = {
       enterMode: CKEDITOR.ENTER_BR,
       shiftEnterMode: CKEDITOR.ENTER_P,

--- a/projects/novo-elements/src/elements/form/NovoFormControl.ts
+++ b/projects/novo-elements/src/elements/form/NovoFormControl.ts
@@ -28,6 +28,7 @@ export class NovoFormControl extends FormControl {
   sortOrder: number;
   controlType: string;
   placeholder: string;
+  minimal: boolean;
   multiple: boolean;
   headerConfig: any;
   optionsType: string;
@@ -91,6 +92,7 @@ export class NovoFormControl extends FormControl {
     this.sortOrder = control.sortOrder;
     this.controlType = control.controlType;
     this.placeholder = control.placeholder;
+    this.minimal = control.minimal;
     this.multiple = control.multiple;
     this.headerConfig = control.headerConfig;
     this.optionsType = control.optionsType;

--- a/projects/novo-elements/src/elements/form/controls/BaseControl.ts
+++ b/projects/novo-elements/src/elements/form/controls/BaseControl.ts
@@ -48,6 +48,7 @@ class ControlConfig {
   maxlength: number;
   metaType: string;
   military?: boolean;
+  minimal?: boolean;
   minlength: number;
   multiple: boolean;
   name: string;


### PR DESCRIPTION
## **Description**

There is an existing bug with the CKEditor initialization within dynamic forms where the creation logic does not properly instantiate the editor component. 

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**

CURRENT DYNAMIC FORM DEMO (Broken)

![Screen Shot 2020-01-30 at 9 58 54 AM](https://user-images.githubusercontent.com/3843503/73468147-f3ca0c80-4349-11ea-96b3-2a2abb3f803c.png)


DYNAMIC FORM DEMO AFTER (Fixed)

![Screen Shot 2020-01-30 at 9 57 26 AM](https://user-images.githubusercontent.com/3843503/73468175-fb89b100-4349-11ea-8a7c-d6bbf6177a04.png)
