### PR TITLE
fix(): safari styling for type=button

### DIFF
--- a/projects/novo-elements/src/styles/reset.scss
+++ b/projects/novo-elements/src/styles/reset.scss
@@ -195,7 +195,6 @@ select {
  */
 
 button,
-[type="button"],
 [type="reset"],
 [type="submit"] {
   -webkit-appearance: button;


### PR DESCRIPTION
## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**