### PR TITLE
fix(datepickerInput): fix calendar UI not respecting valid date in input field

### DIFF
--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -287,7 +287,10 @@ export class NovoDatePickerInputElement implements OnInit, OnChanges, ControlVal
 
   private _setCalendarValue(value: any): void {
     if (value instanceof Date && this.value instanceof Date) {
-      value = new Date(value).setHours(0, 0, 0, 0);
+      let newDate = new Date(value);
+      newDate.setHours(0,0,0,0);
+      this.value = newDate;
+      return;
     }
     this.value = value;
   }


### PR DESCRIPTION
## **Description**

I modified the _setCalendarValue method in NovoDatePickerInputElement class. The date picker input did not respect the date that was in the input field unless the enter key was pressed and then the calendar ui would highlight the date in the input field. The reason this was happening was that this code value = new Date(value).setHours(0, 0, 0, 0); was returning a date as a timestamp instead of a date object.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**