### PR TITLE
feat(DataTable): Expose sort and filter in novo-data-table

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -260,7 +260,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   @HostBinding('class.global-search-hidden') globalSearchHiddenClassToggle: boolean = false;
 
   @ContentChildren(NovoTemplate) customTemplates: QueryList<NovoTemplate>;
-  @ContentChild(NovoDataTableSortFilter) sortFilterDirective: NovoDataTableSortFilter<T>;
+  @ContentChild(NovoDataTableSortFilter, { static: false }) sortFilterDirective: NovoDataTableSortFilter<T>;
   @ViewChildren(NovoTemplate) defaultTemplates: QueryList<NovoTemplate>;
   @ViewChildren(NovoDataTableCellHeader) cellHeaders: QueryList<NovoDataTableCellHeader<T>>;
   @ViewChild('novoDataTableContainer', { static: false }) novoDataTableContainer: ElementRef;

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -17,6 +17,7 @@ import {
   TemplateRef,
   ViewChild,
   ViewChildren,
+  forwardRef
 } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { NovoLabelService } from '../../services/novo-label-service';
@@ -260,7 +261,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   @HostBinding('class.global-search-hidden') globalSearchHiddenClassToggle: boolean = false;
 
   @ContentChildren(NovoTemplate) customTemplates: QueryList<NovoTemplate>;
-  @ContentChild(NovoDataTableSortFilter, { static: false }) sortFilterDirective: NovoDataTableSortFilter<T>;
+  @ContentChild(forwardRef(() => NovoDataTableSortFilter), { static: false }) sortFilterDirective: NovoDataTableSortFilter<T>;
   @ViewChildren(NovoTemplate) defaultTemplates: QueryList<NovoTemplate>;
   @ViewChildren(NovoDataTableCellHeader) cellHeaders: QueryList<NovoDataTableCellHeader<T>>;
   @ViewChild('novoDataTableContainer', { static: false }) novoDataTableContainer: ElementRef;

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -5,6 +5,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  ContentChild,
   ContentChildren,
   ElementRef,
   EventEmitter,
@@ -35,6 +36,7 @@ import { StaticDataTableService } from './services/static-data-table.service';
 import { DataTableState } from './state/data-table-state.service';
 import { NovoDataTableCellHeader } from './cell-headers/data-table-header-cell.component';
 import { ListInteractionDictionary, ListInteractionEvent } from './ListInteractionTypes';
+import { NovoDataTableSortFilter } from './sort-filter/sort-filter.directive';
 
 @Component({
   selector: 'novo-data-table',
@@ -258,6 +260,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   @HostBinding('class.global-search-hidden') globalSearchHiddenClassToggle: boolean = false;
 
   @ContentChildren(NovoTemplate) customTemplates: QueryList<NovoTemplate>;
+  @ContentChild(NovoDataTableSortFilter) sortFilterDirective: NovoDataTableSortFilter<T>;
   @ViewChildren(NovoTemplate) defaultTemplates: QueryList<NovoTemplate>;
   @ViewChildren(NovoDataTableCellHeader) cellHeaders: QueryList<NovoDataTableCellHeader<T>>;
   @ViewChild('novoDataTableContainer', { static: false }) novoDataTableContainer: ElementRef;
@@ -626,6 +629,17 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
       }
     }
     return true;
+  }
+
+  public filter(
+    id: string,
+    type: string,
+    value: any,
+    transform: Function,
+    allowMultipleFilters: boolean = false,
+    selectedOption?: Object,
+    ): void {
+    this.sortFilterDirective.filter(id, type, value, transform, allowMultipleFilters, selectedOption);
   }
 
   private configureLastDisplayedColumn(): void {

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -647,7 +647,6 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
     this.sortFilterDirective.sort(id, value, transform);
   }
 
-
   private configureLastDisplayedColumn(): void {
     if (this.columns && this.displayedColumns && 0 !== this.columns.length && 0 !== this.displayedColumns.length) {
       this.columns.forEach((column: IDataTableColumn<T>) => {

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -261,10 +261,10 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   @HostBinding('class.global-search-hidden') globalSearchHiddenClassToggle: boolean = false;
 
   @ContentChildren(NovoTemplate) customTemplates: QueryList<NovoTemplate>;
-  @ContentChild(forwardRef(() => NovoDataTableSortFilter), { static: false }) sortFilterDirective: NovoDataTableSortFilter<T>;
   @ViewChildren(NovoTemplate) defaultTemplates: QueryList<NovoTemplate>;
   @ViewChildren(NovoDataTableCellHeader) cellHeaders: QueryList<NovoDataTableCellHeader<T>>;
   @ViewChild('novoDataTableContainer', { static: false }) novoDataTableContainer: ElementRef;
+  @ViewChild(forwardRef(() => NovoDataTableSortFilter), { static: false }) sortFilterDirective: NovoDataTableSortFilter<T>;
   @Output() resized: EventEmitter<IDataTableColumn<T>> = new EventEmitter();
 
   @Input()
@@ -642,6 +642,11 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
     ): void {
     this.sortFilterDirective.filter(id, type, value, transform, allowMultipleFilters, selectedOption);
   }
+
+  public sort(id: string, value: string, transform: Function): void {
+    this.sortFilterDirective.sort(id, value, transform);
+  }
+
 
   private configureLastDisplayedColumn(): void {
     if (this.columns && this.displayedColumns && 0 !== this.columns.length && 0 !== this.displayedColumns.length) {

--- a/projects/novo-elements/src/elements/data-table/data-table.module.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.module.ts
@@ -89,6 +89,7 @@ import { NovoDataTableClearButton } from './data-table-clear-button.component';
     DateTableTimeRendererPipe,
     DataTableBigDecimalRendererPipe,
     NovoDataTableClearButton,
+    NovoDataTableSortFilter,
   ],
 })
 export class NovoDataTableModule {}

--- a/projects/novo-elements/src/elements/data-table/data-table.module.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.module.ts
@@ -89,7 +89,6 @@ import { NovoDataTableClearButton } from './data-table-clear-button.component';
     DateTableTimeRendererPipe,
     DataTableBigDecimalRendererPipe,
     NovoDataTableClearButton,
-    NovoDataTableSortFilter,
   ],
 })
 export class NovoDataTableModule {}


### PR DESCRIPTION
## **Description**

Expose sort and filter as methods in novo-data-table.  This allows content on the table to be manipulated, without directly manipulating state.  The distinction for this feature versus manipulating `outsideFilter` is the persistence of the filter as a preference. 

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**