### PR TITLE
feat(chips): modified value to return just the id when object is passed

### DIFF
--- a/projects/novo-elements/src/elements/chips/Chips.spec.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.spec.ts
@@ -229,7 +229,7 @@ describe('Elements: NovoChipsElement', () => {
         }]
       };
       const result = component.getLabelFromOptions({ id: 2 });
-      expect(result).toStrictEqual({ value: { id: 2 }, label: 'option 2'});
+      expect(result).toStrictEqual({ value: 2, label: 'option 2'});
     });
     it('should return a proper response if passed an number as value', () => {
       component.source = {

--- a/projects/novo-elements/src/elements/chips/Chips.spec.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.spec.ts
@@ -214,6 +214,41 @@ describe('Elements: NovoChipsElement', () => {
     });
   });
 
+  describe('Method: getLabelFromOptions', () => {
+    it('should return a proper response if passed an object as value', () => {
+      component.source = {
+        options: [{
+          value: 1,
+          label: 'option 1',
+        }, {
+          value: 2,
+          label: 'option 2',
+        }, {
+          value: 3,
+          label: 'option 3',
+        }]
+      };
+      const result = component.getLabelFromOptions({ id: 2 });
+      expect(result).toStrictEqual({ value: { id: 2 }, label: 'option 2'});
+    });
+    it('should return a proper response if passed an number as value', () => {
+      component.source = {
+        options: [{
+          value: 1,
+          label: 'option 1',
+        }, {
+          value: 2,
+          label: 'option 2',
+        }, {
+          value: 3,
+          label: 'option 3',
+        }]
+      };
+      const result = component.getLabelFromOptions(2);
+      expect(result).toStrictEqual({ value: 2, label: 'option 2'});
+    });
+  });
+
   describe('Method: registerOnTouched()', () => {
     it('should be defined.', () => {
       expect(component.registerOnTouched).toBeDefined();

--- a/projects/novo-elements/src/elements/chips/Chips.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.ts
@@ -241,7 +241,10 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
   }
 
   getLabelFromOptions(value) {
-    const optLabel = this.source.options.find((val) => val.value === value);
+    let optLabel = this.source.options.find((val) => val.value === value);
+    if (!optLabel && value.hasOwnProperty('id')) {
+      optLabel = this.source.options.find((val) => val.value === value.id);
+    }
     return {
       value,
       label: optLabel ? optLabel.label : value,

--- a/projects/novo-elements/src/elements/chips/Chips.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.ts
@@ -241,12 +241,14 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
   }
 
   getLabelFromOptions(value) {
+    let id = value;
     let optLabel = this.source.options.find((val) => val.value === value);
     if (!optLabel && value.hasOwnProperty('id')) {
       optLabel = this.source.options.find((val) => val.value === value.id);
+      id = value.id;
     }
     return {
-      value,
+      value: id,
       label: optLabel ? optLabel.label : value,
     };
   }


### PR DESCRIPTION
## **Description**

Modified value to return just the id when object is passed

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**