### PR TITLE
Set to percent value to null when the displayValue changes on percent…

### DIFF
--- a/projects/novo-elements/src/elements/form/Control.ts
+++ b/projects/novo-elements/src/elements/form/Control.ts
@@ -417,6 +417,8 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
       this.percentChangeSubscription = this.form.controls[this.control.key].displayValueChanges.subscribe((value) => {
         if (!Helpers.isEmpty(value)) {
           this.templateContext.$implicit.percentValue = Number((value * 100).toFixed(6).replace(/\.?0*$/, ''));
+        } else {
+          this.templateContext.$implicit.percentValue = null;
         }
       });
     }


### PR DESCRIPTION
## **Description**

Set percent value to null when the displayValue changes to empty on percentage fields

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**