### PR TITLE
feat(FormGroup): allow overrides for enableAllControls

### DIFF
--- a/projects/novo-elements/src/elements/form/NovoFormGroup.spec.ts
+++ b/projects/novo-elements/src/elements/form/NovoFormGroup.spec.ts
@@ -21,6 +21,19 @@ describe('Elements: NovoFormGroup', () => {
         expect((component.controls[key] as NovoFormControl).enable).toHaveBeenCalled();
       }
     });
+    it('should enable all controls unless included in overrides', () => {
+      component.controls = {
+        firstName: new NovoFormControl('John', {}),
+        lastName: new NovoFormControl('Doe', { readOnly: true }),
+      };
+      spyOn(component.controls.lastName, 'enable');
+      (component.controls.lastName as NovoFormControl).readOnly = true;
+      const overrides: string[] = ['lastName'];
+
+      component.enableAllControls(overrides);
+      expect((component.controls.lastName as NovoFormControl).readOnly).toEqual(true);
+      expect(component.controls.lastName.enable).not.toHaveBeenCalled();
+    });
   });
 
   describe('Method: disableAllControls()', () => {

--- a/projects/novo-elements/src/elements/form/NovoFormGroup.ts
+++ b/projects/novo-elements/src/elements/form/NovoFormGroup.ts
@@ -22,9 +22,9 @@ export class NovoFormGroup extends FormGroup {
     this._value = v;
   }
 
-  public enableAllControls(): void {
+  public enableAllControls(overrides?: string[]): void {
     for (let key in this.controls) {
-      if ((this.controls[key] as NovoFormControl).readOnly) {
+      if ((this.controls[key] as NovoFormControl).readOnly && (!overrides || (overrides && !overrides.includes(key)))) {
         (this.controls[key] as NovoFormControl).readOnly = false;
         this.controls[key].enable();
       }


### PR DESCRIPTION
## **Description**

Allow ability to pass overrides to enable all controls if you don't want certain controls enabled.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**