### PR TITLE
Fix week range select bug with date picker and week-start changes

### DIFF
--- a/projects/novo-elements/src/elements/date-picker/DatePicker.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePicker.ts
@@ -29,6 +29,7 @@ const DATE_PICKER_VALUE_ACCESSOR = {
 export interface RangeModal {
   startDate: Date;
   endDate: Date;
+  selectedDate?: Date;
 }
 export type modelTypes = Date | RangeModal;
 
@@ -310,7 +311,12 @@ export class NovoDatePickerElement implements ControlValueAccessor, OnInit, OnCh
       if (!date) {
         this.clearRange();
       }
-      let value: any = date ? new Date(date) : new Date();
+      let value: any;
+      if (date && date.selectedDate) {
+        value = new Date(date.selectedDate);
+      } else {
+        value = date ? new Date(date) : new Date();
+      }
       value = this.removeTime(value);
       this.month = new Date(value);
       this.monthLabel = this.labels.formatDateWithFormat(this.month, { month: 'short' });
@@ -427,10 +433,12 @@ export class NovoDatePickerElement implements ControlValueAccessor, OnInit, OnCh
         this._onChange({
           startDate: this.selected,
           endDate: this.selected2 ? this.selected2 : null,
+          selectedDate: day.date,
         });
         this.model = {
           startDate: this.selected,
           endDate: this.selected2 ? this.selected2 : null,
+          selectedDate: day.date,
         };
       }
 

--- a/projects/novo-examples/src/form-controls/date-picker/week-start/week-start-example.html
+++ b/projects/novo-examples/src/form-controls/date-picker/week-start/week-start-example.html
@@ -9,7 +9,9 @@
 <br/>
 <div class="date-picker-demo-side-by-side">
     <p>
-        <label>Value</label> {{(weekStartDate | date) || 'N/A'}}
+        <label>Value</label> {{(weekStartDateOne | date) || 'N/A'}}
+        <label>Value</label> {{(weekStartDateTwo | date) || 'N/A'}}
     </p>
-    <novo-date-picker [(ngModel)]="weekStartDate" [weekStart]="weekStart"></novo-date-picker>
+    <novo-date-picker [(ngModel)]="weekStartDateOne" [weekStart]="weekStart"></novo-date-picker>
+    <novo-date-picker [(ngModel)]="weekStartDateTwo" [weekStart]="weekStart" [range]="true" [weekRangeSelect]="true"></novo-date-picker>
 </div>

--- a/projects/novo-examples/src/form-controls/date-picker/week-start/week-start-example.ts
+++ b/projects/novo-examples/src/form-controls/date-picker/week-start/week-start-example.ts
@@ -9,7 +9,8 @@ import { Component } from '@angular/core';
   styleUrls: ['week-start-example.css'],
 })
 export class WeekStartExample {
-  weekStartDate: Date = new Date();
+  weekStartDateOne: Date = new Date();
+  weekStartDateTwo: Date = new Date();
   weekStart: number = 0;
 
   setWeekStart(num: number): void {


### PR DESCRIPTION
## **Description**

Fixed a bug with date-picker - changing the week start date on a date-picker with a range of days already selected causes the calendar to display NaN for all days until the page is reloaded

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**