### PR TITLE
Changes for list interactions to be enabled

### DIFF
--- a/projects/novo-elements/src/elements/data-table/ListInteractionTypes.ts
+++ b/projects/novo-elements/src/elements/data-table/ListInteractionTypes.ts
@@ -1,0 +1,11 @@
+import { NovoDataTable } from './data-table.component';
+
+export type ListInteractionEvent = 'init' | 'change';
+
+export type ListInteraction = {
+  script: (novoDataTable: NovoDataTable<any>, columnId: string) => void;
+  action: string;
+  event: ListInteractionEvent[];
+};
+
+export type ListInteractionDictionary = { [key: string]: ListInteraction[] };

--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
@@ -245,7 +245,7 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
   private _column: IDataTableColumn<T>;
 
   constructor(
-    private changeDetectorRef: ChangeDetectorRef,
+    public changeDetectorRef: ChangeDetectorRef,
     public labels: NovoLabelService,
     private state: DataTableState<T>,
     private renderer: Renderer2,
@@ -260,14 +260,18 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
     if (this._cdkColumnDef) {
       this.id = this._cdkColumnDef.name;
     }
+    this.setupFilterOptions();
 
+    this.changeDetectorRef.markForCheck();
+  }
+
+  public setupFilterOptions() {
     this.checkSortFilterState({ filter: this.state.filter, sort: this.state.sort }, true);
 
     this.multiSelect = this.config.filterConfig && this.config.filterConfig.type ? this.config.filterConfig.type === 'multi-select' : false;
     if (this.multiSelect) {
       this.multiSelectedOptions = this.filter ? [...this.filter] : [];
     }
-    this.changeDetectorRef.markForCheck();
   }
 
   public ngOnDestroy(): void {

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -687,13 +687,14 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   }
 
   performInteractions(event: string): void {
-    for (const column of this.columns) {
-      const allListColumnInteractions = this.listInteractions[column.id];
-      const listColumnInteraction = allListColumnInteractions && allListColumnInteractions.find(int => int.event.includes(event));
-      if (listColumnInteraction) {
-        listColumnInteraction.script(this, column.id);
+    if (this.listInteractions) {
+      for (const column of this.columns) {
+        const allListColumnInteractions = this.listInteractions[column.id];
+        const listColumnInteraction = allListColumnInteractions && allListColumnInteractions.find(int => int.event.includes(event));
+        if (listColumnInteraction) {
+          listColumnInteraction.script(this, column.id);
+        }
       }
     }
-
   }
 }

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -9,6 +9,7 @@ import { DataTableSource } from './data-table.source';
 import { IDataTableColumn, IDataTableFilter, IDataTablePaginationOptions, IDataTablePreferences, IDataTableSearchOptions, IDataTableService, IDataTableSort } from './interfaces';
 import { StaticDataTableService } from './services/static-data-table.service';
 import { DataTableState } from './state/data-table-state.service';
+import { NovoDataTableCellHeader } from './cell-headers/data-table-header-cell.component';
 
 
 @Component({
@@ -234,6 +235,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
 
   @ContentChildren(NovoTemplate) customTemplates: QueryList<NovoTemplate>;
   @ViewChildren(NovoTemplate) defaultTemplates: QueryList<NovoTemplate>;
+  @ViewChildren(NovoDataTableCellHeader) cellHeaders: QueryList<NovoDataTableCellHeader<T>>;
   @ViewChild('novoDataTableContainer', { static: false }) novoDataTableContainer: ElementRef;
   @Output() resized: EventEmitter<IDataTableColumn<T>> = new EventEmitter();
 
@@ -330,6 +332,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   set columns(columns: IDataTableColumn<T>[]) {
     this._columns = columns;
     this.configureColumns();
+    this.performInteractions('init');
   }
   get columns(): IDataTableColumn<T>[] {
     return this._columns;
@@ -401,6 +404,8 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
     return this.loading || (this.dataSource && this.dataSource.loading);
   }
 
+  @Input() listInteractions: any;
+
   constructor(public labels: NovoLabelService, private ref: ChangeDetectorRef, public state: DataTableState<T>) {
     this.scrollListenerHandler = this.scrollListener.bind(this);
     this.sortFilterSubscription = this.state.sortFilterSource.subscribe(
@@ -411,6 +416,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
       }) => {
         if (this.name !== 'novo-data-table') {
           this.preferencesChanged.emit({ name: this.name, sort: event.sort, filter: event.filter, globalSearch: event.globalSearch });
+          this.performInteractions('change');
         } else {
           notify('Must have [name] set on data-table to use preferences!');
         }
@@ -430,6 +436,20 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
         this.ref.detectChanges();
       }, 300);
     });
