### PR TITLE
feat(novo-loading): add a size input for loading indicator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "novo-elements-projects",
-  "version": "5.2.11",
+  "version": "5.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/novo-elements/src/elements/loading/Loading.scss
+++ b/projects/novo-elements/src/elements/loading/Loading.scss
@@ -3,6 +3,7 @@ novo-loading {
   display: flex;
   flex-direction: row;
   font-size: 13px;
+  $jump-percentage: 1;
 
   span.dot {
     display: block;
@@ -27,6 +28,17 @@ novo-loading {
       background-color: #fff !important;
     }
   }
+
+  &[size="small"] {
+    padding: 0;
+    font-size: 3px;
+    span.dot {
+      height: 2px;
+      width: 2px;
+      margin: .5px;
+      $jump-percentage: .3;
+    }
+  }
 }
 
 @keyframes jump {
@@ -40,12 +52,12 @@ novo-loading {
   }
 
   45% {
-    transform: translateY(-1.5em);
+    transform: translateY(calc(-1.5em * $jump-percentage));
     opacity: 0.5;
   }
 
   60% {
-    transform: translateY(0.8em);
+    transform: translateY(calc(0.8em * $jump-percentage));
     opacity: 0.95;
   }
 

--- a/projects/novo-elements/src/elements/loading/Loading.ts
+++ b/projects/novo-elements/src/elements/loading/Loading.ts
@@ -1,4 +1,3 @@
-// NG2
 import { Component, ContentChildren, Directive, EmbeddedViewRef, HostBinding, Input, QueryList, TemplateRef, ViewContainerRef } from '@angular/core';
 
 @Component({
@@ -6,17 +5,23 @@ import { Component, ContentChildren, Directive, EmbeddedViewRef, HostBinding, In
   host: {
     '[class]': 'theme || ""',
   },
-  template: `
-        <span class="dot"></span>
-        <span class="dot"></span>
-        <span class="dot"></span>
-        <span class="dot"></span>
-        <span class="dot"></span>
-    `,
+  template: `<span class="dot" *ngFor="let dot of countArray"></span>`,
 })
 export class NovoLoadingElement {
-  @Input()
-  theme: string;
+  @Input() theme: string;
+  @Input() size: 'small' | 'medium' = 'medium';
+
+  countArray: number[];
+  @Input() set count(value: number) {
+    if (!value) {
+      value = 5;
+    }
+    if (value > 5) {
+      console.warn('Only 5 loading dots are allowed');
+      value = 5;
+    }
+    this.countArray = new Array(value);
+  }
 }
 
 @Component({


### PR DESCRIPTION
## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**