### PR TITLE
Date picker fix

### DIFF
--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -219,7 +219,7 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
 
   private _setCalendarValue(value: any): void {
     if (value instanceof Date && this.value instanceof Date) {
-      value = new Date(value.setHours(0, 0, 0, 0));
+      value = new Date(value).setHours(0, 0, 0, 0);
     }
     this.value = value;
   }

--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -219,7 +219,7 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
 
   private _setCalendarValue(value: any): void {
     if (value instanceof Date && this.value instanceof Date) {
-      value = new Date(value.setHours(this.value.getHours(), this.value.getMinutes()));
+      value = new Date(value.setHours(0, 0, 0, 0));
     }
     this.value = value;
   }


### PR DESCRIPTION
## **Description**

Manual entry was including the current time in the datepicker causing issues for locations operating in multiple timezones. Stripping time from the datepicker to match the behavior when selecting from the calendar,

#### **Verify that...**

- [X] Any related demos were added and `npm start` and `npm run build` still works
- [X] New demos work in `Safari`, `Chrome` and `Firefox`
- [X] `npm run lint` passes
- [X] `npm test` passes and code coverage is increased
- [X] `npm run build` still works

#### **Bullhorn Internal Developers**
- [X] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**