### PR TITLE
Half null date time

### DIFF
--- a/projects/novo-elements/src/elements/date-time-picker/DateTimePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-time-picker/DateTimePickerInput.ts
@@ -109,8 +109,7 @@ export class NovoDateTimePickerInputElement implements ControlValueAccessor {
           ),
         );
       } else if (this.datePart instanceof Date) {
-        this.timePart.setHours(12);
-        this.timePart.setMinutes(0);
+        this.timePart = new Date(this.datePart.getFullYear(), this.datePart.getMonth(), this.datePart.getDate(), 12, 0);
         this.dispatchOnChange(
           new Date(
             this.datePart.getFullYear(),

--- a/projects/novo-elements/src/elements/date-time-picker/DateTimePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-time-picker/DateTimePickerInput.ts
@@ -109,7 +109,17 @@ export class NovoDateTimePickerInputElement implements ControlValueAccessor {
           ),
         );
       } else if (this.datePart instanceof Date) {
-        this.dispatchOnChange(new Date(this.datePart.getFullYear(), this.datePart.getMonth(), this.datePart.getDate(), 12, 0));
+        this.timePart.setHours(12);
+        this.timePart.setMinutes(0);
+        this.dispatchOnChange(
+          new Date(
+            this.datePart.getFullYear(),
+            this.datePart.getMonth(),
+            this.datePart.getDate(),
+            this.timePart.getHours(),
+            this.timePart.getMinutes(),
+          ),
+        );
       } else {
         this.dispatchOnChange(null);
       }

--- a/projects/novo-elements/src/elements/date-time-picker/DateTimePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-time-picker/DateTimePickerInput.ts
@@ -20,8 +20,24 @@ const DATE_VALUE_ACCESSOR = {
   selector: 'novo-date-time-picker-input',
   providers: [DATE_VALUE_ACCESSOR],
   template: `
-        <novo-date-picker-input [ngModel]="datePart" (ngModelChange)="updateDate($event)" [start]="start" [end]="end" [maskOptions]="maskOptions" (blurEvent)="handleBlur($event)" (focusEvent)="handleFocus($event)" [disabled]="disabled"></novo-date-picker-input>
-        <novo-time-picker-input [ngModel]="timePart" (ngModelChange)="updateTime($event)" [military]="military" (blurEvent)="handleBlur($event)" (focusEvent)="handleFocus($event)" [disabled]="disabled"></novo-time-picker-input>
+    <novo-date-picker-input
+      [ngModel]="datePart"
+      (ngModelChange)="updateDate($event)"
+      [start]="start"
+      [end]="end"
+      [maskOptions]="maskOptions"
+      (blurEvent)="handleBlur($event)"
+      (focusEvent)="handleFocus($event)"
+      [disabled]="disabled"
+    ></novo-date-picker-input>
+    <novo-time-picker-input
+      [ngModel]="timePart"
+      (ngModelChange)="updateTime($event)"
+      [military]="military"
+      (blurEvent)="handleBlur($event)"
+      (focusEvent)="handleFocus($event)"
+      [disabled]="disabled"
+    ></novo-time-picker-input>
   `,
 })
 export class NovoDateTimePickerInputElement implements ControlValueAccessor {
@@ -83,14 +99,17 @@ export class NovoDateTimePickerInputElement implements ControlValueAccessor {
   checkParts() {
     try {
       if (this.datePart instanceof Date && this.timePart instanceof Date) {
-        const newDt = new Date(
-          this.datePart.getFullYear(),
-          this.datePart.getMonth(),
-          this.datePart.getDate(),
-          this.timePart.getHours(),
-          this.timePart.getMinutes(),
+        this.dispatchOnChange(
+          new Date(
+            this.datePart.getFullYear(),
+            this.datePart.getMonth(),
+            this.datePart.getDate(),
+            this.timePart.getHours(),
+            this.timePart.getMinutes(),
+          ),
         );
-        this.dispatchOnChange(newDt);
+      } else if (this.datePart instanceof Date) {
+        this.dispatchOnChange(new Date(this.datePart.getFullYear(), this.datePart.getMonth(), this.datePart.getDate(), 12, 0));
       } else {
         this.dispatchOnChange(null);
       }


### PR DESCRIPTION
## **Description**

This allows datetime pickers to have their values persisted when only the date portion of the field has been filled out. The time part will default to 12pm whenever a date is selected and the time is null.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**