### PR TITLE
fix(select): change select default position to above-below

### DIFF
--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -216,7 +216,7 @@ export class NovoSelectElement
   @Input()
   headerConfig: any;
   @Input()
-  position: string = 'bottom';
+  position: string = 'above-below';
   @Input()
   overlayWidth: number;
   @Input()


### PR DESCRIPTION
## **Description**
Change default position to above-below to prevent dropdown from going below page. Dropdown will now appear above if there is not enough space below.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**