### PR TITLE
chore(actions): create manual action to publish novo elements 

### DIFF
--- a/.github/workflows/releaseNovoElements.yml
+++ b/.github/workflows/releaseNovoElements.yml
@@ -2,10 +2,10 @@ name: Release Novo Elements
 on:
   workflow_dispatch:
     inputs:
-    type:
-      description: 'Update Type (patch, major, minor)'
-      required: true
-      default: 'patch'
+      type:
+        description: 'Update Type (major, minor, patch)'
+        required: true
+        default: 'patch'
 
 jobs:
   build:

--- a/.github/workflows/releaseNovoElements.yml
+++ b/.github/workflows/releaseNovoElements.yml
@@ -1,0 +1,44 @@
+name: Release Novo Elements
+on:
+  workflow_dispatch:
+    inputs:
+    type:
+      description: 'Update Type (patch, major, minor)'
+      required: true
+      default: 'patch'
+
+jobs:
+  build:
+    name: Build & Publish
+    runs-on: ubuntu-16.04
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup NodeJS
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.16.3
+      - name: Install Dependencies
+        run: |
+          npm ci
+      - name: Update Version Number
+        run: |
+          npm version ${{ github.event.inputs.type }}
+          cd projects/novo-elements
+          npm version ${{ github.event.inputs.type }}
+          cd ../..
+      - name: Commit & Push Token
+        uses: actions-js/push@v1.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tags: true
+      - name: Build
+        run: |
+          npm run build
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/releaseNovoElements.yml
+++ b/.github/workflows/releaseNovoElements.yml
@@ -1,11 +1,5 @@
 name: Release Novo Elements
-on:
-  workflow_dispatch:
-    inputs:
-      type:
-        description: 'Update Type (major, minor, patch)'
-        required: true
-        default: 'patch'
+on: [workflow_dispatch]
 
 jobs:
   build:
@@ -26,21 +20,6 @@ jobs:
           npm ci
       - name: Update Version Number
         run: |
-          npm version ${{ github.event.inputs.type }}
-          cd projects/novo-elements
-          npm version ${{ github.event.inputs.type }}
-          cd ../..
-      - name: Commit & Push Token
-        uses: actions-js/push@v1.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tags: true
-      - name: Build
-        run: |
-          npm run build
-      - name: Publish
-        run: |
-          cd dist/novo-elements
-          npm publish
+          npm run release:elements
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/releaseNovoElements.yml
+++ b/.github/workflows/releaseNovoElements.yml
@@ -39,6 +39,8 @@ jobs:
         run: |
           npm run build
       - name: Publish
-        run: npm publish
+        run: |
+          cd dist/novo-elements
+          npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## **Description**

Create an action that publishes Novo elements to NPM automatically.  This is run manually from the actions tab. 