### PR TITLE
feat(novo-file): Do not resolve promise for read until read is finished

### DIFF
--- a/projects/novo-elements/src/elements/form/extras/file/extras/file/File.spec.ts
+++ b/projects/novo-elements/src/elements/form/extras/file/extras/file/File.spec.ts
@@ -23,10 +23,20 @@ describe('Class: NovoFile', () => {
   });
 
   describe('Method: read()', () => {
-    it('should read files.', () => {
-      jest.spyOn(file.reader, 'readAsDataURL').mockImplementation(() => {});
-      file.read();
-      expect(file.reader.readAsDataURL).toHaveBeenCalled();
+    it('should read files.', async () => {
+      return new Promise((resolve) => {
+        jest.spyOn(file.reader, 'readAsDataURL').mockImplementation(() => {});
+        file.read().then(() => {
+          expect(file.fileContents).toEqual('The contents');
+          resolve(true);
+        });
+        expect(file.reader.readAsDataURL).toHaveBeenCalled();
+        file.reader.onload({
+          target: {
+            result: 'First,The contents',
+          },
+        } as any);
+      });
     });
   });
 

--- a/projects/novo-elements/src/elements/form/extras/file/extras/file/File.ts
+++ b/projects/novo-elements/src/elements/form/extras/file/extras/file/File.ts
@@ -9,6 +9,7 @@ export class NovoFile {
   fileContents: string;
   dataURL: string;
   reader: FileReader = new FileReader();
+  readPromise: Function;
 
   constructor(file) {
     this.name = `${encodeURIComponent(file.name || '')}`;
@@ -20,12 +21,15 @@ export class NovoFile {
       this.fileContents = event.target.result.split(',')[1];
       this.dataURL = event.target.result;
       this.loaded = true;
+      if (this.readPromise) {
+        this.readPromise(this);
+      }
     };
   }
 
   read() {
     return new Promise((resolve) => {
-      resolve(this);
+      this.readPromise = resolve;
       // when the file is read it triggers the onload event above.
       this.reader.readAsDataURL(this.file);
     });


### PR DESCRIPTION
## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**