### PR TITLE
feat(Field Interactions): Adding isInvokedOnInit to identify to field interactions whether the operation is happening on init or not

### DIFF
--- a/projects/novo-elements/src/elements/form/Control.ts
+++ b/projects/novo-elements/src/elements/form/Control.ts
@@ -336,7 +336,7 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
         }
         if (interaction.invokeOnInit) {
           if (!this.form.controls[this.control.key].restrictFieldInteractions) {
-            this.executeInteraction(interaction);
+            this.executeInteraction(interaction, true);
           }
         }
       }
@@ -533,11 +533,12 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
     return false;
   }
 
-  executeInteraction(interaction) {
+  executeInteraction(interaction, isInvokedOnInit = false) {
     if (interaction.script && Helpers.isFunction(interaction.script)) {
       setTimeout(() => {
         this.fieldInteractionApi.form = this.form;
         this.fieldInteractionApi.currentKey = this.control.key;
+        this.fieldInteractionApi.isInvokedOnInit = isInvokedOnInit;
         try {
           interaction.script(this.fieldInteractionApi, this.control.key);
         } catch (err) {

--- a/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
@@ -52,6 +52,7 @@ export class FieldInteractionApi {
   private _currentKey: string;
   appBridge: AppBridge;
   private asyncBlockTimeout;
+  private _isInvokedOnInit = false;
 
   static FIELD_POSITIONS = {
     ABOVE_FIELD: 'ABOVE_FIELD',
@@ -102,6 +103,14 @@ export class FieldInteractionApi {
 
   get currentKey(): string {
     return this._currentKey;
+  }
+
+  set isInvokedOnInit(isOnInit: boolean) {
+    this._isInvokedOnInit = isOnInit;
+  }
+
+  get isInvokedOnInit(): boolean {
+    return this._isInvokedOnInit;
   }
 
   isActiveControlValid(): boolean {

--- a/projects/novo-examples/src/utils/field-interactions/fi-validation/fi-validation-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-validation/fi-validation-example.html
@@ -6,3 +6,4 @@
 <div class="final-value">Form Value - {{ form.value | json }}</div>
 <div class="final-value">Form Dirty - {{ form.dirty | json }}</div>
 <div class="final-value">Is Form Valid? - {{ form.valid | json }}</div>
+<div class="final-value">Is User Modified? - {{ isUserModified }}</div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-validation/fi-validation-example.ts
+++ b/projects/novo-examples/src/utils/field-interactions/fi-validation/fi-validation-example.ts
@@ -13,6 +13,7 @@ import { FormUtils, TextBoxControl, FieldInteractionApi } from 'novo-elements';
 export class FiValidationExample {
   public form: any = {};
   public controls: any = {};
+  public isUserModified = false;
 
   constructor(private formUtils: FormUtils) {
     const validationFunction = (API: FieldInteractionApi) => {
@@ -21,6 +22,7 @@ export class FiValidationExample {
       if (activeValue > 10) {
         API.markAsInvalid(API.getActiveKey(), 'Too high! Make it a lot lower!!');
       }
+      this.isUserModified = !API.isInvokedOnInit;
     };
 
     // Validation Field Interactions

--- a/projects/novo-examples/src/utils/field-interactions/field-interactions.md
+++ b/projects/novo-examples/src/utils/field-interactions/field-interactions.md
@@ -36,7 +36,7 @@ blur -- gets fired when the field loses focus
 
 The script function represents the function that will be fired for the event, you can see examples of these below.
 
-Lastly, 'invokeOnInit' will also trigger the Field Interaction when the form is created as well.
+Lastly, 'invokeOnInit' will also trigger the Field Interaction when the form is created as well. A script can check `API.isInvokedOnInit` to determine if the current call is due to initialization or due to a user change. 
 
 ##### Getting Current Context
 


### PR DESCRIPTION
## **Description**

Useful to scripts when using invokeOnInit combined with change, blur, or focus.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**