### PR TITLE
fix(NovoDataTable): making pagination marker background color dynamic

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.component.scss
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.scss
@@ -623,7 +623,7 @@ novo-data-table-pagination {
       }
       .page.active {
         color: $company;
-        background-color: $off-white;
+        background-color: rgba(black, .1);
         opacity: 1;
       }
     }

--- a/projects/novo-elements/src/elements/data-table/data-table.component.scss
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.scss
@@ -623,7 +623,7 @@ novo-data-table-pagination {
       }
       .page.active {
         color: $company;
-        background-color: rgba(black, .1);
+        background-color: rgba($black, .1);
         opacity: 1;
       }
     }


### PR DESCRIPTION
## **Description**

This resolves issue https://github.com/bullhorn/novo-elements/issues/1267 by making the background of the data table pagination marker dynamic. instead of a hardcoded color, it's now simply black with an opacity of 10%, so it will render as whatever color the header is, just slightly darker.

![pagination background](https://user-images.githubusercontent.com/18195860/162800258-f1e95bb5-c74d-494c-a2f0-8f4950269814.gif)

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**