### PR TITLE
feat(picker): Adjusting how picker overlay appears for row chips.

### DIFF
--- a/projects/novo-elements/src/elements/chips/RowChips.ts
+++ b/projects/novo-elements/src/elements/chips/RowChips.ts
@@ -95,7 +95,6 @@ export class NovoRowChipElement extends NovoChipElement {
       (typing)="onTyping($event)"
       (blur)="onTouched($event)"
       [selected]="items"
-      [overrideElement]="element"
       *ngIf="!maxlength || (maxlength && items.length < maxlength)"
     >
     </novo-picker>


### PR DESCRIPTION
## **Description**

Adjusting the row chips picker to stay visible on the screen when adding many items to the list. For very long lists of row chip pickers in Novo, the row chip picker overlay needs to be allowed to pop up over the existing rows.


![Screen Shot 2022-03-31 at 11 37 23 AM](https://user-images.githubusercontent.com/3843503/161106537-4866e80e-5bc7-4166-88b7-e3a0c212572c.png)


#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**