### PR TITLE
chore(actions): change build process to build production

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,9 @@ jobs:
           npm test
       - name: Build
         run: |
-          npm run build
+          ng build novo-elements --configuration production
+          ng build chomsky --configuration production
+          npm run postbuild
           npm run build:demo
       - uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,9 +26,7 @@ jobs:
           npm test
       - name: Build
         run: |
-          ng build novo-elements --configuration production
-          ng build chomsky --configuration production
-          npm run postbuild
+          npm run build:ci
           npm run build:demo
       - uses: actions/upload-artifact@master
         with:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "precommit": "lint-staged",
     "build": "ng build novo-elements && ng build chomsky",
     "postbuild": "npm run copy-scss && npm run build:examples",
+    "build:ci":"ng build novo-elements --configuration production && ng build chomsky --configuration production",
+    "postbuild:ci": "npm run postbuild",
     "postinstall": "ngcc ... --tsconfig './projects/novo-elements/tsconfig.lib.json'",
     "build:watch": "ng build novo-elements --watch",
     "build:chomsky": "ng build chomsky",

--- a/snapshot-publish
+++ b/snapshot-publish
@@ -35,15 +35,15 @@ echo "https://${API_TOKEN_GITHUB}:@github.com" > .git/credentials
 
 git status
 git add -A
+if ! git diff-index --quiet HEAD; then
 git commit -m "$commitMessage"
-
-if "$CURRENT_BRANCH" == "master"; then
-    echo "Committing and pushing to master"
-    git tag "$commitSha"
-    git push origin master --tags
-else
-    echo "Committing and pushing to $CURRENT_BRANCH"
-    git push -u origin $CURRENT_BRANCH --force
+  if "$CURRENT_BRANCH" == "master"; then
+      echo "Committing and pushing to master"
+      git tag "$commitSha"
+      git push origin master --tags
+  else
+      echo "Committing and pushing to $CURRENT_BRANCH"
+      git push -u origin $CURRENT_BRANCH --force
+  fi
 fi
-
 echo "Finished publishing snapshot build to $CURRENT_BRANCH"


### PR DESCRIPTION
## **Description**
fixes #1202

This changes the snapshot build to use production configuration

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**