### PR TITLE
fix(Helpers): excluding classes from function deep cloning logic

### DIFF
--- a/projects/novo-elements/src/utils/Helpers.ts
+++ b/projects/novo-elements/src/utils/Helpers.ts
@@ -233,7 +233,7 @@ export class Helpers {
       }
       return newArr;
     }
-    if (typeof item === 'function' && !/\(\) \{ \[native/.test(item.toString())) {
+    if (typeof item === 'function' && !/\(\) \{ \[native/.test(item.toString()) && !item.toString().startsWith('class')) {
       let obj;
       for (const k in item) {
         if (k in item) {


### PR DESCRIPTION
## **Description**

angular 10 upgrade PR introduced a bug where we are now attempting to deep clone classes using logic that exists to deep clone functions, resulting in an exception being thrown when trying to iterate through it and copy it.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**