### PR TITLE
feat(Select): Add optional disabled state and tooltip

### DIFF
--- a/projects/novo-elements/src/elements/select/Select.module.ts
+++ b/projects/novo-elements/src/elements/select/Select.module.ts
@@ -5,10 +5,11 @@ import { FormsModule } from '@angular/forms';
 import { A11yModule } from '@angular/cdk/a11y';
 // App
 import { NovoOverlayModule } from '../overlay/Overlay.module';
+import { NovoTooltipModule } from '../tooltip/Tooltip.module';
 import { NovoSelectElement } from './Select';
 
 @NgModule({
-  imports: [CommonModule, FormsModule, A11yModule, NovoOverlayModule],
+  imports: [CommonModule, FormsModule, A11yModule, NovoOverlayModule, NovoTooltipModule],
   declarations: [NovoSelectElement],
   exports: [NovoSelectElement],
 })

--- a/projects/novo-elements/src/elements/select/Select.scss
+++ b/projects/novo-elements/src/elements/select/Select.scss
@@ -103,10 +103,16 @@ novo-select {
       color: $positive;
       line-height: 1.4em;
     }
-    &:focus,
-    &:hover {
-      background: lighten($light, 10%);
-      color: darken($light, 55%);
+    &.disabled {
+      cursor: not-allowed;
+      color: $grey;
+    }
+    &:not(.disabled) {
+      &:focus,
+      &:hover {
+        background: lighten($light, 10%);
+        color: darken($light, 55%);
+      }
     }
     &.active {
       color: darken($light, 55%);

--- a/projects/novo-elements/src/elements/select/Select.spec.ts
+++ b/projects/novo-elements/src/elements/select/Select.spec.ts
@@ -171,6 +171,18 @@ describe('Elements: NovoSelectElement', () => {
       comp.setValueAndClose({});
       expect(comp.overlay.closePanel).toHaveBeenCalled();
     });
+    it('should invoke not invoke select and close panel for disabled item', () => {
+      const mockEvent: any = {
+        value: { id: 1, label: 'one', disabled: true },
+        index: 1,
+      };
+      spyOn(comp.overlay, 'closePanel');
+      comp.setValueAndClose(mockEvent);
+      expect(comp.selectedIndex).toEqual(-1);
+      expect(comp.selected).toBeUndefined();
+      expect(comp.empty).toEqual(true);
+      expect(comp.overlay.closePanel).not.toHaveBeenCalled();
+    });
   });
 
   describe('Function: select(option, i, fireEvents)', () => {

--- a/projects/novo-elements/src/elements/select/Select.spec.ts
+++ b/projects/novo-elements/src/elements/select/Select.spec.ts
@@ -171,7 +171,7 @@ describe('Elements: NovoSelectElement', () => {
       comp.setValueAndClose({});
       expect(comp.overlay.closePanel).toHaveBeenCalled();
     });
-    it('should invoke not invoke select and close panel for disabled item', () => {
+    it('should not invoke select or close panel for a disabled item', () => {
       const mockEvent: any = {
         value: { id: 1, label: 'one', disabled: true },
         index: 1,

--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -62,9 +62,11 @@ const SELECT_VALUE_ACCESSOR = {
         </li>
         <li
           *ngFor="let option of filteredOptions; let i = index"
-          [ngClass]="{ active: option.active }"
+          [ngClass]="{ active: option.active, disabled: option.disabled }"
           (click)="setValueAndClose({ value: option, index: i })"
           [attr.data-automation-value]="option.label"
+          [tooltip]="option.tooltip"
+          [tooltipPosition]="option.tooltipPosition || 'right'"
         >
           <span [innerHtml]="highlight(option.label, filterTerm)"></span> <i *ngIf="option.active" class="bhi-check"></i>
         </li>
@@ -193,15 +195,17 @@ export class NovoSelectElement implements OnInit, OnChanges, OnDestroy, ControlV
   /** END: Convenient Panel Methods. */
 
   /**
-   * This method closes the panel, and if a value is specified, also sets the associated
-   * control to that value. It will also mark the control as dirty if this interaction
-   * stemmed from the user.
+   * If the item is not disabled, this method closes the panel, and if a value is specified,
+   * also sets the associated control to that value. It will also mark the control as dirty
+   * if this interaction stemmed from the user.
    */
   setValueAndClose(event: any | null): void {
-    if (event.value && event.index >= 0) {
-      this.select(event.value, event.index);
+    if (!event.value?.disabled) {
+      if (event.value && event.index >= 0) {
+        this.select(event.value, event.index);
+      }
+      this.closePanel();
     }
-    this.closePanel();
   }
 
   select(option, i, fireEvents: boolean = true) {

--- a/projects/novo-examples/src/form-controls/select/basic-select/basic-select-example.css
+++ b/projects/novo-examples/src/form-controls/select/basic-select/basic-select-example.css
@@ -1,4 +1,3 @@
-/** No CSS for this example */
 :host {
   padding: 20px 30px;
   border-top-right-radius: 3px;
@@ -20,4 +19,8 @@
 :host .caption {
   font-size: 0.9em;
   margin-right: 5px;
+}
+
+.select-example-container {
+  margin: 1em;
 }

--- a/projects/novo-examples/src/form-controls/select/basic-select/basic-select-example.html
+++ b/projects/novo-examples/src/form-controls/select/basic-select/basic-select-example.html
@@ -1,28 +1,34 @@
-<div>
+<div class="select-example-container">
     <label>
         <span class="caption">Selected Value:</span> {{value}}
     </label>
     <novo-select [options]="options" [placeholder]="placeholder" [(ngModel)]="value"></novo-select>
 </div>
-<div>
+<div class="select-example-container">
     <label>
         <span class="caption">Selected Value:</span> {{withNumbersValue}}
     </label>
     <novo-select [options]="withNumbers" [(ngModel)]="withNumbersValue"></novo-select>
 </div>
-<div>
+<div class="select-example-container">
     <label>
-        <span class="caption">Selected Value:</span> {{withNumbersObject.label}}
+        <span class="caption">Selected Value:</span> {{withNumbersObject | json}}
     </label>
     <novo-select [options]="withNumbers" [(ngModel)]="withNumbersObject"></novo-select>
 </div>
-<div>
+<div class="select-example-container">
+  <label>
+    <span class="caption">Disabled Item with Tooltip - Value: </span> {{disabledWithTooltipValue}}
+  </label>
+  <novo-select [options]="withDisabledAndTooltip" [placeholder]="placeholder" [(ngModel)]="disabledWithTooltipValue"></novo-select>
+</div>
+<div class="select-example-container">
     <label>
         <span class="caption">Disabled State</span>
     </label>
     <novo-select [options]="options" [placeholder]="placeholder" [(ngModel)]="value" disabled></novo-select>
 </div>
-<div>
+<div class="select-example-container">
     <label>
         <span class="caption">No Model With Header</span>
     </label>

--- a/projects/novo-examples/src/form-controls/select/basic-select/basic-select-example.ts
+++ b/projects/novo-examples/src/form-controls/select/basic-select/basic-select-example.ts
@@ -19,6 +19,15 @@ export class BasicSelectExample {
   ];
   public withNumbersValue: number = 4;
   public withNumbersObject: any = { id: 4, label: 'Four' };
+  public withDisabledAndTooltip: Array<any> = [
+    { label: 'One', value: 1 },
+    { label: 'Two', value: 2 },
+    { label: 'Disabled', value: 3, disabled: true },
+    { label: 'Disabled Tooltip', value: 4, disabled: true, tooltip: 'Tooltip on disabled item' },
+    { label: 'Disabled Left Tooltip', value: 5, disabled: true, tooltip: 'Left side tooltip on disabled item', tooltipPosition: 'left' },
+    { label: 'Disabled Bottom Tooltip', value: 5, disabled: true, tooltip: 'Bottom tooltip on disabled item', tooltipPosition: 'bottom' },
+  ];
+  public disabledWithTooltipValue: number = 1;
   public value: string = 'Bravo';
   public headerConfig: any = {
     label: 'Add New Item',


### PR DESCRIPTION
## **Description**

Added an optional disabled state and tooltip for items in the select dropdown.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**

https://user-images.githubusercontent.com/3843503/131854242-d0556cd3-34b4-4a03-9dae-e46f732c42d4.mov

