### PR TITLE
feat(AppBridge): add 'slide-out-add' to NovoApps type

### DIFF
--- a/projects/novo-elements/src/elements/chips/Chips.scss
+++ b/projects/novo-elements/src/elements/chips/Chips.scss
@@ -209,7 +209,7 @@ novo-entity-chips {
           color: $neutral;
         }
       }
-      &.joborder {
+      &.jobshift {
         color: $positive;
         i {
           color: $jobShift;

--- a/projects/novo-elements/src/elements/chips/Chips.scss
+++ b/projects/novo-elements/src/elements/chips/Chips.scss
@@ -209,6 +209,12 @@ novo-entity-chips {
           color: $neutral;
         }
       }
+      &.joborder {
+        color: $positive;
+        i {
+          color: $jobShift;
+        }
+      }
     }
   }
   picker-results {

--- a/projects/novo-elements/src/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
@@ -34,6 +34,26 @@ import { NovoLabelService } from '../../../../services/novo-label-service';
           <i class="bhi-calendar"></i>
           <span [innerHtml]="renderTimestamp(match.data.dateBegin) + ' - ' + renderTimestamp(match.data.dateEnd)"></span>
         </p>
+        <!-- START Date -->
+        <p class="start-date" *ngIf="match.data.startTime && match.data.searchEntity === 'JobShift'">
+            <i class="bhi-calendar"></i>
+            <span [innerHtml]="renderTimestamp(match.data.startTime)"></span>
+        </p>
+        <!-- START & END TIME -->
+        <p class="start-time" *ngIf="match.data.startTime && match.data.searchEntity === 'JobShift'">
+            <i class="bhi-clock"></i>
+            <span [innerHtml]="renderTimeNoOffset(match.data.startTime) + ' - ' + renderTimeNoOffset(match.data.endTime)"></span>
+        </p>
+        <!-- JOBORDER -->
+        <p class="job" *ngIf="match.data.jobOrder && match.data.searchEntity === 'JobShift'">
+            <i class="bhi-job"></i>
+            <span [innerHtml]="highlight(match.data.jobOrder.title, term)"></span>
+        </p>
+        <!-- OPENINGS -->
+        <p class="openings" *ngIf="match.data.openings && match.data.searchEntity === 'JobShift'">
+            <i class="bhi-candidate"></i>
+            <span>{{ match.data.numAssigned }} / {{ match.data.openings }}</span>
+        </p>
         <!-- EMAIL -->
         <p class="email" *ngIf="match.data.email">
           <i class="bhi-email"></i> <span [innerHtml]="highlight(match.data.email, term)"></span>

--- a/projects/novo-elements/src/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
@@ -154,6 +154,15 @@ export class EntityPickerResult {
     return timestamp;
   }
 
+  renderTimeNoOffset(dateStr?: string) {
+    let timestamp = '';
+    if (dateStr) {
+      dateStr = dateStr.slice(0, 19);
+      timestamp = this.labels.formatTime(dateStr);
+    }
+    return timestamp;
+  }
+
   getNameForResult(result?: any) {
     if (result) {
       switch (result.searchEntity) {

--- a/projects/novo-elements/src/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/entity-picker-results/EntityPickerResults.ts
@@ -137,6 +137,8 @@ export class EntityPickerResult {
           return 'user';
         case 'CorporationDepartment':
           return 'department';
+        case 'JobShift':
+          return 'timetable contract';
         default:
           return '';
       }

--- a/projects/novo-elements/src/styles/global/variables.scss
+++ b/projects/novo-elements/src/styles/global/variables.scss
@@ -48,6 +48,7 @@ $earnCode: #696d79;
 $invoiceStatement: #696d79;
 $billableCharge: #696d79;
 $payableCharge: #696d79;
+$jobShift: #454ea0;
 // Color Applications
 $dark: #3d464d;
 $navigation: #2f384f;
@@ -99,6 +100,7 @@ $entity-colors: ('star': $placement,
   'billableCharge': $billableCharge,
   'payableCharge': $payableCharge,
   'invoiceStatement': $invoiceStatement,
+  'jobShift': $jobShift,
 );
 // Generic Color Map
 $app-colors: ('positive': $ocean,
@@ -174,6 +176,7 @@ $dark-colors: ('company': $company,
   'ash': $ash,
   'slate': $slate,
   'charcoal': $charcoal,
+  'jobShift': $jobShift,
 );
 // Light map
 $light-colors: ('background': $off-white,

--- a/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
+++ b/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
@@ -19,7 +19,7 @@ export enum AppBridgeHandler {
 // add/fast-add - the add page for a new record
 // custom       - custom action that opens the url provided in data.url
 // preview      - the preview slideout available only in Novo
-export type NovoApps = 'record' | 'add' | 'fast-add' | 'custom' | 'preview';
+export type NovoApps = 'record' | 'add' | 'fast-add' | 'slide-out-add' | 'custom' | 'preview';
 
 export type AlleyLinkColors =
   | 'purple'


### PR DESCRIPTION
## **Description**

feat(AppBridge): add 'slide-out-add' to NovoApps type.

This will allow scheduler app to add a note to a JobShift via the AddNote slideout in novo

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**