### PR TITLE
feat(data table): Enable data table headers to word wrap

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.component.scss
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.scss
@@ -224,7 +224,7 @@ cdk-table {
 
 .novo-data-table-header-cell {
   border-left: 1px solid $off-white;
-  white-space: nowrap;
+  white-space: normal;
   display: flex;
   align-items: center;
   + .button-header-cell,

--- a/projects/novo-elements/src/elements/data-table/data-table.component.scss
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.scss
@@ -225,6 +225,7 @@ cdk-table {
 .novo-data-table-header-cell {
   border-left: 1px solid $off-white;
   white-space: normal;
+  overflow-wrap: break-word;
   display: flex;
   align-items: center;
   + .button-header-cell,


### PR DESCRIPTION
## **Description**
This fix allows data table headers to word wrap. Previously, the column titles were truncated if they were longer than the column width.
