### PR TITLE
feat(NovoDataTablePagination): implement bare pagination theme

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.component.scss
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.scss
@@ -426,7 +426,8 @@ novo-data-table {
   .novo-data-table-empty-container {
     padding-top: 0;
   }
-  .novo-data-table-no-results-container {
+  .novo-data-table-no-results-container,
+  .novo-data-table-no-more-results-container {
     position: absolute;
     top: 48%;
     left: 0;
@@ -434,7 +435,8 @@ novo-data-table {
     width: 100%;
   }
   .novo-data-table-empty-container,
-  .novo-data-table-no-results-container {
+  .novo-data-table-no-results-container,
+  .novo-data-table-no-more-results-container {
     padding: 2em;
     flex: 1;
     display: flex;
@@ -625,6 +627,66 @@ novo-data-table-pagination {
         color: $company;
         background-color: $off-white;
         opacity: 1;
+      }
+    }
+  }
+  &.bare {
+    display: flex;
+    flex-flow: row nowrap;
+    flex: 1;
+    > * {
+      margin: auto 5px;
+    }
+    h5.rows {
+      padding: 0;
+      font-size: 12px;
+      opacity: 0.75;
+      letter-spacing: 0.1px;
+    }
+    span.spacer {
+      flex: 1;
+    }
+    novo-select {
+      max-width: 100px;
+      min-width: 100px;
+      div[type="button"] {
+        &:hover {
+          i {
+            opacity: 0.75;
+          }
+        }
+        &:active,
+        &:focus {
+          i {
+            opacity: 1;
+          }
+        }
+        i {
+          opacity: 0.45;
+        }
+      }
+    }
+    > button:first-of-type {
+      margin-right: 5px;
+    }
+    > button {
+      span {
+        display: none;
+        @media (min-width: $breakpoint) {
+          display: block;
+        }
+      }
+    }
+    > button[theme][theme="dialogue"][icon][side="left"] {
+      padding: 5px;
+      @media (min-width: $breakpoint) {
+        padding: 5px 15px 5px 5px;
+      }
+    }
+    > button[theme][theme="dialogue"][icon][side="right"] {
+      padding: 5px;
+      @media (min-width: $breakpoint) {
+        padding: 5px 5px 5px 15px;
       }
     }
   }

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -71,6 +71,7 @@ import { DataTableState } from './state/data-table-state.service';
         [dataFeatureId]="paginatorDataFeatureId"
         [canSelectAll]="canSelectAll"
         [allMatchingSelected]="allMatchingSelected"
+        [currentlyEmpty]="dataSource?.currentlyEmpty"
       >
       </novo-data-table-pagination>
       <div class="novo-data-table-actions" *ngIf="templates['customActions']">
@@ -157,10 +158,19 @@ import { DataTableState } from './state/data-table-state.service';
         <div
           class="novo-data-table-no-results-container"
           [style.left.px]="scrollLeft"
-          *ngIf="dataSource?.currentlyEmpty && state.userFiltered && !dataSource?.loading && !loading && !dataSource.pristine"
+          *ngIf="dataSource?.currentlyEmpty && state.userFiltered && state.page === 0 && !dataSource?.loading && !loading && !dataSource.pristine"
         >
           <div class="novo-data-table-empty-message">
             <ng-container *ngTemplateOutlet="templates['noResultsMessage'] || templates['defaultNoResultsMessage']"></ng-container>
+          </div>
+        </div>
+        <div
+          class="novo-data-table-no-more-results-container"
+          [style.left.px]="scrollLeft"
+          *ngIf="dataSource?.currentlyEmpty && state.page > 0 && !dataSource?.loading && !loading && !dataSource.pristine"
+        >
+          <div class="novo-data-table-empty-message">
+            <ng-container *ngTemplateOutlet="templates['noMoreResultsMessage'] || templates['defaultNoMoreResultsMessage']"></ng-container>
           </div>
         </div>
       </div>
@@ -249,6 +259,9 @@ import { DataTableState } from './state/data-table-state.service';
     </ng-template>
     <ng-template novoTemplate="defaultNoResultsMessage">
       <h4><i class="bhi-search-question"></i> {{ labels.noMatchingRecordsMessage }}</h4>
+    </ng-template>
+    <ng-template novoTemplate="defaultNoMoreResultsMessage">
+      <h4><i class="bhi-search-question"></i> {{ labels.noMoreRecordsMessage }}</h4>
     </ng-template>
     <ng-template novoTemplate="defaultEmptyMessage">
       <h4><i class="bhi-search-question"></i> {{ labels.emptyTableMessage }}</h4>

--- a/projects/novo-elements/src/elements/data-table/data-table.source.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.source.ts
@@ -16,7 +16,7 @@ export class DataTableSource<T> extends DataSource<T> {
   private totalSet: boolean = false;
 
   get totallyEmpty(): boolean {
-    return this.total === 0;
+    return this.total === 0 && this.current === 0;
   }
 
   get currentlyEmpty(): boolean {
@@ -43,7 +43,10 @@ export class DataTableSource<T> extends DataSource<T> {
           this.state.outsideFilter,
         );
       }),
-      map((data: { results: T[]; total: number }) => {
+      map((data: { results: T[]; total?: number }) => {
+        if (data.total === undefined) {
+          data.total = null;
+        }
         if (!this.totalSet || this.state.isForceRefresh) {
           this.total = data.total;
           this.totalSet = true;

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -62,7 +62,7 @@ export interface IDataTableColumn<T> {
 }
 
 export interface IDataTablePaginationOptions {
-  theme: 'basic' | 'standard' | 'basic-wide';
+  theme: 'basic' | 'standard' | 'basic-wide' | 'bare';
   page?: number;
   pageSize: number;
   pageSizeOptions: number[] | { value: string; label: string }[];

--- a/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
+++ b/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
@@ -31,7 +31,6 @@ const MAX_PAGES_DISPLAYED = 5;
         </novo-tiles>
         <div *ngIf="displayedPageSizeOptions.length <= 1">{{ pageSize }}</div>
       </div>
-
       <div class="novo-data-table-range-label-long" data-automation-id="novo-data-table-pagination-range-label-long">
         {{ longRangeLabel }}
       </div>
@@ -39,32 +38,8 @@ const MAX_PAGES_DISPLAYED = 5;
         {{ shortRangeLabel }}
       </div>
       <span class="spacer novo-data-table-spacer" *ngIf="theme === 'basic-wide'"></span>
-      <novo-button
-        theme="dialogue"
-        type="button"
-        class="novo-data-table-pagination-navigation-previous"
-        (click)="previousPage()"
-        icon="previous"
-        side="left"
-        [disabled]="!hasPreviousPage()"
-        data-automation-id="novo-data-table-pagination-previous"
-      >
-        <span>{{ labels.previous }}</span>
-      </novo-button>
-      <novo-button
-        theme="dialogue"
-        type="button"
-        class="novo-data-table-pagination-navigation-next"
-        (click)="nextPage()"
-        icon="next"
-        side="right"
-        [disabled]="!hasNextPage()"
-        data-automation-id="novo-data-table-pagination-next"
-      >
-        <span>{{ labels.next }}</span>
-      </novo-button>
     </ng-container>
-    <ng-container *ngIf="theme === 'bare'">
+    <ng-container *ngIf="theme === 'standard' || theme === 'bare'">
       <h5 class="rows">{{ labels.itemsPerPage }}</h5>
       <novo-select
         [options]="displayedPageSizeOptions"
@@ -76,6 +51,8 @@ const MAX_PAGES_DISPLAYED = 5;
       >
       </novo-select>
       <span class="spacer"></span>
+    </ng-container>
+    <ng-container *ngIf="theme === 'basic' || theme === 'basic-wide' || theme === 'bare'">
       <novo-button
         theme="dialogue"
         type="button"
@@ -102,17 +79,6 @@ const MAX_PAGES_DISPLAYED = 5;
       </novo-button>
     </ng-container>
     <ng-container *ngIf="theme === 'standard'">
-      <h5 class="rows">{{ labels.itemsPerPage }}</h5>
-      <novo-select
-        [options]="displayedPageSizeOptions"
-        [placeholder]="labels.select"
-        [(ngModel)]="pageSize"
-        (onSelect)="changePageSize($event.selected)"
-        data-automation-id="pager-select"
-        [attr.data-feature-id]="dataFeatureId"
-      >
-      </novo-select>
-      <span class="spacer"></span>
       <ul class="pager" data-automation-id="pager">
         <li class="page" (click)="selectPage(page - 1)" [ngClass]="{ disabled: page === 0 }">
           <i class="bhi-previous" data-automation-id="pager-previous"></i>

--- a/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
+++ b/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
@@ -64,6 +64,43 @@ const MAX_PAGES_DISPLAYED = 5;
         <span>{{ labels.next }}</span>
       </novo-button>
     </ng-container>
+    <ng-container *ngIf="theme === 'bare'">
+      <h5 class="rows">{{ labels.itemsPerPage }}</h5>
+      <novo-select
+        [options]="displayedPageSizeOptions"
+        [placeholder]="labels.select"
+        [(ngModel)]="pageSize"
+        (onSelect)="changePageSize($event.selected)"
+        data-automation-id="pager-select"
+        [attr.data-feature-id]="dataFeatureId"
+      >
+      </novo-select>
+      <span class="spacer"></span>
+      <novo-button
+        theme="dialogue"
+        type="button"
+        class="novo-data-table-pagination-navigation-previous"
+        (click)="previousPage()"
+        icon="previous"
+        side="left"
+        [disabled]="!hasPreviousPage()"
+        data-automation-id="novo-data-table-pagination-previous"
+      >
+        <span>{{ labels.previous }}</span>
+      </novo-button>
+      <novo-button
+        theme="dialogue"
+        type="button"
+        class="novo-data-table-pagination-navigation-next"
+        (click)="nextPage()"
+        icon="next"
+        side="right"
+        [disabled]="!hasNextPage()"
+        data-automation-id="novo-data-table-pagination-next"
+      >
+        <span>{{ labels.next }}</span>
+      </novo-button>
+    </ng-container>
     <ng-container *ngIf="theme === 'standard'">
       <h5 class="rows">{{ labels.itemsPerPage }}</h5>
       <novo-select
@@ -135,6 +172,8 @@ export class NovoDataTablePagination<T> implements OnInit, OnDestroy {
   public canSelectAll: boolean = false;
   @Input()
   public allMatchingSelected: boolean = false;
+  @Input()
+  public currentlyEmpty: boolean = false;
 
   @Input()
   get length(): number {
@@ -208,6 +247,9 @@ export class NovoDataTablePagination<T> implements OnInit, OnDestroy {
   }
 
   public hasNextPage(): boolean {
+    if (this.length === null) {
+      return !(this.currentlyEmpty && (this.state.page > 0 || (this.state.page === 0 && this.state.userFiltered)));
+    }
     const numberOfPages = Math.ceil(this.length / this.pageSize) - 1;
     return this.page < numberOfPages && this.pageSize !== 0;
   }
@@ -262,6 +304,10 @@ export class NovoDataTablePagination<T> implements OnInit, OnDestroy {
   }
 
   private calculateTotalPages() {
+    if (this.length === null) {
+      return null;
+    }
+
     const totalPages = this.pageSize < 1 ? 1 : Math.ceil(this.length / this.pageSize);
     return Math.max(totalPages || 0, 1);
   }
@@ -276,6 +322,10 @@ export class NovoDataTablePagination<T> implements OnInit, OnDestroy {
 
   private getPages(currentPage: number, totalPages: number): { number: number; text: string; active: boolean }[] {
     const pages = [];
+
+    if (totalPages === null) {
+      return pages;
+    }
 
     // Default page limits
     let startPage = 1;

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -21,6 +21,7 @@ export class NovoLabelService {
   dateAdded = 'Date Added';
   emptyTableMessage = 'No Records to display...';
   noMatchingRecordsMessage = 'No Matching Records';
+  noMoreRecordsMessage = 'No more records. Click "Previous" to go back.';
   erroredTableMessage = 'Oops! An error occurred.';
   pickerError = 'Oops! An error occurred.';
   pickerTextFieldEmpty = 'Begin typing to see results.';
@@ -236,6 +237,10 @@ export class NovoLabelService {
   }
 
   getRangeText(page: number, pageSize: number, length: number, short: boolean): string {
+    if (length === null) {
+      return null;
+    }
+
     if (length === 0 || pageSize === 0) {
       return `Displaying 0 of ${length}`;
     }


### PR DESCRIPTION
## **Description**

Update NovoDataTablePagination with a "bare" theme that handles situations where the total number of records is unknown.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**