### PR TITLE
build (compiler) demo website with sourcemaps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
   - npm run lint
   - npm test
   - npm run build
+  - npm run postbuild
   - npm run build:demo
 
 after_success:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "downlevelIteration": true,
-    // "incremental": true,
     "sourceMap": true,
     "declaration": false,
     "module": "esnext",
@@ -12,16 +11,26 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "target": "es2015",
-    "typeRoots": ["node_modules/@types"],
-    "types": ["jest"],
-    "lib": ["es2017", "dom"],
+    "typeRoots": [
+      "node_modules/@types"
+    ],
+    "types": [
+      "jest"
+    ],
+    "lib": [
+      "es2017",
+      "dom"
+    ],
     "paths": {
-      "novo-elements": ["dist/novo-elements"],
-      "novo-examples": ["dist/novo-examples"],
-      "chomsky": ["dist/chomsky"]
-      // "novo-elements": ["projects/novo-elements/src/index"],
-      // "novo-examples": ["projects/novo-examples/src/index"],
-      // "chomsky": ["projects/chomsky/src/index"],
+      "novo-elements": [
+        "projects/novo-elements/src/index"
+      ],
+      "novo-examples": [
+        "projects/novo-examples/src/index"
+      ],
+      "chomsky": [
+        "projects/chomsky/src/index"
+      ],
       // "@angular/cdk/*": ["../components/src/cdk/*"],
     }
   }


### PR DESCRIPTION
## **Description**

Configure the novo-elements demo website to have the typescript source and not the compiled javascript code.

It would make debugging and fixing demo examples easier. The tradeoff is probably a less optimized demo website.


#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**