### PR TITLE
feat(NovoTable): Adding tool tip on default cell renderers + experimental support for HTML tooltips

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -168,30 +168,30 @@ import { ListInteractionDictionary, ListInteractionEvent } from './ListInteracti
     </div>
     <!-- DEFAULT CELL TEMPLATE -->
     <ng-template novoTemplate="textCellTemplate" let-row let-col="col">
-      <span [style.width.px]="col?.width" [style.min-width.px]="col?.width" [style.max-width.px]="col?.width">{{
+      <span [tooltipSize]="toolTipSize" tooltipPreline="true" tooltipPosition="top" [tooltip]="row[col.id] | dataTableInterpolate: col" [style.width.px]="col?.width" [style.min-width.px]="col?.width" [style.max-width.px]="col?.width">{{
         row[col.id] | dataTableInterpolate: col
       }}</span>
     </ng-template>
     <ng-template novoTemplate="dateCellTemplate" let-row let-col="col">
-      <span>{{ row[col.id] | dataTableInterpolate: col | dataTableDateRenderer: col }}</span>
+      <span [tooltip]="row[col.id] | dataTableInterpolate: col | dataTableDateRenderer: col">{{ row[col.id] | dataTableInterpolate: col | dataTableDateRenderer: col }}</span>
     </ng-template>
     <ng-template novoTemplate="datetimeCellTemplate" let-row let-col="col">
-      <span>{{ row[col.id] | dataTableInterpolate: col | dataTableDateTimeRenderer: col }}</span>
+      <span [tooltip]="row[col.id] | dataTableInterpolate: col | dataTableDateTimeRenderer: col">{{ row[col.id] | dataTableInterpolate: col | dataTableDateTimeRenderer: col }}</span>
     </ng-template>
     <ng-template novoTemplate="timeCellTemplate" let-row let-col="col">
-      <span>{{ row[col.id] | dataTableInterpolate: col | dataTableTimeRenderer: col }}</span>
+      <span [tooltip]="row[col.id] | dataTableInterpolate: col | dataTableTimeRenderer: col">{{ row[col.id] | dataTableInterpolate: col | dataTableTimeRenderer: col }}</span>
     </ng-template>
     <ng-template novoTemplate="currencyCellTemplate" let-row let-col="col">
-      <span>{{ row[col.id] | dataTableInterpolate: col | dataTableCurrencyRenderer: col }}</span>
+      <span [tooltip]="row[col.id] | dataTableInterpolate: col | dataTableCurrencyRenderer: col">{{ row[col.id] | dataTableInterpolate: col | dataTableCurrencyRenderer: col }}</span>
     </ng-template>
     <ng-template novoTemplate="bigdecimalCellTemplate" let-row let-col="col">
-      <span>{{ row[col.id] | dataTableInterpolate: col | dataTableBigDecimalRenderer: col }}</span>
+      <span [tooltip]="row[col.id] | dataTableInterpolate: col | dataTableBigDecimalRenderer: col">{{ row[col.id] | dataTableInterpolate: col | dataTableBigDecimalRenderer: col }}</span>
     </ng-template>
     <ng-template novoTemplate="numberCellTemplate" let-row let-col="col">
-      <span>{{ row[col.id] | dataTableInterpolate: col | dataTableNumberRenderer: col }}</span>
+      <span [tooltip]="row[col.id] | dataTableInterpolate: col | dataTableNumberRenderer: col">{{ row[col.id] | dataTableInterpolate: col | dataTableNumberRenderer: col }}</span>
     </ng-template>
     <ng-template novoTemplate="percentCellTemplate" let-row let-col="col">
-      <span>{{ row[col.id] | dataTableInterpolate: col | dataTableNumberRenderer: col:true }}</span>
+      <span tooltip="row[col.id] | dataTableInterpolate: col | dataTableNumberRenderer: col:true">{{ row[col.id] | dataTableInterpolate: col | dataTableNumberRenderer: col:true }}</span>
     </ng-template>
     <ng-template novoTemplate="linkCellTemplate" let-row let-col="col">
       <a
@@ -421,6 +421,8 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   private scrollListenerHandler: any;
   private initialized: boolean = false;
 
+  public toolTipSize: 'extra-large';
+
   @HostBinding('class.empty')
   get empty() {
     return this.dataSource && this.dataSource.totallyEmpty;
@@ -477,6 +479,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
     header.setupFilterOptions();
     header.changeDetectorRef.markForCheck();
   }
+
 
   public ngOnDestroy(): void {
     if (this.outsideFilterSubscription) {

--- a/projects/novo-elements/src/elements/tooltip/Tooltip.component.ts
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.component.ts
@@ -6,7 +6,8 @@ import { trigger, state, style, animate, transition } from '@angular/animations'
   selector: 'novo-tooltip',
   template: `
     <div [@state]="noAnimate ? 'no-animation' : 'visible'"
-         [ngClass]="[tooltipType, this.rounded ? 'rounded' : '', size ? size : '', this.preline? 'preline' : '', position]">{{message}}</div>`,
+         [ngClass]="[tooltipType, this.rounded ? 'rounded' : '', size ? size : '', this.preline? 'preline' : '', position]"
+         [innerHTML]="message"></div>`,
   animations: [
     trigger('state', [
       state('initial, void, hidden', style({ opacity: '0' })),


### PR DESCRIPTION
## **Description**

- Added tool tip to novo datatable cell renderers
- Made tooltip support HTML content 

#### **Verified that...**

- ✔️  Any related demos were added and `npm start` and `npm run build` still works
- ✔️  New demos work in `Safari`, `Chrome` and `Firefox`
- ✔️ `npm run lint` passes
- ❌   `npm test` passes : one unrelated unit test was failing, assuming it's an existing issue, will discuss with team
- ✔️  `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**
![image](https://user-images.githubusercontent.com/642938/127875320-e44a6e66-63f1-40de-83c4-bd865c699bbe.png)