+  }
+
+  public modifyCellHeaderMultiSelectFilterOptions(column: string, newOptions: {value: any, label: string}[]): void {
+    const header = this.cellHeaders.find(cellHeader => cellHeader.id === column);
+    if (header && header.config && header.config.filterConfig && header.config.filterConfig.options) {
+      const filterOptions: any[] = header.config.filterConfig.options;
+      const optionsToKeep = filterOptions.filter(opt =>
+        header.isSelected(opt, header.multiSelectedOptions) && !newOptions.find(newOpt => opt.value && newOpt.value && (newOpt.value === opt.value)));
+      header.config.filterConfig.options = [...optionsToKeep, ...newOptions];
+    } else {
+      header.config.filterConfig['options'] = newOptions;
+    }
+    header.setupFilterOptions();
+    header.changeDetectorRef.markForCheck();
   }
 
   public ngOnDestroy(): void {
@@ -485,7 +505,6 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
 
     // Scrolling inside table
     (this.novoDataTableContainer.nativeElement as Element).addEventListener('scroll', this.scrollListenerHandler);
-
     this.initialized = true;
     this.ref.markForCheck();
   }
@@ -665,5 +684,16 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
       this.scrollLeft = target.scrollLeft;
     }
     this.ref.markForCheck();
+  }
+
+  performInteractions(event: string): void {
+    for (const column of this.columns) {
+      const allListColumnInteractions = this.listInteractions[column.id];
+      const listColumnInteraction = allListColumnInteractions && allListColumnInteractions.find(int => int.event.includes(event));
+      if (listColumnInteraction) {
+        listColumnInteraction.script(this, column.id);
+      }
+    }
+
   }
 }

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -1,16 +1,40 @@
 import { animate, state as animState, style, transition, trigger } from '@angular/animations';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
-import { AfterContentInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ContentChildren, ElementRef, EventEmitter, HostBinding, Input, OnDestroy, Output, QueryList, TemplateRef, ViewChild, ViewChildren } from '@angular/core';
+import {
+  AfterContentInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ContentChildren,
+  ElementRef,
+  EventEmitter,
+  HostBinding,
+  Input,
+  OnDestroy,
+  Output,
+  QueryList,
+  TemplateRef,
+  ViewChild,
+  ViewChildren,
+} from '@angular/core';
 import { Subscription } from 'rxjs';
 import { NovoLabelService } from '../../services/novo-label-service';
 import { notify } from '../../utils/notifier/notifier.util';
 import { NovoTemplate } from '../common/novo-template/novo-template.directive';
 import { DataTableSource } from './data-table.source';
-import { IDataTableColumn, IDataTableFilter, IDataTablePaginationOptions, IDataTablePreferences, IDataTableSearchOptions, IDataTableService, IDataTableSort } from './interfaces';
+import {
+  IDataTableColumn,
+  IDataTableFilter,
+  IDataTablePaginationOptions,
+  IDataTablePreferences,
+  IDataTableSearchOptions,
+  IDataTableService,
+  IDataTableSort,
+} from './interfaces';
 import { StaticDataTableService } from './services/static-data-table.service';
 import { DataTableState } from './state/data-table-state.service';
 import { NovoDataTableCellHeader } from './cell-headers/data-table-header-cell.component';
