### PR TITLE
Date Control Week Start Day

### DIFF
--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -37,7 +37,7 @@ const DATE_VALUE_ACCESSOR = {
         <i *ngIf="!hasValue" (click)="openPanel()" class="bhi-calendar"></i>
         <i *ngIf="hasValue" (click)="clearValue()" class="bhi-times"></i>
         <novo-overlay-template [parent]="element" position="above-below">
-            <novo-date-picker [start]="start" [end]="end" inline="true" (onSelect)="setValueAndClose($event)" [ngModel]="value"></novo-date-picker>
+            <novo-date-picker [start]="start" [end]="end" inline="true" (onSelect)="setValueAndClose($event)" [ngModel]="value" [weekStart]="weekStart"></novo-date-picker>
         </novo-overlay-template>
   `,
 })
@@ -71,6 +71,8 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
   @HostBinding('class.disabled')
   @Input()
   disabled: boolean = false;
+  @Input()
+  weekStart: number = 0;
   @Output()
   blurEvent: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
   @Output()

--- a/projects/novo-elements/src/elements/date-time-picker/DateTimePicker.ts
+++ b/projects/novo-elements/src/elements/date-time-picker/DateTimePicker.ts
@@ -112,6 +112,7 @@ const DATE_TIME_PICKER_VALUE_ACCESSOR = {
             [maxYear]="maxYear"
             [start]="start"
             [end]="end"
+            [weekStart]="weekStart"
           ></novo-date-picker>
         </div>
         <div class="time-picker">
@@ -132,6 +133,8 @@ export class NovoDateTimePickerElement implements ControlValueAccessor {
   end: any;
   @Input()
   military: any;
+  @Input()
+  weekStart: number = 0;
 
   // Select callback for output
   @Output()

--- a/projects/novo-elements/src/elements/date-time-picker/DateTimePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-time-picker/DateTimePickerInput.ts
@@ -20,7 +20,7 @@ const DATE_VALUE_ACCESSOR = {
   selector: 'novo-date-time-picker-input',
   providers: [DATE_VALUE_ACCESSOR],
   template: `
-        <novo-date-picker-input [ngModel]="datePart" (ngModelChange)="updateDate($event)" [start]="start" [end]="end" [maskOptions]="maskOptions" (blurEvent)="handleBlur($event)" (focusEvent)="handleFocus($event)" [disabled]="disabled"></novo-date-picker-input>
+        <novo-date-picker-input [ngModel]="datePart" (ngModelChange)="updateDate($event)" [start]="start" [end]="end" [maskOptions]="maskOptions" (blurEvent)="handleBlur($event)" (focusEvent)="handleFocus($event)" [disabled]="disabled" [weekStart]="weekStart"></novo-date-picker-input>
         <novo-time-picker-input [ngModel]="timePart" (ngModelChange)="updateTime($event)" [military]="military" (blurEvent)="handleBlur($event)" (focusEvent)="handleFocus($event)" [disabled]="disabled"></novo-time-picker-input>
   `,
 })
@@ -51,6 +51,8 @@ export class NovoDateTimePickerInputElement implements ControlValueAccessor {
   disabled: boolean = false;
   @Input()
   format: string;
+  @Input()
+  weekStart: number = 0;
   @Output()
   blurEvent: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
   @Output()

--- a/projects/novo-elements/src/elements/form/ControlTemplates.ts
+++ b/projects/novo-elements/src/elements/form/ControlTemplates.ts
@@ -100,7 +100,7 @@ import { NovoTemplateService } from '../../services/template/NovoTemplateService
         <!--Date-->
         <ng-template novoTemplate="date" let-control let-form="form" let-errors="errors" let-methods="methods">
           <div [formGroup]="form" class="novo-control-input-container" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" [tooltipAutoPosition]="control?.tooltipAutoPosition">
-            <novo-date-picker-input [attr.id]="control.key" [name]="control.key" [formControlName]="control.key" [start]="control.startDate" [end]="control.endDate" [format]="control.dateFormat" [allowInvalidDate]="control.allowInvalidDate" [textMaskEnabled]="control.textMaskEnabled" [placeholder]="control.placeholder" (focusEvent)="methods.handleFocus($event)" (blurEvent)="methods.handleBlur($event)"></novo-date-picker-input>
+            <novo-date-picker-input [attr.id]="control.key" [name]="control.key" [formControlName]="control.key" [start]="control.startDate" [end]="control.endDate" [format]="control.dateFormat" [allowInvalidDate]="control.allowInvalidDate" [textMaskEnabled]="control.textMaskEnabled" [placeholder]="control.placeholder" [weekStart]="control.weekStart" (focusEvent)="methods.handleFocus($event)" (blurEvent)="methods.handleBlur($event)"></novo-date-picker-input>
           </div>
         </ng-template>
 
@@ -108,7 +108,7 @@ import { NovoTemplateService } from '../../services/template/NovoTemplateService
         <!--Date and Time-->
         <ng-template novoTemplate="date-time" let-control let-form="form" let-errors="errors" let-methods="methods">
           <div [formGroup]="form" class="novo-control-input-container" [tooltip]="control.tooltip" [tooltipPosition]="control.tooltipPosition" [tooltipSize]="control?.tooltipSize" [tooltipPreline]="control?.tooltipPreline" [removeTooltipArrow]="control?.removeTooltipArrow" [tooltipAutoPosition]="control?.tooltipAutoPosition">
-            <novo-date-time-picker-input [attr.id]="control.key" [name]="control.key" [formControlName]="control.key" [start]="control.startDate" [end]="control.endDate" [placeholder]="control.placeholder" [military]="control.military" (focusEvent)="methods.handleFocus($event)" (blurEvent)="methods.handleBlur($event)"></novo-date-time-picker-input>
+            <novo-date-time-picker-input [attr.id]="control.key" [name]="control.key" [formControlName]="control.key" [start]="control.startDate" [end]="control.endDate" [placeholder]="control.placeholder" [military]="control.military" [weekStart]="control.weekStart" (focusEvent)="methods.handleFocus($event)" (blurEvent)="methods.handleBlur($event)"></novo-date-time-picker-input>
           </div>
         </ng-template>
 

--- a/projects/novo-elements/src/elements/form/NovoFormControl.ts
+++ b/projects/novo-elements/src/elements/form/NovoFormControl.ts
@@ -49,6 +49,7 @@ export class NovoFormControl extends FormControl {
   currencyFormat?: string;
   startDate?: Date | Number;
   endDate?: Date | Number;
+  weekStart?: number;
   textMaskEnabled?: boolean;
   maskOptions: IMaskOptions;
   allowInvalidDate?: boolean;
@@ -103,6 +104,7 @@ export class NovoFormControl extends FormControl {
     this.currencyFormat = control.currencyFormat;
     this.startDate = control.startDate;
     this.endDate = control.endDate;
+    this.weekStart = control.weekStart;
     this.textMaskEnabled = control.textMaskEnabled;
     this.textMaskEnabled = control.textMaskEnabled;
     this.maskOptions = control.maskOptions;

--- a/projects/novo-elements/src/elements/form/controls/BaseControl.ts
+++ b/projects/novo-elements/src/elements/form/controls/BaseControl.ts
@@ -95,6 +95,7 @@ class ControlConfig {
   };
   isEmbedded = false;
   isInlineEmbedded = false;
+  weekStart?: number;
 }
 
 export type NovoControlConfig = Partial<ControlConfig>;
@@ -187,5 +188,6 @@ export class BaseControl extends ControlConfig {
     if (config.isEmpty) {
       this.isEmpty = config.isEmpty;
     }
+    this.weekStart = config.weekStart || 0;
   }
 }

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -474,7 +474,7 @@ export class FormUtils {
     meta,
     currencyFormat,
     http,
-    config: { token?: string; restUrl?: string; military?: boolean },
+    config: { token?: string; restUrl?: string; military?: boolean, weekStart?: number },
     overrides?: any,
     forTable: boolean = false,
   ) {

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -224,7 +224,7 @@ export class FormUtils {
   getControlForField(
     field: any,
     http,
-    config: { token?: string; restUrl?: string; military?: boolean },
+    config: { token?: string; restUrl?: string; military?: boolean, weekStart?: number },
     overrides?: any,
     forTable: boolean = false,
     fieldData?: any,
@@ -342,6 +342,7 @@ export class FormUtils {
         break;
       case 'datetime':
         controlConfig.military = config ? !!config.military : false;
+        controlConfig.weekStart = config && config.weekStart ? config.weekStart : 0;
         control = new DateTimeControl(controlConfig);
         break;
       case 'date':
@@ -349,6 +350,7 @@ export class FormUtils {
         controlConfig.textMaskEnabled = field.textMaskEnabled;
         controlConfig.allowInvalidDate = field.allowInvalidDate;
         controlConfig.military = config ? !!config.military : false;
+        controlConfig.weekStart = config && config.weekStart ? config.weekStart : 0;
         control = new DateControl(controlConfig);
         break;
       case 'time':
@@ -510,7 +512,7 @@ export class FormUtils {
     meta,
     currencyFormat,
     http,
-    config: { token?: string; restUrl?: string; military?: boolean },
+    config: { token?: string; restUrl?: string; military?: boolean, weekStart?: number },
     overrides?,
     data?: { [key: string]: any },
   ) {


### PR DESCRIPTION
## **Description**

We are updating the Date and DateTime controls to allow a custom week start day to be specified via a setting

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**