### PR TITLE
feat(Control Group): Allow customizing of icons

### DIFF
--- a/projects/novo-elements/src/elements/form/ControlGroup.html
+++ b/projects/novo-elements/src/elements/form/ControlGroup.html
@@ -12,22 +12,22 @@
       <div *ngFor="let c of controls" class="novo-control-container {{c.key}}" [class.is-label]="c.controlType === 'read-only'" [style.max-width.px]="c.width">
         <novo-control (change)="onChange()" [form]="(form?.controls)[key]['controls'][index]" [control]="c" [condensed]="!vertical || c.controlType === 'read-only'"></novo-control>
       </div>
-      <div class="novo-control-container last" *ngIf="edit && !vertical">
-        <button [disabled]="!disabledArray[index].edit" type="button" *ngIf="edit && !vertical" theme="icon" icon="edit" (click)="editControl(index)" [attr.data-automation-id]="'novo-control-group-edit-' + key" index="-1"></button>
+      <div class="novo-control-container edit last" *ngIf="edit && !vertical">
+        <button [disabled]="!disabledArray[index].edit" type="button" *ngIf="edit && !vertical" theme="icon" [icon]="editIcon" (click)="editControl(index)" [attr.data-automation-id]="'novo-control-group-edit-' + key" index="-1"></button>
       </div>
-      <div class="novo-control-container last" *ngIf="remove && !vertical">
-        <button [disabled]="!disabledArray[index].remove" type="button" *ngIf="remove && !vertical" theme="icon" icon="delete-o" (click)="removeControl(index)" [attr.data-automation-id]="'novo-control-group-delete-' + key" index="-1"></button>
+      <div class="novo-control-container remove last" *ngIf="remove && !vertical">
+        <button [disabled]="!disabledArray[index].remove" type="button" *ngIf="remove && !vertical" theme="icon" [icon]="removeIcon" (click)="removeControl(index)" [attr.data-automation-id]="'novo-control-group-delete-' + key" index="-1"></button>
       </div>
     </div>
-    <button [disabled]="!disabledArray[index].edit" type="button" *ngIf="edit && vertical" theme="icon" icon="edit" (click)="editControl(index)" [attr.data-automation-id]="'novo-control-group-edit-' + key" index="-1"></button>
-    <button [disabled]="!disabledArray[index].remove" type="button" *ngIf="remove && vertical" theme="icon" icon="delete-o" (click)="removeControl(index)" [attr.data-automation-id]="'novo-control-group-delete-' + key" index="-1"></button>
+    <button [disabled]="!disabledArray[index].edit" type="button" *ngIf="edit && vertical" theme="icon" [icon]="editIcon" (click)="editControl(index)" [attr.data-automation-id]="'novo-control-group-edit-' + key" index="-1"></button>
+    <button [disabled]="!disabledArray[index].remove" type="button" *ngIf="remove && vertical" theme="icon" [icon]="removeIcon" (click)="removeControl(index)" [attr.data-automation-id]="'novo-control-group-delete-' + key" index="-1"></button>
   </ng-template>
   <ng-template #defaultColumnLabelTemplate let-form="form" let-key="key">
       <div class="novo-control-group-control-label {{ label.key }}" *ngFor="let label of controlLabels" [style.max-width.px]="label.width" [class.column-required]="label.required">
         <span [attr.data-automation-id]="'novo-control-group-label-' + label.value">{{ label.value }}</span>
       </div>
-      <div class="novo-control-group-control-label last" *ngIf="edit" [attr.data-automation-id]="'novo-control-group-edit-' + key"></div>
-      <div class="novo-control-group-control-label last" *ngIf="remove" [attr.data-automation-id]="'novo-control-group-delete-' + key"></div>
+      <div class="novo-control-group-control-label edit last" *ngIf="edit" [attr.data-automation-id]="'novo-control-group-edit-' + key"></div>
+      <div class="novo-control-group-control-label remove last" *ngIf="remove" [attr.data-automation-id]="'novo-control-group-delete-' + key"></div>
   </ng-template>
   <ng-container *ngIf="!vertical && (form?.controls)[key] && (form?.controls)[key]['controls'].length !== 0">
     <div class="novo-control-group-labels" *ngIf="!vertical && (form?.controls)[key] && (form?.controls)[key]['controls'].length !== 0">

--- a/projects/novo-elements/src/elements/form/ControlGroup.ts
+++ b/projects/novo-elements/src/elements/form/ControlGroup.ts
@@ -85,6 +85,10 @@ export class NovoControlGroup implements AfterContentInit, OnChanges, OnDestroy 
     return this._icon;
   }
   private _icon: string;
+  // Edit icon at the end of each row (no bhi- prefix)
+  @Input() editIcon = 'edit';
+  // Remove icon at the end of each row (no bhi- prefix)
+  @Input() removeIcon = 'delete-o';
   // The initial value object, will create the form rows off of
   @Input() initialValue: {}[];
   // Callback to determine if the user can edit


### PR DESCRIPTION
## **Description**

Small change to allow for the icons in the control group to be defaulted to the current ones but customized as an input.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**