### PR TITLE
feat(DatePickerInput): moving change event emit from handleBlur to dispatchOnChange

### DIFF
--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -156,7 +156,6 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
 
   _handleBlur(event: FocusEvent): void {
     this.blurEvent.emit(event);
-    this.changeEvent.emit(event);
   }
 
   _handleFocus(event: FocusEvent): void {
@@ -206,6 +205,7 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
   public dispatchOnChange(newValue?: any, blur: boolean = false, skip: boolean = false) {
     if (newValue !== this.value) {
       this._onChange(newValue);
+      this.changeEvent.emit(newValue);
       if (blur) {
         !skip && this.writeValue(newValue);
       } else {


### PR DESCRIPTION
## **Description**

Moved the change emit into an existing function already getting called on all changes, instead of calling it on blur which didn't account for all change scenarios.

#### **Verify that...**

- [X] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [X] `npm run lint` passes
- [X] `npm test` passes and code coverage is increased
- [X] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**