### PR TITLE
fix(Aside): Aside ref was missing returning optional result and didn't conform to same api as ModalRef

### DIFF
--- a/projects/novo-elements/src/elements/aside/aside.service.ts
+++ b/projects/novo-elements/src/elements/aside/aside.service.ts
@@ -20,7 +20,7 @@ const DEFAULT_CONFIG: AsideConfig = {
 export class NovoAsideService {
   constructor(private injector: Injector, private overlay: Overlay) {}
 
-  open(component, params = {}, config = {}) {
+  open<R = any>(component, params = {}, config = {}) {
     // Override default configuration
     const asideConfig = this.getOverlayConfig({ ...DEFAULT_CONFIG, ...config });
 
@@ -28,7 +28,7 @@ export class NovoAsideService {
     const overlayRef = this.createOverlay(asideConfig);
 
     // Instantiate remote control
-    const asideRef = new NovoAsideRef(component, params, overlayRef);
+    const asideRef = new NovoAsideRef<typeof params, R>(component, params, overlayRef);
 
     const overlayComponent = this.attachAsideContainer(AsideComponent, overlayRef, asideConfig, asideRef);
 
@@ -37,7 +37,7 @@ export class NovoAsideService {
 
     overlayRef.backdropClick().subscribe(() => asideRef.close());
 
-    return overlayRef;
+    return asideRef;
   }
 
   private createOverlay(config: AsideConfig) {

--- a/projects/novo-elements/src/elements/modal/modal-ref.ts
+++ b/projects/novo-elements/src/elements/modal/modal-ref.ts
@@ -12,29 +12,29 @@ export interface ModalParams {
 }
 export class NovoModalParams implements ModalParams {}
 
-export class NovoModalRef<T = any> {
+export class NovoModalRef<T = any, R = any> {
   constructor(public component: any, public params: T, private overlayRef: OverlayRef) {}
 
-  private _beforeClose = new Subject<any>();
-  private _afterClosed = new Subject<any>();
+  private _beforeClose = new Subject<R>();
+  private _afterClosed = new Subject<R>();
 
   componentInstance: NovoModalContainerComponent;
   isClosed: boolean = false;
 
   // Gets a promise that is resolved when the dialog is closed.
-  get onClosed(): Promise<any> {
+  get onClosed(): Promise<R> {
     return this._afterClosed.toPromise();
   }
 
-  afterClosed(): Observable<any> {
+  afterClosed(): Observable<R> {
     return this._afterClosed.asObservable();
   }
 
-  beforeClose(): Observable<any> {
+  beforeClose(): Observable<R> {
     return this._beforeClose.asObservable();
   }
 
-  close(result?: any): void {
+  close(result?: R): void {
     // Listen for animation 'start' events
     this.componentInstance.animationStateChanged
       .pipe(

--- a/projects/novo-examples/src/components/aside/aside-examples.md
+++ b/projects/novo-examples/src/components/aside/aside-examples.md
@@ -7,7 +7,7 @@ order: 4
 
 ## Custom
 
-In the case where "Success", "Warning", and "Error" notfications aren't enough, use the custom notification. Custom notifcations allow any of the Bullhorn Icons to be used in the notification.
+In the case where "Success", "Warning", and "Error" notifications aren't enough, use the custom notification. Custom notifications allow any of the Bullhorn Icons to be used in the notification.
 
 <code-example example="aside-usage"></code-example>
 

--- a/projects/novo-examples/src/components/aside/aside-usage/aside-usage-example.ts
+++ b/projects/novo-examples/src/components/aside/aside-usage/aside-usage-example.ts
@@ -1,13 +1,18 @@
 import { Component } from '@angular/core';
 import { NovoAsideRef, NovoAsideService } from 'novo-elements';
 
+interface CustomParams {
+  id: number;
+  name: string;
+}
+
 @Component({
   selector: 'aside-custom-demo',
   template: `
     <novo-toolbar>
       <novo-toolbar-row accent="candidate" gap="md">
         <novo-icon>candidate</novo-icon>
-        <novo-title>Ferdinand del Toro</novo-title>
+        <novo-title>{{ ref.params.name }}</novo-title>
         <span class="example-spacer" flex="1"></span>
         <novo-action icon="times" (click)="close()" aria-label="close the aside icon"></novo-action>
       </novo-toolbar-row>
@@ -53,9 +58,9 @@ export class AsideCustomDemo {
     { label: 'Phone', data: '555-555-5555' },
     { label: 'Address', data: 'Boston, MA' },
   ];
-  constructor(private ref: NovoAsideRef) {}
+  constructor(public ref: NovoAsideRef<CustomParams, string>) {}
   close() {
-    this.ref.close();
+    this.ref.close(`successfully closed: ${this.ref.params.name}`);
   }
 }
 
@@ -70,6 +75,9 @@ export class AsideCustomDemo {
 export class AsideUsageExample {
   constructor(private aside: NovoAsideService) {}
   showAside() {
-    this.aside.open(AsideCustomDemo);
+    const ref = this.aside.open<string>(AsideCustomDemo, { id: 100, name: 'Ferdinand del Toro' });
+    ref.onClosed.then((result) => {
+      console.log('Aside has been closed, with result:', result);
+    });
   }
 }

--- a/projects/novo-examples/src/components/modal/modal-examples.md
+++ b/projects/novo-examples/src/components/modal/modal-examples.md
@@ -27,7 +27,7 @@ Error modals indicate that an attempted action has failed. The first line should
 
 ### Custom
 
-In the case where "Success", "Warning", and "Error" notfications aren't enough, use the custom notification. Custom notifcations allow any of the Bullhorn Icons to be used in the notification.
+In the case where "Success", "Warning", and "Error" notifications aren't enough, use the custom notification. Custom notifications allow any of the Bullhorn Icons to be used in the notification.
 
 <code-example example="custom-modal"></code-example>
 

--- a/projects/novo-examples/src/examples.routes.ts
+++ b/projects/novo-examples/src/examples.routes.ts
@@ -302,7 +302,7 @@ export class AsideDevelopPage {
 @Component({
   selector: 'aside-examples-page',
   template: `<h2>Custom</h2>
-<p>In the case where &quot;Success&quot;, &quot;Warning&quot;, and &quot;Error&quot; notfications aren't enough, use the custom notification. Custom notifcations allow any of the Bullhorn Icons to be used in the notification.</p>
+<p>In the case where &quot;Success&quot;, &quot;Warning&quot;, and &quot;Error&quot; notifications aren't enough, use the custom notification. Custom notifications allow any of the Bullhorn Icons to be used in the notification.</p>
 <p><code-example example="aside-usage"></code-example></p>
 <h2>Add</h2>
 <p>Add modals have a colored title bar based on the record type being created. Additionally, due to a greater than average amount of content, they have fixed footers.</p>
@@ -2153,7 +2153,7 @@ export class ModalDevelopPage {
 <p>Error modals indicate that an attempted action has failed. The first line should apologize and state the what happened. The second line should quickly attempt to explain to the user why this has happened, and instruct the user on the best course of action.</p>
 <p><code-example example="error-modal"></code-example></p>
 <h3>Custom</h3>
-<p>In the case where &quot;Success&quot;, &quot;Warning&quot;, and &quot;Error&quot; notfications aren't enough, use the custom notification. Custom notifcations allow any of the Bullhorn Icons to be used in the notification.</p>
+<p>In the case where &quot;Success&quot;, &quot;Warning&quot;, and &quot;Error&quot; notifications aren't enough, use the custom notification. Custom notifications allow any of the Bullhorn Icons to be used in the notification.</p>
 <p><code-example example="custom-modal"></code-example></p>
 <h2>Workflow Modals</h2>
 <h3>Add</h3>


### PR DESCRIPTION
This will close #1276 

## **Description**

Added `onClosed` promise to `NovoAsideRef` to conform to `NovoModalRef`

Added better typing support to both `NovoAsideRef` and `NovoModalRef` to support return type. With T being the type for the Params passed to the **Modal**/**Aside** and R being the returned result. You only need to set R value when calling `asideService.open<string>(...)` the type is optional and will default to any.

```ts
class NovoAsideRef<T = any, R = any> 
class NovoModalRef<T = any, R = any> 
// AsideService
   open<R = any>( ... ) // where R is the return value. 
```

```ts 
    const ref = this.aside.open<string>(AsideCustomDemo, { id: 100, name: 'Ferdinand del Toro' });
    ref.onClosed.then((result) => {
      console.log('Aside has been closed, with result:', result);
    });
```



