### PR TITLE
feat(datePickerInput): Clear invalid date field when tabbing out

### DIFF
--- a/projects/novo-elements/src/elements/date-picker/DatePicker.scss
+++ b/projects/novo-elements/src/elements/date-picker/DatePicker.scss
@@ -36,6 +36,12 @@ novo-date-picker-input {
       border-bottom: 1px solid $ocean;
     }
   }
+  span.error-text {
+    color: $negative;
+    padding-top: 10px;
+    flex: 1;
+    display: flex;
+  }
   > i.bhi-clock,
   > i.bhi-search,
   > i.bhi-times,

--- a/projects/novo-elements/src/elements/date-picker/DatePicker.scss
+++ b/projects/novo-elements/src/elements/date-picker/DatePicker.scss
@@ -12,7 +12,7 @@ input[type='calendar'] {
 novo-date-picker-input {
   flex: 1;
   position: relative;
-  display: block;
+  display: block !important;
   &.disabled {
     pointer-events: none;
     opacity: 1;

--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -145,7 +145,7 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
 
   _handleKeydown(event: KeyboardEvent): void {
     if ((event.keyCode === ESCAPE || event.keyCode === ENTER || event.keyCode === TAB) && this.panelOpen) {
-      this._handleEvent(event, true);
+      this._handleEvent(event, true, true);
       this.closePanel();
       event.stopPropagation();
     }
@@ -153,7 +153,7 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
 
   _handleInput(event: KeyboardEvent): void {
     if (document.activeElement === event.target) {
-      this._handleEvent(event, false);
+      this._handleEvent(event, false, false);
     }
   }
 
@@ -166,23 +166,26 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
     this.focusEvent.emit(event);
   }
 
-  _handleEvent(event: Event, blur: boolean): void {
+  _handleEvent(event: Event, blur: boolean, checkInvalidDate: boolean): void {
     const value = (event.target as HTMLInputElement).value;
     if (value === '') {
       this.clearValue();
       this.closePanel();
     } else {
-      this.formatDate(value, blur);
+      this.formatDate(value, blur, checkInvalidDate);
       this.openPanel();
     }
   }
 
-  protected formatDate(value: string, blur: boolean) {
+  protected formatDate(value: string, blur: boolean, checkInvalidDate?: boolean) {
     try {
-      const [dateTimeValue, formatted] = this.dateFormatService.parseString(value, false, 'date');
-      if (!isNaN(dateTimeValue.getUTCDate())) {
+      const [dateTimeValue, formatted, isInvalidDate] = this.dateFormatService.parseString(value, false, 'date');
+      if (!isNaN(dateTimeValue.getUTCDate()) && !isInvalidDate) {
         const dt = new Date(dateTimeValue);
         this.dispatchOnChange(dt, blur);
+      } else if (checkInvalidDate && isInvalidDate) {
+        this.clearValue();
+        this.closePanel();
       } else {
         this.dispatchOnChange(null, blur);
       }

--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -229,7 +229,7 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
     } else {
       dateFormat = dateFormat.toLowerCase();
     }
-    this.invalidDateErrorMessage = `Invalid date field entered. Date format of ${dateFormat} is required.`
+    this.invalidDateErrorMessage = `Invalid date field entered. Date format of ${dateFormat} is required.`;
   }
 
   public dispatchOnChange(newValue?: any, blur: boolean = false, skip: boolean = false) {

--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -316,4 +316,3 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
     return !Helpers.isEmpty(this.value);
   }
 }
-

--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -316,3 +316,4 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
     return !Helpers.isEmpty(this.value);
   }
 }
+

--- a/projects/novo-elements/src/services/date-format/DateFormat.ts
+++ b/projects/novo-elements/src/services/date-format/DateFormat.ts
@@ -47,7 +47,7 @@ export class DateFormatService {
     return this.labels.timeFormatPlaceholderAM;
   }
 
-  parseDateString(dateString: string): [Date, string] {
+  parseDateString(dateString: string): [Date, string, boolean] {
     let dateFormat: string = this.labels.dateFormatString();
     const dateFormatRegex = /(\w+)[\/|\.|\-](\w+)[\/|\.|\-](\w+)/gi;
     const dateValueRegex = /(\d+)[\/|\.|\-](\d+)[\/|\.|\-](\d+)/gi;
@@ -57,6 +57,7 @@ export class DateFormatService {
     let month: number;
     let day: number;
     let date: Date = new Date();
+    let isInvalidDate = true;
     if (Helpers.isEmpty(dateFormat)) {
       // Default to MM/dd/yyyy
       dateFormat = 'mm/dd/yyyy';
@@ -77,6 +78,7 @@ export class DateFormatService {
       }
       if (month >= 0 && month <= 11 && year > 1900 && day > 0 && day <= 31) {
         date = new Date(year, month, day);
+        isInvalidDate = false;
       }
     } else if (dateFormatTokens && dateFormatTokens.length === 4 && dateString.length >= 1) {
       const twoTokens = /\d{1,4}(\/|\.|\-)(\d{1,2})/.exec(dateString);
@@ -89,7 +91,7 @@ export class DateFormatService {
         dateString = `${dateString}${delimiter[1]}`;
       }
     }
-    return [date, dateString];
+    return [date, dateString, isInvalidDate];
   }
 
   parseTimeString(timeString: string, militaryTime: boolean): [Date, string] {
@@ -143,7 +145,7 @@ export class DateFormatService {
     return [value, timeString];
   }
 
-  parseString(dateTimeString: string, militaryTime: boolean, type: string): [Date, string] {
+  parseString(dateTimeString: string, militaryTime: boolean, type: string): [Date, string, boolean?] {
     switch (type) {
       case 'datetime':
         const str = dateTimeString.replace(/-/g, '/');


### PR DESCRIPTION
## **Description**

When user tabs or clicks away from the date field the field will remove the invalid value and be null
A warning will display that the field was not entered correct

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**