### PR TITLE
fix: bug with dot and minus symbols on percentage fields

### DIFF
--- a/projects/novo-elements/src/elements/form/Control.ts
+++ b/projects/novo-elements/src/elements/form/Control.ts
@@ -417,7 +417,7 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
       this.percentChangeSubscription = this.form.controls[this.control.key].displayValueChanges.subscribe((value) => {
         if (!Helpers.isEmpty(value) && !isNaN(value)) {
           this.templateContext.$implicit.percentValue = Number((value * 100).toFixed(6).replace(/\.?0*$/, ''));
-        } else {
+        } else if (Helpers.isEmpty(value)) {
           this.templateContext.$implicit.percentValue = undefined;
         }
       });

--- a/projects/novo-elements/src/elements/form/Control.ts
+++ b/projects/novo-elements/src/elements/form/Control.ts
@@ -418,7 +418,7 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
         if (!Helpers.isEmpty(value)) {
           this.templateContext.$implicit.percentValue = Number((value * 100).toFixed(6).replace(/\.?0*$/, ''));
         } else {
-          this.templateContext.$implicit.percentValue = null;
+          this.templateContext.$implicit.percentValue = undefined;
         }
       });
     }

--- a/projects/novo-elements/src/elements/form/Control.ts
+++ b/projects/novo-elements/src/elements/form/Control.ts
@@ -415,7 +415,7 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
         );
       }
       this.percentChangeSubscription = this.form.controls[this.control.key].displayValueChanges.subscribe((value) => {
-        if (!Helpers.isEmpty(value)) {
+        if (!Helpers.isEmpty(value) && !isNaN(value)) {
           this.templateContext.$implicit.percentValue = Number((value * 100).toFixed(6).replace(/\.?0*$/, ''));
         } else {
           this.templateContext.$implicit.percentValue = undefined;
@@ -663,8 +663,8 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
   }
 
   handlePercentChange(event: KeyboardEvent) {
-    const value = event.target['value'];
-    const percent = Helpers.isEmpty(value) ? null : Number((value / 100).toFixed(6).replace(/\.?0*$/, ''));
+    const value = event.target['value'] || event['data'];
+    const percent = (Helpers.isEmpty(value) || isNaN(value)) ? value : Number((value / 100).toFixed(6).replace(/\.?0*$/, ''));
     if (!Helpers.isEmpty(percent)) {
       this.change.emit(percent);
       this.form.controls[this.control.key].setValue(percent);


### PR DESCRIPTION
## **Description**

Set percentValue to undefined rather than null

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [x] Run `BBO Automation`

##### **Screenshots**