### PR TITLE
refactor(): some remaining prep work for the upcoming typescript 4 upgrade

### DIFF
--- a/projects/novo-elements/src/elements/form/Control.ts
+++ b/projects/novo-elements/src/elements/form/Control.ts
@@ -553,7 +553,7 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
   }
 
   get hasValue() {
-    return !Helpers.isEmpty(this.form.value[this.control.key]);
+    return !Helpers.isEmpty(this.form.getRawValue()[this.control.key]);
   }
 
   get focused() {
@@ -662,10 +662,10 @@ export class NovoControlElement extends OutsideClick implements OnInit, OnDestro
     } else if (
       this.form.controls[this.control.key].controlType === 'address' &&
       field &&
-      !Helpers.isEmpty(this.form.value[this.control.key]) &&
-      !Helpers.isBlank(this.form.value[this.control.key][field])
+      !Helpers.isEmpty(this.form.getRawValue()[this.control.key]) &&
+      !Helpers.isBlank(this.form.getRawValue()[this.control.key][field])
     ) {
-      this.handleAddressChange({ value: this.form.value[this.control.key][field], field });
+      this.handleAddressChange({ value: this.form.getRawValue()[this.control.key][field], field });
     }
     this._focusEmitter.emit(event);
   }

--- a/projects/novo-elements/src/elements/form/ControlTemplates.ts
+++ b/projects/novo-elements/src/elements/form/ControlTemplates.ts
@@ -6,7 +6,7 @@ import { NovoTemplate } from '../common/novo-template/novo-template.directive';
   template: `
     <!---Readonly--->
     <ng-template novoTemplate="read-only" let-form="form" let-control>
-      <div>{{ form.value[control.key] }}</div>
+      <div>{{ form.getRawValue()[control.key] }}</div>
     </ng-template>
     <!--Textbox--->
     <ng-template novoTemplate="textbox" let-control let-form="form" let-errors="errors" let-methods="methods">
@@ -308,7 +308,7 @@ import { NovoTemplate } from '../common/novo-template/novo-template.directive';
             *ngFor="let option of control.options"
             [value]="option.value"
             [label]="option.label"
-            [checked]="option.value === form.value[control.key] || (form.value[control.key] && option.value === form.value[control.key].id)"
+            [checked]="option.value === form.getRawValue()[control.key] || (form.getRawValue()[control.key] && option.value === form.getRawValue()[control.key].id)"
             [tooltip]="control.tooltip"
             [tooltipPosition]="control.tooltipPosition"
             [tooltipSize]="control?.tooltipSize"

--- a/projects/novo-elements/src/elements/table/Table.ts
+++ b/projects/novo-elements/src/elements/table/Table.ts
@@ -555,7 +555,7 @@ export class NovoTableElement implements DoCheck {
   }
 
   get formValue() {
-    return this.tableForm.value;
+    return this.tableForm.getRawValue();
   }
 
   constructor(public labels: NovoLabelService, private formUtils: FormUtils, private builder: FormBuilder, private cdr: ChangeDetectorRef) {
@@ -1066,7 +1066,7 @@ export class NovoTableElement implements DoCheck {
               }
             }
             // If dirty, grab value off the form
-            changedRow[key] = this.tableForm.value.rows[index][key];
+            changedRow[key] = this.tableForm.getRawValue().rows[index][key];
             // Set value back to row (should be already done via the server call, but do it anyway)
             this._rows[index][key] = changedRow[key];
           } else if (control && control.errors) {

--- a/projects/novo-elements/src/elements/table/extras/date-cell/DateCell.ts
+++ b/projects/novo-elements/src/elements/table/extras/date-cell/DateCell.ts
@@ -18,6 +18,10 @@ export class DateCell extends BaseRenderer {
     this._value = v;
   }
 
+  get value() {
+    return this._value;
+  }
+
   constructor(public labels: NovoLabelService) {
     super();
   }

--- a/projects/novo-elements/src/elements/table/extras/dropdown-cell/DropdownCell.ts
+++ b/projects/novo-elements/src/elements/table/extras/dropdown-cell/DropdownCell.ts
@@ -42,6 +42,10 @@ export class NovoDropdownCell extends BaseRenderer implements OnInit {
     this._value = v;
   }
 
+  get value() {
+    return this._value;
+  }
+
   public ngOnInit(): void {
     // Check for and fix bad config
     if (!this.meta.dropdownCellConfig) {

--- a/projects/novo-elements/src/elements/table/extras/table-cell/TableCell.ts
+++ b/projects/novo-elements/src/elements/table/extras/table-cell/TableCell.ts
@@ -46,14 +46,14 @@ export class TableCell implements OnInit, OnDestroy {
         const componentRef = this.componentUtils.append(this.column.renderer, this.container) as any;
         componentRef.instance.meta = this.column;
         componentRef.instance.data = this.row;
-        componentRef.instance.value = this.form && this.hasEditor ? this.form.value[this.column.name] : this.row[this.column.name];
+        componentRef.instance.value = this.form && this.hasEditor ? this.form.getRawValue()[this.column.name] : this.row[this.column.name];
         // TODO - save ref to this and update in the valueChanges below!!
       } else {
         // TODO - wtf to do here?
         this.value = this.column.renderer(this.row);
       }
     } else {
-      this.value = this.form && this.hasEditor ? this.form.value[this.column.name] : this.row[this.column.name];
+      this.value = this.form && this.hasEditor ? this.form.getRawValue()[this.column.name] : this.row[this.column.name];
     }
 
     if (this.form && this.hasEditor) {


### PR DESCRIPTION
…grade

## **Description**

Missed a few spots in [!1266.](https://github.com/bullhorn/novo-elements/pull/1266)
Updating a few more .value calls to .getRawValue() on NovoFormGroup objects, and adding some missing getters.

#### **Verify that...**

- [/] Any related demos were added and `npm start` and `npm run build` still works
- [/] New demos work in `Safari`, `Chrome` and `Firefox`
- [/] `npm run lint` passes
- [/] `npm test` passes and code coverage is increased
- [/] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**