### PR TITLE
BH-70094 Fixed incorrect case-sensitivity in dropdown searching

### DIFF
--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -292,7 +292,7 @@ export class NovoSelectElement implements OnInit, OnChanges, OnDestroy, ControlV
         this.filterTerm = '';
       }, 2000);
       const char = event.key;
-      this.filterTerm = this.filterTerm.concat(char);
+      this.filterTerm = this.filterTerm.concat(char).toUpperCase();
       const item = this.filteredOptions.find((i) => i.label.toUpperCase().indexOf(this.filterTerm) === 0);
       if (item) {
         this.select(item, this.filteredOptions.indexOf(item));


### PR DESCRIPTION
## **Description**
Normalizes `select` search strings consistently so you can search without capslock.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**
![image](https://user-images.githubusercontent.com/11037162/110144087-f21d1480-7da5-11eb-8954-8a6cb3d99b12.png)
