### PR TITLE
WIP: BH-68520 passing config.selected to BasePickerResults preselected function

### DIFF
--- a/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.ts
@@ -240,7 +240,9 @@ export class BasePickerResults {
   filterData(matches): Array<any> {
     if (this.term && matches) {
       return matches.filter((match) => {
-        return ~String(match.label).toLowerCase().indexOf(this.term.toLowerCase());
+        return ~String(match.label)
+          .toLowerCase()
+          .indexOf(this.term.toLowerCase());
       });
     }
     // Show no recent results template
@@ -350,16 +352,20 @@ export class BasePickerResults {
   }
 
   preselected(match) {
+    let selected = this.selected;
+    if (this.config.selected) {
+      selected = [...this.selected, ...this.config.selected];
+    }
     if (this.config && this.config.preselected) {
       const preselectedFunc: Function = this.config.preselected;
       return (
-        this.selected.findIndex((item) => {
+        selected.findIndex((item) => {
           return preselectedFunc(match, item);
         }) !== -1
       );
     }
     return (
-      this.selected.findIndex((item) => {
+      selected.findIndex((item) => {
         let isPreselected = false;
         if (item && item.value && match && match.value) {
           if (item.value.id && match.value.id) {

--- a/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.ts
@@ -353,7 +353,7 @@ export class BasePickerResults {
 
   preselected(match) {
     let selected = this.selected;
-    if (this.config.selected) {
+    if (this.config && this.config.selected) {
       selected = [...this.selected, ...this.config.selected];
     }
     if (this.config && this.config.preselected) {


### PR DESCRIPTION
## **Description**

Adding ability to pass in "selected" items to BasePickerResults to disable the option in pickers without them appearing selected in the form

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**