### PR TITLE
style (typescript) use const instead of let

### DIFF
--- a/projects/chomsky/src/utils/formats.ts
+++ b/projects/chomsky/src/utils/formats.ts
@@ -79,16 +79,16 @@ export class Formats {
 
   public formatDate(value: any, format?: string | Intl.DateTimeFormatOptions): string {
     const _value = value === null || value === undefined || value === '' ? new Date() : new Date(value);
-    let options: Intl.DateTimeFormatOptions = this.getDateOptions(format);
+    const options: Intl.DateTimeFormatOptions = this.getDateOptions(format);
     const locales = [ ...(this.overrideDateFormat ? [this.overrideDateFormat] : []), this.locale, 'en-US'];
     return new Intl.DateTimeFormat(locales, options).format(_value);
   }
 
   public formatTime(value: any, format?: string | Intl.DateTimeFormatOptions): string {
     const _value = (value === null || value === undefined || value === '') ? new Date() : new Date(value);
-    let options: Intl.DateTimeFormatOptions = this.getDateOptions(format);
+    const options: Intl.DateTimeFormatOptions = this.getDateOptions(format);
     const locales = [ ...(this.overrideDateFormat ? [this.overrideDateFormat] : []), this.locale, 'en-US'];
-    let timeParts: { [p: string]: string } = Intl.DateTimeFormat(locales, options).formatToParts(_value).reduce((obj, part) => {
+    const timeParts: { [p: string]: string } = Intl.DateTimeFormat(locales, options).formatToParts(_value).reduce((obj, part) => {
       obj[part.type] = part.value;
       return obj;
     }, {});

--- a/projects/novo-elements/src/elements/ace-editor/AceEditor.ts
+++ b/projects/novo-elements/src/elements/ace-editor/AceEditor.ts
@@ -74,7 +74,7 @@ export class NovoAceEditor implements ControlValueAccessor, OnInit, OnDestroy {
   }
 
   private initializeEditor() {
-    let el = this.elementRef.nativeElement;
+    const el = this.elementRef.nativeElement;
     this.editor = ace.edit(el);
     this.editor.$blockScrolling = Infinity;
   }
@@ -93,7 +93,7 @@ export class NovoAceEditor implements ControlValueAccessor, OnInit, OnDestroy {
   }
 
   private updateText() {
-    let newVal = this.editor.getValue(),
+    const newVal = this.editor.getValue(),
       that = this;
 
     if (newVal === this.oldText) {

--- a/projects/novo-elements/src/elements/card/Card.ts
+++ b/projects/novo-elements/src/elements/card/Card.ts
@@ -90,8 +90,8 @@ export class CardElement implements OnChanges, OnInit {
     this.config = this.config || {};
     this.cardAutomationId = `${(this.title || this.config.title || 'no-title').toLowerCase().replace(/\s/g, '-')}-card`;
 
-    let newIcon: string = this.icon || this.config.icon;
-    let newMessageIcon: string = this.messageIcon || this.config.messageIcon;
+    const newIcon: string = this.icon || this.config.icon;
+    const newMessageIcon: string = this.messageIcon || this.config.messageIcon;
     this.iconClass = newIcon ? `bhi-${newIcon}` : null;
     this.messageIconClass = newMessageIcon ? `bhi-${newMessageIcon}` : null;
   }

--- a/projects/novo-elements/src/elements/category-dropdown/CategoryDropdown.ts
+++ b/projects/novo-elements/src/elements/category-dropdown/CategoryDropdown.ts
@@ -95,12 +95,12 @@ export class NovoCategoryDropdownElement extends OutsideClick implements OnInit,
   }
 
   ngOnInit() {
-    let button = this.element.nativeElement.querySelector('button');
+    const button = this.element.nativeElement.querySelector('button');
     button.addEventListener('click', this.clickHandler);
   }
 
   ngOnDestroy() {
-    let button = this.element.nativeElement.querySelector('button');
+    const button = this.element.nativeElement.querySelector('button');
     if (button) {
       button.removeEventListener('click', this.clickHandler);
     }

--- a/projects/novo-elements/src/elements/chips/Chips.spec.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.spec.ts
@@ -110,7 +110,7 @@ describe('Elements: NovoChipsElement', () => {
 
   describe('Method: remove(event, item)', () => {
     it('should remove an item', () => {
-      let item = { value: 'test' };
+      const item = { value: 'test' };
       component.items = [item];
       component.remove(null, item);
       expect(component.items.length).toBe(0);

--- a/projects/novo-elements/src/elements/chips/Chips.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.ts
@@ -194,8 +194,8 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
   setItems() {
     this.items = [];
     if (this.model && Array.isArray(this.model)) {
-      let noLabels = [];
-      for (let value of this.model) {
+      const noLabels = [];
+      for (const value of this.model) {
         let label;
         if (this.source && this.source.format && Helpers.validateInterpolationProps(this.source.format, value)) {
           label = Helpers.interpolate(this.source.format, value);
@@ -220,7 +220,7 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
       }
       if (noLabels.length > 0 && this.source && this.source.getLabels && typeof this.source.getLabels === 'function') {
         this.source.getLabels(noLabels).then((result) => {
-          for (let value of result) {
+          for (const value of result) {
             if (value.hasOwnProperty('label')) {
               this.items.push({
                 value,
@@ -241,7 +241,7 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
   }
 
   getLabelFromOptions(value) {
-    let optLabel = this.source.options.find((val) => val.value === value);
+    const optLabel = this.source.options.find((val) => val.value === value);
     return {
       value,
       label: optLabel ? optLabel.label : value,
@@ -280,7 +280,7 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
       this.items.push(event);
       this.value = this.source && this.source.valueFormatter ? this.source.valueFormatter(this.items) : this.items.map((i) => i.value);
       // Set focus on the picker
-      let input = this.element.nativeElement.querySelector('novo-picker > input');
+      const input = this.element.nativeElement.querySelector('novo-picker > input');
       if (input) {
         input.focus();
       }

--- a/projects/novo-elements/src/elements/ckeditor/CKEditor.ts
+++ b/projects/novo-elements/src/elements/ckeditor/CKEditor.ts
@@ -86,7 +86,7 @@ export class NovoCKEditorElement implements OnDestroy, AfterViewInit, ControlVal
   }
 
   ngAfterViewInit() {
-    let config = Object.assign(this.getBaseConfig(), this.config);
+    const config = Object.assign(this.getBaseConfig(), this.config);
     if (this.startupFocus) {
       config.startupFocus = true;
     }
@@ -126,7 +126,7 @@ export class NovoCKEditorElement implements OnDestroy, AfterViewInit, ControlVal
     // CKEditor change event
     this.instance.on('change', () => {
       this.onTouched();
-      let value = this.instance.getData();
+      const value = this.instance.getData();
 
       // Debounce update
       if (this.debounce) {
@@ -257,7 +257,7 @@ export class NovoCKEditorElement implements OnDestroy, AfterViewInit, ControlVal
   }
 
   insertText(text) {
-    let trimmedText = text.trim();
+    const trimmedText = text.trim();
     this.instance.insertText(trimmedText);
   }
 }

--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.spec.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.spec.ts
@@ -295,7 +295,7 @@ describe('Elements: NovoDataTableCellHeader', () => {
       spyOn(component.renderer, 'setStyle');
       component.startResize(mouseDownEvent);
 
-      let mouseMoveEvent: MouseEvent = window.document.createEvent('MouseEvents');
+      const mouseMoveEvent: MouseEvent = window.document.createEvent('MouseEvents');
       mouseMoveEvent.initMouseEvent('mousemove', true, true, window, 1, 50, 50, 550, 50, false, false, false, false, 0, null);
       window.document.dispatchEvent(mouseMoveEvent);
 

--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
@@ -215,7 +215,7 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
     };
     this.resizable = this.config.resizable;
 
-    let transforms: { filter?: Function; sort?: Function } = {};
+    const transforms: { filter?: Function; sort?: Function } = {};
 
     if (column.filterable && Helpers.isObject(column.filterable)) {
       this.config.filterConfig = column.filterable as IDataTableColumnFilterConfig;
@@ -337,12 +337,12 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
       if (this.config.filterConfig.options) {
         if (typeof this.config.filterConfig.options[0] === 'string') {
           this.multiSelectedOptionIsHidden = (this.config.filterConfig.options as string[]).map(
-            (option: string): { option: string; hidden: boolean } => ({ option: option, hidden: false }),
+            (option: string): { option: string; hidden: boolean } => ({ option, hidden: false }),
           );
         } else {
           this.multiSelectedOptionIsHidden = (this.config.filterConfig.options as IDataTableColumnFilterOption[]).map(
             (option: IDataTableColumnFilterOption): { option: IDataTableColumnFilterOption; hidden: boolean } => ({
-              option: option,
+              option,
               hidden: false,
             }),
           );
@@ -356,7 +356,7 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
     if (optionsList) {
       const optionValue = option.hasOwnProperty('value') ? option.value : option;
 
-      let found = optionsList.find((item) => this.optionPresentCheck(item, optionValue));
+      const found = optionsList.find((item) => this.optionPresentCheck(item, optionValue));
       return found !== undefined;
     }
     return false;
@@ -365,7 +365,7 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
   public toggleSelection(option) {
     const optionValue = option.hasOwnProperty('value') ? option.value : option;
 
-    let optionIndex = this.multiSelectedOptions.findIndex((item) => this.optionPresentCheck(item, optionValue));
+    const optionIndex = this.multiSelectedOptions.findIndex((item) => this.optionPresentCheck(item, optionValue));
     this.error = false;
     if (optionIndex > -1) {
       this.multiSelectedOptions.splice(optionIndex, 1);
@@ -401,7 +401,7 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
       this.multiSelectHasVisibleOptions() && this.dropdown ? (this.error = true) : null;
     } else {
       this.clearOptionFilter();
-      let actualFilter = this.multiSelectedOptions.length > 0 ? [...this.multiSelectedOptions] : undefined;
+      const actualFilter = this.multiSelectedOptions.length > 0 ? [...this.multiSelectedOptions] : undefined;
       this.filterData(actualFilter);
       this.dropdown.closePanel();
     }
@@ -471,9 +471,9 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
   public startResize(mouseDownEvent: MouseEvent): void {
     mouseDownEvent.preventDefault();
     const minimumWidth = 60 + (this.config.filterable ? 30 : 0) + (this.config.sortable ? 30 : 0);
-    let startingWidth: number = this.elementRef.nativeElement.getBoundingClientRect().width;
+    const startingWidth: number = this.elementRef.nativeElement.getBoundingClientRect().width;
     const mouseMoveSubscription: Subscription = fromEvent(window.document, 'mousemove').subscribe((middleMouseEvent: MouseEvent) => {
-      let differenceWidth: number = middleMouseEvent.clientX - mouseDownEvent.clientX;
+      const differenceWidth: number = middleMouseEvent.clientX - mouseDownEvent.clientX;
       let width: number = startingWidth + differenceWidth;
       if (width < minimumWidth) {
         width = minimumWidth;
@@ -486,7 +486,7 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
       this.resized.next(this._column);
     });
 
-    let mouseUpSubscription: Subscription = fromEvent(window.document, 'mouseup').subscribe(() => {
+    const mouseUpSubscription: Subscription = fromEvent(window.document, 'mouseup').subscribe(() => {
       mouseUpSubscription.unsubscribe();
       mouseMoveSubscription.unsubscribe();
       this.changeDetectorRef.markForCheck();
@@ -570,7 +570,7 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
   }
 
   private getDefaultDateFilterOptions(): IDataTableColumnFilterOption[] {
-    let opts: IDataTableColumnFilterOption[] = [
+    const opts: IDataTableColumnFilterOption[] = [
       { label: this.labels.past1Day, min: -1, max: 0 },
       { label: this.labels.past7Days, min: -7, max: 0 },
       { label: this.labels.past30Days, min: -30, max: 0 },

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -266,7 +266,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
       if (this.name !== 'novo-data-table') {
         this.preferencesChanged.emit({
           name: this.name,
-          displayedColumns: displayedColumns,
+          displayedColumns,
         });
       } else {
         notify('Must have [name] set on data-table to use preferences!');
@@ -312,7 +312,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   @Input()
   set rows(rows: T[]) {
     this.loading = false;
-    let service = new StaticDataTableService(rows);
+    const service = new StaticDataTableService(rows);
     this.dataSource = new DataTableSource<T>(service, this.state, this.ref);
     this.ref.detectChanges();
   }
@@ -541,7 +541,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   }
 
   public expandRow(row: T): void {
-    let expanded = this.isExpanded(row);
+    const expanded = this.isExpanded(row);
 
     if (expanded) {
       this.state.expandedRows.delete(`${row[this.rowIdentifier]}`);
@@ -579,7 +579,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   }
 
   public selectRow(row: T): void {
-    let selected = this.isSelected(row);
+    const selected = this.isSelected(row);
 
     if (selected) {
       this.state.selectedRows.delete(`${row[this.rowIdentifier]}`);
@@ -683,7 +683,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
 
   private scrollListener(): void {
     const target: Element = this.novoDataTableContainer.nativeElement as Element;
-    let left: number = target.scrollLeft;
+    const left: number = target.scrollLeft;
     if (left !== this.scrollLeft) {
       this.scrollLeft = target.scrollLeft;
     }

--- a/projects/novo-elements/src/elements/data-table/data-table.pipes.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.pipes.ts
@@ -92,7 +92,7 @@ export class DataTableBigDecimalRendererPipe<T> implements PipeTransform {
   constructor(private labels: NovoLabelService) {}
   transform(value: any, column: IDataTableColumn<T>): string {
     if (!Helpers.isEmpty(value)) {
-      let val = interpolateCell<T>(value, column);
+      const val = interpolateCell<T>(value, column);
       return this.labels.formatBigDecimal(Number(val));
     }
     return '';
@@ -107,7 +107,7 @@ export class DateTableCurrencyRendererPipe<T> implements PipeTransform {
   constructor(private labels: NovoLabelService) {}
   transform(value: any, column: IDataTableColumn<T>): string {
     if (!Helpers.isEmpty(value)) {
-      let val = interpolateCell<T>(value, column);
+      const val = interpolateCell<T>(value, column);
       return this.labels.formatCurrency(Number(val));
     }
     return '';

--- a/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
+++ b/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
@@ -221,7 +221,7 @@ export class NovoDataTablePagination<T> implements OnInit, OnDestroy {
   }
 
   private emitPageEvent(isPageSizeChange: boolean = false): void {
-    let event = {
+    const event = {
       page: this.page,
       pageSize: this.pageSize,
       length: this.length,
@@ -246,14 +246,14 @@ export class NovoDataTablePagination<T> implements OnInit, OnDestroy {
 
   private makePage(number: number, text: string, isActive: boolean): { number: number; text: string; active: boolean } {
     return {
-      number: number,
-      text: text,
+      number,
+      text,
       active: isActive,
     };
   }
 
   private getPages(currentPage: number, totalPages: number): { number: number; text: string; active: boolean }[] {
-    let pages = [];
+    const pages = [];
 
     // Default page limits
     let startPage = 1;

--- a/projects/novo-elements/src/elements/data-table/services/static-data-table.service.spec.ts
+++ b/projects/novo-elements/src/elements/data-table/services/static-data-table.service.spec.ts
@@ -8,10 +8,10 @@ describe('StaticDataTableService', () => {
   let service;
 
   beforeEach(async(() => {
-    let staticDataSet1 = [];
+    const staticDataSet1 = [];
     for (let i = 0; i < 100; i++) {
-      let day = dateFns.subDays(new Date(), i);
-      let rando = Math.floor(Math.random() * 5);
+      const day = dateFns.subDays(new Date(), i);
+      const rando = Math.floor(Math.random() * 5);
       staticDataSet1.push({
         id: i,
         date: day,
@@ -27,13 +27,13 @@ describe('StaticDataTableService', () => {
 
   describe('method: filterData', () => {
     it('should filter data when passed a value', () => {
-      let results = service.filterData(service.currentData, { id: 'id', value: 5 });
-      let resultsAreFiltered = results.every((x) => x.id.toString().includes('5'));
+      const results = service.filterData(service.currentData, { id: 'id', value: 5 });
+      const resultsAreFiltered = results.every((x) => x.id.toString().includes('5'));
       expect(resultsAreFiltered).toBe(true);
     });
     it('should filter data when passed an array of values', () => {
-      let results = service.filterData(service.currentData, { id: 'status', value: [1, 5] });
-      let resultsAreFiltered = results.every((x) => x.status.includes(['1', '5']));
+      const results = service.filterData(service.currentData, { id: 'status', value: [1, 5] });
+      const resultsAreFiltered = results.every((x) => x.status.includes(['1', '5']));
       expect(resultsAreFiltered).toBe(true);
     });
   });

--- a/projects/novo-elements/src/elements/data-table/services/static-data-table.service.ts
+++ b/projects/novo-elements/src/elements/data-table/services/static-data-table.service.ts
@@ -42,17 +42,17 @@ export class StaticDataTableService<T> implements IDataTableService<T> {
         this.currentData = this.currentData.slice(page * pageSize, (page + 1) * pageSize);
       }
     }
-    return of({ results: this.currentData, total: total });
+    return of({ results: this.currentData, total });
   }
 
   public filterData(currentData: T[], filter: IDataTableFilter | IDataTableFilter[]): T[] {
-    let filters = Helpers.convertToArray(filter);
+    const filters = Helpers.convertToArray(filter);
     filters.forEach((aFilter) => {
       if (Array.isArray(aFilter.value)) {
-        let values = Helpers.convertToArray(aFilter.value).map(Helpers.escapeString);
+        const values = Helpers.convertToArray(aFilter.value).map(Helpers.escapeString);
         currentData = currentData.filter(Helpers.filterByField(aFilter.id, values));
       } else {
-        let value = Helpers.escapeString(aFilter.value);
+        const value = Helpers.escapeString(aFilter.value);
         currentData = currentData.filter(Helpers.filterByField(aFilter.id, value));
       }
     });

--- a/projects/novo-elements/src/elements/data-table/sort-filter/sort-filter.directive.spec.ts
+++ b/projects/novo-elements/src/elements/data-table/sort-filter/sort-filter.directive.spec.ts
@@ -3,8 +3,8 @@ import { DataTableState } from '../state/data-table-state.service';
 
 describe('Directive: sort-filter', () => {
   describe('Function: filter', () => {
-    let testState: DataTableState<{}> = new DataTableState();
-    let directive: NovoDataTableSortFilter<{}> = new NovoDataTableSortFilter(testState);
+    const testState: DataTableState<{}> = new DataTableState();
+    const directive: NovoDataTableSortFilter<{}> = new NovoDataTableSortFilter(testState);
 
     it('should set state filter to results', () => {
       directive.filter('test', 'text', 'test', undefined, false, { label: 'test', value: 1 });
@@ -25,8 +25,8 @@ describe('Directive: sort-filter', () => {
   });
 
   describe('Function: sort', () => {
-    let testState: DataTableState<{}> = new DataTableState();
-    let directive: NovoDataTableSortFilter<{}> = new NovoDataTableSortFilter(testState);
+    const testState: DataTableState<{}> = new DataTableState();
+    const directive: NovoDataTableSortFilter<{}> = new NovoDataTableSortFilter(testState);
 
     it('should set state sort to results', () => {
       directive.sort('test', 'test', undefined);
@@ -35,8 +35,8 @@ describe('Directive: sort-filter', () => {
   });
 
   describe('Function: resolveMultiFilter', () => {
-    let testState: DataTableState<{}> = new DataTableState();
-    let directive: NovoDataTableSortFilter<{}> = new NovoDataTableSortFilter(testState);
+    const testState: DataTableState<{}> = new DataTableState();
+    const directive: NovoDataTableSortFilter<{}> = new NovoDataTableSortFilter(testState);
 
     it('should return an array of results', () => {
       testState.filter = { id: 'test', type: 'text', transform: undefined, value: 'test' };

--- a/projects/novo-elements/src/elements/data-table/sort-filter/sort-filter.directive.ts
+++ b/projects/novo-elements/src/elements/data-table/sort-filter/sort-filter.directive.ts
@@ -31,15 +31,15 @@ export class NovoDataTableSortFilter<T> {
 
     this.state.filter = filter;
     this.state.reset(false, true);
-    this.state.updates.next({ filter: filter, sort: this.state.sort });
+    this.state.updates.next({ filter, sort: this.state.sort });
     this.state.onSortFilterChange();
   }
 
   public sort(id: string, value: string, transform: Function): void {
-    let sort = { id, value, transform };
+    const sort = { id, value, transform };
     this.state.sort = sort;
     this.state.reset(false, true);
-    this.state.updates.next({ sort: sort, filter: this.state.filter });
+    this.state.updates.next({ sort, filter: this.state.filter });
     this.state.onSortFilterChange();
   }
 
@@ -48,7 +48,7 @@ export class NovoDataTableSortFilter<T> {
 
     filter = Helpers.convertToArray(this.state.filter);
 
-    let filterIndex = filter.findIndex((aFilter) => aFilter && aFilter.id === id);
+    const filterIndex = filter.findIndex((aFilter) => aFilter && aFilter.id === id);
     if (filterIndex > -1) {
       filter.splice(filterIndex, 1);
     }

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
@@ -114,7 +114,7 @@ export class DataTableState<T> {
       }
 
       if (preferences.filter) {
-        let filters = Helpers.convertToArray(preferences.filter);
+        const filters = Helpers.convertToArray(preferences.filter);
         filters.forEach((filter) => {
           filter.value =
             filter.selectedOption && filter.type

--- a/projects/novo-elements/src/elements/date-picker/DatePicker.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePicker.ts
@@ -200,9 +200,9 @@ export class NovoDatePickerElement implements ControlValueAccessor, OnInit, OnCh
 
   ngOnInit() {
     // Determine the year array
-    let now = new Date();
-    let start = this.minYear ? Number(this.minYear) : now.getFullYear() - 100;
-    let end = this.maxYear ? Number(this.maxYear) : now.getFullYear() + 10;
+    const now = new Date();
+    const start = this.minYear ? Number(this.minYear) : now.getFullYear() - 100;
+    const end = this.maxYear ? Number(this.maxYear) : now.getFullYear() + 10;
 
     for (let i = start; i <= end; i++) {
       this.years.push(i);
@@ -219,7 +219,7 @@ export class NovoDatePickerElement implements ControlValueAccessor, OnInit, OnCh
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    let weekRangeSelectChange: SimpleChange = changes['weekRangeSelect'];
+    const weekRangeSelectChange: SimpleChange = changes['weekRangeSelect'];
     if (
       weekRangeSelectChange &&
       weekRangeSelectChange.currentValue !== weekRangeSelectChange.previousValue &&
@@ -227,7 +227,7 @@ export class NovoDatePickerElement implements ControlValueAccessor, OnInit, OnCh
     ) {
       this.clearRange();
     }
-    let weekStartChanges: SimpleChange = changes['weekStart'];
+    const weekStartChanges: SimpleChange = changes['weekStart'];
     if (weekStartChanges && weekStartChanges.currentValue !== weekStartChanges.previousValue && !weekStartChanges.firstChange) {
       this.weekdays = this.setupWeekdays();
       this.updateView(this.model, false, false);
@@ -238,7 +238,7 @@ export class NovoDatePickerElement implements ControlValueAccessor, OnInit, OnCh
     let weekdays = this.labels.getWeekdays();
     // Weekstart must be 0-6 (Sunday - Saturday)
     if (!Helpers.isBlank(this.weekStart) && this.weekStart > 0 && this.weekStart <= 6) {
-      let newStart = weekdays.splice(this.weekStart);
+      const newStart = weekdays.splice(this.weekStart);
       weekdays = [...newStart, ...weekdays];
     }
     return weekdays;
@@ -246,12 +246,12 @@ export class NovoDatePickerElement implements ControlValueAccessor, OnInit, OnCh
 
   isSelectingRange(range, day, selected, selected2, hoverDay, rangeSelectMode, weekRangeSelect) {
     if (range && !weekRangeSelect) {
-      let isRangeModeEndDate =
+      const isRangeModeEndDate =
         rangeSelectMode === 'endDate' && (selected && selected2 && dateFns.isAfter(day, selected2) && dateFns.isBefore(day, hoverDay));
-      let isRangeModeStartDate =
+      const isRangeModeStartDate =
         rangeSelectMode === 'startDate' && (selected && selected2 && dateFns.isBefore(day, selected) && dateFns.isAfter(day, hoverDay));
-      let isNotSelected = !selected && selected2 && dateFns.isBefore(day, selected2) && dateFns.isAfter(day, hoverDay);
-      let isNotSelected2 = selected && !selected2 && dateFns.isAfter(day, selected) && dateFns.isBefore(day, hoverDay);
+      const isNotSelected = !selected && selected2 && dateFns.isBefore(day, selected2) && dateFns.isAfter(day, hoverDay);
+      const isNotSelected2 = selected && !selected2 && dateFns.isAfter(day, selected) && dateFns.isBefore(day, hoverDay);
       return isNotSelected2 || isNotSelected || isRangeModeStartDate || isRangeModeEndDate;
     }
     return false;
@@ -315,7 +315,7 @@ export class NovoDatePickerElement implements ControlValueAccessor, OnInit, OnCh
       this.month = new Date(value);
       this.monthLabel = this.labels.formatDateWithFormat(this.month, { month: 'short' });
 
-      let start = new Date(value.getTime());
+      const start = new Date(value.getTime());
       start.setDate(1);
       this.removeTime(start.setDate(1));
 
@@ -328,7 +328,7 @@ export class NovoDatePickerElement implements ControlValueAccessor, OnInit, OnCh
   }
 
   setToday() {
-    let tmp = new Date();
+    const tmp = new Date();
     this.updateView(tmp, true, true);
     // Go back to days
     this.open(null, 'days');
@@ -342,16 +342,16 @@ export class NovoDatePickerElement implements ControlValueAccessor, OnInit, OnCh
   }
 
   setMonth(month: number): void {
-    let date = this.month ? this.month : new Date();
-    let tmp = dateFns.setMonth(date, month);
+    const date = this.month ? this.month : new Date();
+    const tmp = dateFns.setMonth(date, month);
     this.updateView(tmp, true, false);
     // Go back to days
     this.open(null, 'days');
   }
 
   setYear(year: number): void {
-    let date = this.month ? this.month : new Date();
-    let tmp = dateFns.setYear(date, year);
+    const date = this.month ? this.month : new Date();
+    const tmp = dateFns.setYear(date, year);
     this.updateView(tmp, true, false);
     // Go back to days
     this.open(null, 'days');
@@ -481,8 +481,8 @@ export class NovoDatePickerElement implements ControlValueAccessor, OnInit, OnCh
     // Make sure to scroll the selected one into view
     if (this.view === 'years' || this.view === 'months') {
       setTimeout(() => {
-        let container = this.element.nativeElement.querySelector(`.calendar-content.${this.view}`);
-        let selectedItem = this.element.nativeElement.querySelector(
+        const container = this.element.nativeElement.querySelector(`.calendar-content.${this.view}`);
+        const selectedItem = this.element.nativeElement.querySelector(
           `.calendar-content.${this.view} .${this.view === 'years' ? 'year' : 'month'}.selected`,
         );
         if (container && selectedItem) {
@@ -496,13 +496,13 @@ export class NovoDatePickerElement implements ControlValueAccessor, OnInit, OnCh
 
   prevMonth(event: Event): void {
     Helpers.swallowEvent(event);
-    let tmp = dateFns.subMonths(this.month, 1);
+    const tmp = dateFns.subMonths(this.month, 1);
     this.updateView(tmp, false, false);
   }
 
   nextMonth(event: Event): void {
     Helpers.swallowEvent(event);
-    let tmp = dateFns.addMonths(this.month, 1);
+    const tmp = dateFns.addMonths(this.month, 1);
     this.updateView(tmp, false, false);
   }
 
@@ -524,7 +524,7 @@ export class NovoDatePickerElement implements ControlValueAccessor, OnInit, OnCh
    * @returns with time stripped out
    */
   removeTime(date: any): Date {
-    let ret = new Date(date);
+    const ret = new Date(date);
     ret.setHours(12);
     ret.setSeconds(0);
     ret.setMilliseconds(0);
@@ -554,7 +554,7 @@ export class NovoDatePickerElement implements ControlValueAccessor, OnInit, OnCh
 
   buildWeek(date: Date, month: Date): Array<Object> {
     // Build out of the days of the week
-    let days = [];
+    const days = [];
 
     // Iterate over the days of the week
     for (let i = 0; i < 7; i++) {
@@ -563,7 +563,7 @@ export class NovoDatePickerElement implements ControlValueAccessor, OnInit, OnCh
         name: this.weekdays[i],
         number: date.getDate(),
         isToday: dateFns.isToday(date),
-        date: date,
+        date,
       });
 
       // Increment for the next iteration

--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.spec.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.spec.ts
@@ -26,7 +26,7 @@ xdescribe('Elements: NovoDatePickerInputElement', () => {
     it('should call parseString from the dateFormatService and then dispatchOnChange.', () => {
       spyOn(component.dateFormatService, 'parseString').and.callThrough();
       spyOn(component, 'dispatchOnChange');
-      let mockValue: String = '01/01/2020';
+      const mockValue: String = '01/01/2020';
       component.formatDate(mockValue, true);
       expect(component.dateFormatService.parseString).toHaveBeenCalled();
       expect(component.dispatchOnChange).toHaveBeenCalled();

--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -140,16 +140,16 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
   }
 
   _handleEvent(event: Event, blur: boolean): void {
-    let value = (event.target as HTMLInputElement).value;
+    const value = (event.target as HTMLInputElement).value;
     this.formatDate(value, blur);
     this.openPanel();
   }
 
   protected formatDate(value: string, blur: boolean) {
     try {
-      let [dateTimeValue, formatted] = this.dateFormatService.parseString(value, false, 'date');
+      const [dateTimeValue, formatted] = this.dateFormatService.parseString(value, false, 'date');
       if (!isNaN(dateTimeValue.getUTCDate())) {
-        let dt = new Date(dateTimeValue);
+        const dt = new Date(dateTimeValue);
         this.dispatchOnChange(dt, blur);
       } else {
         this.dispatchOnChange(null, blur);
@@ -199,7 +199,7 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
 
   private _setFormValue(value: any): void {
     if (this.value) {
-      let test = this.formatDateValue(this.value);
+      const test = this.formatDateValue(this.value);
       this.formattedValue = test;
     }
   }
@@ -225,7 +225,7 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
   }
 
   public formatDateValue(value) {
-    let originalValue = value;
+    const originalValue = value;
     try {
       if (!value) {
         return '';

--- a/projects/novo-elements/src/elements/date-time-picker/DateTimePicker.spec.ts
+++ b/projects/novo-elements/src/elements/date-time-picker/DateTimePicker.spec.ts
@@ -76,7 +76,7 @@ xdescribe('Elements: NovoDateTimePickerElement', () => {
   });
 
   describe('Method: onDateSelected()', () => {
-    let now = new Date();
+    const now = new Date();
     beforeEach(() => {
       spyOn(component, 'setDateLabels');
       spyOn(component, '_onChange');
@@ -93,7 +93,7 @@ xdescribe('Elements: NovoDateTimePickerElement', () => {
   });
 
   describe('Method: onTimeSelected()', () => {
-    let now = new Date();
+    const now = new Date();
     beforeEach(() => {
       spyOn(component, '_onChange');
       spyOn(component, 'setTimeLabels');
@@ -115,7 +115,7 @@ xdescribe('Elements: NovoDateTimePickerElement', () => {
       spyOn(component, 'setTimeLabels');
     });
     it('set the model and labels with correct date', () => {
-      let now = new Date();
+      const now = new Date();
       component.writeValue(now);
       expect(component.model).toEqual(now);
       expect(component.timePickerValue).toEqual(now);
@@ -132,7 +132,7 @@ xdescribe('Elements: NovoDateTimePickerElement', () => {
 
   describe('Method: registerOnChange()', () => {
     it('should set the fn', () => {
-      let test = () => {};
+      const test = () => {};
       component.registerOnChange(test);
       expect(component._onChange).toEqual(test);
     });
@@ -140,7 +140,7 @@ xdescribe('Elements: NovoDateTimePickerElement', () => {
 
   describe('Method: registerOnTouched()', () => {
     it('should set the fn', () => {
-      let test = () => {};
+      const test = () => {};
       component.registerOnTouched(test);
       expect(component._onTouched).toEqual(test);
     });

--- a/projects/novo-elements/src/elements/date-time-picker/DateTimePicker.ts
+++ b/projects/novo-elements/src/elements/date-time-picker/DateTimePicker.ts
@@ -165,7 +165,7 @@ export class NovoDateTimePickerElement implements ControlValueAccessor {
 
   setTimeLabels(value: Date) {
     let hours = value.getHours();
-    let minutes = value.getMinutes();
+    const minutes = value.getMinutes();
 
     this.meridian = value.toLocaleTimeString().slice(-2);
 

--- a/projects/novo-elements/src/elements/date-time-picker/DateTimePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-time-picker/DateTimePickerInput.ts
@@ -83,7 +83,7 @@ export class NovoDateTimePickerInputElement implements ControlValueAccessor {
   checkParts() {
     try {
       if (this.datePart instanceof Date && this.timePart instanceof Date) {
-        let newDt = new Date(
+        const newDt = new Date(
           this.datePart.getFullYear(),
           this.datePart.getMonth(),
           this.datePart.getDate(),

--- a/projects/novo-elements/src/elements/dragula/Dragula.spec.ts
+++ b/projects/novo-elements/src/elements/dragula/Dragula.spec.ts
@@ -31,8 +31,8 @@ describe('Elements: NovoDragulaElement', () => {
     });
   });
   describe('Class: ', () => {
-    let mockElement = document.createElement('div');
-    let component = new NovoDragulaElement({ nativeElement: mockElement }, new NovoDragulaService());
+    const mockElement = document.createElement('div');
+    const component = new NovoDragulaElement({ nativeElement: mockElement }, new NovoDragulaService());
 
     describe('Method: ngOnInit()', () => {
       it('should initialize the dragula with the element reference passed into the constructor if the service doesn\'t return any containers.', () => {

--- a/projects/novo-elements/src/elements/dragula/Dragula.ts
+++ b/projects/novo-elements/src/elements/dragula/Dragula.ts
@@ -22,7 +22,7 @@ export class NovoDragulaElement implements OnInit, OnChanges {
   }
 
   ngOnInit() {
-    let bag = this.dragulaService.find(this.bag);
+    const bag = this.dragulaService.find(this.bag);
 
     if (bag) {
       this.drake = bag.drake;
@@ -51,7 +51,7 @@ export class NovoDragulaElement implements OnInit, OnChanges {
     if (changes && changes.dragulaModel) {
       if (this.drake) {
         if (this.drake.models) {
-          let modelIndex = this.drake.models.indexOf(changes.dragulaModel.previousValue);
+          const modelIndex = this.drake.models.indexOf(changes.dragulaModel.previousValue);
           this.drake.models.splice(modelIndex, 1, changes.dragulaModel.currentValue);
         } else {
           this.drake.models = [changes.dragulaModel.currentValue];

--- a/projects/novo-elements/src/elements/dragula/DragulaService.ts
+++ b/projects/novo-elements/src/elements/dragula/DragulaService.ts
@@ -31,8 +31,8 @@ export class NovoDragulaService {
       throw new Error(`Bag named: ${name} already exists.`);
     }
     bag = {
-      name: name,
-      drake: drake,
+      name,
+      drake,
     };
     this.bags.push(bag);
     if (drake.models) {
@@ -63,8 +63,8 @@ export class NovoDragulaService {
    * @param name
    */
   destroy(name) {
-    let bag = this.find(name);
-    let i = this.bags.indexOf(bag);
+    const bag = this.find(name);
+    const i = this.bags.indexOf(bag);
     this.bags.splice(i, 1);
     bag.drake.destroy();
   }
@@ -75,7 +75,7 @@ export class NovoDragulaService {
    * @param options
    */
   setOptions(name, options) {
-    let bag = this.add(name, dragula(options));
+    const bag = this.add(name, dragula(options));
     this.handleModels(name, bag.drake);
   }
 
@@ -110,9 +110,9 @@ export class NovoDragulaService {
       if (target === source) {
         sourceModel.splice(dropIndex, 0, sourceModel.splice(dragIndex, 1)[0]);
       } else {
-        let notCopy = dragElm === dropElm;
-        let targetModel = drake.models[drake.containers.indexOf(target)];
-        let dropElmModel = notCopy ? sourceModel[dragIndex] : JSON.parse(JSON.stringify(sourceModel[dragIndex]));
+        const notCopy = dragElm === dropElm;
+        const targetModel = drake.models[drake.containers.indexOf(target)];
+        const dropElmModel = notCopy ? sourceModel[dragIndex] : JSON.parse(JSON.stringify(sourceModel[dragIndex]));
 
         if (notCopy) {
           sourceModel.splice(dragIndex, 1);
@@ -130,10 +130,10 @@ export class NovoDragulaService {
    */
   setupEvents(bag) {
     bag.initEvents = true;
-    let that = this;
-    let emitter = (type) => {
+    const that = this;
+    const emitter = (type) => {
       function replicate() {
-        let args = Array.prototype.slice.call(arguments);
+        const args = Array.prototype.slice.call(arguments);
         that[type].emit([bag.name].concat(args));
       }
 

--- a/projects/novo-elements/src/elements/dropdown/Dropdown.ts
+++ b/projects/novo-elements/src/elements/dropdown/Dropdown.ts
@@ -84,7 +84,7 @@ export class NovoDropdownElement implements OnInit, OnDestroy {
       notify(`'appendToBody' has been deprecated. Please remove this attribute.`);
     }
     // Add a click handler to the button to toggle the menu
-    let button = this.element.nativeElement.querySelector('button');
+    const button = this.element.nativeElement.querySelector('button');
     button.addEventListener('click', this.clickHandler);
     if (this.parentScrollSelector) {
       this.parentScrollElement = Helpers.findAncestor(this.element.nativeElement, this.parentScrollSelector);
@@ -93,7 +93,7 @@ export class NovoDropdownElement implements OnInit, OnDestroy {
 
   public ngOnDestroy(): void {
     // Remove listener
-    let button = this.element.nativeElement.querySelector('button');
+    const button = this.element.nativeElement.querySelector('button');
     if (button) {
       button.removeEventListener('click', this.clickHandler);
     }
@@ -202,9 +202,9 @@ export class NovoDropdownElement implements OnInit, OnDestroy {
       this.filterTermTimeout = setTimeout(() => {
         this.filterTerm = '';
       }, 2000);
-      let char = String.fromCharCode(event.keyCode);
+      const char = String.fromCharCode(event.keyCode);
       this.filterTerm = this.filterTerm.concat(char);
-      let index = this._textItems.findIndex((value: string) => {
+      const index = this._textItems.findIndex((value: string) => {
         return new RegExp(`^${this.filterTerm.toLowerCase()}`).test(value.trim().toLowerCase());
       });
       if (index !== -1) {
@@ -234,8 +234,8 @@ export class NovoDropdownElement implements OnInit, OnDestroy {
   }
 
   private scrollToActive(): void {
-    let container = this.overlay.overlayRef.overlayElement.querySelector('.dropdown-container');
-    let item = this._items.toArray()[this.activeIndex];
+    const container = this.overlay.overlayRef.overlayElement.querySelector('.dropdown-container');
+    const item = this._items.toArray()[this.activeIndex];
     if (container && item) {
       container.scrollTop = item.element.nativeElement.offsetTop;
     }

--- a/projects/novo-elements/src/elements/form/Control.spec.ts
+++ b/projects/novo-elements/src/elements/form/Control.spec.ts
@@ -67,10 +67,10 @@ describe('Elements: NovoAutoSize', () => {
 });
 
 describe('Test Localization', () => {
-  let mockElement: ElementRef = new ElementRef(document.createElement('div'));
+  const mockElement: ElementRef = new ElementRef(document.createElement('div'));
 
   it('should set decimal separator based on locale correctly', () => {
-    let component = new NovoControlElement(mockElement, null, null, null, null, null, 'fr-FR');
+    const component = new NovoControlElement(mockElement, null, null, null, null, null, 'fr-FR');
     expect(component.decimalSeparator).toBe('.');
   });
 });
@@ -122,7 +122,7 @@ describe('NovoControlElement', () => {
     };
 
     // Act
-    let testBoolean = component.showCount;
+    const testBoolean = component.showCount;
 
     // Assert
     expect(testBoolean).toEqual(false);
@@ -146,7 +146,7 @@ describe('NovoControlElement', () => {
     (component as any).handleFocus(new FocusEvent('input'));
 
     // Act
-    let testBoolean = component.showCount;
+    const testBoolean = component.showCount;
 
     // Assert
     expect(testBoolean).toEqual(true);
@@ -169,7 +169,7 @@ describe('NovoControlElement', () => {
     (component as any).handleFocus(new FocusEvent('input'));
 
     // Act
-    let testBoolean = component.showCount;
+    const testBoolean = component.showCount;
 
     // Assert
     expect(testBoolean).toEqual(false);
@@ -193,7 +193,7 @@ describe('NovoControlElement', () => {
     (component as any).handleFocus(new FocusEvent('input'));
 
     // Act
-    let testBoolean = component.showCount;
+    const testBoolean = component.showCount;
 
     // Assert
     expect(testBoolean).toEqual(false);

--- a/projects/novo-elements/src/elements/form/Control.ts
+++ b/projects/novo-elements/src/elements/form/Control.ts
@@ -267,7 +267,7 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
 
   get showCount() {
     const MAX_LENGTH_CONTROL_TYPES: string[] = ['textbox', 'picker', 'text-area'];
-    let charCount: boolean =
+    const charCount: boolean =
       this.focused &&
       !!this.form.controls[this.control.key].maxlength &&
       MAX_LENGTH_CONTROL_TYPES.includes(this.form.controls[this.control.key].controlType);
@@ -294,7 +294,7 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
     const DO_NOT_FOCUS_ME: string[] = ['picker', 'time', 'date', 'date-time'];
     if (this.autoFocus && !DO_NOT_FOCUS_ME.includes(this.control.controlType)) {
       setTimeout(() => {
-        let input: HTMLElement = this.element.nativeElement.querySelector('input');
+        const input: HTMLElement = this.element.nativeElement.querySelector('input');
         if (input) {
           input.focus();
         }
@@ -305,7 +305,7 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
   ngAfterContentInit() {
     // Subscribe to control interactions
     if (this.control.interactions && !this.form.controls[this.control.key].restrictFieldInteractions) {
-      for (let interaction of this.control.interactions) {
+      for (const interaction of this.control.interactions) {
         switch (interaction.event) {
           case 'blur':
             this.valueChangeSubscription = this.onBlur.pipe(debounceTime(300)).subscribe(() => {
@@ -638,7 +638,7 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
     const NUMBERS_WITH_DECIMAL_DOT = /[0-9\.\-]/;
     const NUMBERS_WITH_DECIMAL_DOT_AND_COMMA = /[0-9\.\,\-]/;
     const UTILITY_KEYS = ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight', 'Tab'];
-    let key = event.key;
+    const key = event.key;
 
     // Numbers or numbers and decimal characters only
     if (this.form.controls[this.control.key].subType === 'number' && !(NUMBERS_ONLY.test(key) || UTILITY_KEYS.includes(key))) {
@@ -660,8 +660,8 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
   }
 
   handlePercentChange(event: KeyboardEvent) {
-    let value = event.target['value'];
-    let percent = Helpers.isEmpty(value) ? null : Number((value / 100).toFixed(6).replace(/\.?0*$/, ''));
+    const value = event.target['value'];
+    const percent = Helpers.isEmpty(value) ? null : Number((value / 100).toFixed(6).replace(/\.?0*$/, ''));
     if (!Helpers.isEmpty(percent)) {
       this.change.emit(percent);
       this.form.controls[this.control.key].setValue(percent);
@@ -721,7 +721,7 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
   }
 
   updateValidity(shouldEventBeEmitted): void {
-    let emitEvent: boolean = shouldEventBeEmitted ? true : false;
+    const emitEvent: boolean = shouldEventBeEmitted ? true : false;
     this.form.controls[this.control.key].updateValueAndValidity({ emitEvent });
   }
 }

--- a/projects/novo-elements/src/elements/form/ControlGroup.ts
+++ b/projects/novo-elements/src/elements/form/ControlGroup.ts
@@ -126,7 +126,7 @@ export class NovoControlGroup implements AfterContentInit, OnChanges {
   }
 
   public ngOnChanges(changes: SimpleChanges) {
-    let initialValueChange: SimpleChange = changes['initialValue'];
+    const initialValueChange: SimpleChange = changes['initialValue'];
 
     // If initial value changes, clear the controls
     if (initialValueChange && initialValueChange.currentValue !== initialValueChange.previousValue && !initialValueChange.firstChange) {
@@ -200,7 +200,7 @@ export class NovoControlGroup implements AfterContentInit, OnChanges {
   public removeControl(index: number, emitEvent: boolean = true): void {
     const control: FormArray = <FormArray>this.form.controls[this.key];
     if (emitEvent) {
-      this.onRemove.emit({ value: control.at(index).value, index: index });
+      this.onRemove.emit({ value: control.at(index).value, index });
     }
     control.removeAt(index);
     this.disabledArray = this.disabledArray.filter((value: NovoControlGroupRowConfig, idx: number) => idx !== index);
@@ -211,7 +211,7 @@ export class NovoControlGroup implements AfterContentInit, OnChanges {
 
   public editControl(index: number): void {
     const control: FormArray = <FormArray>this.form.controls[this.key];
-    this.onEdit.emit({ value: control.at(index).value, index: index });
+    this.onEdit.emit({ value: control.at(index).value, index });
   }
 
   public toggle(event: MouseEvent) {
@@ -249,7 +249,7 @@ export class NovoControlGroup implements AfterContentInit, OnChanges {
   }
 
   private getNewControls(controls: BaseControl[]) {
-    let ret: BaseControl[] = [];
+    const ret: BaseControl[] = [];
     (this.controls || []).forEach((control: BaseControl) => {
       ret.push(new BaseControl(control.__type, control));
     });

--- a/projects/novo-elements/src/elements/form/DynamicForm.ts
+++ b/projects/novo-elements/src/elements/form/DynamicForm.ts
@@ -127,8 +127,8 @@ export class NovoDynamicFormElement implements OnChanges, OnInit, AfterContentIn
       });
     }
 
-    let requiredFields: Array<any> = [];
-    let nonRequiredFields: Array<any> = [];
+    const requiredFields: Array<any> = [];
+    const nonRequiredFields: Array<any> = [];
     this.fieldsets.forEach((fieldset) => {
       fieldset.controls.forEach((control) => {
         if (control.required) {
@@ -231,7 +231,7 @@ export class NovoDynamicFormElement implements OnChanges, OnInit, AfterContentIn
 
   public forceValidation(): void {
     Object.keys(this.form.controls).forEach((key: string) => {
-      let control: any = this.form.controls[key];
+      const control: any = this.form.controls[key];
       if (control.required && Helpers.isBlank(this.form.value[control.key])) {
         control.markAsDirty();
         control.markAsTouched();

--- a/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
@@ -159,7 +159,7 @@ export class FieldInteractionApi {
       return null;
     }
 
-    let control = this.form.controls[key];
+    const control = this.form.controls[key];
     if (!control) {
       console.error('[FieldInteractionAPI] - could not find a control in the form by the key --', key); // tslint:disable-line
       return null;
@@ -169,7 +169,7 @@ export class FieldInteractionApi {
   }
 
   public getValue(key: string): any {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control) {
       return control.value;
     }
@@ -177,7 +177,7 @@ export class FieldInteractionApi {
   }
 
   public getRawValue(key: string): any {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control) {
       return control.rawValue;
     }
@@ -185,7 +185,7 @@ export class FieldInteractionApi {
   }
 
   public getInitialValue(key: string): any {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control) {
       return control.initialValue;
     }
@@ -202,10 +202,10 @@ export class FieldInteractionApi {
       emitViewToModelChange?: boolean;
     },
   ): void {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       control.setValue(value, options);
-      this.triggerEvent({ controlKey: key, prop: 'value', value: value });
+      this.triggerEvent({ controlKey: key, prop: 'value', value });
     }
   }
 
@@ -219,15 +219,15 @@ export class FieldInteractionApi {
       emitViewToModelChange?: boolean;
     },
   ): void {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       control.setValue(value, options);
-      this.triggerEvent({ controlKey: key, prop: 'value', value: value });
+      this.triggerEvent({ controlKey: key, prop: 'value', value });
     }
   }
 
   public setReadOnly(key: string, isReadOnly: boolean): void {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       control.setReadOnly(isReadOnly);
       this.triggerEvent({ controlKey: key, prop: 'readOnly', value: isReadOnly });
@@ -235,7 +235,7 @@ export class FieldInteractionApi {
   }
 
   public setRequired(key: string, required: boolean): void {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       control.setRequired(required);
       this.triggerEvent({ controlKey: key, prop: 'required', value: required });
@@ -243,7 +243,7 @@ export class FieldInteractionApi {
   }
 
   public hide(key: string, clearValue: boolean = true): void {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       control.hide(clearValue);
       this.disable(key, { emitEvent: false });
@@ -252,7 +252,7 @@ export class FieldInteractionApi {
   }
 
   public show(key: string): void {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       control.show();
       this.enable(key, { emitEvent: false });
@@ -281,7 +281,7 @@ export class FieldInteractionApi {
       emitEvent?: boolean;
     },
   ): void {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       control.disable(options);
       this.triggerEvent({ controlKey: key, prop: 'readOnly', value: true });
@@ -295,7 +295,7 @@ export class FieldInteractionApi {
       emitEvent?: boolean;
     },
   ): void {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       control.enable(options);
       this.triggerEvent({ controlKey: key, prop: 'readOnly', value: false });
@@ -303,7 +303,7 @@ export class FieldInteractionApi {
   }
 
   public markAsInvalid(key: string, validationMessage?: string): void {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control) {
       if (control && !control.restrictFieldInteractions) {
         control.markAsInvalid(validationMessage);
@@ -317,7 +317,7 @@ export class FieldInteractionApi {
       onlySelf?: boolean;
     },
   ): void {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       control.markAsDirty(options);
     }
@@ -329,7 +329,7 @@ export class FieldInteractionApi {
       onlySelf?: boolean;
     },
   ): void {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       control.markAsPending(options);
     }
@@ -341,7 +341,7 @@ export class FieldInteractionApi {
       onlySelf?: boolean;
     },
   ): void {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       control.markAsPristine(options);
     }
@@ -353,7 +353,7 @@ export class FieldInteractionApi {
       onlySelf?: boolean;
     },
   ): void {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       control.markAsTouched(options);
     }
@@ -365,7 +365,7 @@ export class FieldInteractionApi {
       onlySelf?: boolean;
     },
   ): void {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       control.markAsUntouched(options);
     }
@@ -378,7 +378,7 @@ export class FieldInteractionApi {
       emitEvent?: boolean;
     },
   ): void {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       control.updateValueAndValidity(options);
     }
@@ -391,11 +391,11 @@ export class FieldInteractionApi {
   }
 
   public displayTip(key: string, tip: string, icon?: string, allowDismiss?: boolean, sanitize?: boolean): void {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       control.tipWell = {
-        tip: tip,
-        icon: icon,
+        tip,
+        icon,
         button: allowDismiss,
         sanitize: sanitize !== false, // defaults to true when undefined
       };
@@ -404,7 +404,7 @@ export class FieldInteractionApi {
   }
 
   public setTooltip(key: string, tooltip: string): void {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       control.tooltip = tooltip;
       if (tooltip.length >= 40 && tooltip.length <= 400) {
@@ -418,10 +418,10 @@ export class FieldInteractionApi {
   }
 
   public confirmChanges(key: string, message?: string): Promise<boolean> {
-    let history = this.getProperty(key, 'valueHistory');
-    let oldValue = history[history.length - 2];
-    let newValue = this.getValue(key);
-    let label = this.getProperty(key, 'label');
+    const history = this.getProperty(key, 'valueHistory');
+    const oldValue = history[history.length - 2];
+    const newValue = this.getValue(key);
+    const label = this.getProperty(key, 'label');
     (document.activeElement as any).blur();
     return this.modalService.open(ControlConfirmModal, { oldValue, newValue, label, message, key }).onClosed.then((result) => {
       if (!result) {
@@ -431,21 +431,21 @@ export class FieldInteractionApi {
   }
 
   public promptUser(key: string, changes: string[]): Promise<boolean> {
-    let showYes: boolean = true;
+    const showYes: boolean = true;
     (document.activeElement as any).blur();
-    return this.modalService.open(ControlPromptModal, { changes: changes, key: key }).onClosed;
+    return this.modalService.open(ControlPromptModal, { changes, key }).onClosed;
   }
 
   public setProperty(key: string, prop: string, value: any): void {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       control[prop] = value;
-      this.triggerEvent({ controlKey: key, prop: prop, value: value });
+      this.triggerEvent({ controlKey: key, prop, value });
     }
   }
 
   public getProperty(key: string, prop: string): any {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       return control[prop];
     }
@@ -453,12 +453,12 @@ export class FieldInteractionApi {
   }
 
   public isValueEmpty(key: string): boolean {
-    let value = this.getValue(key);
+    const value = this.getValue(key);
     return Helpers.isEmpty(value);
   }
 
   public isValueBlank(key: string): boolean {
-    let value = this.getValue(key);
+    const value = this.getValue(key);
     return Helpers.isBlank(value);
   }
 
@@ -467,13 +467,13 @@ export class FieldInteractionApi {
   }
 
   public addStaticOption(key: string, newOption: any): void {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     let optionToAdd = newOption;
     let isUnique: boolean = true;
     if (control && !control.restrictFieldInteractions) {
       let currentOptions = this.getProperty(key, 'options');
       if (!currentOptions || !currentOptions.length) {
-        let config = this.getProperty(key, 'config');
+        const config = this.getProperty(key, 'config');
         if (config) {
           currentOptions = config.options;
           if (currentOptions && Array.isArray(currentOptions)) {
@@ -505,11 +505,11 @@ export class FieldInteractionApi {
   }
 
   public removeStaticOption(key: string, optionToRemove: string): void {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       let currentOptions = this.getProperty(key, 'options');
       if (!currentOptions || !currentOptions.length) {
-        let config = this.getProperty(key, 'config');
+        const config = this.getProperty(key, 'config');
         if (config) {
           currentOptions = config.options;
           if (currentOptions && Array.isArray(currentOptions)) {
@@ -564,7 +564,7 @@ export class FieldInteractionApi {
   }
 
   public mutatePickerConfig(key: string, args: ModifyPickerConfigArgs, mapper?: (item: unknown) => unknown): void {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       const { minSearchLength, enableInfiniteScroll, filteredOptionsCreator, format, getLabels, emptyPickerMessage } = control.config;
       const optionsConfig = this.getOptionsConfig(args, mapper, filteredOptionsCreator, format);
@@ -585,7 +585,7 @@ export class FieldInteractionApi {
   }
 
   addPropertiesToPickerConfig(key: string, properties: { [key: string]: unknown }) {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (!control || control.restrictFieldInteractions) {
       return;
     }
@@ -652,7 +652,7 @@ export class FieldInteractionApi {
   };
 
   public setLoading(key: string, loading: boolean) {
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       if (loading) {
         this.form.controls[key].fieldInteractionloading = true;
@@ -698,7 +698,7 @@ export class FieldInteractionApi {
       return null;
     }
 
-    let control = this.form.controls[key];
+    const control = this.form.controls[key];
     let fieldsetIndex, controlIndex;
     if (control) {
       fieldsetIndex = -1;
@@ -738,9 +738,9 @@ export class FieldInteractionApi {
       }
 
       if (fieldsetIndex !== -1 && controlIndex !== -1) {
-        let novoControl = this.formUtils.getControlForField(metaForNewField, this.http, {});
+        const novoControl = this.formUtils.getControlForField(metaForNewField, this.http, {});
         novoControl.hidden = false;
-        let formControl = new NovoFormControl(initialValue, novoControl);
+        const formControl = new NovoFormControl(initialValue, novoControl);
         this.form.addControl(novoControl.key, formControl);
         this.form.fieldsets[fieldsetIndex].controls.splice(controlIndex, 0, novoControl);
         this.triggerEvent({ controlKey: key, prop: 'addControl', value: formControl });
@@ -753,7 +753,7 @@ export class FieldInteractionApi {
       // Field is not on the form
       return null;
     }
-    let control = this.getControl(key);
+    const control = this.getControl(key);
     if (control && !control.restrictFieldInteractions) {
       let fieldsetIndex = -1;
       let controlIndex = -1;

--- a/projects/novo-elements/src/elements/form/Form.ts
+++ b/projects/novo-elements/src/elements/form/Form.ts
@@ -90,7 +90,7 @@ export class NovoFormElement implements AfterContentInit, OnInit {
 
   public forceValidation(): void {
     Object.keys(this.form.controls).forEach((key: string) => {
-      let control: any = this.form.controls[key];
+      const control: any = this.form.controls[key];
       if (control.required && Helpers.isBlank(this.form.value[control.key])) {
         control.markAsDirty();
         control.markAsTouched();

--- a/projects/novo-elements/src/elements/form/FormValidators.spec.ts
+++ b/projects/novo-elements/src/elements/form/FormValidators.spec.ts
@@ -6,11 +6,11 @@ import { FormValidators } from './FormValidators';
  */
 function createAddress(address1, city, state, zip, countryName) {
   return {
-    address1: address1,
-    city: city,
-    state: state,
-    zip: zip,
-    countryName: countryName,
+    address1,
+    city,
+    state,
+    zip,
+    countryName,
   };
 }
 

--- a/projects/novo-elements/src/elements/form/FormValidators.ts
+++ b/projects/novo-elements/src/elements/form/FormValidators.ts
@@ -38,14 +38,14 @@ export class FormValidators {
 
   // Make sure the control value is an email
   static isEmail(control) {
-    let EMAIL_REGEXP = /^[a-z0-9!#$%&'*+\/=?^_`{|}~.-]+@[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/i;
+    const EMAIL_REGEXP = /^[a-z0-9!#$%&'*+\/=?^_`{|}~.-]+@[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/i;
     return !control.value || EMAIL_REGEXP.test(control.value) ? null : { invalidEmail: true };
   }
   // Makes sure the control value is a valid address
   static isValidAddress(control) {
-    let fieldList: string[] = ['address1', 'address2', 'city', 'state', 'zip', 'countryID'];
-    let invalidAddressFields: string[] = [];
-    let maxlengthFields: string[] = [];
+    const fieldList: string[] = ['address1', 'address2', 'city', 'state', 'zip', 'countryID'];
+    const invalidAddressFields: string[] = [];
+    const maxlengthFields: string[] = [];
     let returnVal: {
       invalidAddress?: boolean;
       invalidAddressFields?: string[];
@@ -54,7 +54,7 @@ export class FormValidators {
       maxlengthFields?: string[];
     } = null;
     let maxlengthError: boolean = false;
-    let showCountryRequiredFlag = (subfield, ctrl) => {
+    const showCountryRequiredFlag = (subfield, ctrl) => {
       return (
         subfield === 'countryID' &&
         !Helpers.isEmpty(ctrl.config.countryID) &&
@@ -64,7 +64,7 @@ export class FormValidators {
       );
     };
 
-    let showStateRequiredFlag = (subfield, ctrl): boolean => {
+    const showStateRequiredFlag = (subfield, ctrl): boolean => {
       return (
         subfield === 'state' &&
         !Helpers.isEmpty(ctrl.config.state) &&

--- a/projects/novo-elements/src/elements/form/NovoFormControl.spec.ts
+++ b/projects/novo-elements/src/elements/form/NovoFormControl.spec.ts
@@ -4,7 +4,7 @@ import { Validators } from '@angular/forms';
 import { NovoFormControl } from './NovoFormControl';
 
 describe('Elements: NovoFormControl', () => {
-  let component = new NovoFormControl('1', { validators: [] });
+  const component = new NovoFormControl('1', { validators: [] });
   it('initialize correctly', () => {
     expect(component).toBeDefined();
   });

--- a/projects/novo-elements/src/elements/form/NovoFormControl.ts
+++ b/projects/novo-elements/src/elements/form/NovoFormControl.ts
@@ -158,7 +158,7 @@ export class NovoFormControl extends FormControl {
     this.required = isRequired;
     // Update validators to have the required
     if (this.required && !this.hasRequiredValidator) {
-      let validators: any = [...this.validators];
+      const validators: any = [...this.validators];
       validators.push(Validators.required);
       // TODO: duplicated below
       this.setValidators(validators);

--- a/projects/novo-elements/src/elements/form/NovoFormGroup.spec.ts
+++ b/projects/novo-elements/src/elements/form/NovoFormGroup.spec.ts
@@ -3,7 +3,7 @@ import { NovoFormGroup } from './NovoFormGroup';
 import { NovoFormControl } from './NovoFormControl';
 
 describe('Elements: NovoFormGroup', () => {
-  let component = new NovoFormGroup({});
+  const component = new NovoFormGroup({});
 
   describe('Method: enableAllControls()', () => {
     it('should enable all controls', () => {
@@ -11,12 +11,12 @@ describe('Elements: NovoFormGroup', () => {
         firstName: new NovoFormControl('John', {}),
         lastName: new NovoFormControl('Doe', {}),
       };
-      for (let key in component.controls) {
+      for (const key in component.controls) {
         spyOn(component.controls[key], 'enable');
         (component.controls[key] as NovoFormControl).readOnly = true;
       }
       component.enableAllControls();
-      for (let key in component.controls) {
+      for (const key in component.controls) {
         expect((component.controls[key] as NovoFormControl).readOnly).toEqual(false);
         expect((component.controls[key] as NovoFormControl).enable).toHaveBeenCalled();
       }
@@ -29,12 +29,12 @@ describe('Elements: NovoFormGroup', () => {
         firstName: new NovoFormControl('John', {}),
         lastName: new NovoFormControl('Doe', {}),
       };
-      for (let key in component.controls) {
+      for (const key in component.controls) {
         spyOn(component.controls[key], 'disable');
         (component.controls[key] as NovoFormControl).readOnly = false;
       }
       component.disableAllControls();
-      for (let key in component.controls) {
+      for (const key in component.controls) {
         expect((component.controls[key] as NovoFormControl).readOnly).toEqual(true);
         expect((component.controls[key] as NovoFormControl).disable).toHaveBeenCalled();
       }

--- a/projects/novo-elements/src/elements/form/NovoFormGroup.ts
+++ b/projects/novo-elements/src/elements/form/NovoFormGroup.ts
@@ -23,7 +23,7 @@ export class NovoFormGroup extends FormGroup {
   }
 
   public enableAllControls(): void {
-    for (let key in this.controls) {
+    for (const key in this.controls) {
       if ((this.controls[key] as NovoFormControl).readOnly) {
         (this.controls[key] as NovoFormControl).readOnly = false;
         this.controls[key].enable();
@@ -32,7 +32,7 @@ export class NovoFormGroup extends FormGroup {
   }
 
   public disableAllControls(): void {
-    for (let key in this.controls) {
+    for (const key in this.controls) {
       if (!(this.controls[key] as NovoFormControl).readOnly) {
         (this.controls[key] as NovoFormControl).readOnly = true;
         this.controls[key].disable();

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -340,7 +340,7 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit {
     this.isInvalid(field);
     this.isValid(field);
     if (event) {
-      this.change.emit({ value: this.model[field], field: field });
+      this.change.emit({ value: this.model[field], field });
     }
   }
 
@@ -355,7 +355,7 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit {
   }
 
   onCountryChange(evt) {
-    let country: any = evt && evt.rawValue ? evt.rawValue : null;
+    const country: any = evt && evt.rawValue ? evt.rawValue : null;
     let field: any;
     let statesUpdatable: boolean = false;
     this.config.countryID.updated = true;
@@ -388,7 +388,7 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit {
   }
 
   onStateChange(evt) {
-    let state: any = evt && evt.value ? evt.value : null;
+    const state: any = evt && evt.value ? evt.value : null;
     this.config.state.updated = true;
     this.model.state = state;
     this.updateControl();
@@ -396,7 +396,7 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit {
   }
 
   setStateLabel(model: any) {
-    let state: string = model.state;
+    const state: string = model.state;
     if (!Helpers.isBlank(state)) {
       if (this.config.state.required) {
         this.valid.state = true;
@@ -469,7 +469,7 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit {
       } else if (model.countryID) {
         if (this.config.countryID.pickerConfig && this.config.countryID.pickerConfig.getLabels) {
           if (Helpers.isFunction(this.config.countryID.pickerConfig.getLabels)) {
-            let promise: any = this.config.countryID.pickerConfig.getLabels(model.countryID);
+            const promise: any = this.config.countryID.pickerConfig.getLabels(model.countryID);
             loadingCountries = true;
             if (promise.then) {
               promise.then((result: any) => {
@@ -485,7 +485,7 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit {
       if (countryName) {
         countryName = countryName.trim();
         model.state = model.state || '';
-        this.model = Object.assign(model, { countryName: countryName });
+        this.model = Object.assign(model, { countryName });
       } else {
         this.model = model;
       }
@@ -534,7 +534,7 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit {
       },
       getLabels: (countryID) => {
         return new Promise((resolve: any) => {
-          let country: any = findByCountryId(countryID);
+          const country: any = findByCountryId(countryID);
           if (country) {
             resolve({ value: country.id, label: country.name });
           } else {

--- a/projects/novo-elements/src/elements/form/extras/checkbox/CheckList.ts
+++ b/projects/novo-elements/src/elements/form/extras/checkbox/CheckList.ts
@@ -59,7 +59,7 @@ export class NovoCheckListElement implements ControlValueAccessor, OnInit {
     this._options = [];
     if (this.options.length && !this.options[0].value) {
       this.options.forEach((option) => {
-        let formattedOption = {
+        const formattedOption = {
           value: option,
           label: option,
           checked: this.model && this.model.length && this.model.indexOf(option.value) !== -1,
@@ -68,7 +68,7 @@ export class NovoCheckListElement implements ControlValueAccessor, OnInit {
       });
     } else {
       this.options.forEach((option) => {
-        let formattedOption = option;
+        const formattedOption = option;
         formattedOption.checked = this.model && this.model.length && this.model.indexOf(option.value) !== -1;
         this._options.push(formattedOption);
       });
@@ -76,7 +76,7 @@ export class NovoCheckListElement implements ControlValueAccessor, OnInit {
   }
 
   setModel(): void {
-    let checkedOptions = this.options.filter((checkBox) => checkBox.checked).map((x) => x.value);
+    const checkedOptions = this.options.filter((checkBox) => checkBox.checked).map((x) => x.value);
     this.writeValue(checkedOptions);
   }
 

--- a/projects/novo-elements/src/elements/form/extras/file/FileInput.spec.ts
+++ b/projects/novo-elements/src/elements/form/extras/file/FileInput.spec.ts
@@ -12,7 +12,7 @@ describe('Elements: NovoFileInputElement', () => {
   let fixture;
   let component;
 
-  let FakeEvent = () => {};
+  const FakeEvent = () => {};
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -71,7 +71,7 @@ describe('Elements: NovoFileInputElement', () => {
   });
   describe('Method: initializeDragula()', () => {
     it('should correctly initialize dragula', () => {
-      let expectedBag = 'file-output-1';
+      const expectedBag = 'file-output-1';
       component.dragula = {
         bags: [{ name: 'TEST', drake: {} }],
         setOptions: () => {},
@@ -91,8 +91,8 @@ describe('Elements: NovoFileInputElement', () => {
     it('should correctly insert templates by default', () => {
       expect(component.insertTemplatesBasedOnLayout).toBeDefined();
       spyOn(component.container, 'createEmbeddedView');
-      let expected = ['fileOutput', 'fileInput'];
-      let insertedOrder = component.insertTemplatesBasedOnLayout();
+      const expected = ['fileOutput', 'fileInput'];
+      const insertedOrder = component.insertTemplatesBasedOnLayout();
       expect(component.container.createEmbeddedView).toHaveBeenCalled();
       expect(insertedOrder).toEqual(expected);
     });
@@ -100,8 +100,8 @@ describe('Elements: NovoFileInputElement', () => {
       component.layoutOptions.order = 'displayFilesBelow';
       expect(component.insertTemplatesBasedOnLayout).toBeDefined();
       spyOn(component.container, 'createEmbeddedView');
-      let expected = ['fileInput', 'fileOutput'];
-      let insertedOrder = component.insertTemplatesBasedOnLayout();
+      const expected = ['fileInput', 'fileOutput'];
+      const insertedOrder = component.insertTemplatesBasedOnLayout();
       expect(component.container.createEmbeddedView).toHaveBeenCalled();
       expect(insertedOrder).toEqual(expected);
     });

--- a/projects/novo-elements/src/elements/form/extras/file/FileInput.ts
+++ b/projects/novo-elements/src/elements/form/extras/file/FileInput.ts
@@ -216,7 +216,7 @@ export class NovoFileInputElement implements ControlValueAccessor, OnInit, OnDes
     ['dragenter', 'dragleave', 'dragover', 'drop'].forEach((type) => {
       this.element.nativeElement.removeEventListener(type, this.commands[type]);
     });
-    let dragulaHasFileOutputBag = this.dragula.bags.length > 0 && this.dragula.bags.filter((x) => x.name === this.fileOutputBag).length > 0;
+    const dragulaHasFileOutputBag = this.dragula.bags.length > 0 && this.dragula.bags.filter((x) => x.name === this.fileOutputBag).length > 0;
     if (dragulaHasFileOutputBag) {
       this.dragula.destroy(this.fileOutputBag);
     }
@@ -286,8 +286,8 @@ export class NovoFileInputElement implements ControlValueAccessor, OnInit, OnDes
     if (event.dataTransfer.types[0] !== 'Files') {
       return;
     }
-    let options: any = this.layoutOptions;
-    let filelist = Array.from(event.dataTransfer.files);
+    const options: any = this.layoutOptions;
+    const filelist = Array.from(event.dataTransfer.files);
     if (options.customActions) {
       this.upload.emit(this.multiple ? filelist : [filelist[0]]);
     } else {

--- a/projects/novo-elements/src/elements/loading/Loading.ts
+++ b/projects/novo-elements/src/elements/loading/Loading.ts
@@ -161,7 +161,7 @@ export class NovoIsLoadingDirective {
   }
   destroyViews(views: EmbeddedViewRef<any>[]) {
     if (views) {
-      for (let view of views) {
+      for (const view of views) {
         view.destroy();
       }
     }

--- a/projects/novo-elements/src/elements/multi-picker/MultiPicker.ts
+++ b/projects/novo-elements/src/elements/multi-picker/MultiPicker.ts
@@ -136,7 +136,7 @@ export class NovoMultiPickerElement implements OnInit {
     this._options = [];
     if (this.options) {
       this.options.forEach((option) => {
-        let formattedOption = this.setupOptionsByType(option);
+        const formattedOption = this.setupOptionsByType(option);
         this._options.push(formattedOption);
       });
     }
@@ -144,7 +144,7 @@ export class NovoMultiPickerElement implements OnInit {
   }
 
   setupOptionsByType(section) {
-    let formattedSection: any = {
+    const formattedSection: any = {
       type: section.type,
       label: section.label || section.type,
     };
@@ -152,7 +152,7 @@ export class NovoMultiPickerElement implements OnInit {
       return this.formatOption(section, item);
     });
     if (this.selectAllOption) {
-      let selectAll = this.createSelectAllOption(section);
+      const selectAll = this.createSelectAllOption(section);
       formattedSection.data.splice(0, 0, selectAll);
     }
     formattedSection.originalData = formattedSection.data.slice();
@@ -160,7 +160,7 @@ export class NovoMultiPickerElement implements OnInit {
   }
 
   formatOption(section, item) {
-    let obj = {
+    const obj = {
       value: section.field ? item[section.field] : item.value || item,
       label: section.format ? Helpers.interpolate(section.format, item) : item.label || String(item.value || item),
       type: section.type,
@@ -175,7 +175,7 @@ export class NovoMultiPickerElement implements OnInit {
   }
 
   createSelectAllOption(section) {
-    let selectAll = {
+    const selectAll = {
       value: 'ALL',
       label: `All ${section.type}`,
       type: section.type,
@@ -184,7 +184,7 @@ export class NovoMultiPickerElement implements OnInit {
       isChildOf: section.isChildOf,
     };
     if (section.isChildOf) {
-      let allParents = section.data.reduce((accum, next) => {
+      const allParents = section.data.reduce((accum, next) => {
         return accum.concat(next[section.isChildOf]);
       }, []);
       selectAll[section.isChildOf] = allParents;
@@ -216,7 +216,7 @@ export class NovoMultiPickerElement implements OnInit {
       }
       this.modifyAffectedParentsOrChildren(event.checked, event);
       // Set focus on the picker
-      let input = this.element.nativeElement.querySelector('novo-picker > input');
+      const input = this.element.nativeElement.querySelector('novo-picker > input');
       if (input) {
         input.focus();
       }
@@ -237,8 +237,8 @@ export class NovoMultiPickerElement implements OnInit {
   }
 
   updateAllItemState(type) {
-    let allOfType = this.getAllOfType(type);
-    let allOfTypeSelected = this.allItemsSelected(allOfType, type);
+    const allOfType = this.getAllOfType(type);
+    const allOfTypeSelected = this.allItemsSelected(allOfType, type);
     if (allOfTypeSelected) {
       this.selectAll(allOfType, type);
     }
@@ -249,12 +249,12 @@ export class NovoMultiPickerElement implements OnInit {
     if (!this.selectAllOption) {
       return;
     }
-    let allItem = allOfType[0];
+    const allItem = allOfType[0];
     allItem.indeterminate = status;
   }
 
   updateDisplayItems(item, action) {
-    let adding = action === 'add';
+    const adding = action === 'add';
     if (adding) {
       this.items.push(item);
     } else {
@@ -268,19 +268,19 @@ export class NovoMultiPickerElement implements OnInit {
 
   updateDisplayText(items) {
     this.notShown = [];
-    let notShown = items.slice(this.chipsCount);
+    const notShown = items.slice(this.chipsCount);
     if (notShown.length > 0) {
       this.types.forEach((type) => {
         let count;
-        let selectedOfType = notShown.filter((x) => x.type === type.value);
+        const selectedOfType = notShown.filter((x) => x.type === type.value);
         if (selectedOfType.length === 1 && selectedOfType[0].value === 'ALL') {
           count = this.getAllOfType(type.value).length - 1;
         } else {
           count = selectedOfType.length;
         }
-        let displayType = count === 1 ? type.singular : type.plural || type.value;
+        const displayType = count === 1 ? type.singular : type.plural || type.value;
         if (count > 0) {
-          this.notShown.push({ type: displayType, count: count });
+          this.notShown.push({ type: displayType, count });
         }
       });
     }
@@ -291,7 +291,7 @@ export class NovoMultiPickerElement implements OnInit {
     if (event) {
       triggeredByEvent = true;
     }
-    let itemToRemove = item;
+    const itemToRemove = item;
     if (itemToRemove.value === 'ALL') {
       triggeredByEvent = false;
       this.modifyAllOfType(itemToRemove.type, 'unselect');
@@ -314,7 +314,7 @@ export class NovoMultiPickerElement implements OnInit {
   }
 
   removeValue(item) {
-    let updatedValues = this.value[item.type].filter((x) => x !== item.value);
+    const updatedValues = this.value[item.type].filter((x) => x !== item.value);
     this.value[item.type] = updatedValues;
     this.triggerValueUpdate();
     this.updateDisplayItems(item, 'remove');
@@ -341,8 +341,8 @@ export class NovoMultiPickerElement implements OnInit {
   }
 
   modifyAllOfType(type, action) {
-    let selecting = action === 'select';
-    let allOfType = this.getAllOfType(type);
+    const selecting = action === 'select';
+    const allOfType = this.getAllOfType(type);
     allOfType.forEach((item) => {
       item.checked = selecting;
       item.indeterminate = false;
@@ -361,7 +361,7 @@ export class NovoMultiPickerElement implements OnInit {
   }
 
   triggerValueUpdate() {
-    let updatedObject = {};
+    const updatedObject = {};
     this.types.forEach((x) => (updatedObject[x.value] = this.value[x.value]));
     this.value = updatedObject;
   }
@@ -371,13 +371,13 @@ export class NovoMultiPickerElement implements OnInit {
       return;
     }
     allOfType[0].checked = true;
-    let values = allOfType.map((i) => {
+    const values = allOfType.map((i) => {
       return i.value;
     });
     // remove 'ALL' value
     values.splice(0, 1);
     this.value[type] = values;
-    let updatedItems = this.items.filter((x) => x.type !== type);
+    const updatedItems = this.items.filter((x) => x.type !== type);
     this.items = updatedItems;
     this.updateDisplayItems(allOfType[0], 'add');
   }
@@ -386,14 +386,14 @@ export class NovoMultiPickerElement implements OnInit {
     if (!this.selectAllOption) {
       return;
     }
-    let type = item.type;
-    let allOfType = this.getAllOfType(type);
-    let allItem = allOfType[0];
+    const type = item.type;
+    const allOfType = this.getAllOfType(type);
+    const allItem = allOfType[0];
     this.removeItem(allItem);
     allItem.indeterminate = true;
-    let selectedItems = allOfType.filter((i) => i.checked === true);
+    const selectedItems = allOfType.filter((i) => i.checked === true);
     this.items = [...this.items, ...selectedItems];
-    let values = selectedItems.map((i) => {
+    const values = selectedItems.map((i) => {
       return i.value;
     });
     this.value[type] = [...values];
@@ -423,18 +423,18 @@ export class NovoMultiPickerElement implements OnInit {
     if (!itemChanged.isChildOf && !itemChanged.isParentOf) {
       return;
     }
-    let parent = this.types.filter((x) => !!x.isParentOf)[0];
-    let parentType = parent.value;
-    let allParentType = this.getAllOfType(parentType);
-    let childType = allParentType[0].isParentOf;
-    let allChildren = this.getAllOfType(childType);
-    let allCheckedChildren = allChildren.filter((x) => !!x.checked);
+    const parent = this.types.filter((x) => !!x.isParentOf)[0];
+    const parentType = parent.value;
+    const allParentType = this.getAllOfType(parentType);
+    const childType = allParentType[0].isParentOf;
+    const allChildren = this.getAllOfType(childType);
+    const allCheckedChildren = allChildren.filter((x) => !!x.checked);
 
     allParentType.forEach((obj) => {
       if (obj.value === 'ALL') {
         return;
       }
-      let selectedChildrenOfParent = allCheckedChildren.filter((x) => {
+      const selectedChildrenOfParent = allCheckedChildren.filter((x) => {
         return x[parentType].filter((y) => y === obj.value).length > 0;
       });
 
@@ -444,7 +444,7 @@ export class NovoMultiPickerElement implements OnInit {
         }
         obj.indeterminate = selectedChildrenOfParent.length > 0;
       } else {
-        let allChildrenOfParent = allChildren.filter((x) => {
+        const allChildrenOfParent = allChildren.filter((x) => {
           return x.value !== 'ALL' && x[parentType].filter((y) => y === obj.value).length > 0;
         });
         if (selectedChildrenOfParent.length > 0) {
@@ -490,9 +490,9 @@ export class NovoMultiPickerElement implements OnInit {
   }
 
   updateAllChildrenValue(item, action) {
-    let selecting = action === 'select';
-    let childType = item.isParentOf;
-    let potentialChildren = this.getAllOfType(childType);
+    const selecting = action === 'select';
+    const childType = item.isParentOf;
+    const potentialChildren = this.getAllOfType(childType);
     if (this.selectAllOption && this.allOfTypeSelected(childType) && !selecting) {
       this.remove(null, potentialChildren[0]);
       return;
@@ -513,9 +513,9 @@ export class NovoMultiPickerElement implements OnInit {
   }
 
   updateAllParentValue(item, action) {
-    let selecting = action === 'select';
-    let parentType = item.isChildOf;
-    let potentialParents = this.getAllOfType(parentType);
+    const selecting = action === 'select';
+    const parentType = item.isChildOf;
+    const potentialParents = this.getAllOfType(parentType);
     potentialParents.forEach((x) => {
       if (!x.checked) {
         x.indeterminate = selecting;
@@ -524,17 +524,17 @@ export class NovoMultiPickerElement implements OnInit {
   }
 
   updateIndeterminateStates(allParentType, allChildren, allCheckedChildren) {
-    let allCheckedOrIndeterminateParents = allParentType.filter((x) => (!!x.checked || !!x.indeterminate) && x.value !== 'ALL');
-    let isParentIndeterminate = !!allParentType[0].checked ? false : allCheckedOrIndeterminateParents.length > 0;
-    let isChildIndeterminate = !!allChildren[0].checked ? false : allCheckedChildren.length > 0;
+    const allCheckedOrIndeterminateParents = allParentType.filter((x) => (!!x.checked || !!x.indeterminate) && x.value !== 'ALL');
+    const isParentIndeterminate = !!allParentType[0].checked ? false : allCheckedOrIndeterminateParents.length > 0;
+    const isChildIndeterminate = !!allChildren[0].checked ? false : allCheckedChildren.length > 0;
     this.setIndeterminateState(allParentType, isParentIndeterminate);
     this.setIndeterminateState(allChildren, isChildIndeterminate);
   }
 
   updateChildrenValue(parent, action) {
-    let selecting = action === 'select';
-    let childType = parent.isParentOf;
-    let potentialChildren = this.getAllOfType(childType);
+    const selecting = action === 'select';
+    const childType = parent.isParentOf;
+    const potentialChildren = this.getAllOfType(childType);
     potentialChildren.forEach((x) => {
       if (x.value === 'ALL') {
         return;
@@ -554,7 +554,7 @@ export class NovoMultiPickerElement implements OnInit {
   }
 
   updateParentValue(child, action) {
-    let allParentType = this.getAllOfType(child.isChildOf);
+    const allParentType = this.getAllOfType(child.isChildOf);
     if (allParentType[0].checked && action !== 'select') {
       this.handleRemoveItemIfAllSelected(allParentType[0]);
     }
@@ -584,18 +584,18 @@ export class NovoMultiPickerElement implements OnInit {
       return;
     }
     this.types.forEach((typeObj) => {
-      let type = typeObj.value;
+      const type = typeObj.value;
       if (this.value[type]) {
         let indeterminateIsSet = false;
-        let options = this.updateAllItemState(type);
-        let optionsByType = options.allOfType;
-        let allSelected = options.allOfTypeSelected;
+        const options = this.updateAllItemState(type);
+        const optionsByType = options.allOfType;
+        const allSelected = options.allOfTypeSelected;
         this.value[type].forEach((item) => {
           if (!allSelected && !indeterminateIsSet) {
             indeterminateIsSet = true;
             this.setIndeterminateState(optionsByType, true);
           }
-          let value = optionsByType.filter((x) => x.value === item)[0];
+          const value = optionsByType.filter((x) => x.value === item)[0];
           value.checked = true;
           if (!allSelected) {
             this.updateDisplayItems(value, 'add');

--- a/projects/novo-elements/src/elements/multi-picker/Multipicker.spec.ts
+++ b/projects/novo-elements/src/elements/multi-picker/Multipicker.spec.ts
@@ -34,8 +34,8 @@ describe('Element: NovoMultiPickerElement', () => {
       component.types = [{ value: 'numbers' }];
       component.items = [1, 2];
       component.value = [1, 2];
-      let one = { value: 1, checked: true };
-      let two = { value: 2, checked: false, indeterminate: true };
+      const one = { value: 1, checked: true };
+      const two = { value: 2, checked: false, indeterminate: true };
       component._options = [{ type: 'numbers', data: [one, two], originalData: [one, two] }];
       component.clearValue();
       expect(component.items.length).toBe(0);
@@ -49,7 +49,7 @@ describe('Element: NovoMultiPickerElement', () => {
     it('should correctly setup options', () => {
       component.source = { options: [{ type: 'numbers', data: [1] }] };
       component.setupOptions();
-      let data = [
+      const data = [
         {
           value: 'ALL',
           label: 'All numbers',
@@ -60,17 +60,17 @@ describe('Element: NovoMultiPickerElement', () => {
         },
         { value: 1, label: '1', type: 'numbers', checked: undefined, isParentOf: undefined, isChildOf: undefined },
       ];
-      let originalData = data;
-      expect(component._options).toEqual([{ type: 'numbers', data: data, originalData: originalData }]);
+      const originalData = data;
+      expect(component._options).toEqual([{ type: 'numbers', data, originalData }]);
       expect(component.source.options).toBe(component._options);
     });
   });
 
   describe('Method: formatOption(section)', () => {
     it('should correctly format a parent option', () => {
-      let section = { type: 'cats', isParentOf: 'kittens' };
-      let item = { value: 1 };
-      let expectedObj = {
+      const section = { type: 'cats', isParentOf: 'kittens' };
+      const item = { value: 1 };
+      const expectedObj = {
         value: 1,
         label: '1',
         type: 'cats',
@@ -78,13 +78,13 @@ describe('Element: NovoMultiPickerElement', () => {
         isParentOf: 'kittens',
         isChildOf: undefined,
       };
-      let actual = component.formatOption(section, item);
+      const actual = component.formatOption(section, item);
       expect(actual).toEqual(expectedObj);
     });
     it('should correctly format a child option', () => {
-      let section = { type: 'kittens', isChildOf: 'cats' };
-      let item = { value: 1, cats: [{ id: 1 }] };
-      let expectedObj = {
+      const section = { type: 'kittens', isChildOf: 'cats' };
+      const item = { value: 1, cats: [{ id: 1 }] };
+      const expectedObj = {
         value: 1,
         label: '1',
         type: 'kittens',
@@ -93,13 +93,13 @@ describe('Element: NovoMultiPickerElement', () => {
         isParentOf: undefined,
         cats: [{ id: 1 }],
       };
-      let actual = component.formatOption(section, item);
+      const actual = component.formatOption(section, item);
       expect(actual).toEqual(expectedObj);
     });
     it('should correctly format a non parent/child option', () => {
-      let section = { type: 'kittens' };
-      let item = { value: 1 };
-      let expectedObj = {
+      const section = { type: 'kittens' };
+      const item = { value: 1 };
+      const expectedObj = {
         value: 1,
         label: '1',
         type: 'kittens',
@@ -107,15 +107,15 @@ describe('Element: NovoMultiPickerElement', () => {
         isChildOf: undefined,
         isParentOf: undefined,
       };
-      let actual = component.formatOption(section, item);
+      const actual = component.formatOption(section, item);
       expect(actual).toEqual(expectedObj);
     });
   });
 
   describe('Method: createSelectAllOption(section, item)', () => {
     it('should correctly create a select all option for a child type', () => {
-      let section = { type: 'kittens', isChildOf: 'cats', data: [{ cats: [{ id: 1 }, { id: 2 }] }] };
-      let expected = {
+      const section = { type: 'kittens', isChildOf: 'cats', data: [{ cats: [{ id: 1 }, { id: 2 }] }] };
+      const expected = {
         value: 'ALL',
         label: 'All kittens',
         type: 'kittens',
@@ -124,12 +124,12 @@ describe('Element: NovoMultiPickerElement', () => {
         isChildOf: 'cats',
         cats: [{ id: 1 }, { id: 2 }],
       };
-      let actualResult = component.createSelectAllOption(section);
+      const actualResult = component.createSelectAllOption(section);
       expect(actualResult).toEqual(expected);
     });
     it('should correctly create a select all option for a parent type', () => {
-      let section = { type: 'cats', isParentOf: 'kittens', data: [{ cats: [{ id: 1 }, { id: 2 }] }] };
-      let expected = {
+      const section = { type: 'cats', isParentOf: 'kittens', data: [{ cats: [{ id: 1 }, { id: 2 }] }] };
+      const expected = {
         value: 'ALL',
         label: 'All cats',
         type: 'cats',
@@ -137,7 +137,7 @@ describe('Element: NovoMultiPickerElement', () => {
         isParentOf: 'kittens',
         isChildOf: undefined,
       };
-      let actualResult = component.createSelectAllOption(section);
+      const actualResult = component.createSelectAllOption(section);
       expect(actualResult).toEqual(expected);
     });
   });
@@ -145,16 +145,16 @@ describe('Element: NovoMultiPickerElement', () => {
   describe('Method: setupOptionByType(section)', () => {
     it('should correctly format a section of options without the ALL section', () => {
       component.selectAllOption = false;
-      let section = { type: 'cats', label: 'cats', data: ['Kitty'] };
-      let data = [{ value: 'Kitty', label: 'Kitty', type: 'cats', checked: undefined, isParentOf: undefined, isChildOf: undefined }];
-      let expected = { type: 'cats', label: 'cats', data: data, originalData: data };
-      let actualResult = component.setupOptionsByType(section);
+      const section = { type: 'cats', label: 'cats', data: ['Kitty'] };
+      const data = [{ value: 'Kitty', label: 'Kitty', type: 'cats', checked: undefined, isParentOf: undefined, isChildOf: undefined }];
+      const expected = { type: 'cats', label: 'cats', data, originalData: data };
+      const actualResult = component.setupOptionsByType(section);
       expect(actualResult).toEqual(expected);
     });
     it('should correctly format a section of options with the ALL section', () => {
       component.selectAllOption = true;
-      let section = { type: 'cats', label: 'cats', data: ['Kitty'] };
-      let data = [
+      const section = { type: 'cats', label: 'cats', data: ['Kitty'] };
+      const data = [
         {
           value: 'ALL',
           label: 'All cats',
@@ -165,8 +165,8 @@ describe('Element: NovoMultiPickerElement', () => {
         },
         { value: 'Kitty', label: 'Kitty', type: 'cats', checked: undefined, isParentOf: undefined, isChildOf: undefined },
       ];
-      let expected = { type: 'cats', label: 'cats', data: data, originalData: data };
-      let actualResult = component.setupOptionsByType(section);
+      const expected = { type: 'cats', label: 'cats', data, originalData: data };
+      const actualResult = component.setupOptionsByType(section);
       expect(actualResult).toEqual(expected);
     });
   });
@@ -189,7 +189,7 @@ describe('Element: NovoMultiPickerElement', () => {
 
   xdescribe('Method: clickOption(event)', () => {
     it('should remove item if checked is false', () => {
-      let item = { checked: false };
+      const item = { checked: false };
       jest.spyOn(component, 'remove').mockImplementation(() => {});
       jest.spyOn(component, 'modifyAffectedParentsOrChildren').mockImplementation(() => {});
       component.clickOption(item);
@@ -198,7 +198,7 @@ describe('Element: NovoMultiPickerElement', () => {
     });
 
     it('should add item if checked is true', () => {
-      let item = { checked: true };
+      const item = { checked: true };
       jest.spyOn(component, 'add').mockImplementation(() => {});
       jest.spyOn(component, 'modifyAffectedParentsOrChildren').mockImplementation(() => {});
       component.clickOption(item);
@@ -210,13 +210,13 @@ describe('Element: NovoMultiPickerElement', () => {
   describe('Method: updateDisplayItems(item, action)', () => {
     it('should update items if adding', () => {
       component.items = [];
-      let item = { value: 'Cat', label: 'Cat' };
+      const item = { value: 'Cat', label: 'Cat' };
       component.updateDisplayItems(item, 'add');
       expect(component.items.length).toBe(1);
     });
 
     it('should update items if removing', () => {
-      let item = { value: 'Cat', label: 'Cat' };
+      const item = { value: 'Cat', label: 'Cat' };
       component.items = [item];
       component.updateDisplayItems(item, 'remove');
       expect(component.items.length).toBe(0);
@@ -225,7 +225,7 @@ describe('Element: NovoMultiPickerElement', () => {
 
   describe('Method: remove(event, item)', () => {
     it('should remove ALL item correctly', () => {
-      let item = { value: 'ALL' };
+      const item = { value: 'ALL' };
       jest.spyOn(component, 'modifyAllOfType').mockImplementation(() => {});
       jest.spyOn(component, 'removeItem').mockImplementation(() => {});
       component.remove(null, item);
@@ -235,7 +235,7 @@ describe('Element: NovoMultiPickerElement', () => {
 
     it('should remove normal item if ALL selected', () => {
       component.items = [{ value: 'ALL', label: 'Cat', type: 'cats' }];
-      let itemToRemove = { value: 'Cat', label: 'Cat', type: 'cats' };
+      const itemToRemove = { value: 'Cat', label: 'Cat', type: 'cats' };
       jest.spyOn(component, 'handleRemoveItemIfAllSelected').mockImplementation(() => {});
       jest.spyOn(component, 'removeItem').mockImplementation(() => {});
       component.remove(null, itemToRemove);
@@ -245,7 +245,7 @@ describe('Element: NovoMultiPickerElement', () => {
 
     it('should remove item normally if ALL is not selected', () => {
       component.items = [{ value: 'Cat', label: 'Cat', type: 'cats' }];
-      let itemToRemove = { value: 'Cat', label: 'Cat', type: 'cats' };
+      const itemToRemove = { value: 'Cat', label: 'Cat', type: 'cats' };
       jest.spyOn(component, 'removeItem').mockImplementation(() => {});
       component.remove(null, itemToRemove);
       expect(component.removeItem).toHaveBeenCalled();
@@ -254,7 +254,7 @@ describe('Element: NovoMultiPickerElement', () => {
 
   describe('Method: add(event)', () => {
     it('should add ALL item correctly', () => {
-      let item = { value: 'ALL' };
+      const item = { value: 'ALL' };
       jest.spyOn(component, 'modifyAllOfType').mockImplementation(() => {});
       jest.spyOn(component, 'select').mockImplementation(() => {});
       component.add(item);
@@ -266,7 +266,7 @@ describe('Element: NovoMultiPickerElement', () => {
       component.types = [{ value: 'cats' }];
       component.value = { cats: [] };
       component._options = [{ type: 'cats', data: [{ value: 'ALL', indeterminate: undefined }, { value: 'Kitty' }, { value: 'Tiger' }] }];
-      let itemToAdd = { value: 'Cat', label: 'Cat', type: 'cats' };
+      const itemToAdd = { value: 'Cat', label: 'Cat', type: 'cats' };
       jest.spyOn(component, 'updateDisplayItems').mockImplementation(() => {});
       jest.spyOn(component, 'updateAllItemState').mockImplementation(() => {});
       component.add(itemToAdd);
@@ -278,7 +278,7 @@ describe('Element: NovoMultiPickerElement', () => {
 
   describe('Method: removeItem(item)', () => {
     it('should handle removing item correctly from value and items and update checked state', () => {
-      let item = { value: 'Cat', checked: true, type: 'cats' };
+      const item = { value: 'Cat', checked: true, type: 'cats' };
       jest.spyOn(component, 'removeValue').mockImplementation(() => {});
       jest.spyOn(component, 'updateParentOrChildren').mockImplementation(() => {});
       component.removeItem(item);
@@ -290,7 +290,7 @@ describe('Element: NovoMultiPickerElement', () => {
 
   describe('Method: removeValue(item)', () => {
     it('should handle removing item correctly from value', () => {
-      let item = { value: 'Cat', type: 'cats' };
+      const item = { value: 'Cat', type: 'cats' };
       component.types = [{ value: 'cats' }];
       component.value = { cats: ['Tiger', 'Cat'] };
       jest.spyOn(component, 'updateDisplayItems').mockImplementation(() => {});
@@ -305,7 +305,7 @@ describe('Element: NovoMultiPickerElement', () => {
 
   describe('Method: updateDisplayText(items)', () => {
     it('should create an object with correct type and count when count is above 2', () => {
-      let items = [
+      const items = [
         { value: 1, type: 'numbers' },
         { value: 2, type: 'numbers' },
         { value: 3, type: 'numbers' },
@@ -323,7 +323,7 @@ describe('Element: NovoMultiPickerElement', () => {
       expect(component.notShown[0].count).toBe(2);
     });
     it('not add type and count to object if count is 0', () => {
-      let items = [
+      const items = [
         { value: 1, type: 'numbers' },
         { value: 2, type: 'numbers' },
         { value: 3, type: 'numbers' },
@@ -334,7 +334,7 @@ describe('Element: NovoMultiPickerElement', () => {
       expect(component.notShown.length).toBe(0);
     });
     it('add all items to count if all of type is selected', () => {
-      let items = [
+      const items = [
         { value: 1, type: 'numbers' },
         { value: 2, type: 'numbers' },
         { value: 3, type: 'numbers' },
@@ -359,7 +359,7 @@ describe('Element: NovoMultiPickerElement', () => {
       expect(component.notShown[0].count).toBe(7);
     });
     it('should create an object with correct type, count, and singular label when count is 1 above chipsCount', () => {
-      let items = [
+      const items = [
         { value: 1, type: 'numbers' },
         { value: 2, type: 'numbers' },
         { value: 3, type: 'numbers' },
@@ -377,7 +377,7 @@ describe('Element: NovoMultiPickerElement', () => {
       expect(component.notShown[0].count).toBe(1);
     });
     it('should create an object with correct type, count, and plural label when count is 2+ above chipsCount', () => {
-      let items = [
+      const items = [
         { value: 1, type: 'numbers' },
         { value: 2, type: 'numbers' },
         { value: 3, type: 'numbers' },
@@ -399,13 +399,13 @@ describe('Element: NovoMultiPickerElement', () => {
 
   describe('Method: allOfTypeSelected(type)', () => {
     it('should return true if ALL of type is selected', () => {
-      let item = { value: 'ALL', checked: true, type: 'cats' };
+      const item = { value: 'ALL', checked: true, type: 'cats' };
       component.items = [item];
       expect(component.allOfTypeSelected('cats')).toBeTruthy();
     });
 
     it('should return false if ALL of type is not selected', () => {
-      let item = { value: 'Kitty', checked: true, type: 'cats' };
+      const item = { value: 'Kitty', checked: true, type: 'cats' };
       component.items = [item];
       expect(component.allOfTypeSelected('cats')).toBeFalsy();
     });
@@ -414,8 +414,8 @@ describe('Element: NovoMultiPickerElement', () => {
   xdescribe('Method: modifyAllOfType(type, action)', () => {
     it('should select all if selecting', () => {
       component.types = [{ value: 'cats' }];
-      let kitty = { value: 'Kitty', checked: true, type: 'cats' };
-      let allItem = { value: 'ALL', checked: false, type: 'cats' };
+      const kitty = { value: 'Kitty', checked: true, type: 'cats' };
+      const allItem = { value: 'ALL', checked: false, type: 'cats' };
       component._options = [{ type: 'cats', data: [allItem, kitty], originalData: [allItem, kitty] }];
       component.value = { cats: [] };
       component.modifyAllOfType('cats', 'select');
@@ -426,7 +426,7 @@ describe('Element: NovoMultiPickerElement', () => {
 
     it('should unselect all if unselecting', () => {
       component.types = [{ value: 'cats' }];
-      let kitty = { value: 'Kitty', checked: true, type: 'cats' };
+      const kitty = { value: 'Kitty', checked: true, type: 'cats' };
       component._options = [
         {
           type: 'cats',
@@ -444,9 +444,9 @@ describe('Element: NovoMultiPickerElement', () => {
   xdescribe('Method: selectAll(type)', () => {
     it('should correctly update value and items when selecting all', () => {
       component.types = [{ value: 'cats' }];
-      let kitty = { value: 'Kitty', checked: false, type: 'cats' };
-      let allItem = { value: 'ALL', checked: false, type: 'cats' };
-      let tiger = { value: 'Tiger', checked: false, type: 'cats' };
+      const kitty = { value: 'Kitty', checked: false, type: 'cats' };
+      const allItem = { value: 'ALL', checked: false, type: 'cats' };
+      const tiger = { value: 'Tiger', checked: false, type: 'cats' };
       component._options = [{ type: 'cats', data: [allItem, kitty, tiger], originalData: [allItem, kitty, tiger] }];
       component.value = { cats: [{ value: 'Kitty', checked: false, type: 'cats' }] };
       component.selectAll(component._options[0].data, 'cats');
@@ -475,10 +475,10 @@ describe('Element: NovoMultiPickerElement', () => {
 
   xdescribe('Method: setInitialValue(model)', () => {
     it('should correctly set intial value and items if a model is passed in to start', () => {
-      let model = { cats: ['Kitty'] };
+      const model = { cats: ['Kitty'] };
       component.types = [{ value: 'cats' }];
-      let allItem = { value: 'ALL', checked: false, type: 'cats' };
-      let kitty = { value: 'Kitty', checked: true, type: 'cats' };
+      const allItem = { value: 'ALL', checked: false, type: 'cats' };
+      const kitty = { value: 'Kitty', checked: true, type: 'cats' };
       component._options = [{ type: 'cats', data: [allItem, kitty], originalData: [allItem, kitty] }];
       component.setInitialValue(model);
       expect(component._options[0].data[1].checked).toBeTruthy();
@@ -510,13 +510,13 @@ describe('Element: NovoMultiPickerElement', () => {
   xdescribe('Method: setIndeterminateState(type, status)', () => {
     it('should correctly set "ALL [type]" to true', () => {
       component.types = [{ value: 'cats' }];
-      let allOfType = [{ value: 'ALL', checked: false, type: 'cats', indeterminate: undefined }];
+      const allOfType = [{ value: 'ALL', checked: false, type: 'cats', indeterminate: undefined }];
       component.setIndeterminateState(allOfType, true);
       expect(allOfType[0].indeterminate).toBeTruthy();
     });
     it('should correctly set "ALL [type]" to false', () => {
       component.types = [{ value: 'cats' }];
-      let allOfType = [{ value: 'ALL', checked: false, type: 'cats', indeterminate: undefined }];
+      const allOfType = [{ value: 'ALL', checked: false, type: 'cats', indeterminate: undefined }];
       component.setIndeterminateState(allOfType, false);
       expect(allOfType[0].indeterminate).toBeFalsy();
     });
@@ -526,7 +526,7 @@ describe('Element: NovoMultiPickerElement', () => {
     it('should get all of type', () => {
       component.types = [{ value: 'cats' }];
       component._options = [{ type: 'cats', originalData: [1, 2, 3, 4] }];
-      let result = component.getAllOfType('cats');
+      const result = component.getAllOfType('cats');
       expect(result.length).toBe(4);
     });
   });
@@ -534,13 +534,13 @@ describe('Element: NovoMultiPickerElement', () => {
   describe('Method: allItemsSelected(optionsByType, type)', () => {
     it('should return true if all individual items are selected', () => {
       component.types = [{ value: 'cats' }];
-      let options = ['All', 'Kitty', 'Tiger'];
+      const options = ['All', 'Kitty', 'Tiger'];
       component.value = { cats: ['Kitty', 'Tiger'] };
       expect(component.allItemsSelected(options, 'cats')).toBeTruthy();
     });
     it('should return false if all individual items are not selected', () => {
       component.types = [{ value: 'cats' }];
-      let options = ['All', 'Kitty', 'Tiger'];
+      const options = ['All', 'Kitty', 'Tiger'];
       component.value = { cats: ['Kitty'] };
       expect(component.allItemsSelected(options, 'cats')).toBeFalsy();
     });
@@ -549,14 +549,14 @@ describe('Element: NovoMultiPickerElement', () => {
   xdescribe('Method: addIndividualChildren(parent, checked)', () => {
     it('should add an item', () => {
       component.value = { cats: [1] };
-      let item = { type: 'cats', value: 2 };
+      const item = { type: 'cats', value: 2 };
       jest.spyOn(component, 'add').mockImplementation(() => {});
       component.addIndividualChildren([item]);
       expect(component.add).toHaveBeenCalled();
     });
     it('should not add a duplicate item', () => {
       component.value = { cats: [1] };
-      let item = { type: 'cats', value: 1 };
+      const item = { type: 'cats', value: 1 };
       jest.spyOn(component, 'add').mockImplementation(() => {});
       component.addIndividualChildren([item]);
       expect(component.add).not.toHaveBeenCalled();
@@ -565,7 +565,7 @@ describe('Element: NovoMultiPickerElement', () => {
 
   xdescribe('Method: updateParentOrChildren(item, action)', () => {
     it('should call updateChildrenValue if item isParentOf', () => {
-      let item = { isParentOf: true };
+      const item = { isParentOf: true };
       jest.spyOn(component, 'updateChildrenValue').mockImplementation(() => {});
       jest.spyOn(component, 'updateParentValue').mockImplementation(() => {});
       component.updateParentOrChildren(item);
@@ -573,7 +573,7 @@ describe('Element: NovoMultiPickerElement', () => {
       expect(component.updateParentValue).not.toHaveBeenCalled();
     });
     it('should call updateParentValue if item isChildOf', () => {
-      let item = { isChildOf: true };
+      const item = { isChildOf: true };
       jest.spyOn(component, 'updateChildrenValue').mockImplementation(() => {});
       jest.spyOn(component, 'updateParentValue').mockImplementation(() => {});
       component.updateParentOrChildren(item);
@@ -584,7 +584,7 @@ describe('Element: NovoMultiPickerElement', () => {
 
   xdescribe('Method: updateParentOrChildren(item, action)', () => {
     it('should call updateChildrenValue if item isParentOf', () => {
-      let item = { isParentOf: true };
+      const item = { isParentOf: true };
       jest.spyOn(component, 'updateChildrenValue').mockImplementation(() => {});
       jest.spyOn(component, 'updateParentValue').mockImplementation(() => {});
       component.updateParentOrChildren(item);
@@ -592,7 +592,7 @@ describe('Element: NovoMultiPickerElement', () => {
       expect(component.updateParentValue).not.toHaveBeenCalled();
     });
     it('should call updateParentValue if item isChildOf', () => {
-      let item = { isChildOf: true };
+      const item = { isChildOf: true };
       jest.spyOn(component, 'updateChildrenValue').mockImplementation(() => {});
       jest.spyOn(component, 'updateParentValue').mockImplementation(() => {});
       component.updateParentOrChildren(item);
@@ -603,7 +603,7 @@ describe('Element: NovoMultiPickerElement', () => {
 
   xdescribe('Method: updateAllParentsOrChildren(item, action)', () => {
     it('should call updateChildrenValue if item isParentOf', () => {
-      let item = { isParentOf: true };
+      const item = { isParentOf: true };
       jest.spyOn(component, 'updateAllChildrenValue').mockImplementation(() => {});
       jest.spyOn(component, 'updateAllParentValue').mockImplementation(() => {});
       component.updateAllParentsOrChildren(item);
@@ -611,7 +611,7 @@ describe('Element: NovoMultiPickerElement', () => {
       expect(component.updateAllParentValue).not.toHaveBeenCalled();
     });
     it('should call updateParentValue if item isChildOf', () => {
-      let item = { isChildOf: true };
+      const item = { isChildOf: true };
       jest.spyOn(component, 'updateAllChildrenValue').mockImplementation(() => {});
       jest.spyOn(component, 'updateAllParentValue').mockImplementation(() => {});
       component.updateAllParentsOrChildren(item);
@@ -631,7 +631,7 @@ describe('Element: NovoMultiPickerElement', () => {
 
   describe('Method: updateAllParentValue(item, action)', () => {
     it('should set all parents to indeterminate if not already checked', () => {
-      let cat = { checked: false, type: 'cats', indeterminate: false };
+      const cat = { checked: false, type: 'cats', indeterminate: false };
       component._options = [{ type: 'cats', data: [cat], originalData: [cat] }];
       component.updateAllParentValue({ isChildOf: 'cats' }, 'select');
       expect(component._options[0].data[0].indeterminate).toBeTruthy();
@@ -640,7 +640,7 @@ describe('Element: NovoMultiPickerElement', () => {
 
   describe('Method: updateChildrenValue(parent, action)', () => {
     it('should set children to checked if selecting', () => {
-      let cat = { checked: false, type: 'cats', indeterminate: false, cats: [1] };
+      const cat = { checked: false, type: 'cats', indeterminate: false, cats: [1] };
       component._options = [{ type: 'kittens', data: [cat], originalData: [cat] }];
       component.updateChildrenValue({ type: 'cats', value: 1, isParentOf: 'kittens' }, 'select');
       expect(component._options[0].data[0].checked).toBeTruthy();
@@ -649,7 +649,7 @@ describe('Element: NovoMultiPickerElement', () => {
 
   describe('Method: onKeyDown(selecting, itemChanged)', () => {
     it('remove item if selected', () => {
-      let event = {
+      const event = {
         keyCode: KeyCodes.BACKSPACE,
         target: { value: [] },
         stopPropagation: () => {},
@@ -662,7 +662,7 @@ describe('Element: NovoMultiPickerElement', () => {
       expect(component.remove).toHaveBeenCalled();
     });
     it('select item if none selected', () => {
-      let event = {
+      const event = {
         keyCode: KeyCodes.BACKSPACE,
         target: { value: [] },
         stopPropagation: () => {},
@@ -678,10 +678,10 @@ describe('Element: NovoMultiPickerElement', () => {
 
   xdescribe('Method: modifyAffectedParentsOrChildren(selecting, itemChanged)', () => {
     it('should update indeterminate states for parent and child type', () => {
-      let kitty = { value: 'Kitty', checked: false, type: 'cats', isParentOf: 'kittens' };
-      let allCat = { value: 'ALL', checked: true, type: 'cats', isParentOf: 'kittens' };
-      let allKitten = { value: 'ALL', checked: true, type: 'kittens', isChildOf: 'cats', cats: [1] };
-      let cat = { value: 'Cat', checked: true, type: 'kittens', isChildOf: 'cats', cats: [1] };
+      const kitty = { value: 'Kitty', checked: false, type: 'cats', isParentOf: 'kittens' };
+      const allCat = { value: 'ALL', checked: true, type: 'cats', isParentOf: 'kittens' };
+      const allKitten = { value: 'ALL', checked: true, type: 'kittens', isChildOf: 'cats', cats: [1] };
+      const cat = { value: 'Cat', checked: true, type: 'kittens', isChildOf: 'cats', cats: [1] };
       component._options = [
         { type: 'cats', data: [allCat, kitty], originalData: [allCat, kitty] },
         { type: 'kittens', data: [allKitten, cat], originalData: [allKitten, cat] },

--- a/projects/novo-elements/src/elements/overlay/Overlay.ts
+++ b/projects/novo-elements/src/elements/overlay/Overlay.ts
@@ -248,8 +248,8 @@ export class NovoOverlayTemplateComponent implements OnDestroy {
         .withFallbackPosition({ originX: 'start', originY: 'bottom' }, { overlayX: 'start', overlayY: 'bottom' });
     }
 
-    let [originX, fallbackX]: HorizontalConnectionPos[] = this.position.includes('right') ? ['end', 'start'] : ['start', 'end'];
-    let [originY, overlayY]: VerticalConnectionPos[] = this.position.includes('top') ? ['top', 'bottom'] : ['bottom', 'top'];
+    const [originX, fallbackX]: HorizontalConnectionPos[] = this.position.includes('right') ? ['end', 'start'] : ['start', 'end'];
+    const [originY, overlayY]: VerticalConnectionPos[] = this.position.includes('top') ? ['top', 'bottom'] : ['bottom', 'top'];
 
     let strategy: ConnectedPositionStrategy = this.overlay
       .position()
@@ -265,7 +265,7 @@ export class NovoOverlayTemplateComponent implements OnDestroy {
         .withFallbackPosition({ originX: fallbackX, originY: 'top' }, { overlayX: fallbackX, overlayY: 'bottom' });
       if (!this.position.includes('above-below')) {
         strategy = strategy
-          .withFallbackPosition({ originX: originX, originY: 'center' }, { overlayX: originX, overlayY: 'center' })
+          .withFallbackPosition({ originX, originY: 'center' }, { overlayX: originX, overlayY: 'center' })
           .withFallbackPosition({ originX: fallbackX, originY: 'center' }, { overlayX: fallbackX, overlayY: 'center' });
       }
     }

--- a/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.spec.ts
+++ b/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.spec.ts
@@ -12,8 +12,8 @@ class MockCDR {
 }
 
 describe('Elements: BasePickerResults', () => {
-  let elementRef = new ElementRef(document.createElement('div'));
-  let component = new BasePickerResults(elementRef, new MockCDR());
+  const elementRef = new ElementRef(document.createElement('div'));
+  const component = new BasePickerResults(elementRef, new MockCDR());
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.ts
@@ -40,7 +40,7 @@ export class BasePickerResults {
   }
 
   cleanUp(): void {
-    let element: Element = this.getListElement();
+    const element: Element = this.getListElement();
     if (element && element.hasAttribute('scrollListener')) {
       element.removeAttribute('scrollListener');
       element.removeEventListener('scroll', this.scrollHandler);
@@ -48,9 +48,9 @@ export class BasePickerResults {
   }
 
   onScrollDown(event: WheelEvent) {
-    let element: any = event.target;
+    const element: any = event.target;
     if (element) {
-      let offset = element.offsetHeight + element.scrollTop,
+      const offset = element.offsetHeight + element.scrollTop,
         bottom = element.scrollHeight - 300;
       if (offset >= bottom) {
         event.stopPropagation();
@@ -97,7 +97,7 @@ export class BasePickerResults {
 
   addScrollListener(): void {
     if (this.config.enableInfiniteScroll) {
-      let element: Element = this.getListElement();
+      const element: Element = this.getListElement();
       if (element && !element.hasAttribute('scrollListener')) {
         element.setAttribute('scrollListener', 'true');
         element.addEventListener('scroll', this.scrollHandler);
@@ -143,7 +143,7 @@ export class BasePickerResults {
   }
 
   search(term, mode?): Observable<any> {
-    let options = this.config.options;
+    const options = this.config.options;
     return from(
       new Promise((resolve, reject) => {
         // Check if there is match data
@@ -176,7 +176,7 @@ export class BasePickerResults {
             if (this.config.defaultOptions) {
               this.isStatic = false;
               if (typeof this.config.defaultOptions === 'function') {
-                let defaultOptions = this.config.defaultOptions(term, ++this.page);
+                const defaultOptions = this.config.defaultOptions(term, ++this.page);
                 if (Object.getPrototypeOf(defaultOptions).hasOwnProperty('then')) {
                   defaultOptions.then(this.structureArray.bind(this)).then(resolve, reject);
                 } else {
@@ -214,7 +214,7 @@ export class BasePickerResults {
    * 'name' field by default.
    */
   structureArray(collection: any): any {
-    let dataArray = collection.data ? collection.data : collection;
+    const dataArray = collection.data ? collection.data : collection;
     if (dataArray && (typeof dataArray[0] === 'string' || typeof dataArray[0] === 'number')) {
       return collection.map((item) => {
         return {
@@ -228,7 +228,7 @@ export class BasePickerResults {
       if (this.config.valueFormat) {
         value = Helpers.interpolate(this.config.valueFormat, data);
       }
-      let label = this.config.format ? Helpers.interpolate(this.config.format, data) : data.label || String(value);
+      const label = this.config.format ? Helpers.interpolate(this.config.format, data) : data.label || String(value);
       return { value, label, data };
     });
   }
@@ -267,7 +267,7 @@ export class BasePickerResults {
    * @description This function sets activeMatch to the match before the current node.
    */
   prevActiveMatch() {
-    let index = this.matches.indexOf(this.activeMatch);
+    const index = this.matches.indexOf(this.activeMatch);
     this.activeMatch = this.matches[index - 1 < 0 ? this.matches.length - 1 : index - 1];
     this.scrollToActive();
     this.ref.markForCheck();
@@ -279,7 +279,7 @@ export class BasePickerResults {
    * @description This function sets activeMatch to the match after the current node.
    */
   nextActiveMatch() {
-    let index = this.matches.indexOf(this.activeMatch);
+    const index = this.matches.indexOf(this.activeMatch);
     this.activeMatch = this.matches[index + 1 > this.matches.length - 1 ? 0 : index + 1];
     this.scrollToActive();
     this.ref.markForCheck();
@@ -298,10 +298,10 @@ export class BasePickerResults {
   }
 
   scrollToActive() {
-    let list = this.getListElement();
-    let items = this.getChildrenOfListElement();
-    let index = this.matches.indexOf(this.activeMatch);
-    let item = items[index];
+    const list = this.getListElement();
+    const items = this.getChildrenOfListElement();
+    const index = this.matches.indexOf(this.activeMatch);
+    const item = items[index];
     if (item) {
       list.scrollTop = item.offsetTop;
     }
@@ -379,7 +379,7 @@ export class BasePickerResults {
 
   preselected(match) {
     if (this.config.preselected) {
-      let preselectedFunc: Function = this.config.preselected;
+      const preselectedFunc: Function = this.config.preselected;
       return (
         this.selected.findIndex((item) => {
           return preselectedFunc(match, item);

--- a/projects/novo-elements/src/elements/picker/extras/checklist-picker-results/ChecklistPickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/checklist-picker-results/ChecklistPickerResults.ts
@@ -54,7 +54,7 @@ export class ChecklistPickerResults extends BasePickerResults {
   }
 
   search(): Observable<any> {
-    let options = this.config.options;
+    const options = this.config.options;
     // only set this the first time
     return from(
       new Promise((resolve, reject) => {
@@ -88,7 +88,7 @@ export class ChecklistPickerResults extends BasePickerResults {
   filterData(matches): any {
     if (this.term && matches) {
       this.filteredMatches = matches.map((section) => {
-        let items = section.originalData.filter((match) => {
+        const items = section.originalData.filter((match) => {
           return ~String(match.label)
             .toLowerCase()
             .indexOf(this.term.toLowerCase());
@@ -123,7 +123,7 @@ export class ChecklistPickerResults extends BasePickerResults {
       item.checked = !item.checked;
     }
 
-    let selected = this.activeMatch;
+    const selected = this.activeMatch;
     if (selected) {
       this.parent.value = selected;
     }

--- a/projects/novo-elements/src/elements/picker/extras/entity-picker-results/EntityPickerResults.spec.ts
+++ b/projects/novo-elements/src/elements/picker/extras/entity-picker-results/EntityPickerResults.spec.ts
@@ -71,7 +71,7 @@ describe('Elements: EntityPickerResult', () => {
 
   describe('Method: getNameForResult(result)', () => {
     it('should return a correctly formatted name for ClientContact', () => {
-      let input = {
+      const input = {
         searchEntity: 'ClientContact',
         firstName: 'James',
         lastName: 'Bond',
@@ -79,14 +79,14 @@ describe('Elements: EntityPickerResult', () => {
       expect(component.getNameForResult(input)).toBe('James Bond');
     });
     it('should return a correctly formatted name for ClientCorporation', () => {
-      let input = {
+      const input = {
         searchEntity: 'ClientCorporation',
         name: 'Bottles, Inc.',
       };
       expect(component.getNameForResult(input)).toBe('Bottles, Inc.');
     });
     it('should return a correctly formatted name for Opportunity', () => {
-      let input = {
+      const input = {
         searchEntity: 'Opportunity',
         id: 789,
         title: 'Bottlemaking Opportunity',
@@ -94,7 +94,7 @@ describe('Elements: EntityPickerResult', () => {
       expect(component.getNameForResult(input)).toBe('789 | Bottlemaking Opportunity');
     });
     it('should return a correctly formatted name for Lead', () => {
-      let input = {
+      const input = {
         searchEntity: 'Lead',
         firstName: 'James',
         lastName: 'Bond',
@@ -102,7 +102,7 @@ describe('Elements: EntityPickerResult', () => {
       expect(component.getNameForResult(input)).toBe('James Bond');
     });
     it('should return a correctly formatted name for Candidate', () => {
-      let input = {
+      const input = {
         searchEntity: 'Candidate',
         firstName: 'James',
         lastName: 'Bond',
@@ -110,7 +110,7 @@ describe('Elements: EntityPickerResult', () => {
       expect(component.getNameForResult(input)).toBe('James Bond');
     });
     it('should return a correctly formatted name for Job Order', () => {
-      let input = {
+      const input = {
         searchEntity: 'JobOrder',
         id: 567,
         title: 'Mock Job Title',
@@ -118,7 +118,7 @@ describe('Elements: EntityPickerResult', () => {
       expect(component.getNameForResult(input)).toBe('567 | Mock Job Title');
     });
     it('when candidate and job are defined, should concatenate id, candidate name, and job title', () => {
-      let input = {
+      const input = {
         searchEntity: 'Placement',
         id: 1234,
         candidate: {
@@ -132,7 +132,7 @@ describe('Elements: EntityPickerResult', () => {
       expect(component.getNameForResult(input)).toBe('1234 | James Bond - Gud Picker');
     });
     it('when candidate is undefined and job is defined, should concatenate id and job title', () => {
-      let input = {
+      const input = {
         searchEntity: 'Placement',
         id: 1234,
         jobOrder: {
@@ -142,14 +142,14 @@ describe('Elements: EntityPickerResult', () => {
       expect(component.getNameForResult(input)).toBe('1234 | Gud Picker');
     });
     it('when candidate and job are undefined, should only return id', () => {
-      let input = {
+      const input = {
         searchEntity: 'Placement',
         id: 1234,
       };
       expect(component.getNameForResult(input)).toBe('1234');
     });
     it('when candidate is defined and job is undefined, should concatenate id and candidate name', () => {
-      let input = {
+      const input = {
         searchEntity: 'Placement',
         id: 1234,
         candidate: {
@@ -160,14 +160,14 @@ describe('Elements: EntityPickerResult', () => {
       expect(component.getNameForResult(input)).toBe('1234 | James Bond');
     });
     it('should return the name when present for an unknown entity', () => {
-      let input = {
+      const input = {
         searchEntity: 'Unknown',
         name: 'James Bond',
       };
       expect(component.getNameForResult(input)).toBe('James Bond');
     });
     it('should return an empty string when name is not present for an unknown entity', () => {
-      let input = {
+      const input = {
         searchEntity: 'Unknown',
         title: 'Mock Job Title',
       };

--- a/projects/novo-elements/src/elements/picker/extras/grouped-multi-picker-results/GroupedMultiPickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/grouped-multi-picker-results/GroupedMultiPickerResults.ts
@@ -169,7 +169,7 @@ export class GroupedMultiPickerResults extends BasePickerResults implements OnIn
     // If we have display all, set the all categories up
     if (this.config.displayAll) {
       this.selectedCategory = { value: 'all', label: 'all' };
-      let allItems = [];
+      const allItems = [];
       Array.from(this.config.categoryMap.values())
         .filter((category: { value: string }) => {
           return category.value !== 'all';
@@ -187,7 +187,7 @@ export class GroupedMultiPickerResults extends BasePickerResults implements OnIn
     // Set focus
     this.inputElement.nativeElement.focus();
     // Find new items
-    let key: string = category.value;
+    const key: string = category.value;
     this.selectedCategory = category;
     // Clear
     this.matches = [];
@@ -216,7 +216,7 @@ export class GroupedMultiPickerResults extends BasePickerResults implements OnIn
     // Only fire if we have a selected category
     if (this.selectCategory) {
       // Find new items
-      let key: string = this.selectedCategory.value;
+      const key: string = this.selectedCategory.value;
       // Get new matches
       this.getNewMatches(this.selectedCategory, key);
       this.ref.markForCheck();
@@ -252,7 +252,7 @@ export class GroupedMultiPickerResults extends BasePickerResults implements OnIn
       if (!this.internalMap.get(key)) {
         this.isLoading = true;
         this.config.getItemsForCategoryAsync(key, this.customFilterValue).then((items: { value: string; label: string }[]) => {
-          this.internalMap.set(key, { value: category.value, label: category.label, items: items });
+          this.internalMap.set(key, { value: category.value, label: category.label, items });
           this.matches = this.filter(items, true);
           this.isLoading = false;
           this.ref.markForCheck();

--- a/projects/novo-elements/src/elements/places/places.component.ts
+++ b/projects/novo-elements/src/elements/places/places.component.ts
@@ -130,7 +130,7 @@ export class PlacesListComponent implements OnInit, OnChanges {
 
   // function called when there is a change in input. (Binded with view)
   searchinputCallback(event: any): any {
-    let inputVal: any = this.locationInput;
+    const inputVal: any = this.locationInput;
     if (inputVal) {
       this.getListQuery(inputVal);
     } else {
@@ -179,7 +179,7 @@ export class PlacesListComponent implements OnInit, OnChanges {
 
   // function to manually trigger the callback to parent component when clicked search button.
   userQuerySubmit(selectedOption?: any): any {
-    let _userOption: any = selectedOption === 'false' ? '' : this.userSelectedOption;
+    const _userOption: any = selectedOption === 'false' ? '' : this.userSelectedOption;
     if (_userOption) {
       this.select.emit(this.userSelectedOption);
     } else {
@@ -254,10 +254,10 @@ export class PlacesListComponent implements OnInit, OnChanges {
 
   // function to set user settings if it is available.
   private setUserSettings(): Settings {
-    let _tempObj: any = {};
+    const _tempObj: any = {};
     if (this.userSettings && typeof this.userSettings === 'object') {
-      let keys: string[] = Object.keys(this.defaultSettings);
-      for (let value of keys) {
+      const keys: string[] = Object.keys(this.defaultSettings);
+      for (const value of keys) {
         _tempObj[value] = this.userSettings[value] !== undefined ? this.userSettings[value] : this.defaultSettings[value];
       }
       return _tempObj;
@@ -270,7 +270,7 @@ export class PlacesListComponent implements OnInit, OnChanges {
   private getListQuery(value: string): any {
     this.recentDropdownOpen = false;
     if (this.settings.useGoogleGeoApi) {
-      let _tempParams: any = {
+      const _tempParams: any = {
         query: value,
         countryRestriction: this.settings.geoCountryRestriction,
         geoTypes: this.settings.geoTypes,
@@ -294,7 +294,7 @@ export class PlacesListComponent implements OnInit, OnChanges {
   private extractServerList(arrayList: any, data: any): any {
     if (arrayList.length) {
       let _tempData: any = data;
-      for (let key of arrayList) {
+      for (const key of arrayList) {
         _tempData = _tempData[key];
       }
       return _tempData;

--- a/projects/novo-elements/src/elements/places/places.service.ts
+++ b/projects/novo-elements/src/elements/places/places.service.ts
@@ -52,10 +52,10 @@ export class GooglePlacesService {
   getGeoCurrentLocation(): Promise<any> {
     return new Promise((resolve) => {
       if (isPlatformBrowser(this.platformId)) {
-        let _window: any = this._global.nativeGlobal;
+        const _window: any = this._global.nativeGlobal;
         if (_window.navigator.geolocation) {
           _window.navigator.geolocation.getCurrentPosition((pos) => {
-            let latlng: any = { lat: parseFloat(pos.coords.latitude + ''), lng: parseFloat(pos.coords.longitude + '') };
+            const latlng: any = { lat: parseFloat(pos.coords.latitude + ''), lng: parseFloat(pos.coords.longitude + '') };
             resolve(latlng);
           });
         } else {
@@ -70,8 +70,8 @@ export class GooglePlacesService {
   getGeoLatLngDetail(latlng: any): Promise<any> {
     return new Promise((resolve) => {
       if (isPlatformBrowser(this.platformId)) {
-        let _window: any = this._global.nativeGlobal;
-        let geocoder: any = new _window.google.maps.Geocoder();
+        const _window: any = this._global.nativeGlobal;
+        const geocoder: any = new _window.google.maps.Geocoder();
         geocoder.geocode({ location: latlng }, (results, status) => {
           if (status === 'OK') {
             this.getGeoPlaceDetail(results[0].place_id).then((result) => {
@@ -94,10 +94,10 @@ export class GooglePlacesService {
   getGeoPrediction(params: any): Promise<any> {
     return new Promise((resolve) => {
       if (isPlatformBrowser(this.platformId)) {
-        let _window: any = this._global.nativeGlobal;
-        let placesService: any = new _window.google.maps.places.AutocompleteService();
+        const _window: any = this._global.nativeGlobal;
+        const placesService: any = new _window.google.maps.places.AutocompleteService();
         let queryInput: any = {};
-        let promiseArr: any = [];
+        const promiseArr: any = [];
         if (params.countryRestriction.length) {
           queryInput = {
             input: params.query,
@@ -114,7 +114,7 @@ export class GooglePlacesService {
         }
         if (params.geoTypes.length) {
           for (let i: number = 0; i < params.geoTypes.length; i++) {
-            let _tempQuery: any = queryInput;
+            const _tempQuery: any = queryInput;
             _tempQuery['types'] = new Array(params.geoTypes[i]);
             promiseArr.push(this.geoPredictionCall(placesService, _tempQuery));
           }
@@ -123,7 +123,7 @@ export class GooglePlacesService {
         }
 
         Promise.all(promiseArr).then((values) => {
-          let val: any = values;
+          const val: any = values;
           if (val.length > 1) {
             let _tempArr: any = [];
             for (let j: number = 0; j < val.length; j++) {
@@ -146,9 +146,9 @@ export class GooglePlacesService {
   getGeoPlaceDetail(placeId: string): Promise<any> {
     return new Promise((resolve) => {
       if (isPlatformBrowser(this.platformId)) {
-        let _window: any = this._global.nativeGlobal;
-        let placesService: any = new _window.google.maps.places.PlacesService(document.createElement('div'));
-        placesService.getDetails({ placeId: placeId }, (result: any, status: any) => {
+        const _window: any = this._global.nativeGlobal;
+        const placesService: any = new _window.google.maps.places.PlacesService(document.createElement('div'));
+        placesService.getDetails({ placeId }, (result: any, status: any) => {
           if (result === null || result.length === 0) {
             this.getGeoPaceDetailByReferance(result.referance).then((referanceData: any) => {
               if (!referanceData) {
@@ -170,8 +170,8 @@ export class GooglePlacesService {
   getGeoPaceDetailByReferance(referance: string): Promise<any> {
     return new Promise((resolve) => {
       if (isPlatformBrowser(this.platformId)) {
-        let _window: any = this._global.nativeGlobal;
-        let placesService: any = new _window.google.maps.places.PlacesService();
+        const _window: any = this._global.nativeGlobal;
+        const placesService: any = new _window.google.maps.places.PlacesService();
         placesService.getDetails({ reference: referance }, (result: any, status: any) => {
           if (status === _window.google.maps.places.PlacesServiceStatus.OK) {
             resolve(result);
@@ -220,7 +220,7 @@ export class GooglePlacesService {
   }
 
   private geoPredictionCall(placesService: any, queryInput: any): Promise<any> {
-    let _window: any = this._global.nativeGlobal;
+    const _window: any = this._global.nativeGlobal;
     return new Promise((resolve) => {
       placesService.getPlacePredictions(queryInput, (result: any, status: any) => {
         if (status === _window.google.maps.places.PlacesServiceStatus.OK) {

--- a/projects/novo-elements/src/elements/popover/PopOver.spec.ts
+++ b/projects/novo-elements/src/elements/popover/PopOver.spec.ts
@@ -30,7 +30,7 @@ describe('Elements: PopOverDirective', () => {
     });
 
     describe('Class: ', () => {
-      let mockComponentFactoryResolver: ComponentFactoryResolver = {
+      const mockComponentFactoryResolver: ComponentFactoryResolver = {
         resolveComponentFactory<T>(c: { new (...args: any[]) }): ComponentFactory<T> {
           // This was a monster to mock...
           if (c) {
@@ -40,7 +40,7 @@ describe('Elements: PopOverDirective', () => {
         },
       };
 
-      let component = new PopOverDirective(directive, mockComponentFactoryResolver);
+      const component = new PopOverDirective(directive, mockComponentFactoryResolver);
       describe('Method: ngOnChanges()', () => {
         it('should be defined.', () => {
           expect(component.ngOnChanges).toBeDefined();

--- a/projects/novo-elements/src/elements/popover/PopOverContent.ts
+++ b/projects/novo-elements/src/elements/popover/PopOverContent.ts
@@ -86,33 +86,33 @@ export class PopOverContent implements AfterViewInit {
     positionStr: string,
     appendToBody = false,
   ): { top: number; left: number } {
-    let positionStrParts = positionStr.split('-');
-    let mainSide = (this.effectivePlacement = this.getEffectivePlacement(positionStrParts[0] || 'right', hostEl, targetEl));
-    let orientation = (this.effectiveAlignment = positionStrParts[1] || 'center');
-    let hostElPos = appendToBody ? this.offset(hostEl) : this.position(hostEl);
-    let targetElWidth = targetEl.offsetWidth;
-    let targetElHeight = targetEl.offsetHeight;
+    const positionStrParts = positionStr.split('-');
+    const mainSide = (this.effectivePlacement = this.getEffectivePlacement(positionStrParts[0] || 'right', hostEl, targetEl));
+    const orientation = (this.effectiveAlignment = positionStrParts[1] || 'center');
+    const hostElPos = appendToBody ? this.offset(hostEl) : this.position(hostEl);
+    const targetElWidth = targetEl.offsetWidth;
+    const targetElHeight = targetEl.offsetHeight;
 
-    let shiftWidth: any = {
-      center: function(): number {
+    const shiftWidth: any = {
+      center(): number {
         return hostElPos.left + (hostElPos.width - targetElWidth) / 2;
       },
-      right: function(): number {
+      right(): number {
         return hostElPos.left;
       },
-      left: function(): number {
+      left(): number {
         return hostElPos.left + (hostElPos.width - targetElWidth);
       },
     };
 
-    let shiftHeight: any = {
-      center: function(): number {
+    const shiftHeight: any = {
+      center(): number {
         return hostElPos.top + (hostElPos.height - targetElHeight) / 2;
       },
-      bottom: function(): number {
+      bottom(): number {
         return hostElPos.top;
       },
-      top: function(): number {
+      top(): number {
         return hostElPos.top + (hostElPos.height - targetElHeight);
       },
     };

--- a/projects/novo-elements/src/elements/quick-note/QuickNote.spec.ts
+++ b/projects/novo-elements/src/elements/quick-note/QuickNote.spec.ts
@@ -133,8 +133,8 @@ describe('Elements: QuickNoteElement', () => {
             domEvent: {
               $: {
                 // The native element
-                key: key,
-                keyCode: keyCode,
+                key,
+                keyCode,
               },
             },
           },

--- a/projects/novo-elements/src/elements/quick-note/QuickNote.ts
+++ b/projects/novo-elements/src/elements/quick-note/QuickNote.ts
@@ -272,9 +272,9 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
         }
       } else {
         // Loop through all triggers and turn on tagging mode if the user just pressed a trigger character
-        let triggers = this.config.triggers || {};
+        const triggers = this.config.triggers || {};
         Object.keys(triggers).forEach((key) => {
-          let trigger = triggers[key] || {};
+          const trigger = triggers[key] || {};
           if (event.key === trigger) {
             this.isTagging = true;
             this.taggingMode = key;
@@ -294,7 +294,7 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
     let value = this.ckeInstance.getData();
 
     // Remove empty 'ZERO WIDTH SPACE' characters that can get added erroneously by the editor
-    let regex = new RegExp(String.fromCharCode(8203), 'g');
+    const regex = new RegExp(String.fromCharCode(8203), 'g');
     value = value.replace(regex, '');
 
     // Make sure that any references in the model are still valid
@@ -327,13 +327,13 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
    */
   private showResults(): void {
     if (this.isTagging) {
-      let searchTerm = this.getSearchTerm();
+      const searchTerm = this.getSearchTerm();
       if (searchTerm.length) {
         // Update Matches
         if (this.quickNoteResults) {
           // Update existing list
           this.quickNoteResults.instance.term = {
-            searchTerm: searchTerm,
+            searchTerm,
             taggingMode: this.taggingMode,
           };
         } else {
@@ -342,7 +342,7 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
           this.quickNoteResults.instance.parent = this;
           this.quickNoteResults.instance.config = this.config;
           this.quickNoteResults.instance.term = {
-            searchTerm: searchTerm,
+            searchTerm,
             taggingMode: this.taggingMode,
           };
           this.positionResultsDropdown();
@@ -380,16 +380,16 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
     this.isTagging = false;
 
     // Replace searchTerm with link
-    let symbol = this.config.triggers[taggingMode];
-    let renderer = this.getRenderer(taggingMode);
-    let renderedText = renderer(symbol, selected);
+    const symbol = this.config.triggers[taggingMode];
+    const renderer = this.getRenderer(taggingMode);
+    const renderedText = renderer(symbol, selected);
 
     this.replaceWordAtCursor(renderedText);
 
     // Add the new reference, if it doesn't already exist
     this.model.references = this.model.references || {};
     this.model.references[taggingMode] = this.model.references[taggingMode] || [];
-    let matchingItems = this.model.references[taggingMode].filter((item) => JSON.stringify(item) === JSON.stringify(selected));
+    const matchingItems = this.model.references[taggingMode].filter((item) => JSON.stringify(item) === JSON.stringify(selected));
     if (matchingItems.length === 0) {
       this.model.references[taggingMode].push(selected);
     }
@@ -405,7 +405,7 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
   private getSearchTerm(): string {
     let word = this.getWordAtCursor().trim();
     if (this.isTagging) {
-      let symbol = this.config.triggers[this.taggingMode];
+      const symbol = this.config.triggers[this.taggingMode];
       if (!word.includes(symbol)) {
         this.hideResults();
         return '';
@@ -422,16 +422,16 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
    * @returns plain text string (removes all html formatting)
    */
   private getWordAtCursor(): string {
-    let range = this.ckeInstance.getSelection().getRanges()[0];
-    let start = range.startContainer;
+    const range = this.ckeInstance.getSelection().getRanges()[0];
+    const start = range.startContainer;
 
     if (start.type === CKEDITOR.NODE_TEXT && range.startOffset) {
-      let text = start.getText();
-      let symbol = this.config.triggers[this.taggingMode];
+      const text = start.getText();
+      const symbol = this.config.triggers[this.taggingMode];
       let wordStart = text.lastIndexOf(symbol, range.startOffset - 1);
 
       if (wordStart > 0) {
-        let beforeSymbol: string = text.charAt(wordStart - 1);
+        const beforeSymbol: string = text.charAt(wordStart - 1);
         // We don't want to trigger the lookup call unless the symbol was preceded by whitespace
         if (beforeSymbol !== '\u200B' && /\S/.test(beforeSymbol)) {
           return '';
@@ -463,18 +463,18 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
    * the line, replacing only the current word.
    */
   private replaceWordAtCursor(newWord: string): void {
-    let originalWord = this.getWordAtCursor().trim();
-    let range = this.ckeInstance.getSelection().getRanges()[0];
-    let start = range.startContainer;
-    let parentNode = start.getParent();
+    const originalWord = this.getWordAtCursor().trim();
+    const range = this.ckeInstance.getSelection().getRanges()[0];
+    const start = range.startContainer;
+    const parentNode = start.getParent();
 
     if (start.type === CKEDITOR.NODE_TEXT && parentNode) {
-      let line = parentNode.getHtml();
-      let index = line.lastIndexOf(originalWord);
+      const line = parentNode.getHtml();
+      const index = line.lastIndexOf(originalWord);
 
       if (index >= 0) {
         // Add a space after the replaced word so that multiple references can be added back to back
-        let newLine = line.substring(0, index) + newWord + ' ' + line.substring(index + originalWord.length);
+        const newLine = line.substring(0, index) + newWord + ' ' + line.substring(index + originalWord.length);
         parentNode.setHtml(newLine);
 
         // Place selection at the end of the line
@@ -492,16 +492,16 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
 
     // CKEditor stopped supporting the config.forceSimpleAmpersand setting, so we have to convert '&amp;' to '&'
     // when we pull html from the editor - see: https://dev.ckeditor.com/ticket/13723
-    let ampRegex = new RegExp('&amp;', 'g');
+    const ampRegex = new RegExp('&amp;', 'g');
     html = html.replace(ampRegex, '&');
 
     Object.keys(this.model.references).forEach((taggingMode) => {
-      let array = this.model.references[taggingMode] || [];
-      let symbol = this.config.triggers[taggingMode];
-      let renderer = this.getRenderer(taggingMode);
+      const array = this.model.references[taggingMode] || [];
+      const symbol = this.config.triggers[taggingMode];
+      const renderer = this.getRenderer(taggingMode);
 
       this.model.references[taggingMode] = array.filter((item) => {
-        let renderedText = renderer(symbol, item);
+        const renderedText = renderer(symbol, item);
         return html.includes(renderedText);
       });
 
@@ -522,7 +522,7 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
   private getCKEditorConfig(): any {
     // Use the height of the wrapper element to set the initial height of the editor, then
     // set it to 100% to allow the editor to resize using the grippy.
-    let editorHeight = this.wrapper.nativeElement.clientHeight - QuickNoteElement.TOOLBAR_HEIGHT;
+    const editorHeight = this.wrapper.nativeElement.clientHeight - QuickNoteElement.TOOLBAR_HEIGHT;
     this.wrapper.nativeElement.style.setProperty('height', '100%');
 
     return {
@@ -558,19 +558,19 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
    * Returns the current screen position of the cursor in CKEditor, accounting for any scrolling in the editor.
    */
   private getCursorPosition(): any {
-    let range = this.ckeInstance.getSelection().getRanges()[0];
-    let parentElement = range.startContainer.$.parentElement;
-    let editorElement = this.ckeInstance.editable().$;
+    const range = this.ckeInstance.getSelection().getRanges()[0];
+    const parentElement = range.startContainer.$.parentElement;
+    const editorElement = this.ckeInstance.editable().$;
 
     // Since the editor is a text node in the DOM that does not know about it's position, a temporary element has to
     // be inserted in order to locate the cursor position.
-    let cursorElement = document.createElement('img');
+    const cursorElement = document.createElement('img');
     cursorElement.setAttribute('src', 'null');
     cursorElement.setAttribute('width', '0');
     cursorElement.setAttribute('height', '0');
 
     parentElement.appendChild(cursorElement);
-    let cursorPosition = {
+    const cursorPosition = {
       top: cursorElement.offsetTop - editorElement.scrollTop,
       left: cursorElement.offsetLeft - editorElement.scrollLeft,
     };
@@ -586,7 +586,7 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
     const MIN_MARGIN_TOP: number = QuickNoteElement.TOOLBAR_HEIGHT * 2;
     const MAX_MARGIN_TOP: number = this.getContentHeight() + QuickNoteElement.TOOLBAR_HEIGHT;
 
-    let cursorPosition = this.getCursorPosition();
+    const cursorPosition = this.getCursorPosition();
     let marginTop: number = cursorPosition.top + QuickNoteElement.TOOLBAR_HEIGHT;
 
     // Check that the margin is within the visible bounds
@@ -608,7 +608,7 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
       this.ckeInstance.ui.contentsElement.$ &&
       this.ckeInstance.ui.contentsElement.$.style
     ) {
-      let cssText: string = this.ckeInstance.ui.contentsElement.$.style.cssText;
+      const cssText: string = this.ckeInstance.ui.contentsElement.$.style.cssText;
       if (cssText.indexOf('height: ') !== -1) {
         let height: string = cssText.split('height: ')[1];
         height = height.split('px')[0];

--- a/projects/novo-elements/src/elements/quick-note/extras/quick-note-results/QuickNoteResults.ts
+++ b/projects/novo-elements/src/elements/quick-note/extras/quick-note-results/QuickNoteResults.ts
@@ -59,7 +59,7 @@ export class QuickNoteResults extends PickerResults {
   }
 
   search(term: string, taggingMode): Observable<any> {
-    let searchCall = this.config.options[taggingMode];
+    const searchCall = this.config.options[taggingMode];
     return from(
       new Promise((resolve, reject) => {
         // Check if there is match data
@@ -112,8 +112,8 @@ export class QuickNoteResults extends PickerResults {
       });
     }
     return collection.map((data) => {
-      let value = this.config.field ? data[this.config.field[this.taggingMode]] : data.value || data;
-      let label = this.config.format ? Helpers.interpolate(this.config.format[this.taggingMode], data) : data.label || String(value);
+      const value = this.config.field ? data[this.config.field[this.taggingMode]] : data.value || data;
+      const label = this.config.format ? Helpers.interpolate(this.config.format[this.taggingMode], data) : data.label || String(value);
       return { value, label, data };
     });
   }
@@ -130,7 +130,7 @@ export class QuickNoteResults extends PickerResults {
       event.preventDefault();
     }
 
-    let selected = this.activeMatch;
+    const selected = this.activeMatch;
     if (selected) {
       this.parent.onSelected(this.taggingMode, selected);
       this.parent.hideResults();

--- a/projects/novo-elements/src/elements/search/SearchBox.ts
+++ b/projects/novo-elements/src/elements/search/SearchBox.ts
@@ -119,7 +119,7 @@ export class NovoSearchBoxElement implements ControlValueAccessor {
       // Reset search
       // Set focus on search
       setTimeout(() => {
-        let element = this.input.nativeElement;
+        const element = this.input.nativeElement;
         if (element) {
           element.focus();
         }

--- a/projects/novo-elements/src/elements/select/Select.spec.ts
+++ b/projects/novo-elements/src/elements/select/Select.spec.ts
@@ -8,7 +8,7 @@ import { KeyCodes } from '../../utils/key-codes/KeyCodes';
 import { NovoLabelService } from '../../services/novo-label-service';
 
 const KeyEvent = (code) => {
-  let event: any = document.createEvent('Event');
+  const event: any = document.createEvent('Event');
   event.keyCode = code;
   return event;
 };

--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -153,8 +153,8 @@ export class NovoSelectElement implements OnInit, OnChanges, OnDestroy, ControlV
     if (!this.model && !this.createdItem) {
       this.clear();
     } else if (this.createdItem) {
-      let item = this.options.find((i) => i.label === this.createdItem);
-      let index = this.options.indexOf(item);
+      const item = this.options.find((i) => i.label === this.createdItem);
+      const index = this.options.indexOf(item);
       this.select(item, index);
     } else {
       this.writeValue(this.model);
@@ -289,9 +289,9 @@ export class NovoSelectElement implements OnInit, OnChanges, OnDestroy, ControlV
       this.filterTermTimeout = setTimeout(() => {
         this.filterTerm = '';
       }, 2000);
-      let char = String.fromCharCode(event.keyCode);
+      const char = String.fromCharCode(event.keyCode);
       this.filterTerm = this.filterTerm.concat(char);
-      let item = this.filteredOptions.find((i) => i.label.toUpperCase().indexOf(this.filterTerm) === 0);
+      const item = this.filteredOptions.find((i) => i.label.toUpperCase().indexOf(this.filterTerm) === 0);
       if (item) {
         this.select(item, this.filteredOptions.indexOf(item));
         this.scrollToSelected();
@@ -310,10 +310,10 @@ export class NovoSelectElement implements OnInit, OnChanges, OnDestroy, ControlV
   }
 
   scrollToIndex(index: number) {
-    let element = this.overlay.overlayRef.overlayElement;
-    let list = element.querySelector('.novo-select-list');
-    let items = list.querySelectorAll('li');
-    let item = items[this.headerConfig ? index + 1 : index];
+    const element = this.overlay.overlayRef.overlayElement;
+    const list = element.querySelector('.novo-select-list');
+    const items = list.querySelectorAll('li');
+    const item = items[this.headerConfig ? index + 1 : index];
     if (item) {
       list.scrollTop = item.offsetTop;
     }

--- a/projects/novo-elements/src/elements/simple-table/activity-table-renderers.ts
+++ b/projects/novo-elements/src/elements/simple-table/activity-table-renderers.ts
@@ -1,6 +1,6 @@
 export class ActivityTableRenderers {
   static propertyRenderer<T>(prop: string): Function {
-    let ret = (data: T): string => {
+    const ret = (data: T): string => {
       // TODO - allow for dots and sub props
       return data[prop];
     };
@@ -8,7 +8,7 @@ export class ActivityTableRenderers {
   }
 
   static dateRenderer<T>(prop: string): Function {
-    let ret = (data: T): string => {
+    const ret = (data: T): string => {
       return data[prop] ? new Date(data[prop]).toLocaleDateString() : '';
     };
     return ret;

--- a/projects/novo-elements/src/elements/simple-table/cell-header.ts
+++ b/projects/novo-elements/src/elements/simple-table/cell-header.ts
@@ -291,7 +291,7 @@ export class NovoSimpleCellHeader implements NovoSimpleSortFilter, OnInit, OnDes
   }
 
   private getDefaultDateFilterOptions(): SimpleTableColumnFilterOption[] {
-    let opts: SimpleTableColumnFilterOption[] = [
+    const opts: SimpleTableColumnFilterOption[] = [
       { label: this.labels.past1Day, min: -1, max: 0 },
       { label: this.labels.past7Days, min: -7, max: 0 },
       { label: this.labels.past30Days, min: -30, max: 0 },

--- a/projects/novo-elements/src/elements/simple-table/pagination.ts
+++ b/projects/novo-elements/src/elements/simple-table/pagination.ts
@@ -175,7 +175,7 @@ export class NovoSimpleTablePagination implements OnInit, OnDestroy {
   }
 
   private emitPageEvent(): void {
-    let event = {
+    const event = {
       page: this.page,
       pageSize: this.pageSize,
       length: this.length,

--- a/projects/novo-elements/src/elements/simple-table/sort.ts
+++ b/projects/novo-elements/src/elements/simple-table/sort.ts
@@ -17,14 +17,14 @@ export class NovoSortFilter {
     }
     this.state.filter = filter;
     this.state.reset(false, true);
-    this.state.updates.next({ filter: filter, sort: this.state.sort });
+    this.state.updates.next({ filter, sort: this.state.sort });
   }
 
   public sort(id: string, value: string, transform: Function): void {
-    let sort = { id, value, transform };
+    const sort = { id, value, transform };
     this.state.sort = sort;
     this.state.reset(false, true);
-    this.state.updates.next({ sort: sort, filter: this.state.filter });
+    this.state.updates.next({ sort, filter: this.state.filter });
   }
 }
 

--- a/projects/novo-elements/src/elements/simple-table/table-source.ts
+++ b/projects/novo-elements/src/elements/simple-table/table-source.ts
@@ -45,7 +45,7 @@ export class StaticActivityTableService<T> implements ActivityTableService<T> {
         ret = ret.filter((item) => Object.keys(item).some((key) => `${item[key]}`.toLowerCase().includes(globalSearch.toLowerCase())));
       }
       if (filter) {
-        let value = Helpers.isString(filter.value) ? filter.value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : filter.value;
+        const value = Helpers.isString(filter.value) ? filter.value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : filter.value;
         ret = ret.filter(Helpers.filterByField(filter.id, value));
       }
       if (sort) {

--- a/projects/novo-elements/src/elements/stepper/stepper.component.ts
+++ b/projects/novo-elements/src/elements/stepper/stepper.component.ts
@@ -70,8 +70,8 @@ export class NovoStepper extends CdkStepper implements AfterContentInit {
 
   get completed(): boolean {
     try {
-      let steps = this._steps.toArray();
-      let length = steps.length - 1;
+      const steps = this._steps.toArray();
+      const length = steps.length - 1;
       return steps[length].completed && length === this.selectedIndex;
     } catch (err) {
       return false;
@@ -85,7 +85,7 @@ export class NovoStepper extends CdkStepper implements AfterContentInit {
 
   complete() {
     try {
-      let steps = this._steps.toArray();
+      const steps = this._steps.toArray();
       steps[this.selectedIndex].completed = true;
       this.next();
       this._stateChanged();
@@ -95,7 +95,7 @@ export class NovoStepper extends CdkStepper implements AfterContentInit {
   }
 
   getIndicatorType(index: number): 'none' | '' | 'edit' | 'done' {
-    let steps = this._steps.toArray();
+    const steps = this._steps.toArray();
     if (index === this.selectedIndex) {
       if (steps[index] && index === steps.length - 1 && steps[index].completed) {
         return 'done';

--- a/projects/novo-elements/src/elements/table/Table.spec.ts
+++ b/projects/novo-elements/src/elements/table/Table.spec.ts
@@ -322,7 +322,7 @@ describe('Elements: NovoTableElement', () => {
     it('should update the row data to reflect the active filters (custom filter).', () => {
       expect(component.onFilterChange).toBeDefined();
       component.config.filtering = (filterValue, data) => {
-        let matches = [];
+        const matches = [];
         data.forEach((row) => {
           if (row.name === 'John') {
             matches.push(row);
@@ -336,7 +336,7 @@ describe('Elements: NovoTableElement', () => {
 
     it('should update the row data to reflect the active filters (custom config filter).', () => {
       expect(component.onFilterChange).toBeDefined();
-      let mockOption = { label: 'Today', min: -2, max: 2 };
+      const mockOption = { label: 'Today', min: -2, max: 2 };
       component.columns = [
         {
           name: 'name',
@@ -366,10 +366,10 @@ describe('Elements: NovoTableElement', () => {
   xdescribe('Method: isFilterActive(columnFilters, filter)', () => {
     it('should return true when the filter is active and false when it is not.', () => {
       expect(component.isFilterActive).toBeDefined();
-      let mockColumnFilters = {
+      const mockColumnFilters = {
         filter: [],
       };
-      let mockFilter = {
+      const mockFilter = {
         label: 'Filter',
       };
       // Using Filter Objects
@@ -439,7 +439,7 @@ describe('Elements: NovoTableElement', () => {
   describe('Method: getDefaultOptions()', () => {
     it('should return a subset of options when the data dates cover a small range.', () => {
       expect(component.getDefaultOptions).toBeDefined();
-      let mockOptions = component.getDefaultOptions();
+      const mockOptions = component.getDefaultOptions();
       expect(mockOptions.length).toBe(10);
     });
   });
@@ -641,49 +641,49 @@ describe('Elements: NovoTableElement', () => {
     });
 
     it('should return true if column has hideColumnOnEdit and in editing mode', () => {
-      let column = { name: 'name', hideColumnOnEdit: true };
+      const column = { name: 'name', hideColumnOnEdit: true };
       component.mode = 2;
       expect(component.isColumnHidden(column)).toBe(true);
     });
 
     it('should return false if column does not have hideColumnOnEdit and in editing mode', () => {
-      let column = { name: 'name' };
+      const column = { name: 'name' };
       component.mode = 2;
       expect(component.isColumnHidden(column)).toBe(false);
     });
 
     it('should return false if column does not have hideColumnOnEdit and not in editing mode', () => {
-      let column = { name: 'name' };
+      const column = { name: 'name' };
       component.mode = 1;
       expect(component.isColumnHidden(column)).toBe(false);
     });
 
     it('should return false if column has hideColumnOnEdit and not in editing mode', () => {
-      let column = { name: 'name', hideColumnOnEdit: true };
+      const column = { name: 'name', hideColumnOnEdit: true };
       component.mode = 1;
       expect(component.isColumnHidden(column)).toBe(false);
     });
 
     it('should return false if column has hideColumnOnView and in editing mode', () => {
-      let column = { name: 'name', hideColumnOnView: true };
+      const column = { name: 'name', hideColumnOnView: true };
       component.mode = 2;
       expect(component.isColumnHidden(column)).toBe(false);
     });
 
     it('should return false if column does not have hideColumnOnView and in editing mode', () => {
-      let column = { name: 'name' };
+      const column = { name: 'name' };
       component.mode = 2;
       expect(component.isColumnHidden(column)).toBe(false);
     });
 
     it('should return false if column does not have hideColumnOnView and not in editing mode', () => {
-      let column = { name: 'name' };
+      const column = { name: 'name' };
       component.mode = 1;
       expect(component.isColumnHidden(column)).toBe(false);
     });
 
     it('should return false if column has hideColumnOnView and not in editing mode', () => {
-      let column = { name: 'name', hideColumnOnView: true };
+      const column = { name: 'name', hideColumnOnView: true };
       component.mode = 1;
       expect(component.isColumnHidden(column)).toBe(true);
     });

--- a/projects/novo-elements/src/elements/table/Table.ts
+++ b/projects/novo-elements/src/elements/table/Table.ts
@@ -314,7 +314,7 @@ export class NovoTableElement implements DoCheck {
           }
           // Find that columns we might need to sum up via the footer
           let columnsToSum = [];
-          let columnSums = {};
+          const columnSums = {};
           if (this.config.footers) {
             this.config.footers.forEach((config) => {
               columnsToSum.push(...config.columns);
@@ -323,16 +323,16 @@ export class NovoTableElement implements DoCheck {
             columnsToSum = columnsToSum.filter((item, index, array) => array.indexOf(item) === index);
           }
           // Make a form for each row
-          let tableFormRows = <FormArray>this.tableForm.controls['rows'];
+          const tableFormRows = <FormArray>this.tableForm.controls['rows'];
           this._rows.forEach((row, index) => {
-            let rowControls = [];
+            const rowControls = [];
             row.controls = {};
             row._editing = {};
             row._expanded = this.config.expandAll;
             row.rowId = this._rows.length;
             this.columns.forEach((column) => {
               // Use the control passed or use a ReadOnlyControl so that the form has the values
-              let control = column.editorConfig
+              const control = column.editorConfig
                 ? ControlFactory.create(column.editorType, column.editorConfig)
                 : new ReadOnlyControl({ key: column.name });
               row.controls[column.name] = control;
@@ -358,7 +358,7 @@ export class NovoTableElement implements DoCheck {
           if (this.config.footers) {
             this.footers = [];
             this.config.footers.forEach((footerConfig, footerConfigIndex) => {
-              let footer = {};
+              const footer = {};
               footer[footerConfig.labelColumn] = footerConfig.label;
               footerConfig.columns.forEach((column) => {
                 if (footerConfig.method === 'AVG' && this._rows.length !== 0) {
@@ -475,7 +475,7 @@ export class NovoTableElement implements DoCheck {
   }
 
   getRowControlForm(i): AbstractControl {
-    let tableFormRows = <FormArray>this.tableForm.controls['rows'];
+    const tableFormRows = <FormArray>this.tableForm.controls['rows'];
     return tableFormRows.controls[i];
   }
 
@@ -638,10 +638,10 @@ export class NovoTableElement implements DoCheck {
    */
   onSortChange(column) {
     this.currentSortColumn = column;
-    let sortedColumns: any = this.columns.filter((thisColumn) => {
+    const sortedColumns: any = this.columns.filter((thisColumn) => {
       return thisColumn.sort && thisColumn !== this.currentSortColumn;
     });
-    for (let sortedColumn of sortedColumns) {
+    for (const sortedColumn of sortedColumns) {
       sortedColumn.sort = null;
     }
 
@@ -709,7 +709,7 @@ export class NovoTableElement implements DoCheck {
    */
   expandAllOnPage(expanded) {
     this.config.expandAll = !expanded;
-    for (let row of this.dataProvider.list) {
+    for (const row of this.dataProvider.list) {
       row._expanded = this.config.expandAll;
     }
   }
@@ -726,7 +726,7 @@ export class NovoTableElement implements DoCheck {
     } else {
       this.indeterminate = false;
       // this.pagedData = this.rows.slice(this.getPageStart(), this.getPageEnd());
-      for (let row of this.pagedData) {
+      for (const row of this.pagedData) {
         row._selected = this.master;
       }
       this.selected = this.dataProvider.list.filter((r) => r._selected);
@@ -744,7 +744,7 @@ export class NovoTableElement implements DoCheck {
   selectAll(value) {
     this.master = value;
     this.indeterminate = false;
-    for (let row of this.dataProvider.list) {
+    for (const row of this.dataProvider.list) {
       row._selected = value;
     }
     this.selected = value ? this.dataProvider.list : [];
@@ -782,7 +782,7 @@ export class NovoTableElement implements DoCheck {
    * @param selected
    */
   emitSelected(selected) {
-    this.onRowSelect.emit({ length: selected.length, selected: selected });
+    this.onRowSelect.emit({ length: selected.length, selected });
   }
 
   /**
@@ -798,7 +798,7 @@ export class NovoTableElement implements DoCheck {
 
   getDefaultOptions(column) {
     // TODO - needs to come from label service - https://github.com/bullhorn/novo-elements/issues/116
-    let opts: any[] = [
+    const opts: any[] = [
       { label: this.labels.past1Day, min: -1, max: 0 },
       { label: this.labels.past7Days, min: -7, max: 0 },
       { label: this.labels.past30Days, min: -30, max: 0 },
@@ -830,11 +830,11 @@ export class NovoTableElement implements DoCheck {
 
   onFilterKeywords(config) {
     if (config && config.filtering && config.filtering.freetextFilter) {
-      let filterKeywords = config.filtering.freetextFilter.toLowerCase();
+      const filterKeywords = config.filtering.freetextFilter.toLowerCase();
       if (!config.filtering.originalOptions) {
         config.filtering.originalOptions = config.filtering.options;
       }
-      let newOptions = config.filtering.originalOptions.filter((option) => {
+      const newOptions = config.filtering.originalOptions.filter((option) => {
         let value = option && option.label ? option.label : option;
         value = value.toLowerCase() ? value.toLowerCase() : value;
         if (value === filterKeywords) {
@@ -917,15 +917,15 @@ export class NovoTableElement implements DoCheck {
    * @memberOf NovoTableElement
    */
   addEditableRow(defaultValue: any = {}): void {
-    let tableFormRows = <FormArray>this.tableForm.controls['rows'];
-    let row: any = {};
-    let rowControls = [];
+    const tableFormRows = <FormArray>this.tableForm.controls['rows'];
+    const row: any = {};
+    const rowControls = [];
     row.controls = {};
     row._editing = {};
     row.rowId = this._rows.length + 1;
     this.columns.forEach((column) => {
       // Use the control passed or use a ReadOnlyControl so that the form has the values
-      let control = column.editorConfig
+      const control = column.editorConfig
         ? ControlFactory.create(column.editorType, column.editorConfig)
         : new ReadOnlyControl({ key: column.name });
       control.value = null; // remove copied column value
@@ -948,15 +948,15 @@ export class NovoTableElement implements DoCheck {
    */
   validateAndGetUpdatedData(): { changed?: any[]; errors?: { errors: any; row: any; index: number }[] } {
     if (this.tableForm && this.tableForm.controls && this.tableForm.controls['rows']) {
-      let changedRows = [];
-      let errors = [];
+      const changedRows = [];
+      const errors = [];
       // Go over the FormArray's controls
       (this.tableForm.controls['rows'] as FormArray).controls.forEach((formGroup: FormGroup, index: number) => {
         let changedRow = null;
         let error = null;
         // Go over the form group controls
         Object.keys(formGroup.controls).forEach((key: string) => {
-          let control = formGroup.controls[key];
+          const control = formGroup.controls[key];
           // Handle value changing
           if (control && control.dirty && !control.errors) {
             if (!changedRow) {
@@ -984,15 +984,15 @@ export class NovoTableElement implements DoCheck {
           changedRows.push(changedRow);
         }
         if (error) {
-          errors.push({ errors: error, row: this._rows[index], index: index });
+          errors.push({ errors: error, row: this._rows[index], index });
         }
       });
-      let ret = {};
+      const ret = {};
       // Return errors if any, otherwise return the changed rows
       if (errors.length === 0) {
         return { changed: changedRows };
       }
-      return { errors: errors };
+      return { errors };
     }
   }
 

--- a/projects/novo-elements/src/elements/table/extras/dropdown-cell/DropdownCell.ts
+++ b/projects/novo-elements/src/elements/table/extras/dropdown-cell/DropdownCell.ts
@@ -44,7 +44,7 @@ export class NovoDropdownCell extends BaseRenderer implements OnInit {
   }
 
   public onClick(config, option, value): void {
-    let callback = option.callback || config.callback;
+    const callback = option.callback || config.callback;
     callback(this.data, value || option);
   }
 }

--- a/projects/novo-elements/src/elements/table/extras/pagination/Pagination.ts
+++ b/projects/novo-elements/src/elements/table/extras/pagination/Pagination.ts
@@ -102,14 +102,14 @@ export class Pagination implements OnInit, OnChanges {
   // Create page object used in template
   makePage(number, text, isActive) {
     return {
-      number: number,
-      text: text,
+      number,
+      text,
       active: isActive,
     };
   }
 
   getPages(currentPage, totalPages) {
-    let pages = [];
+    const pages = [];
     // Default page limits
     let startPage = 1;
     let endPage = totalPages;

--- a/projects/novo-elements/src/elements/table/extras/th-orderable/ThOrderable.spec.ts
+++ b/projects/novo-elements/src/elements/table/extras/th-orderable/ThOrderable.spec.ts
@@ -34,8 +34,8 @@ describe('Elements: ThOrderable', () => {
     });
   });
   describe('Class: ', () => {
-    let mockElement = new ElementRef(document.createElement('div')) as any;
-    let subject = new ThOrderable(mockElement);
+    const mockElement = new ElementRef(document.createElement('div')) as any;
+    const subject = new ThOrderable(mockElement);
     mockElement.nativeElement = {
       parentNode: {
         children: [mockElement],
@@ -63,7 +63,7 @@ describe('Elements: ThOrderable', () => {
     describe('Method: deleteColumns()', () => {
       it('should delete rows from the table', () => {
         expect(subject.deleteColumns).toBeDefined();
-        let mockTable = {
+        const mockTable = {
           rows: [],
           deleteRow: () => {},
         };
@@ -74,7 +74,7 @@ describe('Elements: ThOrderable', () => {
 
     describe('Method: findTable()', () => {
       it('should be defined', () => {
-        let mockHTMLElement = document.createElement('div');
+        const mockHTMLElement = document.createElement('div');
         expect(subject.findTable).toBeDefined();
         subject.findTable(mockHTMLElement);
       });

--- a/projects/novo-elements/src/elements/table/extras/th-orderable/ThOrderable.ts
+++ b/projects/novo-elements/src/elements/table/extras/th-orderable/ThOrderable.ts
@@ -31,7 +31,7 @@ export class ThOrderable implements OnInit {
   get index() {
     let index: number = null;
     if (this.element.nativeElement && this.element.nativeElement.parentNode) {
-      let children: Array<any> = Array.prototype.slice.call(this.element.nativeElement.parentNode.children);
+      const children: Array<any> = Array.prototype.slice.call(this.element.nativeElement.parentNode.children);
       index = children.indexOf(this.element.nativeElement);
     }
     return index;

--- a/projects/novo-elements/src/elements/tabs/Tabs.ts
+++ b/projects/novo-elements/src/elements/tabs/Tabs.ts
@@ -40,7 +40,7 @@ export class NovoNavElement {
     }
 
     // TODO - remove hack to make DOM rerender - jgodi
-    let element = document.querySelector('novo-tab-link.active span.indicator') as any;
+    const element = document.querySelector('novo-tab-link.active span.indicator') as any;
     if (element) {
       element.style.opacity = 0.99;
       setTimeout(() => {
@@ -166,7 +166,7 @@ export class NovoNavOutletElement {
   items: Array<any> = [];
 
   show(index) {
-    let item = this.items[index];
+    const item = this.items[index];
 
     /**
      * Deactivates other tab items

--- a/projects/novo-elements/src/elements/tiles/Tiles.spec.ts
+++ b/projects/novo-elements/src/elements/tiles/Tiles.spec.ts
@@ -37,7 +37,7 @@ describe('Elements: NovoTilesElement', () => {
 
   describe('Method: select(event, item)', () => {
     it('should set label 2 with checked equal to true', () => {
-      let event: any = {
+      const event: any = {
         stopPropagation: () => {},
         preventDefault: () => {},
       };

--- a/projects/novo-elements/src/elements/tiles/Tiles.ts
+++ b/projects/novo-elements/src/elements/tiles/Tiles.ts
@@ -121,7 +121,7 @@ export class NovoTilesElement implements ControlValueAccessor, AfterContentInit,
   setupOptions() {
     if (this.options && this.options.length && (this.options[0].value === undefined || this.options[0].value === null)) {
       this._options = this.options.map((x) => {
-        let item = { value: x, label: x, checked: this.model === x };
+        const item = { value: x, label: x, checked: this.model === x };
         if (item.checked) {
           this.setTile(item);
         }
@@ -151,7 +151,7 @@ export class NovoTilesElement implements ControlValueAccessor, AfterContentInit,
         return;
       }
 
-      for (let option of this._options) {
+      for (const option of this._options) {
         option.checked = false;
       }
 
@@ -175,11 +175,11 @@ export class NovoTilesElement implements ControlValueAccessor, AfterContentInit,
 
   moveTile() {
     setTimeout(() => {
-      let ind = this.element.nativeElement.querySelector('.active-indicator');
-      let el = this.element.nativeElement.querySelector('.tile.active');
+      const ind = this.element.nativeElement.querySelector('.active-indicator');
+      const el = this.element.nativeElement.querySelector('.tile.active');
       if (ind && el) {
-        let w: number = el.clientWidth;
-        let left: number = el.offsetLeft - el.offsetTop; // Removes the border width that Firefox adds without affecting other browsers
+        const w: number = el.clientWidth;
+        const left: number = el.offsetLeft - el.offsetTop; // Removes the border width that Firefox adds without affecting other browsers
         ind.style.width = `calc(${w}px + 0.32em)`;
         ind.style.left = `${left}px`;
         this.state = 'active';

--- a/projects/novo-elements/src/elements/time-picker/TimePicker.ts
+++ b/projects/novo-elements/src/elements/time-picker/TimePicker.ts
@@ -93,7 +93,7 @@ export class NovoTimePickerElement implements ControlValueAccessor, OnInit, OnCh
       this.HOURS = ['0', ...this.HOURS, '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23'];
       this.increments = this.flatten([...this.HOURS.map((hour) => [`${hour}:00`, `${hour}:15`, `${hour}:30`, `${hour}:45`])]);
     } else {
-      let hours: Array<string> = ['12', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11'];
+      const hours: Array<string> = ['12', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11'];
       this.increments = this.flatten([
         ...hours.map((hour) => [`${hour}:00 AM`, `${hour}:15 AM`, `${hour}:30 AM`, `${hour}:45 AM`]),
         ...hours.map((hour) => [`${hour}:00 PM`, `${hour}:15 PM`, `${hour}:30 PM`, `${hour}:45 PM`]),
@@ -112,7 +112,7 @@ export class NovoTimePickerElement implements ControlValueAccessor, OnInit, OnCh
   }
 
   init(value, dispatch) {
-    let _value = new Date(value);
+    const _value = new Date(value);
     let hours: string | number = _value.getHours();
     let minutes: string | number = _value.getMinutes();
 
@@ -135,8 +135,8 @@ export class NovoTimePickerElement implements ControlValueAccessor, OnInit, OnCh
   setValue(event, value) {
     Helpers.swallowEvent(event);
     this.selected = value;
-    let [time, meridian] = value.split(' ');
-    let [hours, minutes] = time.split(':');
+    const [time, meridian] = value.split(' ');
+    const [hours, minutes] = time.split(':');
     this.hours = hours;
     this.minutes = minutes;
     this.meridian = meridian;
@@ -190,13 +190,13 @@ export class NovoTimePickerElement implements ControlValueAccessor, OnInit, OnCh
       }
     }
 
-    let value = new Date();
+    const value = new Date();
     value.setHours(hours);
     value.setMinutes(this.minutes);
     value.setSeconds(0);
     this.value = `${this.hours}:${this.minutes} ${this.meridian}`;
     this.onSelect.next({
-      hours: hours,
+      hours,
       minutes: this.minutes,
       meridian: this.meridian,
       date: value,

--- a/projects/novo-elements/src/elements/time-picker/TimePickerInput.ts
+++ b/projects/novo-elements/src/elements/time-picker/TimePickerInput.ts
@@ -102,7 +102,7 @@ export class NovoTimePickerInputElement implements OnInit, ControlValueAccessor 
   openPanel(): void {
     if (!this.overlay.panelOpen) {
       this.overlay.openPanel();
-      let hour = new Date().getHours();
+      const hour = new Date().getHours();
       Promise.resolve(null).then(() => this.scrollToIndex(hour * 4));
     }
   }
@@ -128,15 +128,15 @@ export class NovoTimePickerInputElement implements OnInit, ControlValueAccessor 
   _handleInput(event: KeyboardEvent): void {
     if (document.activeElement === event.target) {
       // this._onChange((event.target as HTMLInputElement).value);
-      let text = (event.target as HTMLInputElement).value;
+      const text = (event.target as HTMLInputElement).value;
       if (this.military ? text.replace(/_/g, '').length === 5 : text.replace(/_/g, '').length === 8) {
-        let [dateTimeValue, formatted] = this.dateFormatService.parseString(text, this.military, 'time');
+        const [dateTimeValue, formatted] = this.dateFormatService.parseString(text, this.military, 'time');
         this.dispatchOnChange(dateTimeValue);
       } else {
         this.dispatchOnChange(null);
       }
       this.openPanel();
-      let num = Number(text.split(':')[0]);
+      const num = Number(text.split(':')[0]);
       this.scrollToIndex(num * 4);
     }
   }
@@ -207,7 +207,7 @@ export class NovoTimePickerInputElement implements OnInit, ControlValueAccessor 
     if (!value) {
       return '';
     }
-    let format = this.labels.formatTimeWithFormat(value, {
+    const format = this.labels.formatTimeWithFormat(value, {
       hour: 'numeric',
       minute: '2-digit',
       hour12: !this.military,
@@ -223,10 +223,10 @@ export class NovoTimePickerInputElement implements OnInit, ControlValueAccessor 
   }
 
   public scrollToIndex(index: number) {
-    let element = this.overlay.overlayRef.overlayElement;
-    let list = element.querySelector('.increments');
-    let items = list.querySelectorAll('novo-list-item');
-    let item = items[index];
+    const element = this.overlay.overlayRef.overlayElement;
+    const list = element.querySelector('.increments');
+    const items = list.querySelectorAll('novo-list-item');
+    const item = items[index];
     if (item) {
       list.scrollTop = (item as HTMLElement).offsetTop;
     }

--- a/projects/novo-elements/src/elements/tip-well/TipWell.ts
+++ b/projects/novo-elements/src/elements/tip-well/TipWell.ts
@@ -84,7 +84,7 @@ export class NovoTipWellElement implements OnInit {
     this.localStorageKey = `novo-tw_${this.name}`;
     // Check localStorage for state
     if (this.isLocalStorageEnabled) {
-      let storedValue = JSON.parse(localStorage.getItem(this.localStorageKey));
+      const storedValue = JSON.parse(localStorage.getItem(this.localStorageKey));
       this.isActive = storedValue !== false;
     }
   }

--- a/projects/novo-elements/src/elements/toast/ToastService.spec.ts
+++ b/projects/novo-elements/src/elements/toast/ToastService.spec.ts
@@ -4,9 +4,9 @@ import { ComponentUtils } from '../../utils/component-utils/ComponentUtils';
 
 describe('Elements: NovoToastService', () => {
   describe('Service: ', () => {
-    let resolver: any = null;
-    let utils = new ComponentUtils(resolver);
-    let service = new NovoToastService(utils);
+    const resolver: any = null;
+    const utils = new ComponentUtils(resolver);
+    const service = new NovoToastService(utils);
 
     it('should be defined.', () => {
       expect(service).toBeDefined();
@@ -18,7 +18,7 @@ describe('Elements: NovoToastService', () => {
       });
 
       it('should call setToastOnSession.', () => {
-        let options = {
+        const options = {
           isCloseable: false,
           hideDelay: 3000,
           message: 'test message',
@@ -32,7 +32,7 @@ describe('Elements: NovoToastService', () => {
       });
 
       it('should call toastTimer if not isCloseable.', () => {
-        let toast = {
+        const toast = {
           isCloseable: false,
         };
         spyOn(service, 'toastTimer');
@@ -43,10 +43,10 @@ describe('Elements: NovoToastService', () => {
       });
 
       it('should NOT call toastTimer if isCloseable.', () => {
-        let toast = {
+        const toast = {
           isCloseable: true,
         };
-        let options = {
+        const options = {
           isCloseable: true,
         };
         spyOn(service, 'toastTimer');
@@ -63,21 +63,21 @@ describe('Elements: NovoToastService', () => {
       });
 
       it('should return false is toast.show = false.', () => {
-        let toast = {
+        const toast = {
           show: false,
         };
 
-        let result = service.isVisible(toast);
+        const result = service.isVisible(toast);
 
         expect(result).toBeFalsy();
       });
 
       it('should return true is toast.show = true.', () => {
-        let toast = {
+        const toast = {
           show: true,
         };
 
-        let result = service.isVisible(toast);
+        const result = service.isVisible(toast);
 
         expect(result).toBeTruthy();
       });

--- a/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
@@ -104,7 +104,7 @@ export class TooltipDirective implements OnDestroy, OnInit {
     this.overlayRef.detach();
     this.portal = this.portal || new ComponentPortal(NovoTooltip, this.viewContainerRef);
 
-    let tooltipInstance = this.overlayRef.attach(this.portal).instance;
+    const tooltipInstance = this.overlayRef.attach(this.portal).instance;
     tooltipInstance.message = this.tooltip;
     tooltipInstance.tooltipType = this.type;
     tooltipInstance.rounded = this.rounded;

--- a/projects/novo-elements/src/elements/unless/Unless.ts
+++ b/projects/novo-elements/src/elements/unless/Unless.ts
@@ -23,8 +23,8 @@ export class Unless {
   check(): void {
     let display: boolean = false;
     if (~this.permissions.indexOf('||')) {
-      let ps: any = this.permissions.split('||');
-      for (let p of ps) {
+      const ps: any = this.permissions.split('||');
+      for (const p of ps) {
         if (this.security.has(p.trim())) {
           display = true;
         }

--- a/projects/novo-elements/src/elements/value/EntityList.ts
+++ b/projects/novo-elements/src/elements/value/EntityList.ts
@@ -66,7 +66,7 @@ export class EntityList implements OnInit {
     this.metaDisplay = Helpers.deepClone(this.meta);
     this.metaDisplay.type = 'TO_ONE';
     this.baseEntity = this.meta.associatedEntity.entity;
-    for (let entity of this.data.data) {
+    for (const entity of this.data.data) {
       entity.isLinkable = this.isLinkable(entity);
       entity.class = this.getClass(entity);
     }

--- a/projects/novo-elements/src/elements/value/Render.spec.ts
+++ b/projects/novo-elements/src/elements/value/Render.spec.ts
@@ -38,11 +38,11 @@ xdescribe('Render', () => {
     });
     it('should return true when two objects are identical.', () => {
       expect(pipe.equals).toBeDefined();
-      let b: any = a;
+      const b: any = a;
       expect(pipe.equals(a, b)).toBeTruthy();
     });
     it('should return false when two objects are not identical.', () => {
-      let b: any = {
+      const b: any = {
         id: 1,
         sub: {
           subSub: {
@@ -85,42 +85,42 @@ xdescribe('Render', () => {
     });
     it('should render an address.', () => {
       expect(pipe.render).toBeDefined();
-      let mockValue: any = {
+      const mockValue: any = {
         address1: 'Derp',
         address2: '264 Hess Rd',
         city: 'Leola',
         state: 'PA',
         zip: '17540',
       };
-      let mockArgs: any = {
+      const mockArgs: any = {
         type: 'Address',
       };
       expect(pipe.render(mockValue, mockArgs)).toBe(mockValue);
     });
     it('should render an SecondaryAddress.', () => {
       expect(pipe.render).toBeDefined();
-      let mockValue: any = {
+      const mockValue: any = {
         address1: 'Derp',
         address2: '264 Hess Rd',
         city: 'Leola',
         state: 'PA',
         zip: '17540',
       };
-      let mockArgs: any = {
+      const mockArgs: any = {
         type: 'SecondaryAddress',
       };
       expect(pipe.render(mockValue, mockArgs)).toBe(mockValue);
     });
     it('should render an BillingAddress.', () => {
       expect(pipe.render).toBeDefined();
-      let mockValue: any = {
+      const mockValue: any = {
         address1: 'Derp',
         address2: '264 Hess Rd',
         city: 'Leola',
         state: 'PA',
         zip: '17540',
       };
-      let mockArgs: any = {
+      const mockArgs: any = {
         type: 'BillingAddress',
       };
       expect(pipe.render(mockValue, mockArgs)).toBe(mockValue);
@@ -129,50 +129,50 @@ xdescribe('Render', () => {
     // WILL BREAK THE NEXT DAY
     xit('should render a timestamp.', () => {
       expect(pipe.render).toBeDefined();
-      let mockValue: any = new Date();
-      let mockArgs: any = {
+      const mockValue: any = new Date();
+      const mockArgs: any = {
         dataType: 'Timestamp',
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toEqual('12/02/2016');
     });
     it('should render a timestamp with conversion skipped.', () => {
       expect(pipe.render).toBeDefined();
-      let mockValue: any = new Date('5/10/2017 23:59:59').getTime();
-      let mockArgs: any = {
+      const mockValue: any = new Date('5/10/2017 23:59:59').getTime();
+      const mockArgs: any = {
         dataType: 'Timestamp',
         optionsType: 'skipConversion',
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toEqual('5/10/2017');
     });
     // TODO: Phone/Email
     it('should render money.', () => {
       expect(pipe.render).toBeDefined();
-      let mockValue: any = 123.56;
-      let mockArgs: any = {
+      const mockValue: any = 123.56;
+      const mockArgs: any = {
         dataSpecialization: 'MONEY',
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toEqual('$123.56');
     });
     it('should render a percentage.', () => {
       expect(pipe.render).toBeDefined();
-      let mockValue: any = 0.1556;
-      let mockArgs: any = {
+      const mockValue: any = 0.1556;
+      const mockArgs: any = {
         dataSpecialization: 'PERCENTAGE',
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toEqual('15.56%');
     });
     // TODO: Double/BigDecimal
     it('should render a Integer.', () => {
       expect(pipe.render).toBeDefined();
-      let mockValue: any = 103;
-      let mockArgs: any = {
+      const mockValue: any = 103;
+      const mockArgs: any = {
         dataType: 'Integer',
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toBe(103);
     });
     // TODO: Lead/Candidate/ClientContact/CorporateUser/Person
@@ -181,8 +181,8 @@ xdescribe('Render', () => {
     // TODO: WorkersCompensationRate
     it('should render a Options.', () => {
       expect(pipe.render).toBeDefined();
-      let mockValue: any = 'John';
-      let mockArgs: any = {
+      const mockValue: any = 'John';
+      const mockArgs: any = {
         inputType: 'SELECT',
         options: [
           {
@@ -191,12 +191,12 @@ xdescribe('Render', () => {
           },
         ],
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toBe('John Snow');
     });
     it('should render a ToMany.', () => {
       expect(pipe.render).toBeDefined();
-      let mockValue: any = {
+      const mockValue: any = {
         data: [
           {
             firstName: 'Jane',
@@ -204,234 +204,234 @@ xdescribe('Render', () => {
           },
         ],
       };
-      let mockArgs: any = {
+      const mockArgs: any = {
         type: 'TO_MANY',
         associatedEntity: {
           entity: 'Candidate',
         },
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toBe('Jane Smith');
     });
     it('should render a Country.', () => {
       expect(pipe.render).toBeDefined();
-      let mockValue: any = 1;
-      let mockArgs: any = {
+      const mockValue: any = 1;
+      const mockArgs: any = {
         optionsType: 'Country',
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toBe('United States');
     });
     it('should render a DistributionList', () => {
       expect(pipe.render).toBeDefined();
-      let mockArgs: any = {
+      const mockArgs: any = {
         type: 'TO_ONE',
         associatedEntity: {
           entity: 'DistributionList',
         },
       };
-      let mockValue: any = {
+      const mockValue: any = {
         name: 'distributionList',
         label: 'List of Cheese Farmers',
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toBe('List of Cheese Farmers');
     });
     it('should render a Tearsheet', () => {
       expect(pipe.render).toBeDefined();
-      let mockArgs: any = {
+      const mockArgs: any = {
         type: 'TO_ONE',
         associatedEntity: {
           entity: 'Tearsheet',
         },
       };
-      let mockValue: any = {
+      const mockValue: any = {
         name: 'tearsheet',
         label: 'ShortList of Cheese Farmers',
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toBe('ShortList of Cheese Farmers');
     });
     it('should render a Skill', () => {
       expect(pipe.render).toBeDefined();
-      let mockArgs: any = {
+      const mockArgs: any = {
         type: 'TO_ONE',
         associatedEntity: {
           entity: 'Skill',
         },
       };
-      let mockValue: any = {
+      const mockValue: any = {
         name: 'skill',
         label: 'Makes awesome cheese',
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toBe('Makes awesome cheese');
     });
     it('should render a Category', () => {
       expect(pipe.render).toBeDefined();
-      let mockArgs: any = {
+      const mockArgs: any = {
         type: 'TO_ONE',
         associatedEntity: {
           entity: 'Category',
         },
       };
-      let mockValue: any = {
+      const mockValue: any = {
         name: 'category',
         label: 'Cheese Making',
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toBe('Cheese Making');
     });
     it('should render a Business Sector', () => {
       expect(pipe.render).toBeDefined();
-      let mockArgs: any = {
+      const mockArgs: any = {
         type: 'TO_ONE',
         associatedEntity: {
           entity: 'BusinessSector',
         },
       };
-      let mockValue: any = {
+      const mockValue: any = {
         name: 'businessSector',
         label: 'Dairy',
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toBe('Dairy');
     });
     it('should render a Certification', () => {
       expect(pipe.render).toBeDefined();
-      let mockArgs: any = {
+      const mockArgs: any = {
         type: 'TO_ONE',
         associatedEntity: {
           entity: 'Certification',
         },
       };
-      let mockValue: any = {
+      const mockValue: any = {
         name: 'certification',
         label: 'CMP - Cheese Making Professional',
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toBe('CMP - Cheese Making Professional');
     });
     it('should render a ClientCorporation', () => {
       expect(pipe.render).toBeDefined();
-      let mockArgs: any = {
+      const mockArgs: any = {
         type: 'TO_ONE',
         associatedEntity: {
           entity: 'ClientCorporation',
         },
       };
-      let mockValue: any = {
+      const mockValue: any = {
         name: 'clientCorporation',
         label: 'Cheese R Us',
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toBe('Cheese R Us');
     });
     it('should render a CorporationDepartment', () => {
       expect(pipe.render).toBeDefined();
-      let mockArgs: any = {
+      const mockArgs: any = {
         type: 'TO_ONE',
         associatedEntity: {
           entity: 'CorporationDepartment',
         },
       };
-      let mockValue: any = {
+      const mockValue: any = {
         name: 'corporationDepartment',
         label: 'Bringers of Cheese',
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toBe('Bringers of Cheese');
     });
     // checking name conditional for TO_ONE
     it('should render a CorporationDepartment', () => {
       expect(pipe.render).toBeDefined();
-      let mockArgs: any = {
+      const mockArgs: any = {
         type: 'TO_ONE',
         associatedEntity: {
           entity: 'CorporationDepartment',
         },
       };
-      let mockValue: any = {
+      const mockValue: any = {
         name: 'corporationDepartment',
         label: '',
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toBe('corporationDepartment');
     });
     // checking blank conditional for TO_ONE
     it('should render a CorporationDepartment', () => {
       expect(pipe.render).toBeDefined();
-      let mockArgs: any = {
+      const mockArgs: any = {
         type: 'TO_ONE',
         associatedEntity: {
           entity: 'CorporationDepartment',
         },
       };
-      let mockValue: any = {
+      const mockValue: any = {
         name: '',
         label: '',
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toBe('');
     });
     it('should render a CandidateComment.', () => {
       expect(pipe.render).toBeDefined();
-      let mockArgs: any = {
+      const mockArgs: any = {
         type: 'TO_ONE',
         associatedEntity: {
           entity: 'CandidateComment',
         },
       };
-      let mockValue: any = {
+      const mockValue: any = {
         name: 'David S. Pumpkins',
         comments: 'I am so in the weeds with David Pumpkins!',
         dateLastModified: 1500999002330,
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toBe('7/25/2017 (David S. Pumpkins) - I am so in the weeds with David Pumpkins!');
     });
     it('should render a CandidateComment.', () => {
       expect(pipe.render).toBeDefined();
-      let mockArgs: any = {
+      const mockArgs: any = {
         type: 'TO_ONE',
         associatedEntity: {
           entity: 'CandidateComment',
         },
       };
-      let mockValue: any = {
+      const mockValue: any = {
         name: 'David S. Pumpkins',
         comments: '',
         dateLastModified: 1500999002330,
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toBe('');
     });
     it('should render SkillText if array passed in', () => {
       expect(pipe.render).toBeDefined();
-      let mockValue: any = ['Skill1', 'Skill2', 'Skill3'];
-      let mockArgs: any = {
+      const mockValue: any = ['Skill1', 'Skill2', 'Skill3'];
+      const mockArgs: any = {
         optionsType: 'SkillText',
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toBe('Skill1, Skill2, Skill3');
     });
     it('should render SkillText if array not passed in', () => {
       expect(pipe.render).toBeDefined();
-      let mockValue: any = 'Skill1';
-      let mockArgs: any = {
+      const mockValue: any = 'Skill1';
+      const mockArgs: any = {
         optionsType: 'SkillText',
       };
-      let result: any = pipe.render(mockValue, mockArgs);
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toBe('Skill1');
     });
     it('should render Html strings as sanitized Html content.', () => {
-      let mockArgs: any = {
+      const mockArgs: any = {
         type: 'SCALAR',
         dataType: 'String',
         dataSpecialization: 'HTML',
       };
-      let mockValue: any = '<span style="color:#c0392b">Some Green Text</span>';
-      let result: any = pipe.render(mockValue, mockArgs);
+      const mockValue: any = '<span style="color:#c0392b">Some Green Text</span>';
+      const result: any = pipe.render(mockValue, mockArgs);
       expect(result).toEqual('TrustedHTML');
     });
   });
@@ -451,7 +451,7 @@ xdescribe('Render', () => {
   describe('Function: concat(list, ...fields)', () => {
     it('should concatenate properties of the object being passed in.', () => {
       expect(pipe.concat).toBeDefined();
-      let result: any = pipe.concat([{ firstName: 'Jane', lastName: 'Smith' }], 'firstName', 'lastName');
+      const result: any = pipe.concat([{ firstName: 'Jane', lastName: 'Smith' }], 'firstName', 'lastName');
       expect(result).toBe('Jane Smith');
     });
   });
@@ -461,8 +461,8 @@ xdescribe('Render', () => {
       expect(pipe.options).toBeDefined();
     });
     it('should return an array of corresponding labels for values passed', () => {
-      let values = ['1', '3'];
-      let list = [{ label: 'Archived', value: '1' }, { label: 'New Lead', value: '2' }, { label: 'Old Lead', value: '3' }];
+      const values = ['1', '3'];
+      const list = [{ label: 'Archived', value: '1' }, { label: 'New Lead', value: '2' }, { label: 'Old Lead', value: '3' }];
       expect(pipe.options(values, list)).toEqual(['Archived', 'Old Lead']);
     });
   });

--- a/projects/novo-elements/src/elements/value/Render.ts
+++ b/projects/novo-elements/src/elements/value/Render.ts
@@ -53,8 +53,8 @@ export class RenderPipe implements PipeTransform {
     if (objectOne !== objectOne && objectTwo !== objectTwo) {
       return true;
     }
-    let t1: any = typeof objectOne;
-    let t2: any = typeof objectTwo;
+    const t1: any = typeof objectOne;
+    const t2: any = typeof objectTwo;
     let length: number;
     let key: any;
     let keySet: any;
@@ -203,7 +203,7 @@ export class RenderPipe implements PipeTransform {
         case 'AddressWithoutCountry':
         case 'SecondaryAddress':
         case 'BillingAddress':
-          let country: any = findByCountryId(Number(value.countryName));
+          const country: any = findByCountryId(Number(value.countryName));
           text = '';
           if (value.address1 || value.address2) {
             text += `${value.address1 || ''} ${value.address2 || ''}<br />\n`;
@@ -307,7 +307,7 @@ export class RenderPipe implements PipeTransform {
           }
           break;
         case 'Country':
-          let countryObj: any = findByCountryId(Number(value));
+          const countryObj: any = findByCountryId(Number(value));
           text = countryObj ? countryObj.name : value;
           break;
         case 'Html':
@@ -362,10 +362,10 @@ export class RenderPipe implements PipeTransform {
    * @param fields - list of fields to extract
    */
   concat(list: any, ...fields: any[]): any {
-    let data: any = [];
-    for (let item of list) {
-      let label: any = [];
-      for (let field of fields) {
+    const data: any = [];
+    for (const item of list) {
+      const label: any = [];
+      for (const field of fields) {
         label.push(`${item[field]}`);
       }
       data.push(label.join(' '));
@@ -403,8 +403,8 @@ export class RenderPipe implements PipeTransform {
   getNumberDecimalPlaces(value: any): any {
     let decimalPlaces: any;
     if (value) {
-      let numberString: any = parseFloat(value).toString();
-      let decimalPlace: any = (numberString || '').split('.')[1] || '';
+      const numberString: any = parseFloat(value).toString();
+      const decimalPlace: any = (numberString || '').split('.')[1] || '';
       decimalPlaces = decimalPlace.length;
     }
     return decimalPlaces || 1;

--- a/projects/novo-elements/src/elements/value/Value.spec.ts
+++ b/projects/novo-elements/src/elements/value/Value.spec.ts
@@ -31,26 +31,26 @@ xdescribe('Elements: NovoValueElement', () => {
   describe('iconClass ', () => {
     it('should set iconClass to icon iconCls', () => {
       component.launched = false;
-      let icon: object = {
+      const icon: object = {
         iconCls: 'test',
         onIconClick: '',
       };
-      let result = component.iconClass(icon);
+      const result = component.iconClass(icon);
       expect(result).toBe('bhi-test actions');
     });
 
     it('should set iconClass to iconCls and clickable', () => {
       component.launched = false;
-      let icon: object = {
+      const icon: object = {
         iconCls: 'test',
-        onIconClick: function() {},
+        onIconClick() {},
       };
-      let result = component.iconClass(icon);
+      const result = component.iconClass(icon);
       expect(result).toBe('bhi-test actions clickable');
     });
 
     it('should set iconClass to empty if no icon defined', () => {
-      let result = component.iconClass({});
+      const result = component.iconClass({});
       expect(result).toBe('');
     });
   });
@@ -129,9 +129,9 @@ xdescribe('Elements: NovoValueElement', () => {
 
   describe('onValueClick ', () => {
     it('should return true if icon is defined and not empty', () => {
-      let icon: any = {
+      const icon: any = {
         iconCls: 'test',
-        onIconClick: function() {},
+        onIconClick() {},
       };
       component.data = 'test';
       spyOn(icon, 'onIconClick');
@@ -140,7 +140,7 @@ xdescribe('Elements: NovoValueElement', () => {
     });
 
     it('should return flase if icon is defined and not empty', () => {
-      let icon: any = {
+      const icon: any = {
         iconCls: 'test',
         onIconClick: '',
       };
@@ -154,7 +154,7 @@ xdescribe('Elements: NovoValueElement', () => {
   describe('openLink ', () => {
     it('should return true if icon is defined and not empty', () => {
       component.meta = {
-        openLink: function() {},
+        openLink() {},
       };
       component.data = 'test';
       spyOn(component.meta, 'openLink');

--- a/projects/novo-elements/src/elements/value/Value.ts
+++ b/projects/novo-elements/src/elements/value/Value.ts
@@ -120,7 +120,7 @@ export class NovoValueElement implements OnInit, OnChanges {
     if (this.meta && this.isLinkField(this.meta, this.data)) {
       this._type = NOVO_VALUE_TYPE.LINK;
       // Make sure the value has a protocol, otherwise the URL will be relative
-      let hasProtocol: any = new RegExp('^(http|https)://', 'i');
+      const hasProtocol: any = new RegExp('^(http|https)://', 'i');
       if (!hasProtocol.test(this.data)) {
         this.url = `http://${this.data}`;
       } else {
@@ -151,9 +151,9 @@ export class NovoValueElement implements OnInit, OnChanges {
   }
 
   isLinkField(field: { name?: string; type?: NOVO_VALUE_TYPE }, data: any): boolean {
-    let linkFields: any = ['companyURL', 'clientCorporationCompanyURL'];
-    let regex: any = new RegExp('^(https?://(?:www.|(?!www))[^s.]+.[^s]{2,}|www.[^s]+.[^s]{2,})$', 'gi');
-    let isURL: any = Helpers.isString(data) && regex.exec(data.trim());
+    const linkFields: any = ['companyURL', 'clientCorporationCompanyURL'];
+    const regex: any = new RegExp('^(https?://(?:www.|(?!www))[^s.]+.[^s]{2,}|www.[^s]+.[^s]{2,})$', 'gi');
+    const isURL: any = Helpers.isString(data) && regex.exec(data.trim());
     return linkFields.indexOf(field.name) > -1 || !!isURL || field.type === NOVO_VALUE_TYPE.LINK;
   }
 

--- a/projects/novo-elements/src/pipes/decode-uri/DecodeURI.spec.ts
+++ b/projects/novo-elements/src/pipes/decode-uri/DecodeURI.spec.ts
@@ -10,7 +10,7 @@ describe('Pipe: DecodeURIPipe', () => {
 
   describe('When rendering strings', () => {
     it('should transform a URL encoded value into a decoded value.', () => {
-      let encodedString: string = encodeURIComponent('Hello! This, is. a# string');
+      const encodedString: string = encodeURIComponent('Hello! This, is. a# string');
       const val: string = pipe.transform(encodedString);
       expect(val).toBe('Hello! This, is. a# string');
     });

--- a/projects/novo-elements/src/pipes/plural/Plural.ts
+++ b/projects/novo-elements/src/pipes/plural/Plural.ts
@@ -3,11 +3,11 @@ import { Injectable, Pipe, PipeTransform } from '@angular/core';
 
 // Rule storage - pluralize and singularize need to be run sequentially,
 // while other rules can be optimized using an object for instant lookups.
-let pluralRules = [];
-let singularRules = [];
-let uncountables = {};
-let irregularPlurals = {};
-let irregularSingles = {};
+const pluralRules = [];
+const singularRules = [];
+const uncountables = {};
+const irregularPlurals = {};
+const irregularSingles = {};
 
 /**
  * Title case a string.
@@ -67,11 +67,11 @@ function sanitizeWord(token: string, word: string, collection: RegExp[]): string
   let len = collection.length;
   // Iterate over the sanitization rules and use the first one to match.
   while (len--) {
-    let rule = collection[len];
+    const rule = collection[len];
     // If the rule passes, return the replacement.
     if (rule[0].test(word)) {
       return word.replace(rule[0], (match, index, words) => {
-        let result = interpolate(rule[1], [match, index, words]);
+        const result = interpolate(rule[1], [match, index, words]);
         if (match === '') {
           return restoreCase(words[index - 1], result);
         }
@@ -88,7 +88,7 @@ function sanitizeWord(token: string, word: string, collection: RegExp[]): string
 function replaceWord(replaceMap: any, keepMap: any, rules: any[]): Function {
   return (word) => {
     // Get the correct token and case restoration functions.
-    let token = word.toLowerCase();
+    const token = word.toLowerCase();
 
     // Check against the keep object map.
     if (keepMap.hasOwnProperty(token)) {
@@ -107,7 +107,7 @@ function replaceWord(replaceMap: any, keepMap: any, rules: any[]): Function {
 
 class Pluralize {
   static pluralize(word, count = 1, inclusive?) {
-    let pluralized = count === 1 ? Pluralize.singular(word) : Pluralize.plural(word);
+    const pluralized = count === 1 ? Pluralize.singular(word) : Pluralize.plural(word);
     return (inclusive ? `${count} ` : '') + pluralized;
   }
 
@@ -139,8 +139,8 @@ class Pluralize {
   }
 
   static addIrregularRule(single, plural) {
-    let one = plural.toLowerCase();
-    let many = single.toLowerCase();
+    const one = plural.toLowerCase();
+    const many = single.toLowerCase();
 
     irregularSingles[one] = many;
     irregularPlurals[many] = one;

--- a/projects/novo-elements/src/services/data-provider/ArrayCollection.spec.ts
+++ b/projects/novo-elements/src/services/data-provider/ArrayCollection.spec.ts
@@ -36,7 +36,7 @@ describe('Services: ArrayCollection', () => {
 
   describe('Objects', () => {
     let collection: Collection<any>;
-    let source: Array<any> = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    const source: Array<any> = [{ id: 1 }, { id: 2 }, { id: 3 }];
     beforeEach(() => {
       collection = new ArrayCollection<any>(source);
     });

--- a/projects/novo-elements/src/services/data-provider/ArrayCollection.ts
+++ b/projects/novo-elements/src/services/data-provider/ArrayCollection.ts
@@ -225,8 +225,8 @@ export class ArrayCollection<T> implements Collection<T> {
    * @memberOf ArrayCollection
    */
   merge(newData: Array<T>): void {
-    for (let obj of newData) {
-      let existing = ~this.getItemIndex(obj);
+    for (const obj of newData) {
+      const existing = ~this.getItemIndex(obj);
       if (existing) {
         this.replaceItem(obj, existing);
       } else {
@@ -256,7 +256,7 @@ export class ArrayCollection<T> implements Collection<T> {
    * @memberOf ArrayCollection
    */
   removeItem(item: T): boolean {
-    let index = this.getItemIndex(item);
+    const index = this.getItemIndex(item);
     return this.removeItemAt(index);
   }
 
@@ -268,7 +268,7 @@ export class ArrayCollection<T> implements Collection<T> {
    * @memberOf ArrayCollection
    */
   removeItemAt(index: number): boolean {
-    let success = !!this.source.splice(index, 1);
+    const success = !!this.source.splice(index, 1);
     this.refresh();
     return success;
   }
@@ -282,7 +282,7 @@ export class ArrayCollection<T> implements Collection<T> {
    * @memberOf ArrayCollection
    */
   replaceItem(newItem: any, oldItem: any): any {
-    let index = this.getItemIndex(oldItem);
+    const index = this.getItemIndex(oldItem);
     if (index >= 0) {
       this.replaceItemAt(newItem, index);
     }
@@ -352,10 +352,10 @@ export class ArrayCollection<T> implements Collection<T> {
 
   refresh(): void {
     this.filterData = this.isEditing ? this.editData.slice() : this.source.slice();
-    for (let item of this._sort.reverse()) {
+    for (const item of this._sort.reverse()) {
       this.sortOn(item.field, item.reverse);
     }
-    for (let key in this._filter) {
+    for (const key in this._filter) {
       if (key) {
         this.filterOn(key, this._filter[key]);
       }

--- a/projects/novo-elements/src/services/data-provider/PagedArrayCollection.ts
+++ b/projects/novo-elements/src/services/data-provider/PagedArrayCollection.ts
@@ -71,18 +71,18 @@ export class PagedArrayCollection<T> extends ArrayCollection<T> implements Paged
 
   refresh(): void {
     this.filterData = this.isEditing ? this.editData.slice() : this.source.slice();
-    for (let item of this._sort.reverse()) {
+    for (const item of this._sort.reverse()) {
       this.sortOn(item.field, item.reverse);
     }
-    for (let key in this._filter) {
+    for (const key in this._filter) {
       if (key) {
         this.filterOn(key, this._filter[key]);
       }
     }
     if (this.page >= 0) {
-      let start = (this.page - 1) * this.pageSize;
-      let end = start + this.pageSize;
-      let result = this.filterData.slice(start, end);
+      const start = (this.page - 1) * this.pageSize;
+      const end = start + this.pageSize;
+      const result = this.filterData.slice(start, end);
       this.onDataChange(new CollectionEvent(CollectionEvent.CHANGE, result));
     } else {
       this.onDataChange(new CollectionEvent(CollectionEvent.CHANGE, this.filterData));

--- a/projects/novo-elements/src/services/date-format/DateFormat.spec.ts
+++ b/projects/novo-elements/src/services/date-format/DateFormat.spec.ts
@@ -16,37 +16,37 @@ describe('Service: DateFormatService', () => {
     });
     it('should return a default mask', () => {
       service.labels.dateFormat = '';
-      let actual = service.getDateMask();
+      const actual = service.getDateMask();
       expect(actual.length).toBeGreaterThan(0);
     });
     it('should return a mask that supports a date with format dd-MM-yyyy', () => {
-      let value = '11-02-2017';
-      let dateMask = service.getDateMask();
-      for (let i in dateMask) {
+      const value = '11-02-2017';
+      const dateMask = service.getDateMask();
+      for (const i in dateMask) {
         if (dateMask[i]) {
           expect(value[i].match(dateMask[i])).toBeTruthy();
         }
       }
     });
     it('should return a mask that supports dd.MM.yyyy', () => {
-      let value = '11.02.2017';
-      let dateMask = service.getDateMask();
-      for (let i in dateMask) {
+      const value = '11.02.2017';
+      const dateMask = service.getDateMask();
+      for (const i in dateMask) {
         if (dateMask[i]) {
           expect(value[i].match(dateMask[i])).toBeTruthy();
         }
       }
     });
     it('should return a mask that supports d/M/yyyy', () => {
-      let value: Array<string> = '1/2/2017'.split('');
-      let dateMask = service.getDateMask();
+      const value: Array<string> = '1/2/2017'.split('');
+      const dateMask = service.getDateMask();
       value.forEach((v, i) => {
         expect(v.match(dateMask[i])).toBeTruthy();
       });
     });
     it('should return a mask that supports M/d/yyyy', () => {
-      let value: Array<string> = '11/2/2017'.split('');
-      let dateMask = service.getDateMask();
+      const value: Array<string> = '11/2/2017'.split('');
+      const dateMask = service.getDateMask();
       value.forEach((v, i) => {
         expect(v.match(dateMask[i])).toBeTruthy();
       });
@@ -63,25 +63,25 @@ describe('Service: DateFormatService', () => {
         militaryTimeMask = service.getTimeMask(true);
       });
       it('should work for 1:23', () => {
-        let timeString = '01:23'.split('');
+        const timeString = '01:23'.split('');
         timeString.forEach((v, i) => {
           expect(v.match(militaryTimeMask[i])).toBeTruthy();
         });
       });
       it('should work for 12:23', () => {
-        let timeString = '12:23'.split('');
+        const timeString = '12:23'.split('');
         timeString.forEach((v, i) => {
           expect(v.match(militaryTimeMask[i])).toBeTruthy();
         });
       });
       it('should work for 00:23', () => {
-        let timeString = '00:23'.split('');
+        const timeString = '00:23'.split('');
         timeString.forEach((v, i) => {
           expect(v.match(militaryTimeMask[i])).toBeTruthy();
         });
       });
       it('should work for 23:23', () => {
-        let timeString = '23:23'.split('');
+        const timeString = '23:23'.split('');
         timeString.forEach((v, i) => {
           expect(v.match(militaryTimeMask[i])).toBeTruthy();
         });
@@ -89,45 +89,45 @@ describe('Service: DateFormatService', () => {
     });
     describe('For 12hour time', () => {
       it('should work for 12:23am', () => {
-        let timeMask = service.getTimeMask(false);
-        let timeString = '12:23am'.split('');
+        const timeMask = service.getTimeMask(false);
+        const timeString = '12:23am'.split('');
         timeString.forEach((v, i) => {
           expect(v.match(timeMask[i])).toBeTruthy();
         });
       });
       it('should work for 12:23pm', () => {
-        let timeMask = service.getTimeMask(false);
-        let timeString = '12:23pm'.split('');
+        const timeMask = service.getTimeMask(false);
+        const timeString = '12:23pm'.split('');
         timeString.forEach((v, i) => {
           expect(v.match(timeMask[i])).toBeTruthy();
         });
       });
       it('should work for 1:23pm', () => {
-        let timeMask = service.getTimeMask(false);
-        let timeString = '1:23pm'.split('');
+        const timeMask = service.getTimeMask(false);
+        const timeString = '1:23pm'.split('');
         timeString.forEach((v, i) => {
           expect(v.match(timeMask[i])).toBeTruthy();
         });
       });
       it('should work for 1:23am', () => {
-        let timeMask = service.getTimeMask(false);
-        let timeString = '1:23am'.split('');
+        const timeMask = service.getTimeMask(false);
+        const timeString = '1:23am'.split('');
         timeString.forEach((v, i) => {
           expect(v.match(timeMask[i])).toBeTruthy();
         });
       });
       it('should work for 1:23 A.M.', () => {
         service.labels.timeFormatPlaceholderAM = 'hh:mm A.M.';
-        let timeMask = service.getTimeMask(false);
-        let timeString = '1:23 A.M.'.split('');
+        const timeMask = service.getTimeMask(false);
+        const timeString = '1:23 A.M.'.split('');
         timeString.forEach((v, i) => {
           expect(v.match(timeMask[i])).toBeTruthy();
         });
       });
       it('should work for 1:23 P.M.', () => {
         service.labels.timeFormatPlaceholderAM = 'hh:mm A.M.';
-        let timeMask = service.getTimeMask(false);
-        let timeString = '1:23 P.M.'.split('');
+        const timeMask = service.getTimeMask(false);
+        const timeString = '1:23 P.M.'.split('');
         timeString.forEach((v, i) => {
           expect(v.match(timeMask[i])).toBeTruthy();
         });
@@ -282,22 +282,22 @@ describe('Service: DateFormatService', () => {
       expect(service.parseTimeString).toBeDefined();
     });
     it('should not parse if the string doesn\'t contain :', () => {
-      let [value, timeString] = service.parseTimeString('', false);
+      const [value, timeString] = service.parseTimeString('', false);
       expect(timeString).toEqual('');
     });
     describe('for 24hour time', () => {
       it('should parse 1:45', () => {
-        let [value, timeString] = service.parseTimeString('1:45', true);
+        const [value, timeString] = service.parseTimeString('1:45', true);
         expect(value.getHours()).toEqual(1);
         expect(value.getMinutes()).toEqual(45);
       });
       it('should parse 07:45', () => {
-        let [value, timeString] = service.parseTimeString('07:45', true);
+        const [value, timeString] = service.parseTimeString('07:45', true);
         expect(value.getHours()).toEqual(7);
         expect(value.getMinutes()).toEqual(45);
       });
       it('should parse 12:45', () => {
-        let [value, timeString] = service.parseTimeString('12:45', true);
+        const [value, timeString] = service.parseTimeString('12:45', true);
         expect(value.getHours()).toEqual(12);
         expect(value.getMinutes()).toEqual(45);
       });
@@ -310,12 +310,12 @@ describe('Service: DateFormatService', () => {
           service.labels.timeFormatPM = 'PM';
         });
         it('should convert 12:45 AM to 00:45', () => {
-          let [value, timeString] = service.parseTimeString('12:45AM', false);
+          const [value, timeString] = service.parseTimeString('12:45AM', false);
           expect(value.getHours()).toEqual(0);
           expect(value.getMinutes()).toEqual(45);
         });
         it('should convert 1:45 AM to 1:45', () => {
-          let [value, timeString] = service.parseTimeString('12:45AM', false);
+          const [value, timeString] = service.parseTimeString('12:45AM', false);
           expect(value.getHours()).toEqual(0);
           expect(value.getMinutes()).toEqual(45);
         });
@@ -327,12 +327,12 @@ describe('Service: DateFormatService', () => {
           service.labels.timeFormatPM = 'P.M.';
         });
         it('should convert 1:45 P.M. to 13:45', () => {
-          let [value, timeString] = service.parseTimeString('1:45 P.M.', false);
+          const [value, timeString] = service.parseTimeString('1:45 P.M.', false);
           expect(value.getHours()).toEqual(13);
           expect(value.getMinutes()).toEqual(45);
         });
         it('should convert 12:45 P.M. to 12:45', () => {
-          let [value, timeString] = service.parseTimeString('12:45 P.M.', false);
+          const [value, timeString] = service.parseTimeString('12:45 P.M.', false);
           expect(value.getHours()).toEqual(12);
           expect(value.getMinutes()).toEqual(45);
         });

--- a/projects/novo-elements/src/services/date-format/DateFormat.ts
+++ b/projects/novo-elements/src/services/date-format/DateFormat.ts
@@ -12,14 +12,14 @@ export class DateFormatService {
     let mask: Array<RegExp> = [/\d/, /\d/, /:/, /\d/, /\d/],
       timeFormatArray: Array<string> = [],
       timeFormatPartsArray: Array<string> = [];
-    let timeFormat: string = this.labels.timeFormatPlaceholderAM.toLowerCase();
+    const timeFormat: string = this.labels.timeFormatPlaceholderAM.toLowerCase();
     if (militaryTime) {
       return mask;
     } else {
       timeFormatArray = timeFormat.split('hh:mm');
       if (timeFormatArray && timeFormatArray.length) {
         mask = [];
-        for (let timeFormatPart of timeFormatArray) {
+        for (const timeFormatPart of timeFormatArray) {
           if (timeFormatPart === '') {
             mask = mask.concat([/\d/, /\d|:/, /:|\d/, /\d|\w|\s/, /\d|\s|\w/]);
           } else if (timeFormatPart.length) {
@@ -80,10 +80,10 @@ export class DateFormatService {
         date = new Date(year, month, day);
       }
     } else if (dateFormatTokens && dateFormatTokens.length === 4 && dateString.length >= 1) {
-      let twoTokens = /\d{1,4}(\/|\.|\-)(\d{1,2})/.exec(dateString);
-      let oneToken = /^(\d{1,4})$/.exec(dateString);
-      let delimiter = /\w+(\/|\.|\-)\w+[\/|\.|\-]\w+/gi.exec(dateFormat);
-      let dateStringWithDelimiter = dateString[dateString.length - 1].match(/\/|\.|\-/);
+      const twoTokens = /\d{1,4}(\/|\.|\-)(\d{1,2})/.exec(dateString);
+      const oneToken = /^(\d{1,4})$/.exec(dateString);
+      const delimiter = /\w+(\/|\.|\-)\w+[\/|\.|\-]\w+/gi.exec(dateFormat);
+      const dateStringWithDelimiter = dateString[dateString.length - 1].match(/\/|\.|\-/);
       if (twoTokens && twoTokens.length === 3 && this.isValidDatePart(twoTokens[2], dateFormatTokens[2]) && !dateStringWithDelimiter) {
         dateString = `${dateString}${delimiter[1]}`;
       } else if (oneToken && oneToken.length === 2 && this.isValidDatePart(oneToken[1], dateFormatTokens[1]) && !dateStringWithDelimiter) {
@@ -115,7 +115,7 @@ export class DateFormatService {
         pm = true;
       }
       if (splits && splits.length) {
-        for (let item of splits) {
+        for (const item of splits) {
           if (item && item.trim().includes(':')) {
             timeStringParts = item.trim().split(':');
           }
@@ -148,11 +148,11 @@ export class DateFormatService {
   parseString(dateTimeString: string, militaryTime: boolean, type: string): [Date, string] {
     switch (type) {
       case 'datetime':
-        let str = dateTimeString.replace(/-/g, '/');
-        let parts = str.split(' ');
-        let [dt, dts] = this.parseDateString(parts[0]);
+        const str = dateTimeString.replace(/-/g, '/');
+        const parts = str.split(' ');
+        const [dt, dts] = this.parseDateString(parts[0]);
         if (parts.length > 1) {
-          let [tm, tms] = this.parseTimeString(parts[1], militaryTime);
+          const [tm, tms] = this.parseTimeString(parts[1], militaryTime);
           return [new Date(dt.setHours(tm.getHours(), tm.getMinutes())), `${dts} ${tms}`];
         }
         return [dt, dts];
@@ -166,7 +166,7 @@ export class DateFormatService {
   }
 
   isValidDatePart(value: string, format: string): boolean {
-    let datePart = parseInt(value);
+    const datePart = parseInt(value);
     if (format.includes('m') && (datePart >= 2 || value.length === 2)) {
       return true;
     } else if (format.includes('d') && (datePart >= 4 || value.length === 2)) {

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -150,7 +150,7 @@ export class NovoLabelService {
   }
 
   formatDateWithFormat(value: any, format: Intl.DateTimeFormatOptions) {
-    let date = value instanceof Date ? value : new Date(value);
+    const date = value instanceof Date ? value : new Date(value);
     if (date.getTime() !== date.getTime()) {
       return value;
     }
@@ -158,11 +158,11 @@ export class NovoLabelService {
   }
 
   formatTimeWithFormat(value: any, format: Intl.DateTimeFormatOptions): string {
-    let date = value instanceof Date ? value : new Date(value);
+    const date = value instanceof Date ? value : new Date(value);
     if (date.getTime() !== date.getTime()) {
       return value;
     }
-    let timeParts: { [type: string]: string } = Intl.DateTimeFormat(this.userLocale, format)
+    const timeParts: { [type: string]: string } = Intl.DateTimeFormat(this.userLocale, format)
       .formatToParts(date)
       .reduce((obj, part) => {
         obj[part.type] = part.value;
@@ -174,7 +174,7 @@ export class NovoLabelService {
 
   getWeekdays(): string[] {
     function getDay(dayOfWeek) {
-      let dt = new Date();
+      const dt = new Date();
       return dt.setDate(dt.getDate() - dt.getDay() + dayOfWeek);
     }
 
@@ -186,7 +186,7 @@ export class NovoLabelService {
 
   getMonths(): string[] {
     function getMonth(month) {
-      let dt = new Date();
+      const dt = new Date();
       return dt.setMonth(month, 1);
     }
 
@@ -229,7 +229,7 @@ export class NovoLabelService {
   }
 
   formatCurrency(value: number): string {
-    let options = { style: 'currency', currency: 'USD' };
+    const options = { style: 'currency', currency: 'USD' };
     return new Intl.NumberFormat(this.userLocale, options).format(value);
   }
 
@@ -255,7 +255,7 @@ export class NovoLabelService {
   }
 
   formatDateShort(value: any): string {
-    let options: Intl.DateTimeFormatOptions = {
+    const options: Intl.DateTimeFormatOptions = {
       // DD/MM/YYYY, HH:MM A - 02/14/2017, 1:17 PM
       month: '2-digit',
       day: '2-digit',
@@ -263,28 +263,28 @@ export class NovoLabelService {
       hour: 'numeric',
       minute: '2-digit',
     };
-    let _value = value === null || value === undefined || value === '' ? new Date() : new Date(value);
+    const _value = value === null || value === undefined || value === '' ? new Date() : new Date(value);
     return new Intl.DateTimeFormat(this.userLocale, options).format(_value);
   }
 
   formatTime(value: any): string {
-    let options: Intl.DateTimeFormatOptions = {
+    const options: Intl.DateTimeFormatOptions = {
       // HH:MM A - 1:17 PM
       hour: 'numeric',
       minute: '2-digit',
     };
-    let _value = value === null || value === undefined || value === '' ? new Date() : new Date(value);
+    const _value = value === null || value === undefined || value === '' ? new Date() : new Date(value);
     return new Intl.DateTimeFormat(this.userLocale, options).format(_value);
   }
 
   formatDate(value: any): string {
-    let options: Intl.DateTimeFormatOptions = {
+    const options: Intl.DateTimeFormatOptions = {
       // DD/MM/YYYY - 02/14/2017
       month: '2-digit',
       day: '2-digit',
       year: 'numeric',
     };
-    let _value = value === null || value === undefined || value === '' ? new Date() : new Date(value);
+    const _value = value === null || value === undefined || value === '' ? new Date() : new Date(value);
     return new Intl.DateTimeFormat(this.userLocale, options).format(_value);
   }
 }

--- a/projects/novo-elements/src/services/options/OptionsService.spec.ts
+++ b/projects/novo-elements/src/services/options/OptionsService.spec.ts
@@ -29,12 +29,12 @@ describe('Element: OptionsService', () => {
   });
   describe('Function: getOptionsConfig()', () => {
     it('should return default config', () => {
-      let http = {
+      const http = {
         get: (test) => {
           return { subscribe: (x, y) => {} };
         },
       };
-      let field = {
+      const field = {
         optionsUrl: 'test',
       };
       expect(service.getOptionsConfig(http, field, {}, {}).format).toEqual('$label');

--- a/projects/novo-elements/src/services/security/Security.spec.ts
+++ b/projects/novo-elements/src/services/security/Security.spec.ts
@@ -2,7 +2,7 @@
 import { Security } from './Security';
 
 describe('Services: Security', () => {
-  let service: Security = new Security();
+  const service: Security = new Security();
 
   describe('Method: grant()', () => {
     it('should be defined.', () => {
@@ -11,13 +11,13 @@ describe('Services: Security', () => {
       service.grant([]);
     });
     it('should handle array of values', () => {
-      let permissions = ['A', 'B', 'C'];
+      const permissions = ['A', 'B', 'C'];
       service.clear();
       service.grant(permissions);
       expect(service.credentials).toEqual(permissions);
     });
     it('should handle an object with arrays of values', () => {
-      let permissions = {
+      const permissions = {
         one: ['A', 'B', 'C'],
         two: ['D'],
       };

--- a/projects/novo-elements/src/services/security/Security.ts
+++ b/projects/novo-elements/src/services/security/Security.ts
@@ -7,15 +7,15 @@ export class Security {
   change: EventEmitter<any> = new EventEmitter();
 
   grant(data: any[] | Object): void {
-    let parsed: any[] = [];
+    const parsed: any[] = [];
     if (data instanceof Array) {
-      for (let permission of data) {
+      for (const permission of data) {
         parsed.push(permission.replace(/\s/gi, ''));
       }
     } else if (typeof data === 'object') {
-      for (let key in data) {
+      for (const key in data) {
         if (data[key] instanceof Array) {
-          for (let permission of data[key]) {
+          for (const permission of data[key]) {
             parsed.push(`${key}.${permission}`);
           }
         }
@@ -30,7 +30,7 @@ export class Security {
   }
 
   revoke(value: any): void {
-    let i: number = this.credentials.indexOf(value);
+    const i: number = this.credentials.indexOf(value);
     this.credentials.splice(i, 1);
     this.change.emit(this.credentials);
   }
@@ -48,8 +48,8 @@ export class Security {
     routes: { entities?: any[]; permissions?: any[] | Function; path?: string; label?: string; canDisable?: Boolean }[],
     options: { entityType?: string },
   ): any {
-    let filtered: any[] = [];
-    for (let route of routes) {
+    const filtered: any[] = [];
+    for (const route of routes) {
       if (route.entities && ~route.entities.indexOf(options.entityType)) {
         if (route.permissions instanceof Function) {
           if (route.permissions(options, this)) {

--- a/projects/novo-elements/src/services/template/NovoTemplateService.ts
+++ b/projects/novo-elements/src/services/template/NovoTemplateService.ts
@@ -10,7 +10,7 @@ export class NovoTemplateService {
   constructor() {}
 
   getAll(): any {
-    let templates: any = {};
+    const templates: any = {};
     const customTemplateTypes: string[] = Object.keys(this.templates.custom);
     const defaultTemplateTypes: string[] = Object.keys(this.templates.default);
     defaultTemplateTypes.forEach((type: string) => {

--- a/projects/novo-elements/src/utils/Helpers.spec.ts
+++ b/projects/novo-elements/src/utils/Helpers.spec.ts
@@ -4,73 +4,73 @@ import { Helpers, binarySearch } from './Helpers';
 describe('Utils: Helpers', () => {
   xdescribe('Method: swallowEvent(event)', () => {
     it('should be defined.', () => {
-      let event = new Event('open');
+      const event = new Event('open');
       expect(Helpers.swallowEvent(event));
     });
   });
 
   xdescribe('Method: interpolate(str, props)', () => {
     it('should interpolate using the right properties', () => {
-      let format: string = '$name';
-      let data: { name: string } = {
+      const format: string = '$name';
+      const data: { name: string } = {
         name: 'Stuff',
       };
-      let expected: string = 'Stuff';
+      const expected: string = 'Stuff';
       expect(Helpers.interpolate(format, data)).toBe(expected);
     });
 
     it('should interpolate correctly when format requires 2 properties', () => {
-      let format: string = '$firstName $lastName';
-      let data: { firstName: string; lastName: string } = {
+      const format: string = '$firstName $lastName';
+      const data: { firstName: string; lastName: string } = {
         firstName: 'James',
         lastName: 'Bond',
       };
-      let expected: string = 'James Bond';
+      const expected: string = 'James Bond';
       expect(Helpers.interpolate(format, data)).toBe(expected);
     });
 
     it('should interpolate correctly when format has non-replacable characters', () => {
-      let format: string = '$id: $title';
-      let data: { id: number; title: string } = {
+      const format: string = '$id: $title';
+      const data: { id: number; title: string } = {
         id: 213,
         title: 'Bond',
       };
-      let expected: string = '213: Bond';
+      const expected: string = '213: Bond';
       expect(Helpers.interpolate(format, data)).toEqual(expected);
     });
 
     it('should interpolate correctly when properties are undefined', () => {
-      let format: string = '$id: $title';
-      let data: { id: number } = {
+      const format: string = '$id: $title';
+      const data: { id: number } = {
         id: 123,
       };
-      let expected: string = '123: ';
+      const expected: string = '123: ';
       expect(Helpers.interpolate(format, data)).toBe(expected);
     });
   });
 
   describe('Method: getNextElementSibling(element)', () => {
     it('should return nextElementSibling if present.', () => {
-      let parent = document.createElement('div');
-      let origin = document.createElement('h1');
-      let sibling = document.createElement('h2');
+      const parent = document.createElement('div');
+      const origin = document.createElement('h1');
+      const sibling = document.createElement('h2');
       parent.appendChild(origin);
       parent.appendChild(sibling);
       expect(Helpers.getNextElementSibling(origin)).toEqual(sibling);
     });
     it('should skip over non-element sibling nodes.', () => {
-      let parent = document.createElement('div');
-      let origin = document.createElement('h1');
-      let textNode = document.createTextNode('Some Text');
-      let sibling = document.createElement('h2');
+      const parent = document.createElement('div');
+      const origin = document.createElement('h1');
+      const textNode = document.createTextNode('Some Text');
+      const sibling = document.createElement('h2');
       parent.appendChild(origin);
       parent.appendChild(textNode);
       parent.appendChild(sibling);
       expect(Helpers.getNextElementSibling(origin)).toEqual(sibling);
     });
     it('should return null if sibling is not present.', () => {
-      let parent = document.createElement('div');
-      let origin = document.createElement('h1');
+      const parent = document.createElement('div');
+      const origin = document.createElement('h1');
       parent.appendChild(origin);
       expect(Helpers.getNextElementSibling(origin)).toEqual(null);
     });

--- a/projects/novo-elements/src/utils/Helpers.ts
+++ b/projects/novo-elements/src/utils/Helpers.ts
@@ -16,10 +16,10 @@ export class Helpers {
       props = this.dateToObject(props);
     }
     return str.replace(/\$([\w\.]+)/g, (original: string, key: string) => {
-      let keys: string[] = key.split('.');
+      const keys: string[] = key.split('.');
       let value = props[keys.shift()];
       while (keys.length && value !== undefined) {
-        let k = keys.shift();
+        const k = keys.shift();
         value = k ? value[k] : `${value}.`;
       }
       return value !== undefined ? value : '';
@@ -32,15 +32,15 @@ export class Helpers {
     // It will either return the first successful replacement of ALL variables,
     // or an empty string
     if (Array.isArray(formatString)) {
-      let successes: string[] = [];
-      let failures: string[] = [];
+      const successes: string[] = [];
+      const failures: string[] = [];
       formatString.forEach((format: string) => {
         let isSuccess: boolean = true;
-        let attempt = format.replace(/\$([\w\.]+)/g, (original, key) => {
-          let keys = key.split('.');
+        const attempt = format.replace(/\$([\w\.]+)/g, (original, key) => {
+          const keys = key.split('.');
           let value = data[keys.shift()];
           while (keys.length && value !== undefined) {
-            let k = keys.shift();
+            const k = keys.shift();
             value = k ? value[k] : `${value}.`;
           }
           if (isSuccess && Helpers.isEmpty(value)) {
@@ -69,7 +69,7 @@ export class Helpers {
    * @param props The params to replace in string.
    */
   static validateInterpolationProps(str: string, props: any): boolean {
-    let keys = str.match(/\$([\w\.]+)/g);
+    const keys = str.match(/\$([\w\.]+)/g);
     return keys.every((key) => {
       return props.hasOwnProperty(key.substr(1));
     });
@@ -148,7 +148,7 @@ export class Helpers {
         fields = [fields];
       }
       for (let i = 0; i < fields.length; i++) {
-        let field: string = fields[i];
+        const field: string = fields[i];
         let first = previous[field] || '';
         let second = current[field] || '';
 
@@ -178,7 +178,7 @@ export class Helpers {
 
   static filterByField(key, value) {
     return (item) => {
-      let results = [];
+      const results = [];
       let field = can(item).have(key);
       if (value instanceof Function) {
         results.push(value(field, item));
@@ -207,9 +207,9 @@ export class Helpers {
         if (value.not) {
           results.push(!Helpers.filterByField(key, value.not)(item));
         }
-        for (let subkey in value) {
+        for (const subkey in value) {
           if (['min', 'max', 'any', 'all', 'not'].indexOf(subkey) < 0) {
-            let subvalue = value[subkey];
+            const subvalue = value[subkey];
             results.push(Helpers.filterByField(`${key}.${subkey}`, subvalue)(item));
           }
         }
@@ -227,7 +227,7 @@ export class Helpers {
 
   static deepClone(item: any): any {
     if (Array.isArray(item)) {
-      let newArr = [];
+      const newArr = [];
       for (let i = item.length; i-- > 0; ) {
         // tslint:disable-line
         newArr[i] = Helpers.deepClone(item[i]);
@@ -237,7 +237,7 @@ export class Helpers {
     if (typeof item === 'function' && !/\(\) \{ \[native/.test(item.toString())) {
       let obj;
       eval('obj = ' + item.toString()); // tslint:disable-line
-      for (let k in item) {
+      for (const k in item) {
         if (k in item) {
           obj[k] = Helpers.deepClone(item[k]);
         }
@@ -245,8 +245,8 @@ export class Helpers {
       return obj;
     }
     if (item && typeof item === 'object') {
-      let obj = {};
-      for (let k in item) {
+      const obj = {};
+      for (const k in item) {
         if (k in item) {
           obj[k] = Helpers.deepClone(item[k]);
         }
@@ -333,7 +333,7 @@ export class Helpers {
     weekday: string;
     year: string;
   } {
-    let dateObj = {
+    const dateObj = {
       day: '',
       dayPeriod: '',
       era: '',
@@ -372,7 +372,7 @@ export class Can {
   }
 
   have(key: string): any {
-    let props = key.split('.');
+    const props = key.split('.');
     let item: any = this.obj;
     for (let i = 0; i < props.length; i++) {
       item = item[props[i]];

--- a/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
+++ b/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
@@ -288,7 +288,7 @@ export class AppBridge {
           }
         });
       } else {
-        let openListPacket = {};
+        const openListPacket = {};
         Object.assign(openListPacket, { type: 'List', entityType: packet.type, keywords: packet.keywords, criteria: packet.criteria });
         postRobot
           .sendToParent(MESSAGE_TYPES.OPEN_LIST, packet)
@@ -359,7 +359,7 @@ export class AppBridge {
         if (packet) {
           console.info('[AppBridge] - close(packet) is deprecated! Please just use close()!'); // tslint:disable-line
         }
-        let realPacket = { id: this.id, windowName: this.windowName };
+        const realPacket = { id: this.id, windowName: this.windowName };
         postRobot
           .sendToParent(MESSAGE_TYPES.CLOSE, realPacket)
           .then((event) => {
@@ -394,7 +394,7 @@ export class AppBridge {
         if (packet) {
           console.info('[AppBridge] - refresh(packet) is deprecated! Please just use refresh()!'); // tslint:disable-line
         }
-        let realPacket = { id: this.id, windowName: this.windowName };
+        const realPacket = { id: this.id, windowName: this.windowName };
         postRobot
           .sendToParent(MESSAGE_TYPES.REFRESH, realPacket)
           .then((event) => {
@@ -429,7 +429,7 @@ export class AppBridge {
         if (packet) {
           console.info('[AppBridge] - pin(packet) is deprecated! Please just use pin()!'); // tslint:disable-line
         }
-        let realPacket = { id: this.id, windowName: this.windowName };
+        const realPacket = { id: this.id, windowName: this.windowName };
         postRobot
           .sendToParent(MESSAGE_TYPES.PIN, realPacket)
           .then((event) => {
@@ -555,7 +555,7 @@ export class AppBridge {
   public httpGET(relativeURL: string): Promise<any> {
     return new Promise<any>((resolve, reject) => {
       if (this._handlers[AppBridgeHandler.HTTP]) {
-        this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.GET, relativeURL: relativeURL }, (data: any, error: any) => {
+        this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.GET, relativeURL }, (data: any, error: any) => {
           resolve({ data, error });
         });
       } else {
@@ -579,14 +579,14 @@ export class AppBridge {
     return new Promise<any>((resolve, reject) => {
       if (this._handlers[AppBridgeHandler.HTTP]) {
         this._handlers[AppBridgeHandler.HTTP](
-          { verb: HTTP_VERBS.POST, relativeURL: relativeURL, data: postData },
+          { verb: HTTP_VERBS.POST, relativeURL, data: postData },
           (data: any, error: any) => {
             resolve({ data, error });
           },
         );
       } else {
         postRobot
-          .sendToParent(MESSAGE_TYPES.HTTP_POST, { relativeURL: relativeURL, data: postData })
+          .sendToParent(MESSAGE_TYPES.HTTP_POST, { relativeURL, data: postData })
           .then((event: any) => {
             resolve({ data: event.data.data, error: event.data.error });
           })
@@ -605,14 +605,14 @@ export class AppBridge {
     return new Promise<any>((resolve, reject) => {
       if (this._handlers[AppBridgeHandler.HTTP]) {
         this._handlers[AppBridgeHandler.HTTP](
-          { verb: HTTP_VERBS.PUT, relativeURL: relativeURL, data: putData },
+          { verb: HTTP_VERBS.PUT, relativeURL, data: putData },
           (data: any, error: any) => {
             resolve({ data, error });
           },
         );
       } else {
         postRobot
-          .sendToParent(MESSAGE_TYPES.HTTP_PUT, { relativeURL: relativeURL, data: putData })
+          .sendToParent(MESSAGE_TYPES.HTTP_PUT, { relativeURL, data: putData })
           .then((event: any) => {
             resolve({ data: event.data.data, error: event.data.error });
           })
@@ -630,7 +630,7 @@ export class AppBridge {
   public httpDELETE(relativeURL: string): Promise<any> {
     return new Promise<any>((resolve, reject) => {
       if (this._handlers[AppBridgeHandler.HTTP]) {
-        this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.DELETE, relativeURL: relativeURL }, (data: any, error: any) => {
+        this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.DELETE, relativeURL }, (data: any, error: any) => {
           resolve({ data, error });
         });
       } else {
@@ -674,7 +674,7 @@ export class AppBridge {
       this._registeredFrames.forEach((frame) => {
         postRobot.send(frame.source, MESSAGE_TYPES.CUSTOM_EVENT, {
           eventType: event,
-          data: data,
+          data,
         });
       });
     }
@@ -698,10 +698,10 @@ export class DevAppBridge extends AppBridge {
 
   constructor(traceName: string = 'DevAppBridge', private http: HttpClient) {
     super(traceName);
-    let cookie = this.getCookie('UlEncodedIdentity');
+    const cookie = this.getCookie('UlEncodedIdentity');
     if (cookie && cookie.length) {
-      let identity = JSON.parse(decodeURIComponent(cookie));
-      let endpoints = identity.sessions.reduce((obj, session) => {
+      const identity = JSON.parse(decodeURIComponent(cookie));
+      const endpoints = identity.sessions.reduce((obj, session) => {
         obj[session.name] = session.value.endpoint;
         return obj;
       }, {});
@@ -744,8 +744,8 @@ export class DevAppBridge extends AppBridge {
 
   private getCookie(cname: string): any {
     if (document) {
-      let name = `${cname}=`;
-      let ca = document.cookie.split(';');
+      const name = `${cname}=`;
+      const ca = document.cookie.split(';');
       for (let i = 0; i < ca.length; i++) {
         let c = ca[i];
         while (c.charAt(0) === ' ') {

--- a/projects/novo-elements/src/utils/calendar-utils/CalendarUtils.ts
+++ b/projects/novo-elements/src/utils/calendar-utils/CalendarUtils.ts
@@ -374,7 +374,7 @@ export function getWeekView({
       });
 
       if (otherRowEvents.length > 0) {
-        let totalEventsForRow = otherRowEvents.length + 1;
+        const totalEventsForRow = otherRowEvents.length + 1;
 
         event.span = 1 / totalEventsForRow;
 

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
@@ -36,11 +36,11 @@ function createAddress(address1, city, state, zip, countryName) {
     };
   }
   return {
-    address1: address1,
-    city: city,
-    state: state,
-    zip: zip,
-    countryName: countryName,
+    address1,
+    city,
+    state,
+    zip,
+    countryName,
   };
 }
 
@@ -48,7 +48,7 @@ describe('Utils: FormUtils', () => {
   let formUtils;
 
   beforeEach(async(() => {
-    let optionsService = {
+    const optionsService = {
       getOptionEntity: () => {
         return '';
       },
@@ -85,8 +85,8 @@ describe('Utils: FormUtils', () => {
   describe('Method: toFormGroup(controls)', () => {
     it('should create a FormGroup from a collection of controls.', () => {
       expect(formUtils.toFormGroup).toBeDefined();
-      let mockControls: Array<any> = [{ key: 'Test' }];
-      let result = formUtils.toFormGroup(mockControls);
+      const mockControls: Array<any> = [{ key: 'Test' }];
+      const result = formUtils.toFormGroup(mockControls);
       expect(result instanceof FormGroup).toBe(true);
       expect(result.controls.Test).toBeDefined();
       expect(result.controls.Test instanceof NovoFormControl).toBe(true);
@@ -96,7 +96,7 @@ describe('Utils: FormUtils', () => {
   describe('Method: addControls(formGroup, controls)', () => {
     it('should add controls to a form group.', () => {
       expect(formUtils.addControls).toBeDefined();
-      let formGroup: FormGroup = formUtils.toFormGroup([{ key: 'Test' }]);
+      const formGroup: FormGroup = formUtils.toFormGroup([{ key: 'Test' }]);
       formUtils.addControls(formGroup, [{ key: 'Test2' }]);
       // Can't use `.Test2` because the formGroup isn't returned
       expect(formGroup.controls['Test2']).toBeDefined();
@@ -107,7 +107,7 @@ describe('Utils: FormUtils', () => {
   describe('Method: removeControls(formGroup, controls)', () => {
     it('should remove controls from a form group.', () => {
       expect(formUtils.removeControls).toBeDefined();
-      let formGroup: FormGroup = formUtils.toFormGroup([{ key: 'Test' }, { key: 'Test2' }]);
+      const formGroup: FormGroup = formUtils.toFormGroup([{ key: 'Test' }, { key: 'Test2' }]);
       formUtils.removeControls(formGroup, [{ key: 'Test2' }]);
       // Can't use `.Test2` because the formGroup isn't returned
       expect(formGroup.controls['Test2']).not.toBeDefined();
@@ -117,8 +117,8 @@ describe('Utils: FormUtils', () => {
   describe('Method: toFormGroupFromFieldset(fieldsets)', () => {
     it('should create FormGroups from a collection of FieldSets that contain controls.', () => {
       expect(formUtils.toFormGroup).toBeDefined();
-      let mockControls: Array<any> = [{ key: 'Test' }];
-      let fieldSet = formUtils.toFormGroupFromFieldset([{ title: 'Test', controls: mockControls }]);
+      const mockControls: Array<any> = [{ key: 'Test' }];
+      const fieldSet = formUtils.toFormGroupFromFieldset([{ title: 'Test', controls: mockControls }]);
       expect(fieldSet.controls.Test).toBeDefined();
       expect(fieldSet.controls.Test instanceof NovoFormControl).toBe(true);
     });
@@ -258,81 +258,81 @@ describe('Utils: FormUtils', () => {
   describe('Method: getControlForField(field, http, config)', () => {
     xit('should return the right component for entitychips', () => {
       expect(formUtils.getControlForField).toBeDefined();
-      let result = formUtils.getControlForField({ type: 'entitychips' });
+      const result = formUtils.getControlForField({ type: 'entitychips' });
       expect(result instanceof PickerControl).toBe(true);
     });
     xit('should return the right component for entitypicker', () => {
       expect(formUtils.getControlForField).toBeDefined();
-      let result = formUtils.getControlForField({ type: 'entitypicker' });
+      const result = formUtils.getControlForField({ type: 'entitypicker' });
       expect(result instanceof PickerControl).toBe(true);
     });
     it('should return the right component for picker', () => {
       expect(formUtils.getControlForField).toBeDefined();
-      let result = formUtils.getControlForField({ type: 'picker' });
+      const result = formUtils.getControlForField({ type: 'picker' });
       expect(result instanceof PickerControl).toBe(true);
     });
     it('should return the right component for datetime', () => {
       expect(formUtils.getControlForField).toBeDefined();
-      let result = formUtils.getControlForField({ type: 'datetime' });
+      const result = formUtils.getControlForField({ type: 'datetime' });
       expect(result instanceof DateTimeControl).toBe(true);
     });
     it('should return the right component for date', () => {
       expect(formUtils.getControlForField).toBeDefined();
-      let result = formUtils.getControlForField({ type: 'date' });
+      const result = formUtils.getControlForField({ type: 'date' });
       expect(result instanceof DateControl).toBe(true);
     });
     it('should return the right component for time', () => {
       expect(formUtils.getControlForField).toBeDefined();
-      let result = formUtils.getControlForField({ type: 'time' });
+      const result = formUtils.getControlForField({ type: 'time' });
       expect(result instanceof TimeControl).toBe(true);
     });
     it('should return the right component for currency', () => {
       expect(formUtils.getControlForField).toBeDefined();
-      let result = formUtils.getControlForField({ type: 'currency' });
+      const result = formUtils.getControlForField({ type: 'currency' });
       expect(result instanceof TextBoxControl).toBe(true);
     });
     it('should return the right component for text', () => {
       expect(formUtils.getControlForField).toBeDefined();
-      let result = formUtils.getControlForField({ type: 'text' });
+      const result = formUtils.getControlForField({ type: 'text' });
       expect(result instanceof TextBoxControl).toBe(true);
     });
     it('should return the right component for textarea', () => {
       expect(formUtils.getControlForField).toBeDefined();
-      let result = formUtils.getControlForField({ type: 'textarea' });
+      const result = formUtils.getControlForField({ type: 'textarea' });
       expect(result instanceof TextAreaControl).toBe(true);
     });
     it('should return the right component for editor', () => {
       expect(formUtils.getControlForField).toBeDefined();
-      let result = formUtils.getControlForField({ type: 'editor' });
+      const result = formUtils.getControlForField({ type: 'editor' });
       expect(result instanceof EditorControl).toBe(true);
     });
     it('should return the right component for tiles', () => {
       expect(formUtils.getControlForField).toBeDefined();
-      let result = formUtils.getControlForField({ type: 'tiles' });
+      const result = formUtils.getControlForField({ type: 'tiles' });
       expect(result instanceof TilesControl).toBe(true);
     });
     it('should return the right component for checkbox', () => {
       expect(formUtils.getControlForField).toBeDefined();
-      let result = formUtils.getControlForField({ type: 'checkbox' });
+      const result = formUtils.getControlForField({ type: 'checkbox' });
       expect(result instanceof CheckboxControl).toBe(true);
     });
     it('should return the right component for checklist', () => {
       expect(formUtils.getControlForField).toBeDefined();
-      let result = formUtils.getControlForField({ type: 'checklist' });
+      const result = formUtils.getControlForField({ type: 'checklist' });
       expect(result instanceof CheckListControl).toBe(true);
     });
     it('should return the right component for radio', () => {
       expect(formUtils.getControlForField).toBeDefined();
-      let result = formUtils.getControlForField({ type: 'radio' });
+      const result = formUtils.getControlForField({ type: 'radio' });
       expect(result instanceof RadioControl).toBe(true);
     });
     it('should return the right component for select', () => {
       expect(formUtils.getControlForField).toBeDefined();
-      let result = formUtils.getControlForField({ type: 'select' });
+      const result = formUtils.getControlForField({ type: 'select' });
       expect(result instanceof SelectControl).toBe(true);
     });
     it('should return the right component for editor minimal', () => {
-      let result = formUtils.getControlForField({ type: 'editor-minimal' });
+      const result = formUtils.getControlForField({ type: 'editor-minimal' });
       expect(result instanceof EditorControl).toBeTruthy();
     });
     it('should return the right component for WorkflowOptions and call getControlOptions with data', () => {
@@ -345,12 +345,12 @@ describe('Utils: FormUtils', () => {
     describe('with type: address', () => {
       it('should return the right component for address', () => {
         expect(formUtils.getControlForField).toBeDefined();
-        let result = formUtils.getControlForField({ type: 'address' });
+        const result = formUtils.getControlForField({ type: 'address' });
         expect(result instanceof AddressControl).toBe(true);
       });
       it('should set the right defaults for address sub-fields', () => {
         expect(formUtils.getControlForField).toBeDefined();
-        let result = formUtils.getControlForField({
+        const result = formUtils.getControlForField({
           type: 'address',
           fields: [
             {
@@ -391,7 +391,7 @@ describe('Utils: FormUtils', () => {
     });
     it('should return the right component for file', () => {
       expect(formUtils.getControlForField).toBeDefined();
-      let result = formUtils.getControlForField({ type: 'file' });
+      const result = formUtils.getControlForField({ type: 'file' });
       expect(result instanceof FileControl).toBe(true);
     });
   });
@@ -410,7 +410,7 @@ describe('Utils: FormUtils', () => {
     });
 
     it('should return an array of fieldsets with a title, icon and controls', () => {
-      let meta = {
+      const meta = {
         entity: 'ENTITY_NAME',
         label: 'ENTITY_LABEL',
         fields: [
@@ -453,14 +453,14 @@ describe('Utils: FormUtils', () => {
           },
         ],
       };
-      let fieldset = formUtils.toFieldSets(meta, 'USD', {}, {}, {});
+      const fieldset = formUtils.toFieldSets(meta, 'USD', {}, {}, {});
       expect(fieldset[0].title).toBe('Header');
       expect(fieldset[0].icon).toBe('bhi-certification');
       expect(fieldset[0].controls.length).toBe(3);
       expect(fieldset[0].controls[0].key).toEqual('inlineEmbeddedField.field1');
     });
     it('should call getControlForField with data', () => {
-      let meta = {
+      const meta = {
         entity: 'ENTITY_NAME',
         label: 'ENTITY_LABEL',
         fields: [
@@ -497,7 +497,7 @@ describe('Utils: FormUtils', () => {
     });
     it('should return an object with a function that returns a promise when there is an optionsUrl', () => {
       expect(formUtils.getControlOptions).toBeDefined();
-      let result = formUtils.getControlOptions({ optionsUrl: 'TEST' });
+      const result = formUtils.getControlOptions({ optionsUrl: 'TEST' });
       expect(result.field).toBe('value');
       expect(result.format).toBe('$label');
       expect(result.options('') instanceof Promise).toBe(true);
@@ -507,12 +507,12 @@ describe('Utils: FormUtils', () => {
     });
     it('should return an object with a function that returns a promise when there is an optionsUrl that calls an API', () => {
       expect(formUtils.getControlOptions).toBeDefined();
-      let mockHttp = {
+      const mockHttp = {
         get: () => {
           return from([]);
         },
       };
-      let result = formUtils.getControlOptions({ optionsUrl: 'TEST' }, mockHttp, { token: '1' });
+      const result = formUtils.getControlOptions({ optionsUrl: 'TEST' }, mockHttp, { token: '1' });
       expect(result.field).toBe('value');
       expect(result.format).toBe('$label');
       expect(result.options('') instanceof Promise).toBe(true);
@@ -522,14 +522,14 @@ describe('Utils: FormUtils', () => {
     });
     it('should return an object with an array, label, and format for chips', () => {
       expect(formUtils.getControlOptions).toBeDefined();
-      let result = formUtils.getControlOptions({ type: 'chips', options: [1] });
+      const result = formUtils.getControlOptions({ type: 'chips', options: [1] });
       expect(result.options.length).toBe(1);
       expect(result.field).toBe('value');
       expect(result.format).toBe('$label');
     });
     it('should return an array when options is an array', () => {
       expect(formUtils.getControlOptions).toBeDefined();
-      let result = formUtils.getControlOptions({ dataSpecialization: 'DATETIME' });
+      const result = formUtils.getControlOptions({ dataSpecialization: 'DATETIME' });
     });
     it('should return an array when there are WorkflowOptions', () => {
       const field: { workflowOptions: Object } = {

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -68,9 +68,9 @@ export class FormUtils {
   constructor(public labels: NovoLabelService, public optionsService: OptionsService) {}
 
   toFormGroup(controls: Array<any>): NovoFormGroup {
-    let group: any = {};
+    const group: any = {};
     controls.forEach((control) => {
-      let value = Helpers.isBlank(control.value) ? '' : control.value;
+      const value = Helpers.isBlank(control.value) ? '' : control.value;
       group[control.key] = new NovoFormControl(value, control);
     });
     return new NovoFormGroup(group);
@@ -82,8 +82,8 @@ export class FormUtils {
 
   addControls(formGroup: NovoFormGroup, controls: Array<NovoControlConfig>): void {
     controls.forEach((control) => {
-      let value = Helpers.isBlank(control.value) ? '' : control.value;
-      let formControl = new NovoFormControl(value, control);
+      const value = Helpers.isBlank(control.value) ? '' : control.value;
+      const formControl = new NovoFormControl(value, control);
       formGroup.addControl(control.key, formControl);
     });
   }
@@ -99,7 +99,7 @@ export class FormUtils {
    * @param fieldsets
    */
   toFormGroupFromFieldset(fieldsets: Array<NovoFieldset>): NovoFormGroup {
-    let controls: Array<NovoFormControl> = [];
+    const controls: Array<NovoFormControl> = [];
     fieldsets.forEach((fieldset) => {
       controls.push(...fieldset.controls);
     });
@@ -120,7 +120,7 @@ export class FormUtils {
    */
   determineInputType(field: FormField): string {
     let type: string;
-    let dataSpecializationTypeMap = {
+    const dataSpecializationTypeMap = {
       DATETIME: 'datetime',
       TIME: 'time',
       MONEY: 'currency',
@@ -134,27 +134,27 @@ export class FormUtils {
       SpecializedOptionsLookup: 'select',
       SimplifiedOptionsLookup: 'select',
     };
-    let dataTypeToTypeMap = {
+    const dataTypeToTypeMap = {
       Timestamp: 'date',
       Date: 'date',
       Boolean: 'tiles',
     };
-    let inputTypeToTypeMap = {
+    const inputTypeToTypeMap = {
       CHECKBOX: 'radio',
       RADIO: 'radio',
       SELECT: 'select',
       TILES: 'tiles',
     };
-    let inputTypeMultiToTypeMap = {
+    const inputTypeMultiToTypeMap = {
       CHECKBOX: 'checklist',
       RADIO: 'checklist',
       SELECT: 'chips',
     };
-    let typeToTypeMap = {
+    const typeToTypeMap = {
       file: 'file',
       COMPOSITE: 'address',
     };
-    let numberDataTypeToTypeMap = {
+    const numberDataTypeToTypeMap = {
       Double: 'float',
       BigDecimal: 'float',
       Integer: 'number',
@@ -233,9 +233,9 @@ export class FormUtils {
     // TODO: (cont.) as the setter of the field argument
     let type: string = this.determineInputType(field) || field.type;
     let control: any;
-    let controlConfig: NovoControlConfig = {
+    const controlConfig: NovoControlConfig = {
       metaType: field.type,
-      type: type,
+      type,
       key: field.name,
       label: field.label,
       placeholder: field.hint || '',
@@ -406,7 +406,7 @@ export class FormUtils {
         controlConfig.config.required = field.required;
         controlConfig.config.readOnly = controlConfig.readOnly;
         if (field.fields && field.fields.length) {
-          for (let subfield of field.fields) {
+          for (const subfield of field.fields) {
             controlConfig.config[subfield.name] = {
               required: !!subfield.required,
               hidden: !!subfield.readOnly,
@@ -476,12 +476,12 @@ export class FormUtils {
     overrides?: any,
     forTable: boolean = false,
   ) {
-    let controls = [];
+    const controls = [];
     if (meta && meta.fields) {
-      let fields = meta.fields;
+      const fields = meta.fields;
       fields.forEach((field) => {
         if (this.shouldCreateControl(field)) {
-          let control = this.getControlForField(field, http, config, overrides, forTable);
+          const control = this.getControlForField(field, http, config, overrides, forTable);
           // Set currency format
           if (control.subType === 'currency') {
             control.currencyFormat = currencyFormat;
@@ -495,8 +495,8 @@ export class FormUtils {
   }
 
   toTableControls(meta, currencyFormat, http, config: { token?: string; restUrl?: string; military?: boolean }, overrides?: any) {
-    let controls = this.toControls(meta, currencyFormat, http, config, overrides, true);
-    let ret = {};
+    const controls = this.toControls(meta, currencyFormat, http, config, overrides, true);
+    const ret = {};
     controls.forEach((control: BaseControl) => {
       ret[control.key] = {
         editorType: control.__type,
@@ -514,7 +514,7 @@ export class FormUtils {
     overrides?,
     data?: { [key: string]: any },
   ) {
-    let fieldsets: Array<NovoFieldset> = [];
+    const fieldsets: Array<NovoFieldset> = [];
     let formFields = [];
 
     if (meta && meta.fields) {
@@ -528,7 +528,7 @@ export class FormUtils {
         } else if (this.isEmbeddedField(field)) {
           this.insertHeaderToFieldsets(fieldsets, field);
 
-          let embeddedFields = this.getEmbeddedFields(field);
+          const embeddedFields = this.getEmbeddedFields(field);
 
           embeddedFields.forEach((embeddedField) => {
             if (this.shouldCreateControl(embeddedField)) {
@@ -568,7 +568,7 @@ export class FormUtils {
 
   private createControl(field, data, http, config, overrides, currencyFormat) {
     const fieldData = this.isEmbeddedFieldData(field, data) ? this.getEmbeddedFieldData(field, data) : this.getFieldData(field, data);
-    let control = this.getControlForField(field, http, config, overrides, undefined, fieldData);
+    const control = this.getControlForField(field, http, config, overrides, undefined, fieldData);
     // Set currency format
     if (control.subType === 'currency') {
       control.currencyFormat = currencyFormat;
@@ -585,12 +585,12 @@ export class FormUtils {
   }
 
   private getEmbeddedFieldData(field, data) {
-    let [parentFieldName, fieldName] = field.name.split('.');
+    const [parentFieldName, fieldName] = field.name.split('.');
     return (data && data[parentFieldName] && data[parentFieldName][fieldName]) || null;
   }
 
   private getFormFields(meta) {
-    let sectionHeaders = meta.sectionHeaders
+    const sectionHeaders = meta.sectionHeaders
       ? meta.sectionHeaders.map((element) => {
           element.isSectionHeader = true;
           return element;
@@ -687,7 +687,7 @@ export class FormUtils {
     } else if (field.optionsUrl) {
       return this.optionsService.getOptionsConfig(http, field, config);
     } else if (Array.isArray(field.options) && field.type === 'chips') {
-      let options = field.options;
+      const options = field.options;
       return {
         field: 'value',
         format: '$label',
@@ -709,7 +709,7 @@ export class FormUtils {
     }
 
     const currentWorkflowOption: number | string = fieldData.id ? fieldData.id : 'initial';
-    let updateWorkflowOptions: Array<{ value: string | number; label: string | number }> = workflowOptions[currentWorkflowOption] || [];
+    const updateWorkflowOptions: Array<{ value: string | number; label: string | number }> = workflowOptions[currentWorkflowOption] || [];
 
     if (currentValue && !updateWorkflowOptions.find((option) => option.value === currentValue.value)) {
       updateWorkflowOptions.unshift(currentValue);
@@ -779,7 +779,7 @@ export class FormUtils {
 
   forceValidation(form: NovoFormGroup): void {
     Object.keys(form.controls).forEach((key: string) => {
-      let control: any = form.controls[key];
+      const control: any = form.controls[key];
       if (control.required && Helpers.isBlank(form.value[control.key])) {
         control.markAsDirty();
         control.markAsTouched();
@@ -788,7 +788,7 @@ export class FormUtils {
   }
 
   isAddressEmpty(control: any): boolean {
-    let fieldList: string[] = ['address1', 'address2', 'city', 'state', 'zip', 'countryID'];
+    const fieldList: string[] = ['address1', 'address2', 'city', 'state', 'zip', 'countryID'];
     let valid: boolean = true;
     if (control.value && control.config) {
       fieldList.forEach((subfield: string) => {
@@ -850,7 +850,7 @@ export class FormUtils {
       Object.keys(data)
         .filter((fieldName) => fieldName.includes('.'))
         .forEach((field) => {
-          let [parentFieldName, fieldName] = field.split('.');
+          const [parentFieldName, fieldName] = field.split('.');
           if (!data[parentFieldName]) {
             data[parentFieldName] = {};
           }

--- a/projects/novo-elements/src/utils/outside-click/OutsideClick.spec.ts
+++ b/projects/novo-elements/src/utils/outside-click/OutsideClick.spec.ts
@@ -5,7 +5,7 @@ import { OutsideClick } from './OutsideClick';
 
 describe('Util: OutsideClick', () => {
   let outsideClick;
-  let mockElement: ElementRef = new ElementRef(document.createElement('div'));
+  const mockElement: ElementRef = new ElementRef(document.createElement('div'));
   let mockEvent;
 
   beforeEach(() => {

--- a/projects/novo-examples/src/_shared/code-snippet.component.ts
+++ b/projects/novo-examples/src/_shared/code-snippet.component.ts
@@ -38,9 +38,9 @@ export class CodeSnippetComponent implements OnInit {
 
   ngOnInit() {
     this.hljs.isReady.subscribe(() => {
-      let code = decodeURIComponent(EXAMPLE_COMPONENTS[this.example].tsSource);
-      let markup = decodeURIComponent(EXAMPLE_COMPONENTS[this.example].htmlSource);
-      let style = decodeURIComponent(EXAMPLE_COMPONENTS[this.example].cssSource);
+      const code = decodeURIComponent(EXAMPLE_COMPONENTS[this.example].tsSource);
+      const markup = decodeURIComponent(EXAMPLE_COMPONENTS[this.example].htmlSource);
+      const style = decodeURIComponent(EXAMPLE_COMPONENTS[this.example].cssSource);
       this.highlightTS = this.sanitizer.bypassSecurityTrustHtml(this.hljs.highlightAuto(code, ['typescript']).value.trim());
       this.highlightHTML = this.sanitizer.bypassSecurityTrustHtml(this.hljs.highlightAuto(markup, ['html']).value.trim());
       this.highlightCSS = this.sanitizer.bypassSecurityTrustHtml(this.hljs.highlightAuto(style, ['css']).value.trim());

--- a/projects/novo-examples/src/_shared/stackblitz/stackblitz-writer.ts
+++ b/projects/novo-examples/src/_shared/stackblitz/stackblitz-writer.ts
@@ -81,9 +81,9 @@ export class StackblitzWriter {
     this._appendFormInput(form, 'dependencies', JSON.stringify(dependencies));
 
     return new Promise((resolve) => {
-      let templateContents = TEMPLATE_FILES.map((file) => this._readFile(form, data, file, TEMPLATE_PATH));
+      const templateContents = TEMPLATE_FILES.map((file) => this._readFile(form, data, file, TEMPLATE_PATH));
 
-      let exampleContents = [];
+      const exampleContents = [];
       exampleContents.push(
         Promise.resolve(
           this._addFileToForm(form, data, decodeURIComponent(data.source.tsSource), `app/${data.selectorName}.ts`, TEMPLATE_PATH),

--- a/projects/novo-examples/src/components/buttons/button-dynamic/button-dynamic-example.ts
+++ b/projects/novo-examples/src/components/buttons/button-dynamic/button-dynamic-example.ts
@@ -15,7 +15,7 @@ export class ButtonDynamicExample {
   color: string = 'blue';
 
   changeTheme() {
-    let i = Math.floor(Math.random() * 4);
+    const i = Math.floor(Math.random() * 4);
     this.theme = ['primary', 'secondary', 'dialogue', 'standard', 'icon'][i];
   }
 }

--- a/projects/novo-examples/src/components/calendar/big-calendar/big-calendar-example.ts
+++ b/projects/novo-examples/src/components/calendar/big-calendar/big-calendar-example.ts
@@ -200,10 +200,10 @@ export class BigCalendarExample {
   ];
 
   getNewEvent(date, color, type): CalendarEvent {
-    let evt: CalendarEvent = {
+    const evt: CalendarEvent = {
       title: 'Meeting',
       description: 'with @jgodi',
-      color: color,
+      color,
       start: date,
       response: type,
       type: 'Meeting',
@@ -212,13 +212,13 @@ export class BigCalendarExample {
   }
 
   dayClicked(date) {
-    let evt: CalendarEvent = this.getNewEvent(date, colors.blue, CalendarEventResponse.Maybe);
+    const evt: CalendarEvent = this.getNewEvent(date, colors.blue, CalendarEventResponse.Maybe);
     this.events.push(evt);
     this.events = [...this.events];
   }
 
   addShift(event) {
-    let evt: CalendarEvent = this.getNewEvent(event.day.date, colors.blue, CalendarEventResponse.Maybe);
+    const evt: CalendarEvent = this.getNewEvent(event.day.date, colors.blue, CalendarEventResponse.Maybe);
     this.events.push(evt);
     this.events = [...this.events];
   }

--- a/projects/novo-examples/src/components/data-table/data-table-remote/data-table-remote-example.ts
+++ b/projects/novo-examples/src/components/data-table/data-table-remote/data-table-remote-example.ts
@@ -247,7 +247,7 @@ export class DataTableRemoteExample {
 
   constructor(private ref: ChangeDetectorRef, private modalService: NovoModalService) {
     for (let i = 0; i < 1000; i++) {
-      let day = i < 500 ? dateFns.subDays(new Date(), i) : dateFns.addDays(new Date(), i - 500);
+      const day = i < 500 ? dateFns.subDays(new Date(), i) : dateFns.addDays(new Date(), i - 500);
       this.staticDataSet1.push({
         id: i,
         embeddedObj: { id: i, test: `HMM ${i}`, another: { id: 777 } },
@@ -275,7 +275,7 @@ export class DataTableRemoteExample {
   }
 
   public getPriorityOptions() {
-    let options = new Array();
+    const options = new Array();
     let i;
     for (i = 0; i < 49; i++) {
       options.push('test ' + i.toString());
@@ -306,7 +306,7 @@ export class DataTableRemoteExample {
       .open(ConfigureColumnsModal, { columns: this.sharedColumns })
       .onClosed.then((columns: IDataTableColumn<MockData>[]) => {
         if (columns) {
-          let enabledColumns = columns.filter((column: IDataTableColumn<MockData>) => column.enabled);
+          const enabledColumns = columns.filter((column: IDataTableColumn<MockData>) => column.enabled);
           this.sharedDisplayColumns = ['selection', 'expand', ...enabledColumns.map((column: IDataTableColumn<MockData>) => column.id)];
           this.ref.markForCheck();
         }
@@ -336,17 +336,17 @@ class RemoteMockDataService extends RemoteDataTableService<MockData> {
     pageSize: number,
     globalSearch?: string,
   ): Observable<{ results: MockData[]; total: number }> {
-    let whereQuery: string = this.buildWhereClause(filter);
-    let sortQuery: string = this.buildSortColumn(sort);
-    let pageQuery: number = this.buildStart(page, pageSize);
+    const whereQuery: string = this.buildWhereClause(filter);
+    const sortQuery: string = this.buildSortColumn(sort);
+    const pageQuery: number = this.buildStart(page, pageSize);
     this.url = `http://mock-api.com?where=${whereQuery}&sort=${sortQuery}&pageSize=${pageSize}&page=${pageQuery}`;
     return of({ results: this.data, total: this.data.length }).pipe(delay(5000));
   }
 
   private buildWhereClause(filter: IDataTableFilter | IDataTableFilter[]): string {
-    let query: any = {};
+    const query: any = {};
     if (filter) {
-      let filters = Helpers.convertToArray(filter);
+      const filters = Helpers.convertToArray(filter);
       filters.forEach((aFilter) => {
         query[aFilter.id] = aFilter.transform ? aFilter.transform(aFilter.value) : aFilter.value;
       });
@@ -370,9 +370,9 @@ class RemoteMockDataService extends RemoteDataTableService<MockData> {
   }
 
   private toQuerySyntax(data: any) {
-    let queries: Array<string> = [];
-    for (let key in data) {
-      let value = data[key];
+    const queries: Array<string> = [];
+    for (const key in data) {
+      const value = data[key];
       if (key === 'or') {
         queries.push(`(${this.toQuerySyntax(value).replace(/ AND /g, ' OR ')})`);
       } else {
@@ -384,7 +384,7 @@ class RemoteMockDataService extends RemoteDataTableService<MockData> {
   }
 
   private parseQueryValue(key: string, value: any, isNot: boolean = false) {
-    let clauses: Array<string> = [],
+    const clauses: Array<string> = [],
       IN = isNot ? ' NOT IN ' : ' IN ',
       EQ = isNot ? '<>' : '=',
       GT = isNot ? '<' : '>=',
@@ -393,7 +393,7 @@ class RemoteMockDataService extends RemoteDataTableService<MockData> {
       clauses.push(`${key}${IN}(${this.writeQueryValues(value)})`);
     } else if (value instanceof Object) {
       if (typeof value.isNull === 'boolean') {
-        let query: string = value.isNull ? 'IS NULL' : 'IS NOT NULL';
+        const query: string = value.isNull ? 'IS NULL' : 'IS NOT NULL';
         clauses.push(`${key} ${query}`);
       }
       if (value.min !== null && value.min !== undefined) {
@@ -415,7 +415,7 @@ class RemoteMockDataService extends RemoteDataTableService<MockData> {
         clauses.push(`${key} like '%${value.like}%'`);
       }
       if (value.lookup !== null && value.lookup !== undefined) {
-        let obj = {};
+        const obj = {};
         obj[key] = value.lookup;
         clauses.push(this.toQuerySyntax(obj));
       }
@@ -426,13 +426,13 @@ class RemoteMockDataService extends RemoteDataTableService<MockData> {
         clauses.push(`${key} IS EMPTY`);
       }
       if (value.or !== null && value.or !== undefined) {
-        let obj = {};
+        const obj = {};
         obj[key] = value.or;
         clauses.push(this.toQuerySyntax(obj).replace('AND', 'OR'));
       }
-      for (let subkey in value) {
+      for (const subkey in value) {
         if (['min', 'max', 'any', 'all', 'not', 'or', 'like', 'lookup', 'with', 'without', 'isNull'].indexOf(subkey) < 0) {
-          let subvalue = value[subkey];
+          const subvalue = value[subkey];
           clauses.push(this.parseQueryValue(`${key}.${subkey}`, subvalue));
         }
       }

--- a/projects/novo-examples/src/components/data-table/data-table-rows/data-table-rows-example.ts
+++ b/projects/novo-examples/src/components/data-table/data-table-rows/data-table-rows-example.ts
@@ -273,7 +273,7 @@ export class DataTableRowsExample {
 
   constructor(private ref: ChangeDetectorRef, private modalService: NovoModalService) {
     for (let i = 0; i < 1000; i++) {
-      let day = i < 500 ? dateFns.subDays(new Date(), i) : dateFns.addDays(new Date(), i - 500);
+      const day = i < 500 ? dateFns.subDays(new Date(), i) : dateFns.addDays(new Date(), i - 500);
       this.staticDataSet1.push({
         id: i,
         embeddedObj: { id: i, test: `HMM ${i}`, another: { id: 777 } },
@@ -320,7 +320,7 @@ export class DataTableRowsExample {
   }
 
   public getPriorityOptions() {
-    let options = new Array();
+    const options = new Array();
     let i;
     for (i = 0; i < 49; i++) {
       options.push('test ' + i.toString());
@@ -372,7 +372,7 @@ export class DataTableRowsExample {
       .open(ConfigureColumnsModal, { columns: this.sharedColumns })
       .onClosed.then((columns: IDataTableColumn<MockData>[]) => {
         if (columns) {
-          let enabledColumns = columns.filter((column: IDataTableColumn<MockData>) => column.enabled);
+          const enabledColumns = columns.filter((column: IDataTableColumn<MockData>) => column.enabled);
           this.sharedDisplayColumns = ['selection', 'expand', ...enabledColumns.map((column: IDataTableColumn<MockData>) => column.id)];
           this.ref.markForCheck();
         }
@@ -396,7 +396,7 @@ export class DataTableRowsExample {
   }
 
   public filterList(value: any): void {
-    this.table.state.filter = { id: 'status', type: 'text', value: value };
+    this.table.state.filter = { id: 'status', type: 'text', value };
     this.table.state.updates.next({
       globalSearch: this.table.state.globalSearch,
       filter: this.table.state.filter,

--- a/projects/novo-examples/src/components/data-table/data-table-service/data-table-service-example.ts
+++ b/projects/novo-examples/src/components/data-table/data-table-service/data-table-service-example.ts
@@ -247,7 +247,7 @@ export class DataTableServiceExample {
 
   constructor(private ref: ChangeDetectorRef, private modalService: NovoModalService) {
     for (let i = 0; i < 1000; i++) {
-      let day = i < 500 ? dateFns.subDays(new Date(), i) : dateFns.addDays(new Date(), i - 500);
+      const day = i < 500 ? dateFns.subDays(new Date(), i) : dateFns.addDays(new Date(), i - 500);
       this.staticDataSet1.push({
         id: i,
         embeddedObj: { id: i, test: `HMM ${i}`, another: { id: 777 } },
@@ -292,7 +292,7 @@ export class DataTableServiceExample {
   }
 
   public getPriorityOptions() {
-    let options = new Array();
+    const options = new Array();
     let i;
     for (i = 0; i < 49; i++) {
       options.push('test ' + i.toString());
@@ -338,7 +338,7 @@ export class DataTableServiceExample {
       .open(ConfigureColumnsModal, { columns: this.sharedColumns })
       .onClosed.then((columns: IDataTableColumn<MockData>[]) => {
         if (columns) {
-          let enabledColumns = columns.filter((column: IDataTableColumn<MockData>) => column.enabled);
+          const enabledColumns = columns.filter((column: IDataTableColumn<MockData>) => column.enabled);
           this.sharedDisplayColumns = ['selection', 'expand', ...enabledColumns.map((column: IDataTableColumn<MockData>) => column.id)];
           this.ref.markForCheck();
         }

--- a/projects/novo-examples/src/components/table/table-extras.ts
+++ b/projects/novo-examples/src/components/table/table-extras.ts
@@ -16,7 +16,7 @@ export const TableColumns = [
       return object.ext.obj;
     },
     compare: (sort, previous, current) => {
-      let first = previous.obj,
+      const first = previous.obj,
         second = current.obj;
 
       if (first > second) {

--- a/projects/novo-examples/src/design/colors/analytics-colors/analytics-colors-example.ts
+++ b/projects/novo-examples/src/design/colors/analytics-colors/analytics-colors-example.ts
@@ -71,9 +71,9 @@ export class AnalyticsColorsExample {
 
   copyLink(color) {
     // Create dom element to copy from
-    let copyFrom = document.createElement('textarea');
+    const copyFrom = document.createElement('textarea');
     copyFrom.textContent = `#${color.hex}`;
-    let body = document.getElementsByTagName('body')[0];
+    const body = document.getElementsByTagName('body')[0];
     body.appendChild(copyFrom);
     copyFrom.select();
     // Copy text

--- a/projects/novo-examples/src/design/colors/entity-colors/entity-colors-example.ts
+++ b/projects/novo-examples/src/design/colors/entity-colors/entity-colors-example.ts
@@ -101,9 +101,9 @@ export class EntityColorsExample {
 
   copyLink(color) {
     // Create dom element to copy from
-    let copyFrom = document.createElement('textarea');
+    const copyFrom = document.createElement('textarea');
     copyFrom.textContent = `#${color.hex}`;
-    let body = document.getElementsByTagName('body')[0];
+    const body = document.getElementsByTagName('body')[0];
     body.appendChild(copyFrom);
     copyFrom.select();
     // Copy text

--- a/projects/novo-examples/src/design/colors/primary-colors/primary-colors-example.ts
+++ b/projects/novo-examples/src/design/colors/primary-colors/primary-colors-example.ts
@@ -70,9 +70,9 @@ export class PrimaryColorsExample {
 
   copyLink(color) {
     // Create dom element to copy from
-    let copyFrom = document.createElement('textarea');
+    const copyFrom = document.createElement('textarea');
     copyFrom.textContent = `#${color.hex}`;
-    let body = document.getElementsByTagName('body')[0];
+    const body = document.getElementsByTagName('body')[0];
     body.appendChild(copyFrom);
     copyFrom.select();
     // Copy text

--- a/projects/novo-examples/src/form-controls/chips/async-chips/async-chips-example.ts
+++ b/projects/novo-examples/src/form-controls/chips/async-chips/async-chips-example.ts
@@ -14,7 +14,7 @@ export class AsyncChipsExample {
   public placeholder: string = 'Select...';
 
   constructor() {
-    let states = [
+    const states = [
       'Alabama',
       'Alaska',
       'Arizona',
@@ -66,7 +66,7 @@ export class AsyncChipsExample {
       'Wisconsin',
       'Wyoming',
     ];
-    let abbrieviated = [
+    const abbrieviated = [
       {
         value: 'USA',
         label: 'United States',
@@ -95,8 +95,8 @@ export class AsyncChipsExample {
       getLabels: (data) => {
         return new Promise((resolve) => {
           setTimeout(() => {
-            let values = data.map((item) => item.value);
-            let results = abbrieviated.filter((item) => values.includes(item.value));
+            const values = data.map((item) => item.value);
+            const results = abbrieviated.filter((item) => values.includes(item.value));
             resolve(results);
           }, 300);
         });

--- a/projects/novo-examples/src/form-controls/chips/close-on-select-chips/close-on-select-chips-example.ts
+++ b/projects/novo-examples/src/form-controls/chips/close-on-select-chips/close-on-select-chips-example.ts
@@ -14,7 +14,7 @@ export class CloseOnSelectChipsExample {
   public value: any;
 
   constructor() {
-    let collaborators = [
+    const collaborators = [
       {
         id: 1,
         firstName: 'Brian',

--- a/projects/novo-examples/src/form-controls/chips/formatted-chips/formatted-chips-example.ts
+++ b/projects/novo-examples/src/form-controls/chips/formatted-chips/formatted-chips-example.ts
@@ -14,7 +14,7 @@ export class FormattedChipsExample {
   public value: any;
 
   constructor() {
-    let collaborators = [
+    const collaborators = [
       {
         id: 1,
         firstName: 'Brian',

--- a/projects/novo-examples/src/form-controls/chips/grouped-multi-picker/grouped-multi-picker-example.ts
+++ b/projects/novo-examples/src/form-controls/chips/grouped-multi-picker/grouped-multi-picker-example.ts
@@ -23,21 +23,21 @@ export class GroupedMultiPickerExample {
   }
 
   setupGroupedMultiPickerDemo() {
-    let categoryMap = new Map<string, { value: string; label: string; items: { value: string; label: string }[] }>();
+    const categoryMap = new Map<string, { value: string; label: string; items: { value: string; label: string }[] }>();
     for (let i = 0; i < 10; i++) {
-      let items = [];
+      const items = [];
       for (let j = 0; j < 10; j++) {
         items.push({ value: `${i}-${j}`, label: `Category ${i} - Item ${j}` });
       }
-      categoryMap.set(`${i}`, { value: `${i}`, label: `Category ${i}`, items: items });
+      categoryMap.set(`${i}`, { value: `${i}`, label: `Category ${i}`, items });
     }
     this.groupedMultiPicker1 = {
-      categoryMap: categoryMap,
+      categoryMap,
       resultsTemplate: GroupedMultiPickerResults,
       displayAll: true,
     };
     this.groupedMultiPicker2 = {
-      categoryMap: categoryMap,
+      categoryMap,
       resultsTemplate: GroupedMultiPickerResults,
     };
     this.groupedMultiPicker3 = {

--- a/projects/novo-examples/src/form-controls/chips/row-chips/row-chips-example.ts
+++ b/projects/novo-examples/src/form-controls/chips/row-chips/row-chips-example.ts
@@ -15,7 +15,7 @@ export class RowChipsExample {
   public rowValue: any;
 
   constructor() {
-    let collaborators = [
+    const collaborators = [
       {
         id: 1,
         firstName: 'Brian',

--- a/projects/novo-examples/src/form-controls/form-groups/custom-template/custom-template-example.ts
+++ b/projects/novo-examples/src/form-controls/form-groups/custom-template/custom-template-example.ts
@@ -81,11 +81,11 @@ export class CustomTemplateExample {
 
   private setupGroupedFormDemo() {
     this.formGroup = this.formUtils.emptyFormGroup();
-    let label = new ReadOnlyControl({ key: 'label', value: 'Label :)' });
-    let c1 = new SelectControl({ key: 'text', label: 'Text Box', options: [{ value: 'hello', label: 'Hello' }] });
-    let c2 = new TextBoxControl({ type: 'percentage', key: 'percentage', label: 'Percent', required: true });
-    let c3 = new CheckboxControl({ key: 'checkbox', label: 'Check Me!', width: 100 });
-    let c4 = new TextBoxControl({ key: 'test4', label: 'TEST4' });
+    const label = new ReadOnlyControl({ key: 'label', value: 'Label :)' });
+    const c1 = new SelectControl({ key: 'text', label: 'Text Box', options: [{ value: 'hello', label: 'Hello' }] });
+    const c2 = new TextBoxControl({ type: 'percentage', key: 'percentage', label: 'Percent', required: true });
+    const c3 = new CheckboxControl({ key: 'checkbox', label: 'Check Me!', width: 100 });
+    const c4 = new TextBoxControl({ key: 'test4', label: 'TEST4' });
     this.controls.push(label);
     this.controls.push(c1);
     this.controls.push(c2);

--- a/projects/novo-examples/src/form-controls/form-groups/horizontal-options/horizontal-options-example.ts
+++ b/projects/novo-examples/src/form-controls/form-groups/horizontal-options/horizontal-options-example.ts
@@ -81,11 +81,11 @@ export class HorizontalOptionsExample {
 
   private setupGroupedFormDemo() {
     this.formGroup = this.formUtils.emptyFormGroup();
-    let label = new ReadOnlyControl({ key: 'label', value: 'Label :)' });
-    let c1 = new SelectControl({ key: 'text', label: 'Text Box', options: [{ value: 'hello', label: 'Hello' }] });
-    let c2 = new TextBoxControl({ type: 'percentage', key: 'percentage', label: 'Percent', required: true });
-    let c3 = new CheckboxControl({ key: 'checkbox', label: 'Check Me!', width: 100 });
-    let c4 = new TextBoxControl({ key: 'test4', label: 'TEST4' });
+    const label = new ReadOnlyControl({ key: 'label', value: 'Label :)' });
+    const c1 = new SelectControl({ key: 'text', label: 'Text Box', options: [{ value: 'hello', label: 'Hello' }] });
+    const c2 = new TextBoxControl({ type: 'percentage', key: 'percentage', label: 'Percent', required: true });
+    const c3 = new CheckboxControl({ key: 'checkbox', label: 'Check Me!', width: 100 });
+    const c4 = new TextBoxControl({ key: 'test4', label: 'TEST4' });
     this.controls.push(label);
     this.controls.push(c1);
     this.controls.push(c2);

--- a/projects/novo-examples/src/form-controls/form-groups/horizontal/horizontal-example.ts
+++ b/projects/novo-examples/src/form-controls/form-groups/horizontal/horizontal-example.ts
@@ -81,11 +81,11 @@ export class HorizontalExample {
 
   private setupGroupedFormDemo() {
     this.formGroup = this.formUtils.emptyFormGroup();
-    let label = new ReadOnlyControl({ key: 'label', value: 'Label :)' });
-    let c1 = new SelectControl({ key: 'text', label: 'Text Box', options: [{ value: 'hello', label: 'Hello' }] });
-    let c2 = new TextBoxControl({ type: 'percentage', key: 'percentage', label: 'Percent', required: true });
-    let c3 = new CheckboxControl({ key: 'checkbox', label: 'Check Me!', width: 100 });
-    let c4 = new TextBoxControl({ key: 'test4', label: 'TEST4' });
+    const label = new ReadOnlyControl({ key: 'label', value: 'Label :)' });
+    const c1 = new SelectControl({ key: 'text', label: 'Text Box', options: [{ value: 'hello', label: 'Hello' }] });
+    const c2 = new TextBoxControl({ type: 'percentage', key: 'percentage', label: 'Percent', required: true });
+    const c3 = new CheckboxControl({ key: 'checkbox', label: 'Check Me!', width: 100 });
+    const c4 = new TextBoxControl({ key: 'test4', label: 'TEST4' });
     this.controls.push(label);
     this.controls.push(c1);
     this.controls.push(c2);

--- a/projects/novo-examples/src/form-controls/form-groups/vertical-options/vertical-options-example.ts
+++ b/projects/novo-examples/src/form-controls/form-groups/vertical-options/vertical-options-example.ts
@@ -81,11 +81,11 @@ export class VerticalOptionsExample {
 
   private setupGroupedFormDemo() {
     this.formGroup = this.formUtils.emptyFormGroup();
-    let label = new ReadOnlyControl({ key: 'label', value: 'Label :)' });
-    let c1 = new SelectControl({ key: 'text', label: 'Text Box', options: [{ value: 'hello', label: 'Hello' }] });
-    let c2 = new TextBoxControl({ type: 'percentage', key: 'percentage', label: 'Percent', required: true });
-    let c3 = new CheckboxControl({ key: 'checkbox', label: 'Check Me!', width: 100 });
-    let c4 = new TextBoxControl({ key: 'test4', label: 'TEST4' });
+    const label = new ReadOnlyControl({ key: 'label', value: 'Label :)' });
+    const c1 = new SelectControl({ key: 'text', label: 'Text Box', options: [{ value: 'hello', label: 'Hello' }] });
+    const c2 = new TextBoxControl({ type: 'percentage', key: 'percentage', label: 'Percent', required: true });
+    const c3 = new CheckboxControl({ key: 'checkbox', label: 'Check Me!', width: 100 });
+    const c4 = new TextBoxControl({ key: 'test4', label: 'TEST4' });
     this.controls.push(label);
     this.controls.push(c1);
     this.controls.push(c2);

--- a/projects/novo-examples/src/form-controls/form-groups/vertical/vertical-example.ts
+++ b/projects/novo-examples/src/form-controls/form-groups/vertical/vertical-example.ts
@@ -81,11 +81,11 @@ export class VerticalExample {
 
   private setupGroupedFormDemo() {
     this.formGroup = this.formUtils.emptyFormGroup();
-    let label = new ReadOnlyControl({ key: 'label', value: 'Label :)' });
-    let c1 = new SelectControl({ key: 'text', label: 'Text Box', options: [{ value: 'hello', label: 'Hello' }] });
-    let c2 = new TextBoxControl({ type: 'percentage', key: 'percentage', label: 'Percent', required: true });
-    let c3 = new CheckboxControl({ key: 'checkbox', label: 'Check Me!', width: 100 });
-    let c4 = new TextBoxControl({ key: 'test4', label: 'TEST4' });
+    const label = new ReadOnlyControl({ key: 'label', value: 'Label :)' });
+    const c1 = new SelectControl({ key: 'text', label: 'Text Box', options: [{ value: 'hello', label: 'Hello' }] });
+    const c2 = new TextBoxControl({ type: 'percentage', key: 'percentage', label: 'Percent', required: true });
+    const c3 = new CheckboxControl({ key: 'checkbox', label: 'Check Me!', width: 100 });
+    const c4 = new TextBoxControl({ key: 'test4', label: 'TEST4' });
     this.controls.push(label);
     this.controls.push(c1);
     this.controls.push(c2);

--- a/projects/novo-examples/src/form-controls/form/address-control/address-control-example.ts
+++ b/projects/novo-examples/src/form-controls/form/address-control/address-control-example.ts
@@ -125,7 +125,7 @@ export class AddressControlExample {
             },
             getLabels: (value: number) => {
               return new Promise((resolve: any) => {
-                let country: any = findByCountryId(value);
+                const country: any = findByCountryId(value);
                 if (country) {
                   resolve({ value: country.id, label: country.name });
                 } else {
@@ -164,7 +164,7 @@ export class AddressControlExample {
   }
 
   getStateLabel(value: number): string {
-    let state: any = this.states.find((s: any) => {
+    const state: any = this.states.find((s: any) => {
       return s.value === value;
     });
     if (state && state.label) {

--- a/projects/novo-examples/src/form-controls/form/disabled-form/disabled-form-example.ts
+++ b/projects/novo-examples/src/form-controls/form/disabled-form/disabled-form-example.ts
@@ -24,7 +24,7 @@ export class DisabledFormExample {
 
   constructor(private formUtils: FormUtils) {
     // Disabled Form
-    let disabledOverrides: any = {
+    const disabledOverrides: any = {
       address: {
         readOnly: true,
       },

--- a/projects/novo-examples/src/form-controls/form/file-input-controls/file-input-controls-example.ts
+++ b/projects/novo-examples/src/form-controls/form/file-input-controls/file-input-controls-example.ts
@@ -88,7 +88,7 @@ export class FileInputControlsExample {
 
   public checkFileSize(fileList): boolean {
     const maxSizeKb: number = 5120; // (5 MB in KB)
-    for (let file of fileList) {
+    for (const file of fileList) {
       if (file.size > maxSizeKb * 1024) {
         this.message = 'File is bigger than the allowed 5MB';
         return false;

--- a/projects/novo-examples/src/form-controls/form/picker-controls/picker-controls-example.ts
+++ b/projects/novo-examples/src/form-controls/form/picker-controls/picker-controls-example.ts
@@ -25,8 +25,8 @@ export class PickerControlsExample {
   public pickerForm: any;
 
   constructor(private formUtils: FormUtils) {
-    let fruits = ['Apples', 'Oranges', 'Bananas', 'Grapes'];
-    let cities = [
+    const fruits = ['Apples', 'Oranges', 'Bananas', 'Grapes'];
+    const cities = [
       {
         id: 1,
         name: 'Boston',
@@ -52,7 +52,7 @@ export class PickerControlsExample {
         name: 'Chicago',
       },
     ];
-    let states = [
+    const states = [
       {
         value: 'ME',
         label: 'Maine',
@@ -272,7 +272,7 @@ export class PickerControlsExample {
         },
       },
     });
-    let controls = [
+    const controls = [
       this.singlePickerControl,
       this.multiPickerControl,
       this.entityMultiPickerControl,

--- a/projects/novo-examples/src/form-controls/multi-picker/basic-multi-picker/basic-multi-picker-example.ts
+++ b/projects/novo-examples/src/form-controls/multi-picker/basic-multi-picker/basic-multi-picker-example.ts
@@ -16,7 +16,7 @@ export class BasicMultiPickerExample {
   staticDemo: any;
 
   constructor() {
-    let states = [
+    const states = [
       'Alabama',
       'Alaska',
       'Arizona',
@@ -68,7 +68,7 @@ export class BasicMultiPickerExample {
       'Wisconsin',
       'Wyoming',
     ];
-    let collaborators = [
+    const collaborators = [
       {
         id: 1,
         firstName: 'Brian',

--- a/projects/novo-examples/src/form-controls/multi-picker/nested-multi-picker/nested-multi-picker-example.ts
+++ b/projects/novo-examples/src/form-controls/multi-picker/nested-multi-picker/nested-multi-picker-example.ts
@@ -17,7 +17,7 @@ export class NestedMultiPickerExample {
   parentChildValue: any;
 
   constructor() {
-    let departments = [
+    const departments = [
       {
         id: 1,
         name: 'Sales',
@@ -39,7 +39,7 @@ export class NestedMultiPickerExample {
         name: 'Nobody Works Here',
       },
     ];
-    let users = [
+    const users = [
       {
         id: 1,
         departments: [1, 2, 4],

--- a/projects/novo-examples/src/form-controls/picker/async-picker/async-picker-example.ts
+++ b/projects/novo-examples/src/form-controls/picker/async-picker/async-picker-example.ts
@@ -20,7 +20,7 @@ export class AsyncPickerExample {
       options: (term, page) => {
         return new Promise((resolve) => {
           setTimeout(() => {
-            let arr = [];
+            const arr = [];
             for (let i = 0; i < 20; i++) {
               arr.push({ value: `Page: ${page} - Item: ${i + 1}`, label: `Page: ${page} - Item: ${i + 1}` });
             }

--- a/projects/novo-examples/src/form-controls/picker/custom-picker-results/custom-picker-results-example.ts
+++ b/projects/novo-examples/src/form-controls/picker/custom-picker-results/custom-picker-results-example.ts
@@ -39,7 +39,7 @@ export class CustomPickerResultsExample {
   public value: string;
 
   constructor() {
-    let collaborators = [
+    const collaborators = [
       {
         id: 1,
         firstName: 'Brian',

--- a/projects/novo-examples/src/form-controls/picker/default-options-picker/default-options-picker-example.ts
+++ b/projects/novo-examples/src/form-controls/picker/default-options-picker/default-options-picker-example.ts
@@ -17,7 +17,7 @@ export class DefaultOptionsPickerExample {
   public value: string;
 
   constructor() {
-    let states = [
+    const states = [
       'Alabama',
       'Alaska',
       'Arizona',

--- a/projects/novo-examples/src/form-controls/picker/entity-picker/entity-picker-example.ts
+++ b/projects/novo-examples/src/form-controls/picker/entity-picker/entity-picker-example.ts
@@ -14,7 +14,7 @@ export class EntityPickerExample {
   public entity: any;
 
   constructor() {
-    let collaborators = [
+    const collaborators = [
       {
         id: 1,
         firstName: 'Brian',

--- a/projects/novo-examples/src/form-controls/picker/formatted-picker/formatted-picker-example.ts
+++ b/projects/novo-examples/src/form-controls/picker/formatted-picker/formatted-picker-example.ts
@@ -14,7 +14,7 @@ export class FormattedPickerExample {
   public value: string;
 
   constructor() {
-    let collaborators = [
+    const collaborators = [
       {
         id: 1,
         firstName: 'Brian',

--- a/projects/novo-examples/src/form-controls/picker/grouped-picker/grouped-picker-example.ts
+++ b/projects/novo-examples/src/form-controls/picker/grouped-picker/grouped-picker-example.ts
@@ -25,30 +25,30 @@ export class GroupedPickerExample {
   }
 
   setupGroupedPickerDemo() {
-    let categoryMap = new Map<string, { value: string; label: string; items: { value: string; label: string }[] }>();
+    const categoryMap = new Map<string, { value: string; label: string; items: { value: string; label: string }[] }>();
     for (let i = 0; i < 10; i++) {
-      let items = [];
+      const items = [];
       for (let j = 0; j < 10; j++) {
         items.push({ value: `${i}-${j}`, label: `Category ${i} - Item ${j}` });
       }
-      categoryMap.set(`${i}`, { value: `${i}`, label: `Category ${i}`, items: items });
+      categoryMap.set(`${i}`, { value: `${i}`, label: `Category ${i}`, items });
     }
-    let filterCategoryMap = new Map<string, { value: string; label: string; items: { value: string; label: string; data: any }[] }>();
+    const filterCategoryMap = new Map<string, { value: string; label: string; items: { value: string; label: string; data: any }[] }>();
     for (let i = 0; i < 10; i++) {
-      let items = [];
+      const items = [];
       for (let j = 0; j < 10; j++) {
-        let filter = Math.random() >= 0.5;
-        items.push({ value: `${i}-${j}`, label: `Category ${i} - Item ${j} - Data - ${filter}`, data: { filter: filter } });
+        const filter = Math.random() >= 0.5;
+        items.push({ value: `${i}-${j}`, label: `Category ${i} - Item ${j} - Data - ${filter}`, data: { filter } });
       }
-      filterCategoryMap.set(`${i}`, { value: `${i}`, label: `Category ${i}`, items: items });
+      filterCategoryMap.set(`${i}`, { value: `${i}`, label: `Category ${i}`, items });
     }
     this.groupedPicker1 = {
-      categoryMap: categoryMap,
+      categoryMap,
       resultsTemplate: GroupedMultiPickerResults,
       displayAll: true,
     };
     this.groupedPicker2 = {
-      categoryMap: categoryMap,
+      categoryMap,
       resultsTemplate: GroupedMultiPickerResults,
     };
     this.groupedPicker3 = {

--- a/projects/novo-examples/src/form-controls/picker/override-template/override-template-example.ts
+++ b/projects/novo-examples/src/form-controls/picker/override-template/override-template-example.ts
@@ -14,7 +14,7 @@ export class OverrideTemplateExample {
   public overrideDemo: any;
 
   constructor() {
-    let states = [
+    const states = [
       'Alabama',
       'Alaska',
       'Arizona',

--- a/projects/novo-examples/src/layouts/list/basic-list/basic-list-example.ts
+++ b/projects/novo-examples/src/layouts/list/basic-list/basic-list-example.ts
@@ -12,15 +12,15 @@ export class BasicListExample {
   public pulseItems: any;
 
   constructor() {
-    let ONE_HOUR = 60 * 60 * 1000;
+    const ONE_HOUR = 60 * 60 * 1000;
     /* ms */
-    let TWO_HOURS = ONE_HOUR * 2;
-    let THREE_HOURS = ONE_HOUR * 3;
-    let currentDate = new Date();
+    const TWO_HOURS = ONE_HOUR * 2;
+    const THREE_HOURS = ONE_HOUR * 3;
+    const currentDate = new Date();
 
-    let oneHourAgo = currentDate.getTime() - ONE_HOUR;
-    let twoHoursAgo = currentDate.getTime() - TWO_HOURS;
-    let threeHoursAgo = currentDate.getTime() - THREE_HOURS;
+    const oneHourAgo = currentDate.getTime() - ONE_HOUR;
+    const twoHoursAgo = currentDate.getTime() - TWO_HOURS;
+    const threeHoursAgo = currentDate.getTime() - THREE_HOURS;
 
     /* "mockResponse[]" should represent a REST response with improperly formatted data.
     /  The "buildItems()" function is taking this data object and massaging it
@@ -29,7 +29,7 @@ export class BasicListExample {
     /  - @asibilia
     */
 
-    let mockResponse = [
+    const mockResponse = [
       {
         type: 'opportunity',
         dateCreated: oneHourAgo,
@@ -83,8 +83,8 @@ export class BasicListExample {
   }
 
   buildItems(resp) {
-    for (let obj of resp) {
-      let item: any = {};
+    for (const obj of resp) {
+      const item: any = {};
 
       /*
       ||| This is the item structure to be pushed to pulseItems[] and used

--- a/projects/novo-examples/src/layouts/list/themed-list/themed-list-example.ts
+++ b/projects/novo-examples/src/layouts/list/themed-list/themed-list-example.ts
@@ -12,15 +12,15 @@ export class ThemedListExample {
   public pulseItems: any;
 
   constructor() {
-    let ONE_HOUR = 60 * 60 * 1000;
+    const ONE_HOUR = 60 * 60 * 1000;
     /* ms */
-    let TWO_HOURS = ONE_HOUR * 2;
-    let THREE_HOURS = ONE_HOUR * 3;
-    let currentDate = new Date();
+    const TWO_HOURS = ONE_HOUR * 2;
+    const THREE_HOURS = ONE_HOUR * 3;
+    const currentDate = new Date();
 
-    let oneHourAgo = currentDate.getTime() - ONE_HOUR;
-    let twoHoursAgo = currentDate.getTime() - TWO_HOURS;
-    let threeHoursAgo = currentDate.getTime() - THREE_HOURS;
+    const oneHourAgo = currentDate.getTime() - ONE_HOUR;
+    const twoHoursAgo = currentDate.getTime() - TWO_HOURS;
+    const threeHoursAgo = currentDate.getTime() - THREE_HOURS;
 
     /* "mockResponse[]" should represent a REST response with improperly formatted data.
     /  The "buildItems()" function is taking this data object and massaging it
@@ -29,7 +29,7 @@ export class ThemedListExample {
     /  - @asibilia
     */
 
-    let mockResponse = [
+    const mockResponse = [
       {
         type: 'opportunity',
         dateCreated: oneHourAgo,
@@ -83,8 +83,8 @@ export class ThemedListExample {
   }
 
   buildItems(resp) {
-    for (let obj of resp) {
-      let item: any = {};
+    for (const obj of resp) {
+      const item: any = {};
 
       /*
       ||| This is the item structure to be pushed to pulseItems[] and used

--- a/projects/novo-examples/src/patterns/activity-section/activity-section-example.ts
+++ b/projects/novo-examples/src/patterns/activity-section/activity-section-example.ts
@@ -14,7 +14,7 @@ export class ActivitySectionExample {
   public details: any;
 
   constructor() {
-    let columns = [
+    const columns = [
       { title: 'Name', name: 'name', ordering: true, type: 'link', filtering: true },
       { title: 'Position', name: 'position', ordering: true, filtering: true },
       {
@@ -25,7 +25,7 @@ export class ActivitySectionExample {
           return object.ext.obj;
         },
         compare: (sort, previous, current) => {
-          let first = previous.obj,
+          const first = previous.obj,
             second = current.obj;
 
           if (first > second) {

--- a/projects/novo-examples/src/utils/field-interactions/fi-adding-removing/fi-adding-removing-example.ts
+++ b/projects/novo-examples/src/utils/field-interactions/fi-adding-removing/fi-adding-removing-example.ts
@@ -16,7 +16,7 @@ export class FiAddingRemovingExample {
   public controls: any = [];
 
   constructor(private formUtils: FormUtils) {
-    let addingRemovingFunction = (API: FieldInteractionApi) => {
+    const addingRemovingFunction = (API: FieldInteractionApi) => {
       console.log('[FieldInteractionDemo] - addingRemovingFunction'); // tslint:disable-line
       // Control above field
       API.addControl(
@@ -66,10 +66,10 @@ export class FiAddingRemovingExample {
       API.removeControl('jersey-color');
     };
 
-    let removeAddOnChangeFunction = (API: FieldInteractionApi) => {
+    const removeAddOnChangeFunction = (API: FieldInteractionApi) => {
       console.log('[FieldInteractionDemo] - removeAddOnChangeFunction'); // tslint:disable-line
       // Select control with a field interaction on change event
-      let currentValue = API.getActiveValue();
+      const currentValue = API.getActiveValue();
       if (currentValue === 'Yes') {
         API.removeControl('to-be-removed');
       } else {

--- a/projects/novo-examples/src/utils/field-interactions/fi-async/fi-async-example.ts
+++ b/projects/novo-examples/src/utils/field-interactions/fi-async/fi-async-example.ts
@@ -16,7 +16,7 @@ export class FiAsyncExample {
   public controls: any = {};
 
   constructor(private formUtils: FormUtils) {
-    let asyncFunction = (API: FieldInteractionApi) => {
+    const asyncFunction = (API: FieldInteractionApi) => {
       console.log('[FieldInteractionDemo] - asyncFunction'); // tslint:disable-line
       if (API.getActiveKey() === 'async1') {
         API.setLoading(API.getActiveKey(), true);

--- a/projects/novo-examples/src/utils/field-interactions/fi-calculation/fi-calculation-example.ts
+++ b/projects/novo-examples/src/utils/field-interactions/fi-calculation/fi-calculation-example.ts
@@ -16,10 +16,10 @@ export class FiCalculationExample {
   public snippet: any = {};
 
   constructor(private formUtils: FormUtils) {
-    let calculationFunction = (API: FieldInteractionApi) => {
+    const calculationFunction = (API: FieldInteractionApi) => {
       console.log('[FieldInteractionDemo] - calculationFunction'); // tslint:disable-line
-      let a = Number(API.getValue('a'));
-      let b = Number(API.getValue('b'));
+      const a = Number(API.getValue('a'));
+      const b = Number(API.getValue('b'));
       API.setValue('sum', a + b);
       API.setValue('date', new Date());
     };

--- a/projects/novo-examples/src/utils/field-interactions/fi-confirm/fi-confirm-example.ts
+++ b/projects/novo-examples/src/utils/field-interactions/fi-confirm/fi-confirm-example.ts
@@ -15,7 +15,7 @@ export class FiConfirmExample {
   public controls: any = {};
 
   constructor(private formUtils: FormUtils) {
-    let confirmFunction = (API: FieldInteractionApi) => {
+    const confirmFunction = (API: FieldInteractionApi) => {
       console.log('[FieldInteractionDemo] - confirmFunction'); // tslint:disable-line
       if (API.getActiveKey() === 'confirm1') {
         API.confirmChanges(API.getActiveKey());

--- a/projects/novo-examples/src/utils/field-interactions/fi-enable-disable/fi-enable-disable-example.ts
+++ b/projects/novo-examples/src/utils/field-interactions/fi-enable-disable/fi-enable-disable-example.ts
@@ -15,9 +15,9 @@ export class FiEnableDisableExample {
   public controls: any = {};
 
   constructor(private formUtils: FormUtils) {
-    let enableDisableFunction = (API: FieldInteractionApi) => {
+    const enableDisableFunction = (API: FieldInteractionApi) => {
       console.log('[FieldInteractionDemo] - enableDisableFunction'); // tslint:disable-line
-      let currentValue = API.getActiveValue();
+      const currentValue = API.getActiveValue();
       if (!currentValue) {
         API.enable('text');
       } else {

--- a/projects/novo-examples/src/utils/field-interactions/fi-globals/fi-globals-example.ts
+++ b/projects/novo-examples/src/utils/field-interactions/fi-globals/fi-globals-example.ts
@@ -15,7 +15,7 @@ export class FiGlobalsExample {
   public controls: any = {};
 
   constructor(private formUtils: FormUtils) {
-    let globalsFunction = (API: FieldInteractionApi) => {
+    const globalsFunction = (API: FieldInteractionApi) => {
       console.log('[FieldInteractionDemo] - globalsFunction'); // tslint:disable-line
       API.setProperty(API.getActiveKey(), 'label', `${API.getProperty(API.getActiveKey(), 'label')} -- ${API.globals.TEST}`);
     };

--- a/projects/novo-examples/src/utils/field-interactions/fi-hide-show/fi-hide-show-example.ts
+++ b/projects/novo-examples/src/utils/field-interactions/fi-hide-show/fi-hide-show-example.ts
@@ -15,9 +15,9 @@ export class FiHideShowExample {
   public controls: any = {};
 
   constructor(private formUtils: FormUtils) {
-    let hideShowFunction = (API: FieldInteractionApi) => {
+    const hideShowFunction = (API: FieldInteractionApi) => {
       console.log('[FieldInteractionDemo] - hideShowFunction'); // tslint:disable-line
-      let activeValue = API.getActiveValue();
+      const activeValue = API.getActiveValue();
       if (!activeValue) {
         API.show('text');
       } else {

--- a/projects/novo-examples/src/utils/field-interactions/fi-messaging/fi-messaging-example.ts
+++ b/projects/novo-examples/src/utils/field-interactions/fi-messaging/fi-messaging-example.ts
@@ -27,7 +27,7 @@ export class FiMessagingExample {
   public controls: any = {};
 
   constructor(private formUtils: FormUtils) {
-    let messagingFunction = (API: FieldInteractionApi) => {
+    const messagingFunction = (API: FieldInteractionApi) => {
       console.log('[FieldInteractionDemo] - messagingFunction'); // tslint:disable-line
       if (API.getActiveKey() === 'toast') {
         API.displayToast({

--- a/projects/novo-examples/src/utils/field-interactions/fi-modify-options/fi-modify-options-example.ts
+++ b/projects/novo-examples/src/utils/field-interactions/fi-modify-options/fi-modify-options-example.ts
@@ -16,9 +16,9 @@ export class FiModifyOptionsExample {
   public controls: any = {};
 
   constructor(private formUtils: FormUtils) {
-    let modifyOptionsAddFunction = (API: FieldInteractionApi) => {
+    const modifyOptionsAddFunction = (API: FieldInteractionApi) => {
       console.log('[FieldInteractionDemo] - modifyOptionsAddFunction'); // tslint:disable-line
-      let currentValue = API.getActiveValue();
+      const currentValue = API.getActiveValue();
       if (!currentValue) {
         API.removeStaticOption('select', 'NEW');
         API.removeStaticOption('picker', 'NEW');
@@ -28,9 +28,9 @@ export class FiModifyOptionsExample {
         API.addStaticOption('picker', 'NEW');
       }
     };
-    let modifyOptionsAsyncFunction = (API: FieldInteractionApi) => {
+    const modifyOptionsAsyncFunction = (API: FieldInteractionApi) => {
       console.log('[FieldInteractionDemo] - modifyOptionsAsyncFunction'); // tslint:disable-line
-      let currentValue = API.getActiveValue();
+      const currentValue = API.getActiveValue();
       switch (currentValue) {
         case 1:
           // Static
@@ -76,7 +76,7 @@ export class FiModifyOptionsExample {
           API.setProperty('picker', 'label', 'Async Picker (with options promise)');
           API.modifyPickerConfig('picker', {
             format: '$name $test',
-            optionsPromise: function(query, http) {
+            optionsPromise(query, http) {
               return new Promise(function(resolve, reject) {
                 if (query && query.length) {
                   http

--- a/projects/novo-examples/src/utils/field-interactions/fi-required/fi-required-example.ts
+++ b/projects/novo-examples/src/utils/field-interactions/fi-required/fi-required-example.ts
@@ -15,9 +15,9 @@ export class FiRequiredExample {
   public controls: any = {};
 
   constructor(formUtils: FormUtils) {
-    let requiredFunction = (API: FieldInteractionApi) => {
+    const requiredFunction = (API: FieldInteractionApi) => {
       console.log('[FieldInteractionDemo] - requiredFunction'); // tslint:disable-line
-      let activeValue = API.getActiveValue();
+      const activeValue = API.getActiveValue();
       if (activeValue) {
         API.setRequired('required', true);
       } else {

--- a/projects/novo-examples/src/utils/field-interactions/fi-tooltip/fi-tooltip-example.ts
+++ b/projects/novo-examples/src/utils/field-interactions/fi-tooltip/fi-tooltip-example.ts
@@ -15,12 +15,12 @@ export class FiTooltipExample {
   public controls: any = {};
 
   constructor(private formUtils: FormUtils) {
-    let tooltipFunction = (API: FieldInteractionApi) => {
+    const tooltipFunction = (API: FieldInteractionApi) => {
       console.log('[FieldInteractionDemo] - tooltipFunction'); // tslint:disable-line
       API.setTooltip(API.getActiveKey(), API.getActiveValue());
     };
 
-    let tooltipUpdateFunction = (API: FieldInteractionApi) => {
+    const tooltipUpdateFunction = (API: FieldInteractionApi) => {
       console.log('[FieldInteractionDemo] - tooltipUpdateFunction'); // tslint:disable-line
       API.getControl(this.controls.tooltipControl.key).tooltipSize = API.getValue(this.controls.tooltipSizeControl.key);
       API.getControl(this.controls.tooltipControl.key).tooltipPreline = API.getValue(this.controls.tooltipPrelineControl.key);

--- a/projects/novo-examples/src/utils/field-interactions/fi-validation/fi-validation-example.ts
+++ b/projects/novo-examples/src/utils/field-interactions/fi-validation/fi-validation-example.ts
@@ -15,9 +15,9 @@ export class FiValidationExample {
   public controls: any = {};
 
   constructor(private formUtils: FormUtils) {
-    let validationFunction = (API: FieldInteractionApi) => {
+    const validationFunction = (API: FieldInteractionApi) => {
       console.log('[FieldInteractionDemo] - validationFunction'); // tslint:disable-line
-      let activeValue = API.getActiveValue();
+      const activeValue = API.getActiveValue();
       if (activeValue > 10) {
         API.markAsInvalid(API.getActiveKey(), 'Too high! Make it a lot lower!!');
       }

--- a/projects/novo-examples/src/utils/security/security/security-example.ts
+++ b/projects/novo-examples/src/utils/security/security/security-example.ts
@@ -15,7 +15,7 @@ export class SecurityExample {
   constructor(private security: Security) {}
 
   shufflePermissions(): void {
-    let numOfPerms: number = Math.floor(Math.random() * 2) + 1;
+    const numOfPerms: number = Math.floor(Math.random() * 2) + 1;
     this.perms = this.shuffle(['A', 'B', 'C']).slice(0, numOfPerms);
     this.security.clear();
     this.security.grant(this.perms);

--- a/tools/convert-example.ts
+++ b/tools/convert-example.ts
@@ -10,8 +10,8 @@ const examplesPath = path.join('./projects/', 'novo-examples/src');
  * Builds the template for the examples module
  */
 function generateTSTemplate(selector: string): string {
-  let description = convertToSentence(selector);
-  let name = convertToCamelCase(selector);
+  const description = convertToSentence(selector);
+  const name = convertToCamelCase(selector);
   return `
 import {Component} from '@angular/core';
 
@@ -93,36 +93,36 @@ function convertToSentence(name: string): string {
  * Creates the examples files
  */
 const task = () => {
-  let example = process.argv[2];
+  const example = process.argv[2];
   console.log(example);
 
   const matchedFiles = glob(path.join(srcPath, example, 'templates/**/*.html'));
 
-  let dir = path.join(examplesPath, example);
+  const dir = path.join(examplesPath, example);
   fs.mkdirSync(dir);
 
   const mdTmp = generateMDTemplate(example);
-  let mdOutputFile = path.join(dir, `${example}.md`);
+  const mdOutputFile = path.join(dir, `${example}.md`);
   fs.writeFileSync(mdOutputFile, mdTmp);
 
   for (const sourcePath of matchedFiles) {
     console.log('source', sourcePath);
-    let fileName = path.basename(sourcePath, '.html');
-    let name = convertToDashCase(fileName.replace('Demo', ''));
-    let exdir = path.join(dir, `${name}`);
+    const fileName = path.basename(sourcePath, '.html');
+    const name = convertToDashCase(fileName.replace('Demo', ''));
+    const exdir = path.join(dir, `${name}`);
     fs.mkdirSync(exdir);
 
-    let selector = `${name}-example`;
-    let tsTmp = generateTSTemplate(selector);
-    let tsOutputFile = path.join(exdir, `${selector}.ts`);
+    const selector = `${name}-example`;
+    const tsTmp = generateTSTemplate(selector);
+    const tsOutputFile = path.join(exdir, `${selector}.ts`);
     fs.writeFileSync(tsOutputFile, tsTmp);
 
-    let cssTmp = generateCSSTemplate(selector);
-    let cssOutputFile = path.join(exdir, `${selector}.css`);
+    const cssTmp = generateCSSTemplate(selector);
+    const cssOutputFile = path.join(exdir, `${selector}.css`);
     fs.writeFileSync(cssOutputFile, cssTmp);
 
-    let htmlTmp = fs.readFileSync(sourcePath, 'utf-8');
-    let htmlOutputFile = path.join(exdir, `${selector}.html`);
+    const htmlTmp = fs.readFileSync(sourcePath, 'utf-8');
+    const htmlOutputFile = path.join(exdir, `${selector}.html`);
     fs.writeFileSync(htmlOutputFile, htmlTmp);
   }
 };

--- a/tools/create-example.ts
+++ b/tools/create-example.ts
@@ -8,8 +8,8 @@ const examplesPath = path.join('./projects/', 'examples');
  * Builds the template for the examples module
  */
 function generateTSTemplate(selector: string): string {
-  let description = convertToSentence(selector);
-  let name = convertToCamelCase(selector);
+  const description = convertToSentence(selector);
+  const name = convertToCamelCase(selector);
   return `
 import {Component} from '@angular/core';
 
@@ -81,22 +81,22 @@ function convertToSentence(name: string): string {
  * Creates the examples files
  */
 const task = () => {
-  let section = process.argv[2];
-  let example = process.argv[3];
-  let selector = `${example}-example`;
-  let dir = path.join(examplesPath, section, example);
+  const section = process.argv[2];
+  const example = process.argv[3];
+  const selector = `${example}-example`;
+  const dir = path.join(examplesPath, section, example);
   fs.mkdirSync(dir);
 
   const tsTmp = generateTSTemplate(selector);
-  let tsOutputFile = path.join(dir, `${selector}.ts`);
+  const tsOutputFile = path.join(dir, `${selector}.ts`);
   fs.writeFileSync(tsOutputFile, tsTmp);
 
   const cssTmp = generateCSSTemplate(selector);
-  let cssOutputFile = path.join(dir, `${selector}.css`);
+  const cssOutputFile = path.join(dir, `${selector}.css`);
   fs.writeFileSync(cssOutputFile, cssTmp);
 
   const htmlTmp = generateHTMLTemplate(selector);
-  let htmlOutputFile = path.join(dir, `${selector}.html`);
+  const htmlOutputFile = path.join(dir, `${selector}.html`);
   fs.writeFileSync(htmlOutputFile, htmlTmp);
 };
 


### PR DESCRIPTION
## **Description**

There is NO manual refactor in this PR.

I just used:
`npx tslint --fix -c ./my-tslint.json './**/*.ts' -e './node_modules/**/*'`

With my-tslint.json:
```
{
  "rules": {
    "prefer-const": true,
    "object-literal-shorthand": true
  }
}
```

These 2 rules are present by default in a newly created Angular app (`ng new my-app` for example)


#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**