### PR TITLE
BH-68882 Non-English support for dropdown searching

### DIFF
--- a/projects/novo-elements/src/elements/dropdown/Dropdown.ts
+++ b/projects/novo-elements/src/elements/dropdown/Dropdown.ts
@@ -1,5 +1,19 @@
 // NG2
-import { AfterContentInit, ChangeDetectorRef, Component, ContentChildren, ElementRef, EventEmitter, HostListener, Input, OnDestroy, OnInit, Output, QueryList, ViewChild } from '@angular/core';
+import {
+  AfterContentInit,
+  ChangeDetectorRef,
+  Component,
+  ContentChildren,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+  QueryList,
+  ViewChild,
+} from '@angular/core';
 import { Helpers } from '../../utils/Helpers';
 import { KeyCodes } from '../../utils/key-codes/KeyCodes';
 import { notify } from '../../utils/notifier/notifier.util';
@@ -194,7 +208,7 @@ export class NovoDropdownElement implements OnInit, OnDestroy {
       this.filterTermTimeout = setTimeout(() => {
         this.filterTerm = '';
       }, 2000);
-      const char = String.fromCharCode(event.keyCode);
+      const char = event.key;
       this.filterTerm = this.filterTerm.concat(char);
       const index = this._textItems.findIndex((value: string) => {
         return new RegExp(`^${this.filterTerm.toLowerCase()}`).test(value.trim().toLowerCase());
@@ -252,7 +266,7 @@ export class NovoItemElement {
 
   public active: boolean = false;
 
-  constructor(private dropdown: NovoDropdownElement, public element: ElementRef) { }
+  constructor(private dropdown: NovoDropdownElement, public element: ElementRef) {}
 
   @HostListener('click', ['$event'])
   public onClick(event: Event): void {
@@ -276,7 +290,7 @@ export class NovoDropdownListElement implements AfterContentInit {
   @ContentChildren(NovoItemElement)
   public items: QueryList<NovoItemElement>;
 
-  constructor(private dropdown: NovoDropdownElement) { }
+  constructor(private dropdown: NovoDropdownElement) {}
 
   public ngAfterContentInit(): void {
     this.dropdown.items = this.items;
@@ -290,4 +304,4 @@ export class NovoDropdownListElement implements AfterContentInit {
   selector: 'dropdown-item-header',
   template: '<ng-content></ng-content>',
 })
-export class NovoDropDownItemHeaderElement { }
+export class NovoDropDownItemHeaderElement {}

--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -1,6 +1,21 @@
 // NG
 import { FocusMonitor } from '@angular/cdk/a11y';
-import { ChangeDetectorRef, Component, ElementRef, EventEmitter, forwardRef, HostListener, Input, NgZone, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, ViewChild } from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  EventEmitter,
+  forwardRef,
+  HostListener,
+  Input,
+  NgZone,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Output,
+  SimpleChanges,
+  ViewChild,
+} from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { NovoLabelService } from '../../services/novo-label-service';
 import { Helpers } from '../../utils/Helpers';
@@ -84,8 +99,8 @@ export class NovoSelectElement implements OnInit, OnChanges, OnDestroy, ControlV
   createdItem: any;
   selected: any;
   model: any;
-  onModelChange: Function = () => { };
-  onModelTouched: Function = () => { };
+  onModelChange: Function = () => {};
+  onModelTouched: Function = () => {};
   filterTerm: string = '';
   filterTermTimeout;
   filteredOptions: any;
@@ -103,7 +118,7 @@ export class NovoSelectElement implements OnInit, OnChanges, OnDestroy, ControlV
     public ref: ChangeDetectorRef,
     private focusMonitor: FocusMonitor,
     private ngZone: NgZone,
-  ) { }
+  ) {}
 
   ngOnInit() {
     this.focusMonitor.monitor(this.dropdown.nativeElement).subscribe((origin) =>
@@ -276,7 +291,7 @@ export class NovoSelectElement implements OnInit, OnChanges, OnDestroy, ControlV
       this.filterTermTimeout = setTimeout(() => {
         this.filterTerm = '';
       }, 2000);
-      const char = String.fromCharCode(event.keyCode);
+      const char = event.key;
       this.filterTerm = this.filterTerm.concat(char);
       const item = this.filteredOptions.find((i) => i.label.toUpperCase().indexOf(this.filterTerm) === 0);
       if (item) {

--- a/projects/novo-elements/tsconfig.lib.json
+++ b/projects/novo-elements/tsconfig.lib.json
@@ -12,7 +12,7 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "types": [],
-    "lib": ["dom", "es2015"]
+    "lib": ["dom", "es2015", "es2016"]
   },
   "angularCompilerOptions": {
     "annotateForClosureCompiler": true,


### PR DESCRIPTION
## **Description**

Added support for non-English keyboards for typeahead on dropdowns. Uses `event.key` instead of the deprecated `event.keyCode`.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**
Auto-scrolling to an entry with non-english characters:
![image](https://user-images.githubusercontent.com/11037162/105232299-2f9b4a80-5b36-11eb-9c2c-e2bf5aabb468.png)
