### PR TITLE
Fix for #1121 - flex the chips horizontally

### DIFF
--- a/projects/novo-elements/src/elements/chips/Chips.scss
+++ b/projects/novo-elements/src/elements/chips/Chips.scss
@@ -72,6 +72,10 @@ novo-entity-chips {
       border: 1px solid $positive;
     }
   }
+  .novo-chip-container {
+    display: flex;
+    flex-wrap: wrap;
+  }
   .chip-input-container {
     flex-grow: 4;
     input {


### PR DESCRIPTION
## **Description**
Fix for #1121 

Added styles to `.novo-chip-container` that flexes the chip components, allowing them to fall horizontally instead of stacking vertically

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
    * There are failures, but these are inherited from failures in `master`. This is a simple style update. 
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**
### Before:
![image](https://user-images.githubusercontent.com/3904767/85175219-fd92d480-b244-11ea-9ee5-03509d601b2c.png)

### After:
![image](https://user-images.githubusercontent.com/3904767/85175260-0be0f080-b245-11ea-8ea5-61ff17cfbead.png)
