### PR TITLE
feat(ControlGroup): Add optional delete button confirmation

### DIFF
--- a/projects/novo-elements/src/elements/button/Button.scss
+++ b/projects/novo-elements/src/elements/button/Button.scss
@@ -305,6 +305,7 @@ button {
       i {
         margin: 0 !important;
       }
+      &:focus,
       &:hover {
         background: rgba(0, 0, 0, 0.1);
       }
@@ -326,6 +327,7 @@ button {
           background: $color;
         }
       }
+      &:focus,
       &:hover {
         box-shadow: 0px 1px 2px -1px rgba(0, 0, 0, 0.2), 0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 1px 3px 0px rgba(0, 0, 0, 0.12);
       }


### PR DESCRIPTION
## **Description**

Added optional method for a delete button confirmation for form control groups.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`
