### PR TITLE
fix(datePickerInput): use translated and local format as date placeholder

### DIFF
--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -116,7 +116,7 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
     private _changeDetectorRef: ChangeDetectorRef,
     public dateFormatService: DateFormatService,
   ) {
-    this.placeholder = this.labels.localizedDatePlaceholder() || this.labels.dateFormatPlaceholder || this.labels.dateFormatString().toUpperCase() || this.labels.dateFormatPlaceholder;
+    this.placeholder = this.labels.localizedDatePlaceholder();
   }
 
   ngOnInit() {

--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -116,7 +116,7 @@ export class NovoDatePickerInputElement implements OnInit, ControlValueAccessor 
     private _changeDetectorRef: ChangeDetectorRef,
     public dateFormatService: DateFormatService,
   ) {
-    this.placeholder = this.labels.dateFormatString().toUpperCase() || this.labels.dateFormatPlaceholder;
+    this.placeholder = this.labels.localizedDatePlaceholder() || this.labels.dateFormatPlaceholder || this.labels.dateFormatString().toUpperCase() || this.labels.dateFormatPlaceholder;
   }
 
   ngOnInit() {

--- a/projects/novo-elements/src/services/novo-label-service.spec.ts
+++ b/projects/novo-elements/src/services/novo-label-service.spec.ts
@@ -67,6 +67,7 @@ describe('Service: NovoLabelService', () => {
     expect(service.yes).toBeDefined();
     expect(service.search).toBeDefined();
     expect(service.noItems).toBeDefined();
+    expect(service.localDatePlaceholder).toBeDefined();
   });
 
   it('should initialize with all its label values.', () => {
@@ -198,6 +199,13 @@ describe('Service: NovoLabelService', () => {
     it('should allow for negative', () => {
       const value = service.formatBigDecimal(2.14);
       expect(value).toEqual('2.14');
+    });
+  });
+
+  describe('Method: localizedDatePlaceholder()', () => {
+    it('returns the localDatePlaceholder', () => {
+      service.localDatePlaceholder = 'dd.MM.YYYY';
+      expect(service.localizedDatePlaceholder()).toEqual('dd.MM.YYYY');
     });
   });
 });

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -90,6 +90,7 @@ export class NovoLabelService {
   noItems = 'There are no items';
   dateFormat = 'MM/dd/yyyy';
   dateFormatPlaceholder = 'MM/DD/YYYY';
+  localDatePlaceholder ='mm/dd/yyyy';
   timeFormatPlaceholderAM = 'hh:mm AM';
   timeFormatPlaceholder24Hour = 'HH:mm';
   timeFormatAM = 'AM';
@@ -150,6 +151,10 @@ export class NovoLabelService {
 
   dateFormatString(): string {
     return this.dateFormat;
+  }
+
+  localizedDatePlaceholder(): string {
+    return this.localDatePlaceholder;
   }
 
   tabbedGroupClearSuggestion(tabLabelPlural: string): string {

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -90,7 +90,7 @@ export class NovoLabelService {
   noItems = 'There are no items';
   dateFormat = 'MM/dd/yyyy';
   dateFormatPlaceholder = 'MM/DD/YYYY';
-  localDatePlaceholder ='mm/dd/yyyy';
+  localDatePlaceholder = 'mm/dd/yyyy';
   timeFormatPlaceholderAM = 'hh:mm AM';
   timeFormatPlaceholder24Hour = 'HH:mm';
   timeFormatAM = 'AM';


### PR DESCRIPTION
## **Description**

Format and translate the placeholder within the date picker input based on user's locale and setting preferences

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**