### PR TITLE
ci(actions): change events that the action is triggered off of

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
   publish:
     runs-on: ubuntu-16.04
     needs: build
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@master
       - uses: actions/download-artifact@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,7 @@
 name: CI
 
-on:
-  pull_request:
-    branches: [master, f/v5]
+on: [push, pull_request]
+
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push]
 
 
 jobs:


### PR DESCRIPTION
## **Description**

The snapshot is not updated when there are PRs merged to master.  Update the action to run on [PR events](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request) and [push events](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#push)
