### PR TITLE
F/app bridge timeout

### DIFF
--- a/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
+++ b/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
@@ -552,7 +552,7 @@ export class AppBridge {
    * Fires or responds to an HTTP_GET event
    * @param packet any - packet of data to send with the event
    */
-  public httpGET(relativeURL: string, timeout: number = 50000): Promise<any> {
+  public httpGET(relativeURL: string, timeout: number = 10000): Promise<any> {
     return new Promise<any>((resolve, reject) => {
       if (this._handlers[AppBridgeHandler.HTTP]) {
         this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.GET, relativeURL }, (data: any, error: any) => {
@@ -575,7 +575,7 @@ export class AppBridge {
    * Fires or responds to an HTTP_POST event
    * @param packet any - packet of data to send with the event
    */
-  public httpPOST(relativeURL: string, postData: any, timeout: number = 50000): Promise<any> {
+  public httpPOST(relativeURL: string, postData: any, timeout: number = 10000): Promise<any> {
     return new Promise<any>((resolve, reject) => {
       if (this._handlers[AppBridgeHandler.HTTP]) {
         this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.POST, relativeURL, data: postData }, (data: any, error: any) => {
@@ -598,7 +598,7 @@ export class AppBridge {
    * Fires or responds to an HTTP_PUT event
    * @param packet any - packet of data to send with the event
    */
-  public httpPUT(relativeURL: string, putData: any, timeout: number = 50000): Promise<any> {
+  public httpPUT(relativeURL: string, putData: any, timeout: number = 10000): Promise<any> {
     return new Promise<any>((resolve, reject) => {
       if (this._handlers[AppBridgeHandler.HTTP]) {
         this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.PUT, relativeURL, data: putData }, (data: any, error: any) => {
@@ -621,7 +621,7 @@ export class AppBridge {
    * Fires or responds to an HTTP_DELETE event
    * @param packet any - packet of data to send with the event
    */
-  public httpDELETE(relativeURL: string, timeout: number = 50000): Promise<any> {
+  public httpDELETE(relativeURL: string, timeout: number = 10000): Promise<any> {
     return new Promise<any>((resolve, reject) => {
       if (this._handlers[AppBridgeHandler.HTTP]) {
         this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.DELETE, relativeURL }, (data: any, error: any) => {

--- a/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
+++ b/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
@@ -560,7 +560,7 @@ export class AppBridge {
         });
       } else {
         postRobot
-          .sendToParent(MESSAGE_TYPES.HTTP_GET, { relativeURL, timeout })
+          .sendToParent(MESSAGE_TYPES.HTTP_GET, { relativeURL }, { timeout })
           .then((event: any) => {
             resolve({ data: event.data.data, error: event.data.error });
           })
@@ -583,7 +583,7 @@ export class AppBridge {
         });
       } else {
         postRobot
-          .sendToParent(MESSAGE_TYPES.HTTP_POST, { timeout, relativeURL, data: postData })
+          .sendToParent(MESSAGE_TYPES.HTTP_POST, { relativeURL, data: postData }, { timeout })
           .then((event: any) => {
             resolve({ data: event.data.data, error: event.data.error });
           })
@@ -601,12 +601,12 @@ export class AppBridge {
   public httpPUT(relativeURL: string, putData: any, timeout: number = 50000): Promise<any> {
     return new Promise<any>((resolve, reject) => {
       if (this._handlers[AppBridgeHandler.HTTP]) {
-        this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.PUT, relativeURL, timeout, data: putData }, (data: any, error: any) => {
+        this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.PUT, relativeURL, data: putData }, (data: any, error: any) => {
           resolve({ data, error });
         });
       } else {
         postRobot
-          .sendToParent(MESSAGE_TYPES.HTTP_PUT, { relativeURL, data: putData })
+          .sendToParent(MESSAGE_TYPES.HTTP_PUT, { relativeURL, data: putData }, { timeout })
           .then((event: any) => {
             resolve({ data: event.data.data, error: event.data.error });
           })
@@ -629,7 +629,7 @@ export class AppBridge {
         });
       } else {
         postRobot
-          .sendToParent(MESSAGE_TYPES.HTTP_DELETE, { relativeURL, timeout })
+          .sendToParent(MESSAGE_TYPES.HTTP_DELETE, { relativeURL }, { timeout })
           .then((event: any) => {
             resolve({ data: event.data.data, error: event.data.error });
           })

--- a/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
+++ b/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
@@ -552,7 +552,7 @@ export class AppBridge {
    * Fires or responds to an HTTP_GET event
    * @param packet any - packet of data to send with the event
    */
-  public httpGET(relativeURL: string): Promise<any> {
+  public httpGET(relativeURL: string, timeout: number = 50000): Promise<any> {
     return new Promise<any>((resolve, reject) => {
       if (this._handlers[AppBridgeHandler.HTTP]) {
         this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.GET, relativeURL }, (data: any, error: any) => {
@@ -560,7 +560,7 @@ export class AppBridge {
         });
       } else {
         postRobot
-          .sendToParent(MESSAGE_TYPES.HTTP_GET, { relativeURL })
+          .sendToParent(MESSAGE_TYPES.HTTP_GET, { relativeURL, timeout })
           .then((event: any) => {
             resolve({ data: event.data.data, error: event.data.error });
           })
@@ -575,18 +575,15 @@ export class AppBridge {
    * Fires or responds to an HTTP_POST event
    * @param packet any - packet of data to send with the event
    */
-  public httpPOST(relativeURL: string, postData: any): Promise<any> {
+  public httpPOST(relativeURL: string, postData: any, timeout: number = 50000): Promise<any> {
     return new Promise<any>((resolve, reject) => {
       if (this._handlers[AppBridgeHandler.HTTP]) {
-        this._handlers[AppBridgeHandler.HTTP](
-          { verb: HTTP_VERBS.POST, relativeURL, data: postData },
-          (data: any, error: any) => {
-            resolve({ data, error });
-          },
-        );
+        this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.POST, relativeURL, data: postData }, (data: any, error: any) => {
+          resolve({ data, error });
+        });
       } else {
         postRobot
-          .sendToParent(MESSAGE_TYPES.HTTP_POST, { relativeURL, data: postData })
+          .sendToParent(MESSAGE_TYPES.HTTP_POST, { timeout, relativeURL, data: postData })
           .then((event: any) => {
             resolve({ data: event.data.data, error: event.data.error });
           })
@@ -601,15 +598,12 @@ export class AppBridge {
    * Fires or responds to an HTTP_PUT event
    * @param packet any - packet of data to send with the event
    */
-  public httpPUT(relativeURL: string, putData: any): Promise<any> {
+  public httpPUT(relativeURL: string, putData: any, timeout: number = 50000): Promise<any> {
     return new Promise<any>((resolve, reject) => {
       if (this._handlers[AppBridgeHandler.HTTP]) {
-        this._handlers[AppBridgeHandler.HTTP](
-          { verb: HTTP_VERBS.PUT, relativeURL, data: putData },
-          (data: any, error: any) => {
-            resolve({ data, error });
-          },
-        );
+        this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.PUT, relativeURL, timeout, data: putData }, (data: any, error: any) => {
+          resolve({ data, error });
+        });
       } else {
         postRobot
           .sendToParent(MESSAGE_TYPES.HTTP_PUT, { relativeURL, data: putData })
@@ -627,7 +621,7 @@ export class AppBridge {
    * Fires or responds to an HTTP_DELETE event
    * @param packet any - packet of data to send with the event
    */
-  public httpDELETE(relativeURL: string): Promise<any> {
+  public httpDELETE(relativeURL: string, timeout: number = 50000): Promise<any> {
     return new Promise<any>((resolve, reject) => {
       if (this._handlers[AppBridgeHandler.HTTP]) {
         this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.DELETE, relativeURL }, (data: any, error: any) => {
@@ -635,7 +629,7 @@ export class AppBridge {
         });
       } else {
         postRobot
-          .sendToParent(MESSAGE_TYPES.HTTP_DELETE, { relativeURL })
+          .sendToParent(MESSAGE_TYPES.HTTP_DELETE, { relativeURL, timeout })
           .then((event: any) => {
             resolve({ data: event.data.data, error: event.data.error });
           })


### PR DESCRIPTION
## **Description**

Added an optional to timeout to app bridge http calls to enable calls that take longer and added a default timeout of 50s.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still work