### PR TITLE
chore(typescript) remove unused imports

### DIFF
--- a/demo/assets/stackblitz/main.ts
+++ b/demo/assets/stackblitz/main.ts
@@ -1,7 +1,4 @@
 import './polyfills';
-
-import { CdkTableModule } from '@angular/cdk/table';
-import { CdkTreeModule } from '@angular/cdk/tree';
 import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';

--- a/package.json
+++ b/package.json
@@ -38,10 +38,12 @@
         "tsConfig": "<rootDir>/projects/novo-elements/tsconfig.spec.json",
         "diagnostics": true,
         "stringifyContentPathRegex": "\\.html$",
-        "astTransformers": [
-          "jest-preset-angular/build/InlineFilesTransformer",
-          "jest-preset-angular/build/StripStylesTransformer"
-        ]
+        "astTransformers": {
+          "before": [
+            "jest-preset-angular/build/InlineFilesTransformer",
+            "jest-preset-angular/build/StripStylesTransformer"
+          ]
+        }
       }
     },
     "collectCoverage": true,

--- a/projects/novo-elements/src/elements/button/Button.spec.ts
+++ b/projects/novo-elements/src/elements/button/Button.spec.ts
@@ -1,5 +1,5 @@
 // NG2
-import { TestBed, async } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 // APP
 import { NovoButtonElement } from './Button';
 import { setupTestSuite } from '../../../../../utils/test-setup';

--- a/projects/novo-elements/src/elements/data-table/services/static-data-table.service.spec.ts
+++ b/projects/novo-elements/src/elements/data-table/services/static-data-table.service.spec.ts
@@ -1,5 +1,5 @@
 // NG2
-import { TestBed, async } from '@angular/core/testing';
+import { async } from '@angular/core/testing';
 // APP
 import { StaticDataTableService } from './static-data-table.service';
 import * as dateFns from 'date-fns';

--- a/projects/novo-elements/src/elements/form/ControlGroup.spec.ts
+++ b/projects/novo-elements/src/elements/form/ControlGroup.spec.ts
@@ -1,7 +1,7 @@
 // NG2
 import { ChangeDetectorRef } from '@angular/core';
 import { TestBed, async } from '@angular/core/testing';
-import { FormBuilder, FormArray } from '@angular/forms';
+import { FormBuilder } from '@angular/forms';
 // App
 import { NovoControlGroup } from './ControlGroup';
 import { NovoFormModule } from './Form.module';

--- a/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
@@ -417,7 +417,6 @@ export class FieldInteractionApi {
   }
 
   promptUser(key: string, changes: string[]): Promise<boolean> {
-    const showYes = true;
     (document.activeElement as any).blur();
     return this.modalService.open(ControlPromptModal, { changes, key }).onClosed;
   }

--- a/projects/novo-elements/src/elements/form/Form.spec.ts
+++ b/projects/novo-elements/src/elements/form/Form.spec.ts
@@ -1,6 +1,5 @@
 // NG2
 import { TestBed, async } from '@angular/core/testing';
-import { FormGroupDirective } from '@angular/forms';
 // App
 import { NovoFormElement } from './Form';
 import { NovoTemplateService } from '../../services/template/NovoTemplateService';

--- a/projects/novo-elements/src/elements/form/extras/address/Address.spec.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.spec.ts
@@ -7,7 +7,6 @@ import { NovoSelectModule } from '../../../select/Select.module';
 import { NovoLabelService } from '../../../../services/novo-label-service';
 import { NovoPickerModule } from '../../../picker/Picker.module';
 import { NovoTooltipModule } from './../../../tooltip/Tooltip.module';
