### PR TITLE
BH-62199 prefixing truncated bigdecimal values with a ~ to convey tha…

### DIFF
--- a/projects/novo-elements/src/services/novo-label-service.spec.ts
+++ b/projects/novo-elements/src/services/novo-label-service.spec.ts
@@ -125,9 +125,9 @@ describe('Service: NovoLabelService', () => {
       expect(value).toEqual('2.14');
     });
 
-    it('should format positive value as decimal, two decimal places do not round', () => {
+    it('should format positive value as decimal, two decimal places do not round, display tilde', () => {
       const value = service.formatBigDecimal(2.147);
-      expect(value).toEqual('2.14');
+      expect(value).toEqual('~2.14');
     });
 
     it('should format negative value as decimal in parens without negative sign', () => {
@@ -135,14 +135,19 @@ describe('Service: NovoLabelService', () => {
       expect(value).toEqual('(2.00)');
     });
 
+    it('should format negative value as decimal in parens without negative sign, two decimal places do not round, display tilde inside parens', () => {
+      const value = service.formatBigDecimal(-2.147);
+      expect(value).toEqual('(~2.14)');
+    });
+
     it('should format positive value as decimal, one decimal', () => {
       const value = service.formatBigDecimal(2.3);
       expect(value).toEqual('2.30');
     });
 
-    it('should format positive value as decimal, four decimal should truncate', () => {
+    it('should format positive value as decimal, four decimal should truncate, display tilde', () => {
       const value = service.formatBigDecimal(2.3444);
-      expect(value).toEqual('2.34');
+      expect(value).toEqual('~2.34');
     });
 
     it('should format positive value as decimal, large number whole number', () => {
@@ -150,9 +155,9 @@ describe('Service: NovoLabelService', () => {
       expect(value).toEqual('23,444.00');
     });
 
-    it('should format positive value as decimal, large number with four decimal should truncate', () => {
+    it('should format positive value as decimal, large number with four decimal should truncate, display tilde', () => {
       const value = service.formatBigDecimal(23444.1273);
-      expect(value).toEqual('23,444.12');
+      expect(value).toEqual('~23,444.12');
     });
   });
 });

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -235,20 +235,22 @@ export class NovoLabelService {
   }
 
   formatBigDecimal(value: number): string {
+    let prefix = '';
     let valueAsString = value ? value.toString() : '0';
     // truncate at two decimals (do not round)
     const decimalIndex = valueAsString.indexOf('.');
     if (decimalIndex > -1 && decimalIndex + 3 < valueAsString.length) {
       valueAsString = valueAsString.substring(0, valueAsString.indexOf('.') + 3);
+      prefix = '~';
     }
     // convert back to number
     const truncatedValue = Number(valueAsString);
     const options = { style: 'decimal', minimumFractionDigits: 2, maximumFractionDigits: 2 };
     let _value = new Intl.NumberFormat(this.userLocale, options).format(truncatedValue);
     if (value < 0) {
-      _value = `(${_value.slice(1)})`;
+      return `(${prefix}${_value.slice(1)})`;
     }
-    return _value;
+    return `${prefix}${_value}`;
   }
 
   formatNumber(value: any, options?: Intl.NumberFormatOptions): string {


### PR DESCRIPTION
…t they are approx

## **Description**

if we are truncating values to 2 decimal places, we want a way to convey to the user that the displayed values are approximations of the stored values, so we will display a '~' in front of the values in this case.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**