-
+import { ListInteractionDictionary, ListInteractionEvent } from './ListInteractionTypes';
 
 @Component({
   selector: 'novo-data-table',
@@ -404,16 +428,12 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
     return this.loading || (this.dataSource && this.dataSource.loading);
   }
 
-  @Input() listInteractions: any;
+  @Input() listInteractions: ListInteractionDictionary;
 
   constructor(public labels: NovoLabelService, private ref: ChangeDetectorRef, public state: DataTableState<T>) {
     this.scrollListenerHandler = this.scrollListener.bind(this);
     this.sortFilterSubscription = this.state.sortFilterSource.subscribe(
-      (event: {
-        sort: IDataTableSort;
-        filter: IDataTableFilter | IDataTableFilter[];
-        globalSearch: string;
-      }) => {
+      (event: { sort: IDataTableSort; filter: IDataTableFilter | IDataTableFilter[]; globalSearch: string }) => {
         if (this.name !== 'novo-data-table') {
           this.preferencesChanged.emit({ name: this.name, sort: event.sort, filter: event.filter, globalSearch: event.globalSearch });
           this.performInteractions('change');
@@ -438,12 +458,15 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
     });
   }
 
-  public modifyCellHeaderMultiSelectFilterOptions(column: string, newOptions: {value: any, label: string}[]): void {
-    const header = this.cellHeaders.find(cellHeader => cellHeader.id === column);
+  public modifyCellHeaderMultiSelectFilterOptions(column: string, newOptions: { value: any; label: string }[]): void {
+    const header = this.cellHeaders.find((cellHeader) => cellHeader.id === column);
     if (header && header.config && header.config.filterConfig && header.config.filterConfig.options) {
       const filterOptions: any[] = header.config.filterConfig.options;
-      const optionsToKeep = filterOptions.filter(opt =>
-        header.isSelected(opt, header.multiSelectedOptions) && !newOptions.find(newOpt => opt.value && newOpt.value && (newOpt.value === opt.value)));
+      const optionsToKeep = filterOptions.filter(
+        (opt) =>
+          header.isSelected(opt, header.multiSelectedOptions) &&
+          !newOptions.find((newOpt) => opt.value && newOpt.value && newOpt.value === opt.value),
+      );
       header.config.filterConfig.options = [...optionsToKeep, ...newOptions];
     } else {
       header.config.filterConfig['options'] = newOptions;
@@ -614,17 +637,13 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
           column.initialResizable = undefined;
         }
       });
-      const resizableColumns: string[] = this.displayedColumns.filter(
-        (name: string): boolean => {
-          return (
-            this.columns.findIndex(
-              (column: IDataTableColumn<T>): boolean => {
-                return column.resizable && column.id === name;
-              },
-            ) !== -1
-          );
-        },
-      );
+      const resizableColumns: string[] = this.displayedColumns.filter((name: string): boolean => {
+        return (
+          this.columns.findIndex((column: IDataTableColumn<T>): boolean => {
+            return column.resizable && column.id === name;
+          }) !== -1
+        );
+      });
       if (resizableColumns && resizableColumns.length > 0) {
         const lastResizableColumn: IDataTableColumn<T> = this.columns.find((column: IDataTableColumn<T>) => {
           return column.id === resizableColumns[resizableColumns.length - 1];
@@ -686,11 +705,11 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
     this.ref.markForCheck();
   }
 
-  performInteractions(event: string): void {
+  performInteractions(event: ListInteractionEvent): void {
     if (this.listInteractions) {
       for (const column of this.columns) {
         const allListColumnInteractions = this.listInteractions[column.id];
-        const listColumnInteraction = allListColumnInteractions && allListColumnInteractions.find(int => int.event.includes(event));
+        const listColumnInteraction = allListColumnInteractions && allListColumnInteractions.find((int) => int.event.includes(event));
         if (listColumnInteraction) {
           listColumnInteraction.script(this, column.id);
         }


### PR DESCRIPTION
## **Description**

Adds methods that enable novo data tables list interactions.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**