### PR TITLE
feat(DataTableBigDecimalRendererPipe): Add configuration to DataTableBigDecimalRendererPipe to allow overrides without changing existing behavior 

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.pipes.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.pipes.ts
@@ -93,7 +93,7 @@ export class DataTableBigDecimalRendererPipe<T> implements PipeTransform {
   transform(value: any, column: IDataTableColumn<T>): string {
     if (!Helpers.isEmpty(value)) {
       const val = interpolateCell<T>(value, column);
-      return this.labels.formatBigDecimal(Number(val));
+      return this.labels.formatBigDecimal(Number(val), column.configuration);
     }
     return '';
   }

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -58,6 +58,7 @@ export interface IDataTableColumn<T> {
     width: number;
   };
   rightAlignCellContent?: boolean;
+  configuration?: object; // intended to be implemented by each column type if and as needed
 }
 
 export interface IDataTablePaginationOptions {


### PR DESCRIPTION
BH-68304

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**