### PR TITLE
fix(WorkflowOptions): Allow additional data in workflow option

### DIFF
--- a/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.spec.ts
@@ -534,8 +534,8 @@ describe('Utils: FormUtils', () => {
           3: [],
         },
       };
-      const result = formUtils.getControlOptions(field, undefined, undefined, { id: 2 });
-      expect(result).toEqual([{ value: 2, label: 2 }, { value: 3, label: 'three' }]);
+      const result = formUtils.getControlOptions(field, undefined, undefined, { id: 2, label: 'two', shouldRunValidationsOnSave: true, });
+      expect(result).toEqual([{ id: 2, shouldRunValidationsOnSave: true, value: 2, label: 'two' }, { value: 3, label: 'three' }]);
     });
     it('should add current option to array if current value is not there for WorkflowOptions', () => {
       const field: { workflowOptions: Object } = {
@@ -547,7 +547,7 @@ describe('Utils: FormUtils', () => {
         },
       };
       const result = formUtils.getControlOptions(field, undefined, undefined, { id: 3, label: 'three' });
-      expect(result).toEqual([{ value: 3, label: 'three' }]);
+      expect(result).toEqual([{ id: 3, value: 3, label: 'three' }]);
     });
     it('should return initial options when value has no id', () => {
       const field: { workflowOptions: Object } = {

--- a/projects/novo-elements/src/utils/form-utils/FormUtils.ts
+++ b/projects/novo-elements/src/utils/form-utils/FormUtils.ts
@@ -712,14 +712,14 @@ export class FormUtils {
   }
 
   private getWorkflowOptions(workflowOptions: { [key: string]: any },
-                             fieldData: { [key: string]: any } | null): Array<{ value: string | number; label: string | number }> {
-    let currentValue: { value: string | number; label: string | number } = null;
+                             fieldData: { id?: number; value?: string | number; label?: string | number } | null): Array<{ id?: number; value?: string | number; label?: string | number }> {
+    let currentValue: { id?: number; value?: string | number; label?: string | number } = null;
     let currentWorkflowOption: number | string = 'initial';
     if (fieldData?.id) {
-      currentValue = { value: fieldData.id, label: fieldData.label ? fieldData.label : fieldData.id };
+      currentValue = { ...fieldData, value: fieldData.id, label: fieldData.label || fieldData.id };
       currentWorkflowOption = fieldData.id;
     }
-    const updateWorkflowOptions: Array<{ value: string | number; label: string | number }> = workflowOptions[currentWorkflowOption] || [];
+    const updateWorkflowOptions: Array<{ id?: number; value?: string | number; label?: string | number }> = workflowOptions[currentWorkflowOption] || [];
 
     // Ensure that the current value is added to the beginning of the options list
     if (currentValue && !updateWorkflowOptions.find((option) => option.value === currentValue.value)) {


### PR DESCRIPTION
## **Description**

Fix bug where only label/value were being used for current workflow options. This change retains the original properties alongside the new ones using the spread operator assignment.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
