### PR TITLE
fix(Clear Button): Prevent data table clear dropdown from popping up instead of down

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table-clear-button.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table-clear-button.component.ts
@@ -6,7 +6,7 @@ import { NovoLabelService } from '../../services/novo-label-service';
 @Component({
   selector: 'novo-data-table-clear-button',
   template: `
-    <novo-dropdown side="right" class="novo-data-table-clear-button" data-automation-id="novo-data-table-clear-dropdown">
+    <novo-dropdown side="bottom-right" class="novo-data-table-clear-button" data-automation-id="novo-data-table-clear-dropdown">
       <button type="button" theme="primary" color="negative" icon="collapse" data-automation-id="novo-data-table-clear-dropdown-btn">{{ labels.clear }}</button>
       <list>
           <item *ngIf="state.sort" (click)="clearSort()" data-automation-id="novo-data-table-clear-dropdown-clear-sort">{{ labels.clearSort }}</item>


### PR DESCRIPTION
## **Description**

Prevents this bad pop-up behavior from happening in situations where the Clear Button is at the far right, and the browser window is full screen. 

![Screen Shot 2020-07-23 at 12 46 27 PM](https://user-images.githubusercontent.com/3843503/88330899-bc815a80-ccf1-11ea-9ee9-adcc07b5b342.png)

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`