-import { Helpers } from '../../../../utils/Helpers';
 
 describe('Elements: NovoAddressElement', () => {
   let fixture;

--- a/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.spec.ts
+++ b/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.spec.ts
@@ -1,5 +1,5 @@
 // NG2
-import { ElementRef, ChangeDetectorRef } from '@angular/core';
+import { ElementRef } from '@angular/core';
 // App
 import { BasePickerResults } from './BasePickerResults';
 

--- a/projects/novo-elements/src/elements/picker/extras/skills-picker-results/SkillsSpecialtyPickerResults.spec.ts
+++ b/projects/novo-elements/src/elements/picker/extras/skills-picker-results/SkillsSpecialtyPickerResults.spec.ts
@@ -1,7 +1,6 @@
 // NG2
 import { ElementRef } from '@angular/core';
 import { TestBed, async } from '@angular/core/testing';
-import { DomSanitizer } from '@angular/platform-browser';
 // App
 import { NovoListModule } from './../../../list/List.module';
 import { NovoLoadingModule } from './../../../loading/Loading.module';

--- a/projects/novo-elements/src/elements/select/Select.spec.ts
+++ b/projects/novo-elements/src/elements/select/Select.spec.ts
@@ -1,6 +1,5 @@
 // NG
 import { TestBed, async } from '@angular/core/testing';
-import { FormsModule } from '@angular/forms';
 // App
 import { NovoSelectElement } from './Select';
 import { NovoSelectModule } from './Select.module';

--- a/projects/novo-elements/src/elements/table/Table.ts
+++ b/projects/novo-elements/src/elements/table/Table.ts
@@ -926,7 +926,6 @@ export class NovoTableElement implements DoCheck {
           errors.push({ errors: error, row: this._rows[index], index });
         }
       });
