### PR TITLE
chore(build): use node 14 instead of node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: trusty
 
 node_js:
-  - 10
+  - 14
 
 cache:
   directories:

--- a/projects/novo-elements/src/elements/form/Control.spec.ts
+++ b/projects/novo-elements/src/elements/form/Control.spec.ts
@@ -71,7 +71,7 @@ describe('Test Localization', () => {
 
   it('should set decimal separator based on locale correctly', () => {
     const component = new NovoControlElement(mockElement, null, null, null, null, null, 'fr-FR');
-    expect(component.decimalSeparator).toBe('.');
+    expect(component.decimalSeparator).toBe(',');
   });
 });
 


### PR DESCRIPTION
## **Description**

use node 14 instead of node 10
https://nodejs.org/en/about/releases/

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**