### PR TITLE
fix: Added blank value for Date Picker reset

### DIFF
--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -231,6 +231,8 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
     if (this.value) {
       const test = this.formatDateValue(this.value);
       this.formattedValue = test;
+    } else {
+      this.formattedValue = '';
     }
   }
 


### PR DESCRIPTION
## **Description**

using FieldInteraction.SetValue() with null does not clear the visual value for date/dateTime	

