### PR TITLE
chore(typescript): Add interactions to FieldInteractionAPI's addControl metaForNewField properties

### DIFF
--- a/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
@@ -740,7 +740,7 @@ export class FieldInteractionApi {
 
   addControl(
     key: string,
-    metaForNewField: { key?: string, type?: string, name?: string, label?: string },
+    metaForNewField: { key?: string, type?: string, name?: string, label?: string, interactions: Array<{ event?: 'change' | 'focus' | string, invokeOnInit?: boolean, script? }> },
     position: string = FieldInteractionApi.FIELD_POSITIONS.ABOVE_FIELD,
     initialValue?,
     otherForm?: NovoFormGroup,

--- a/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
+++ b/projects/novo-elements/src/elements/form/FieldInteractionApi.ts
@@ -740,7 +740,7 @@ export class FieldInteractionApi {
 
   addControl(
     key: string,
-    metaForNewField: { key?: string, type?: string, name?: string, label?: string, interactions: Array<{ event?: 'change' | 'focus' | string, invokeOnInit?: boolean, script? }> },
+    metaForNewField: { key?: string, type?: string, name?: string, label?: string, interactions?: Array<{ event?: string, invokeOnInit?: boolean, script? }> },
     position: string = FieldInteractionApi.FIELD_POSITIONS.ABOVE_FIELD,
     initialValue?,
     otherForm?: NovoFormGroup,


### PR DESCRIPTION
## **Description**

Allow interactions to be passed with the meta for FieldInteractionAPI's addControl.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**