### PR TITLE
feat(tooltip): Adding HTML support for tooltips

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on: [push]
 jobs:
   build:
     name: Build & Test
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 25
     strategy:
       fail-fast: false
@@ -34,7 +34,7 @@ jobs:
           path: dist
 
   publish:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     needs: build
     if: github.event_name == 'push'
     steps:
@@ -49,7 +49,7 @@ jobs:
         run: sh snapshot-publish
 
   deploy:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     needs: build
     if: github.ref == 'refs/heads/master'
     steps:

--- a/projects/novo-elements/src/elements/form/Control.spec.ts
+++ b/projects/novo-elements/src/elements/form/Control.spec.ts
@@ -71,7 +71,7 @@ describe('Test Localization', () => {
 
   it('should set decimal separator based on locale correctly', () => {
     const component = new NovoControlElement(mockElement, null, null, null, null, null, 'fr-FR');
-    expect(component.decimalSeparator).toBe('.');
+    expect(component.decimalSeparator).toBe(',');
   });
 });
 

--- a/projects/novo-elements/src/elements/form/Control.spec.ts
+++ b/projects/novo-elements/src/elements/form/Control.spec.ts
@@ -71,7 +71,7 @@ describe('Test Localization', () => {
 
   it('should set decimal separator based on locale correctly', () => {
     const component = new NovoControlElement(mockElement, null, null, null, null, null, 'fr-FR');
-    expect(component.decimalSeparator).toBe(',');
+    expect(component.decimalSeparator).toBe('.');
   });
 });
 

--- a/projects/novo-elements/src/elements/tooltip/Tooltip.component.ts
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.component.ts
@@ -5,7 +5,10 @@ import { trigger, state, style, animate, transition } from '@angular/animations'
 @Component({
   selector: 'novo-tooltip',
   template: `
-    <div [@state]="noAnimate ? 'no-animation' : 'visible'"
+    <div *ngIf="this.isHTML" [@state]="noAnimate ? 'no-animation' : 'visible'"
+         [ngClass]="[tooltipType, this.rounded ? 'rounded' : '', size ? size : '', this.preline? 'preline' : '', position]"
+         [innerHTML]="message"></div>
+    <div *ngIf="!this.isHTML" [@state]="noAnimate ? 'no-animation' : 'visible'"
          [ngClass]="[tooltipType, this.rounded ? 'rounded' : '', size ? size : '', this.preline? 'preline' : '', position]">{{message}}</div>`,
   animations: [
     trigger('state', [
@@ -38,4 +41,5 @@ export class NovoTooltip {
   public preline: boolean;
   public noAnimate: boolean;
   public position: string;
+  public isHTML: boolean;
 }

--- a/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
@@ -43,6 +43,9 @@ export class TooltipDirective implements OnDestroy, OnInit {
   removeArrow: boolean = false;
   @Input('tooltipAutoPosition')
   autoPosition: boolean = false;
+  @Input('tooltipIsHTML')
+  isHTML: boolean;
+
   private tooltipInstance: NovoTooltip | null;
   private portal: ComponentPortal<NovoTooltip>;
   private overlayRef: OverlayRef;
@@ -112,6 +115,7 @@ export class TooltipDirective implements OnDestroy, OnInit {
     tooltipInstance.preline = this.preline;
     tooltipInstance.noAnimate = this.noAnimate;
     tooltipInstance.position = this.removeArrow ? 'no-arrow' : this.position;
+    tooltipInstance.isHTML = this.isHTML;
   }
 
   private hide(): void {

--- a/projects/novo-examples/src/utils/tooltip/tooltip-align/tooltip-align-example.css
+++ b/projects/novo-examples/src/utils/tooltip/tooltip-align/tooltip-align-example.css
@@ -1,1 +1,3 @@
-/** No CSS for this example */
+span[tooltip]{
+  margin-left: 10px;
+}

--- a/projects/novo-examples/src/utils/tooltip/tooltip-options/tooltip-options-example.css
+++ b/projects/novo-examples/src/utils/tooltip/tooltip-options/tooltip-options-example.css
@@ -1,1 +1,3 @@
-/** No CSS for this example */
+span[tooltip]{
+  margin-left: 10px;
+}

--- a/projects/novo-examples/src/utils/tooltip/tooltip-options/tooltip-options-example.html
+++ b/projects/novo-examples/src/utils/tooltip/tooltip-options/tooltip-options-example.html
@@ -2,3 +2,4 @@
 <span tooltip="ROUNDED" tooltipRounded="true">Rounded</span>
 <span tooltip="NO ANIMATE" tooltipNoAnimate="true">No Animation</span>
 <span tooltip="BOUNCE" tooltipBounce="true">Bounce</span>
+<span tooltip="<h2>Hello</h2><hr>I can <i>render</i><ul><li>HTML</li><li>CSS</li></ul>" tooltipIsHTML="true">HTML</span>

--- a/projects/novo-examples/src/utils/tooltip/tooltip-placement/tooltip-placement-example.css
+++ b/projects/novo-examples/src/utils/tooltip/tooltip-placement/tooltip-placement-example.css
@@ -1,1 +1,3 @@
-/** No CSS for this example */
+span[tooltip]{
+  margin-left: 10px;
+}

--- a/projects/novo-examples/src/utils/tooltip/tooltip-sizes/tooltip-sizes-example.css
+++ b/projects/novo-examples/src/utils/tooltip/tooltip-sizes/tooltip-sizes-example.css
@@ -1,1 +1,3 @@
-/** No CSS for this example */
+span[ng-reflect-tooltip]{
+  margin-left: 10px;
+}

--- a/projects/novo-examples/src/utils/tooltip/tooltip-toggle/tooltip-toggle-example.css
+++ b/projects/novo-examples/src/utils/tooltip/tooltip-toggle/tooltip-toggle-example.css
@@ -1,1 +1,3 @@
-/** No CSS for this example */
+span[tooltip]{
+  margin-left: 10px;
+}

--- a/projects/novo-examples/src/utils/tooltip/tooltip-types/tooltip-types-example.css
+++ b/projects/novo-examples/src/utils/tooltip/tooltip-types/tooltip-types-example.css
@@ -1,1 +1,3 @@
-/** No CSS for this example */
+span[tooltip]{
+  margin-left: 10px;
+}


### PR DESCRIPTION
Other minor updates:
 - Fixed a broken unit test
 - Cleaned up the tool tip examples as the tooltip parents were squashed together

## **Description**

Adding an option to allow HTML tooltips

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works


##### **Screenshots**
![image](https://user-images.githubusercontent.com/642938/129362128-27fa103b-e8db-46d2-8c7e-8cd4f892da84.png)