### PR TITLE
feat(control): added check that prevents embedded field name being ad…

### DIFF
--- a/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
@@ -680,4 +680,50 @@ describe('Utils: FormUtils', () => {
       expect(returnData).toStrictEqual({});
     });
   });
+  describe('Method: getEmbeddedFields(subheader)', () => {
+    it('should be defined', () => {
+      expect(formUtils.getEmbeddedFields).toBeDefined();
+      const field = {
+        name: 'embeddedField',
+        associatedEntity: {
+          fields: []
+        }
+      };
+      formUtils.getEmbeddedFields(field);
+    });
+    it('should add field name to associated entity fields name', () => {
+      const field = {
+        name: 'embeddedField',
+        associatedEntity: {
+          fields: [{
+            name: 'field1'
+          },
+          {
+            name: 'field2'
+          }]
+        }
+      };
+      const embeddedfields = formUtils.getEmbeddedFields(field);
+      expect(embeddedfields.every((f) => f.name.startsWith(`embeddedField.`))).toBeTruthy();
+      expect(embeddedfields[0].name).toBe(`embeddedField.field1`);
+      expect(embeddedfields[1].name).toBe(`embeddedField.field2`);
+    });
+    it('should not add field name to associated entity fields name if already there', () => {
+      const field = {
+        name: 'embeddedField',
+        associatedEntity: {
+          fields: [{
+            name: 'embeddedField.field1'
+          },
+          {
+            name: 'embeddedField.field2'
+          }]
+        }
+      };
+      const embeddedfields = formUtils.getEmbeddedFields(field);
+      expect(embeddedfields.every((f) => f.name.startsWith(`embeddedField.`))).toBeTruthy();
+      expect(embeddedfields[0].name).toBe(`embeddedField.field1`);
+      expect(embeddedfields[1].name).toBe(`embeddedField.field2`);
+    });
+  });
 });

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -608,7 +608,9 @@ export class FormUtils {
     return subHeader.associatedEntity.fields
       .filter((field) => field.name !== 'id')
       .map((field) => {
-        field.name = `${subHeader.name}.${field.name}`;
+        if (!field.name.startsWith(`${subHeader.name}.`)) {
+          field.name = `${subHeader.name}.${field.name}`;
+        }
         return field;
       })
       .sort(Helpers.sortByField(['sortOrder', 'name']));


### PR DESCRIPTION
…ded as a prefix to the associated field multiple times

## **Description**

When a form was refreshing, the embedded associated field keys were being prefixed with the entity name each time the form rebuilt. This change checks to see if the key already starts with the entity name and if so skips setting the key.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**