### PR TITLE
feat(controGroup): added custom column header template

### DIFF
--- a/projects/novo-elements/src/elements/form/ControlGroup.html
+++ b/projects/novo-elements/src/elements/form/ControlGroup.html
@@ -22,13 +22,19 @@
     <button [disabled]="!disabledArray[index].edit" type="button" *ngIf="edit && vertical" theme="icon" icon="edit" (click)="editControl(index)" [attr.data-automation-id]="'novo-control-group-edit-' + key" index="-1"></button>
     <button [disabled]="!disabledArray[index].remove" type="button" *ngIf="remove && vertical" theme="icon" icon="delete-o" (click)="removeControl(index)" [attr.data-automation-id]="'novo-control-group-delete-' + key" index="-1"></button>
   </ng-template>
-  <div class="novo-control-group-labels" *ngIf="!vertical && (form?.controls)[key] && (form?.controls)[key]['controls'].length !== 0">
-    <div class="novo-control-group-control-label {{ label.key }}" *ngFor="let label of controlLabels" [style.max-width.px]="label.width" [class.column-required]="label.required">
-      <span [attr.data-automation-id]="'novo-control-group-label-' + label.value">{{ label.value }}</span>
+  <ng-template #defaultColumnLabelTemplate let-form="form" let-key="key">
+      <div class="novo-control-group-control-label {{ label.key }}" *ngFor="let label of controlLabels" [style.max-width.px]="label.width" [class.column-required]="label.required">
+        <span [attr.data-automation-id]="'novo-control-group-label-' + label.value">{{ label.value }}</span>
+      </div>
+      <div class="novo-control-group-control-label last" *ngIf="edit" [attr.data-automation-id]="'novo-control-group-edit-' + key"></div>
+      <div class="novo-control-group-control-label last" *ngIf="remove" [attr.data-automation-id]="'novo-control-group-delete-' + key"></div>
+  </ng-template>
+  <ng-container *ngIf="!vertical && (form?.controls)[key] && (form?.controls)[key]['controls'].length !== 0">
+    <div class="novo-control-group-labels" *ngIf="!vertical && (form?.controls)[key] && (form?.controls)[key]['controls'].length !== 0">
+      <ng-template [ngTemplateOutlet]="columnLabelTemplate || defaultColumnLabelTemplate" [ngTemplateOutletContext]="{ form: form, key: key, controlLabels: controlLabels }">
+      </ng-template>
     </div>
-    <div class="novo-control-group-control-label last" *ngIf="edit" [attr.data-automation-id]="'novo-control-group-edit-' + key"></div>
-    <div class="novo-control-group-control-label last" *ngIf="remove" [attr.data-automation-id]="'novo-control-group-delete-' + key"></div>
-  </div>
+  </ng-container>
   <ng-container *ngIf="(form?.controls)[key]">
     <div class="novo-control-group-row" *ngFor="let control of (form?.controls)[key]['controls']; let index = index">
       <ng-template [ngTemplateOutlet]="rowTemplate || defaultTemplate" [ngTemplateOutletContext]="{ form: form, index: index, key: key, controls: controls }">

--- a/projects/novo-elements/src/elements/form/ControlGroup.ts
+++ b/projects/novo-elements/src/elements/form/ControlGroup.ts
@@ -103,9 +103,11 @@ export class NovoControlGroup implements AfterContentInit, OnChanges {
   @Input() canRemove: Function;
   // Template for custom row rendering
   @Input() rowTemplate: TemplateRef<any>;
+  // Template for custom column label rendering
+  @Input() columnLabelTemplate: TemplateRef<any>;
 
-  @Output() onRemove = new EventEmitter<{ value, index }>();
-  @Output() onEdit = new EventEmitter<{ value, index }>();
+  @Output() onRemove = new EventEmitter<{ value; index }>();
+  @Output() onEdit = new EventEmitter<{ value; index }>();
   @Output() onAdd = new EventEmitter<any>();
   @Output() change = new EventEmitter<any>();
 
@@ -115,7 +117,7 @@ export class NovoControlGroup implements AfterContentInit, OnChanges {
 
   currentIndex = 0;
 
-  constructor(private formUtils: FormUtils, private fb: FormBuilder, private ref: ChangeDetectorRef, private labels: NovoLabelService) { }
+  constructor(private formUtils: FormUtils, private fb: FormBuilder, private ref: ChangeDetectorRef, private labels: NovoLabelService) {}
 
   ngAfterContentInit() {
     if (!this.key) {


### PR DESCRIPTION
## **Description**

Added ability to have a custom column header template for horizontal control groups.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**