### PR TITLE
fix(dataTable): Clear all matching selected on reset and when deselec…

### DIFF
--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-checkbox-header-cell.component.spec.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-checkbox-header-cell.component.spec.ts
@@ -57,6 +57,7 @@ describe('Elements: NovoDataTableCheckboxHeaderCell', () => {
         alert: () => {},
       };
       spyOn(component, 'selectAllChanged');
+      spyOn(component, 'resetAllMatchingSelected');
       spyOn(component.dataTable, 'selectRows');
       spyOn(component.toaster, 'alert');
     });
@@ -87,10 +88,19 @@ describe('Elements: NovoDataTableCheckboxHeaderCell', () => {
       expect(component.dataTable.selectRows).not.toHaveBeenCalled();
       expect(component.toaster.alert).toHaveBeenCalledWith(expected);
     });
-    it('should call selectAllChanged if canSelectAll is true', () => {
+    it('should call selectAllChanged if canSelectAll is true and this.checked is false', () => {
       component.dataTable.canSelectAll = true;
+      component.checked = false;
       component.onClick();
       expect(component.selectAllChanged).toHaveBeenCalled();
+      expect(component.resetAllMatchingSelected).not.toHaveBeenCalled();
+    });
+    it('should call resetAllMatchingSelected if canSelectAll is true and this.checked is true', () => {
+      component.dataTable.canSelectAll = true;
+      component.checked = true;
+      component.onClick();
+      expect(component.resetAllMatchingSelected).toHaveBeenCalled();
+      expect(component.selectAllChanged).not.toHaveBeenCalled();
     });
   });
 

--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-checkbox-header-cell.component.spec.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-checkbox-header-cell.component.spec.ts
@@ -66,6 +66,7 @@ describe('Elements: NovoDataTableCheckboxHeaderCell', () => {
       component.onClick();
       expect(component.dataTable.selectRows).toHaveBeenCalled();
       expect(component.selectAllChanged).not.toHaveBeenCalled();
+      expect(component.resetAllMatchingSelected).not.toHaveBeenCalled();
     });
     it('should call call toaster.alert isAtLimit is true', () => {
       const expected = {

--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-checkbox-header-cell.component.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-checkbox-header-cell.component.ts
@@ -73,7 +73,7 @@ export class NovoDataTableCheckboxHeaderCell<T> extends CdkHeaderCell implements
     this.resetSubscription = this.dataTable.state.resetSource.subscribe(() => {
       this.checked = false;
       if (this.dataTable?.canSelectAll) {
-        this.selectAllChanged();
+        this.resetAllMatchingSelected();
       }
       this.ref.markForCheck();
     });
@@ -103,8 +103,17 @@ export class NovoDataTableCheckboxHeaderCell<T> extends CdkHeaderCell implements
       this.dataTable.selectRows(!this.checked);
     }
     if (this.dataTable?.canSelectAll) {
-      this.selectAllChanged();
+      if (this.checked) {
+        this.resetAllMatchingSelected();
+      } else {
+        this.selectAllChanged();
+      }
     }
+  }
+
+  private resetAllMatchingSelected() {
+    this.dataTable.state?.allMatchingSelectedSource?.next(false);
+    this.dataTable.state?.onSelectionChange();
   }
 
   public selectAllChanged(): void {

--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-checkbox-header-cell.component.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-checkbox-header-cell.component.ts
@@ -111,7 +111,7 @@ export class NovoDataTableCheckboxHeaderCell<T> extends CdkHeaderCell implements
     }
   }
 
-  private resetAllMatchingSelected() {
+  private resetAllMatchingSelected(): void {
     this.dataTable.state?.allMatchingSelectedSource?.next(false);
     this.dataTable.state?.onSelectionChange();
   }


### PR DESCRIPTION
…ting header cell

## **Description**

The select all matching variable was not getting properly reset when data table state reset was called (which should reset selection) as well as when the user clicks the data table header checkbox to de-select all records. This issue only applied when canSelectAll was set on the table.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**