### PR TITLE
fix(GroupedMultiPicker): correct typo in groupedMultiPicker empty state

### DIFF
--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -100,7 +100,7 @@ export class NovoLabelService {
   actions = 'Actions';
   all = 'All';
   groupedMultiPickerEmpty = 'No items to display';
-  groupedMultiPickerSelectCategory = 'Select a category from the right to get started';
+  groupedMultiPickerSelectCategory = 'Select a category from the left to get started';
   add = 'Add';
   encryptedFieldTooltip = 'This data has been stored at the highest level of security';
   noStatesForCountry = 'No states available for the selected country';


### PR DESCRIPTION
## **Description**

It says to select a category from the right to get started even though the categories are on the left.

![image](https://user-images.githubusercontent.com/4327754/122063581-02398c80-cdb6-11eb-9541-a4783801a189.png)


#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**