-      const ret = {};
       // Return errors if any, otherwise return the changed rows
       if (errors.length === 0) {
         return { changed: changedRows };

--- a/projects/novo-elements/src/services/date-format/DateFormat.spec.ts
+++ b/projects/novo-elements/src/services/date-format/DateFormat.spec.ts
@@ -1,6 +1,5 @@
 // APP
 import { DateFormatService } from './DateFormat';
-import { Helpers } from '../../utils/Helpers';
 import { NovoLabelService } from '../../services/novo-label-service';
 
 describe('Service: DateFormatService', () => {

--- a/projects/novo-examples/src/_shared/code-example.component.ts
+++ b/projects/novo-examples/src/_shared/code-example.component.ts
@@ -1,6 +1,5 @@
 // NG2
-import { Component, Input, OnInit, ChangeDetectionStrategy } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { Component, Input } from '@angular/core';
 import { ComponentPortal } from '@angular/cdk/portal';
 import { EXAMPLE_COMPONENTS, LiveExample } from '../examples.module';
 

--- a/projects/novo-examples/src/_shared/code-snippet.component.ts
+++ b/projects/novo-examples/src/_shared/code-snippet.component.ts
@@ -1,5 +1,5 @@
 // NG2
-import { Component, Input, OnInit, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import { Component, Input, OnInit, ChangeDetectorRef } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { HighlightJS } from './highlight.service';
 import { EXAMPLE_COMPONENTS } from '../examples.module';

--- a/projects/novo-examples/src/_shared/highlight.service.ts
+++ b/projects/novo-examples/src/_shared/highlight.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject, Optional, InjectionToken } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { take, filter } from 'rxjs/operators';
 

--- a/projects/novo-examples/src/components/data-table/data-table-remote/data-table-remote-example.ts
+++ b/projects/novo-examples/src/components/data-table/data-table-remote/data-table-remote-example.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, ChangeDetectorRef, ViewChild } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
 import { delay } from 'rxjs/operators';
 import * as dateFns from 'date-fns';
 import { Subject, Observable, of } from 'rxjs';

--- a/projects/novo-examples/src/components/table/details-table/details-table-example.ts
+++ b/projects/novo-examples/src/components/table/details-table/details-table-example.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NovoTableConfig, BaseRenderer } from 'novo-elements';
+import { BaseRenderer } from 'novo-elements';
 import { HEADER_COLORS, TableData, TableColumns } from '../table-extras';
 
 @Component({

--- a/projects/novo-examples/src/components/table/editable-table/editable-table-example.ts
+++ b/projects/novo-examples/src/components/table/editable-table/editable-table-example.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NovoTableConfig, ArrayCollection, PercentageCell } from 'novo-elements';
+import { ArrayCollection, PercentageCell } from 'novo-elements';
 
 /**
  * @title Editable Table Example

--- a/projects/novo-examples/src/components/table/select-all-table/select-all-table-example.ts
+++ b/projects/novo-examples/src/components/table/select-all-table/select-all-table-example.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { NovoTableConfig } from 'novo-elements';
 import { HEADER_COLORS, TableData, TableColumns } from '../table-extras';
 
 /**

--- a/projects/novo-examples/src/components/table/table/table-example.ts
+++ b/projects/novo-examples/src/components/table/table/table-example.ts
@@ -1,6 +1,4 @@
 import { Component } from '@angular/core';
-// Vendor
-import { NovoTableConfig } from 'novo-elements';
 import { HEADER_COLORS, TableData, TableColumns } from '../table-extras';
 
 /**

--- a/projects/novo-examples/src/components/table/total-footer-table/total-footer-table-example.ts
+++ b/projects/novo-examples/src/components/table/total-footer-table/total-footer-table-example.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { NovoTableConfig } from 'novo-elements';
 import { HEADER_COLORS } from '../table-extras';
 
 /**

--- a/projects/novo-examples/src/form-controls/date-picker/date-picker/date-picker-example.ts
+++ b/projects/novo-examples/src/form-controls/date-picker/date-picker/date-picker-example.ts
@@ -1,4 +1,4 @@
-import { Component, LOCALE_ID } from '@angular/core';
+import { Component } from '@angular/core';
 import { NovoLabelService } from 'novo-elements';
 
 export class ExtendedLabelService extends NovoLabelService {

--- a/projects/novo-examples/src/form-controls/form/check-box-controls/check-box-controls-example.ts
+++ b/projects/novo-examples/src/form-controls/form/check-box-controls/check-box-controls-example.ts
@@ -1,27 +1,11 @@
-import { Component, Input } from '@angular/core';
+import { Component } from '@angular/core';
 
 // Vendor
 import {
   FormUtils,
-  TextBoxControl,
   CheckboxControl,
   CheckListControl,
-  FileControl,
-  QuickNoteControl,
   TilesControl,
-  DateControl,
-  TimeControl,
-  DateTimeControl,
-  PickerControl,
-  EntityPickerResult,
-  EntityPickerResults,
-  TextAreaControl,
-  NovoFormGroup,
-  BaseControl,
-  AceEditorControl,
-  AddressControl,
-  FieldInteractionApi,
-  findByCountryId,
 } from 'novo-elements';
 
 // import { MockMeta, MockMetaHeaders } from './MockMeta';

--- a/projects/novo-examples/src/form-controls/form/disabled-form/disabled-form-example.ts
+++ b/projects/novo-examples/src/form-controls/form/disabled-form/disabled-form-example.ts
@@ -1,7 +1,7 @@
-import { Component, Input } from '@angular/core';
+import { Component } from '@angular/core';
 
 // Vendor
-import { FormUtils, TextBoxControl, CheckboxControl, FileControl, PickerControl } from 'novo-elements';
+import { FormUtils } from 'novo-elements';
 import { MockMetaForDisabledForm } from '../MockMeta';
 
 /**

--- a/projects/novo-examples/src/form-controls/form/dynamic-form-field-sets/dynamic-form-field-sets-example.ts
+++ b/projects/novo-examples/src/form-controls/form/dynamic-form-field-sets/dynamic-form-field-sets-example.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormUtils } from 'novo-elements';
 import { MockMeta, MockMetaHeaders } from '../MockMeta';
 

--- a/projects/novo-examples/src/form-controls/form/dynamic-form/dynamic-form-example.ts
+++ b/projects/novo-examples/src/form-controls/form/dynamic-form/dynamic-form-example.ts
@@ -1,6 +1,6 @@
-import { Component, Input } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormUtils } from 'novo-elements';
-import { MockMeta, MockMetaHeaders } from '../MockMeta';
+import { MockMeta } from '../MockMeta';
 
 /**
  * @title Dynamic Form Example

--- a/projects/novo-examples/src/form-controls/form/picker-controls/picker-controls-example.ts
+++ b/projects/novo-examples/src/form-controls/form/picker-controls/picker-controls-example.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component } from '@angular/core';
 
 // Vendor
 import { FormUtils, PickerControl, EntityPickerResult, EntityPickerResults } from 'novo-elements';

--- a/projects/novo-examples/src/form-controls/form/updating-form/updating-form-example.ts
+++ b/projects/novo-examples/src/form-controls/form/updating-form/updating-form-example.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component } from '@angular/core';
 
 // Vendor
 import { FormUtils, TextBoxControl, CheckboxControl, FileControl, PickerControl } from 'novo-elements';

--- a/projects/novo-examples/src/form-controls/form/vertical-dynamic-form/vertical-dynamic-form-example.ts
+++ b/projects/novo-examples/src/form-controls/form/vertical-dynamic-form/vertical-dynamic-form-example.ts
@@ -1,6 +1,6 @@
-import { Component, Input } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormUtils } from 'novo-elements';
-import { MockMeta, MockMetaHeaders } from '../MockMeta';
+import { MockMeta } from '../MockMeta';
 
 /**
  * @title Vertical Dynamic Form Example

--- a/projects/novo-examples/src/form-controls/value/address-value/address-value-example.ts
+++ b/projects/novo-examples/src/form-controls/value/address-value/address-value-example.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NOVO_VALUE_TYPE, NOVO_VALUE_THEME } from 'novo-elements';
+import { NOVO_VALUE_THEME } from 'novo-elements';
 
 /**
  * @title Address Value Example

--- a/projects/novo-examples/src/form-controls/value/associated-value/associated-value-example.ts
+++ b/projects/novo-examples/src/form-controls/value/associated-value/associated-value-example.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NOVO_VALUE_TYPE, NOVO_VALUE_THEME } from 'novo-elements';
+import { NOVO_VALUE_THEME } from 'novo-elements';
 
 /**
  * @title Associated Value Example

--- a/projects/novo-examples/src/form-controls/value/basic-value/basic-value-example.ts
+++ b/projects/novo-examples/src/form-controls/value/basic-value/basic-value-example.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NOVO_VALUE_TYPE, NOVO_VALUE_THEME } from 'novo-elements';
+import { NOVO_VALUE_THEME } from 'novo-elements';
 
 /**
  * @title Basic Value Example

--- a/projects/novo-examples/src/form-controls/value/category-value/category-value-example.ts
+++ b/projects/novo-examples/src/form-controls/value/category-value/category-value-example.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NOVO_VALUE_TYPE, NOVO_VALUE_THEME } from 'novo-elements';
+import { NOVO_VALUE_THEME } from 'novo-elements';
 
 /**
  * @title Category Value Example

--- a/projects/novo-examples/src/form-controls/value/corporate-user-value/corporate-user-value-example.ts
+++ b/projects/novo-examples/src/form-controls/value/corporate-user-value/corporate-user-value-example.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NOVO_VALUE_TYPE, NOVO_VALUE_THEME } from 'novo-elements';
+import { NOVO_VALUE_THEME } from 'novo-elements';
 
 /**
  * @title Corporate User Value Example

--- a/projects/novo-examples/src/form-controls/value/date-time-value/date-time-value-example.ts
+++ b/projects/novo-examples/src/form-controls/value/date-time-value/date-time-value-example.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NOVO_VALUE_TYPE, NOVO_VALUE_THEME } from 'novo-elements';
+import { NOVO_VALUE_THEME } from 'novo-elements';
 
 /**
  * @title Date Time Value Example

--- a/projects/novo-examples/src/form-controls/value/entity-list-value/entity-list-value-example.ts
+++ b/projects/novo-examples/src/form-controls/value/entity-list-value/entity-list-value-example.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NOVO_VALUE_TYPE, NOVO_VALUE_THEME } from 'novo-elements';
+import { NOVO_VALUE_THEME } from 'novo-elements';
 
 /**
  * @title Entity List Value Example

--- a/projects/novo-examples/src/form-controls/value/external-link-value/external-link-value-example.ts
+++ b/projects/novo-examples/src/form-controls/value/external-link-value/external-link-value-example.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NOVO_VALUE_TYPE, NOVO_VALUE_THEME } from 'novo-elements';
+import { NOVO_VALUE_THEME } from 'novo-elements';
 
 /**
  * @title Value with Extenal Links Example

--- a/projects/novo-examples/src/form-controls/value/formatter-value/formatter-value-example.ts
+++ b/projects/novo-examples/src/form-controls/value/formatter-value/formatter-value-example.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NOVO_VALUE_TYPE, NOVO_VALUE_THEME } from 'novo-elements';
+import { NOVO_VALUE_THEME } from 'novo-elements';
 
 /**
  * @title Formatter Value Example

--- a/projects/novo-examples/src/form-controls/value/icon-value/icon-value-example.ts
+++ b/projects/novo-examples/src/form-controls/value/icon-value/icon-value-example.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NOVO_VALUE_TYPE, NOVO_VALUE_THEME } from 'novo-elements';
+import { NOVO_VALUE_THEME } from 'novo-elements';
 
 /**
  * @title Icon Value Example

--- a/projects/novo-examples/src/form-controls/value/multi-option-value/multi-option-value-example.ts
+++ b/projects/novo-examples/src/form-controls/value/multi-option-value/multi-option-value-example.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NOVO_VALUE_TYPE, NOVO_VALUE_THEME } from 'novo-elements';
+import { NOVO_VALUE_THEME } from 'novo-elements';
 
 /**
  * @title Multi Option Value Example

--- a/projects/novo-examples/src/patterns/activity-section/activity-section-example.ts
+++ b/projects/novo-examples/src/patterns/activity-section/activity-section-example.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { DateCell, PercentageCell, NovoTableConfig, NovoDropdownCell } from 'novo-elements';
+import { DateCell, PercentageCell } from 'novo-elements';
 
 /**
  * @title Activity Section

--- a/projects/novo-examples/src/utils/field-interactions/fi-async/fi-async-example.ts
+++ b/projects/novo-examples/src/utils/field-interactions/fi-async/fi-async-example.ts
@@ -1,7 +1,5 @@
 import { Component } from '@angular/core';
 import { FormUtils, TextBoxControl, FieldInteractionApi } from 'novo-elements';
-import { map } from 'rxjs/operators';
-import { MockMetaHeaders } from '../MockMeta';
 
 /**
  * @title Fi Async Example

--- a/projects/novo-examples/src/utils/field-interactions/fi-messaging/fi-messaging-example.ts
+++ b/projects/novo-examples/src/utils/field-interactions/fi-messaging/fi-messaging-example.ts
@@ -2,17 +2,10 @@ import { Component } from '@angular/core';
 // Vendor
 import {
   FormUtils,
-  NovoFormGroup,
   TextBoxControl,
   CheckboxControl,
   FieldInteractionApi,
-  SelectControl,
-  PickerControl,
-  DateTimeControl,
-  TilesControl,
 } from 'novo-elements';
-import { map } from 'rxjs/operators';
-import { MockMetaHeaders } from '../MockMeta';
 
 /**
  * @title Fi Messaging Example

--- a/projects/novo-examples/src/utils/toaster/toast-usage/toast-usage-example.ts
+++ b/projects/novo-examples/src/utils/toaster/toast-usage/toast-usage-example.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { NovoToastService } from 'novo-elements';
 
 /**
  * @title Static Toast Usage


### PR DESCRIPTION
## **Description**

remove unused imports with tslint

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**