### PR TITLE
BH-66970 refresh dropdown list array when it changes

### DIFF
--- a/projects/novo-elements/src/elements/dropdown/Dropdown.ts
+++ b/projects/novo-elements/src/elements/dropdown/Dropdown.ts
@@ -25,7 +25,12 @@ import { notify } from '../../utils/notifier/notifier.util';
   template: `
     <ng-content select="button" #trigger></ng-content>
     <novo-overlay-template [parent]="element" [width]="width" [position]="side" [scrollStrategy]="scrollStrategy">
-      <div class="dropdown-container {{ containerClass }}" [style.height.px]="height" [class.has-height]="!!height" (keydown)="onOverlayKeyDown($event)">
+      <div
+        class="dropdown-container {{ containerClass }}"
+        [style.height.px]="height"
+        [class.has-height]="!!height"
+        (keydown)="onOverlayKeyDown($event)"
+      >
         <ng-content></ng-content>
       </div>
     </novo-overlay-template>
@@ -104,6 +109,7 @@ export class NovoDropdownElement implements OnInit, OnDestroy {
 
   public set items(items: QueryList<NovoItemElement>) {
     this._items = items;
+    this.activeIndex = -1;
     // Get the innerText of all the items to allow for searching
     this._textItems = items.map((item: NovoItemElement) => {
       return item.element.nativeElement.innerText;
@@ -288,6 +294,9 @@ export class NovoListElement implements AfterContentInit {
 
   public ngAfterContentInit(): void {
     this.dropdown.items = this.items;
+    this.items.changes.subscribe(() => {
+      this.dropdown.items = this.items;
+    });
   }
 }
 


### PR DESCRIPTION
## **Description**

subscribing to changes on QueryList so that we can reset/reload the `items` property dynamically, since we now have a component that can actively filter dropdown results.

also resetting `activeIndex` when we do this, since we use that to access `items` array elements and will throw errors if we get out of range with shorter, filtered items lists.

QueryList also unsubscribes itself on destroy:
https://github.com/angular/angular/blob/7d137d7f8872a6fba72668e32f9baf2c5dcfc48b/packages/core/src/linker/query_list.ts#L115

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**