### PR TITLE
f/v5 base10 novoapps

### DIFF
--- a/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
+++ b/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
@@ -18,7 +18,7 @@ export enum AppBridgeHandler {
 // add/fast-add - the add page for a new record
 // custom       - custom action that opens the url provided in data.url
 // preview      - the preview slideout available only in Novo
-export type NovoApps = 'record' | 'add' | 'fast-add' | 'custom' | 'preview';
+export type NovoApps = 'record' | 'add' | 'fast-add' | 'slide-out-add' | 'custom' | 'preview';
 
 export interface IAppBridgeOpenEvent {
   type: NovoApps;


### PR DESCRIPTION
## **Description**

Added 'slide-out-add' to NovoApps to allow Shift Schedule to hit the Add Note Slideout

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**