### PR TITLE
fix(Theme): text colors are now darker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ novo-elements.iml
 !.vscode/extensions.json
 
 # misc
+/.angular
 /.sass-cache
 /connect.lock
 /coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "novo-elements",
-  "version": "6.0.3",
+  "version": "6.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/novo-elements/src/elements/button/styles/button-other.scss
+++ b/projects/novo-elements/src/elements/button/styles/button-other.scss
@@ -30,7 +30,7 @@
     border-bottom: 1px solid var(--border);
     border-radius: 0;
     color: var(--text-main);
-    padding: 0;
+    padding: 0 2px 0 0;
     height: 2rem;
     min-height: 2rem;
     position: relative;

--- a/projects/novo-elements/src/elements/calendar/calendar.component.scss
+++ b/projects/novo-elements/src/elements/calendar/calendar.component.scss
@@ -30,7 +30,7 @@
   width: 100%;
   text-align: center;
   background: var(--background-bright);
-  color: var(--text-bright);
+  color: var(--text-main);
   position: relative;
   user-select: none;
 

--- a/projects/novo-elements/src/elements/calendar/month-view/month-view.component.scss
+++ b/projects/novo-elements/src/elements/calendar/month-view/month-view.component.scss
@@ -33,12 +33,12 @@
       font-weight: normal;
       border-radius: 3px;
       &.selected {
-        background-color: $positive;
+        background-color: var(--selection);
         color: #fff;
       }
       &:hover {
         cursor: pointer;
-        background-color: $positive;
+        background-color: var(--selection);
         color: #fff;
       }
     }
@@ -60,7 +60,7 @@
         outline: none;
       }
       &:disabled {
-        color: var(--text-muted, #d7d9e4);
+        color: var(--text-disabled);
         cursor: not-allowed !important;
         box-shadow: none !important;
       }
@@ -69,13 +69,13 @@
       display: table-cell;
 
       &.notinmonth,
-      &.noinmonth > novo-button.day {
-        color: var(--text-muted, #d7d9e4);
+      &.notinmonth:not(.selected) > .day {
+        color: var(--text-disabled);
       }
       &:hover {
         .day {
           cursor: pointer;
-          box-shadow: inset 0 0 0 2px $positive;
+          box-shadow: inset 0 0 0 2px var(--selection);
         }
       }
       &.inRange:hover {
@@ -85,7 +85,7 @@
       }
 
       &.inRange {
-        background: $positive;
+        background: var(--selection);
         color: #fff;
         height: 3.2rem;
         width: 3.2rem;
@@ -118,7 +118,7 @@
           content: "";
           position: absolute;
           height: 100%;
-          background: #4a89dc;
+          background: var(--selection);
           width: 10px;
           top: 0;
           left: -5px;
@@ -127,13 +127,13 @@
       }
       &.selected {
         .day {
-          background: $positive;
+          background: var(--selection);
           color: #fff;
         }
       }
       &.preview:not(.previewStart):not(.previewEnd) {
         .day {
-          border: 1px dashed $positive;
+          border: 1px dashed var(--selection);
         }
         &.selected {
           .day {

--- a/projects/novo-elements/src/elements/common/option/option.component.scss
+++ b/projects/novo-elements/src/elements/common/option/option.component.scss
@@ -21,7 +21,6 @@ $novo-menu-side-padding: 0.5rem;
 
   &:hover:not(.novo-option-inert) {
     background: var(--background-main, rgba($ocean, 0.1));
-    color: var(--text-bright, $dark);
   }
 
   &:active:not(.novo-option-inert),

--- a/projects/novo-elements/src/elements/common/typography/text.mixins.scss
+++ b/projects/novo-elements/src/elements/common/typography/text.mixins.scss
@@ -163,6 +163,6 @@
   font-size: var(--font-size-caption);
   font-weight: 400;
   line-height: 1.375;
-  color: var(--text-muted, $dark);
+  color: var(--text-muted);
   @include base-text-rules();
 }

--- a/projects/novo-elements/src/elements/form/ControlGroup.scss
+++ b/projects/novo-elements/src/elements/form/ControlGroup.scss
@@ -115,7 +115,7 @@ novo-control-group {
         box-sizing: border-box;
         flex: 1;
         > span {
-          color: var(--text-muted, #9e9e9e);
+          color: var(--text-muted);
           font-size: 1rem;
           font-weight: 500;
           text-transform: uppercase;

--- a/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.scss
+++ b/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.scss
@@ -134,7 +134,6 @@
         novo-option {
           &:hover.novo-option-inert {
             background: var(--background-main, rgba($ocean, 0.1));
-            color: var(--text-bright, $dark);
           }
         }
       }

--- a/projects/novo-elements/src/novo-elements.scss
+++ b/projects/novo-elements/src/novo-elements.scss
@@ -98,13 +98,13 @@
   background-color: var(--background-body, $color-silver);
 }
 .txc-main {
-  color: var(--text-main, $color-dark);
-}
-.txc-bright {
-  color: var(--text-bright, $color-black);
+  color: var(--text-main, $color-charcoal);
 }
 .txc-muted {
-  color: var(--text-muted, $color-slate);
+  color: var(--text-muted, $color-neutral);
+}
+.txc-disabled {
+  color: var(--text-disabled, $color-slate);
 }
 
 @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {

--- a/projects/novo-elements/src/styles/themes/dark.scss
+++ b/projects/novo-elements/src/styles/themes/dark.scss
@@ -7,8 +7,8 @@
   --selection: #{$color-ocean}; // #1c76c5;
   --text-selection: #{$color-white};
   --text-main: #{$color-light};
-  --text-bright: #{$color-white};
-  --text-muted: #a9b1ba;
+  --text-muted: #{$color-stone};
+  --text-disabled: #a9b1ba;
   --links: #{$color-sky-blue}; // #41adff;
   --focus: #0096bfab;
   --border: #{$color-onyx};

--- a/projects/novo-elements/src/styles/themes/light.scss
+++ b/projects/novo-elements/src/styles/themes/light.scss
@@ -6,19 +6,18 @@
   --background-bright: #{$color-white}; //fff
   --background-dark: #{$color-silver}; //e2e2e2
   --background-muted: #{$color-sand}; //f4f4f4
+  --text-main: #{$color-charcoal}; //#363636;
+  --text-muted: #{$color-neutral}; //#70777f;
+  --text-disabled: #{$color-slate}; //#70777f;
   --selection: #{$color-ocean}; //#9e9e9e;
   --text-selection: #{$color-white};
-  --text-main: #{$color-dark}; //#363636;
-  --text-bright: #{$color-black};
-  --text-muted: #{$color-slate}; //#70777f;
-  // do we need disabled.
   --links: #{$color-ocean};
   --focus: #{$color-ocean};
   --border: #{$color-light}; //#dbdbdb;
   --code: #{$color-job};
   --animation-duration: 0.1s;
   --button-background: #{$light};
-  --button-text: #{$dark};
+  --button-text: #{$color-charcoal};
   --button-hover: #aaa;
   --scrollbar-thumb: #{$color-stone};
   --scrollbar-thumb-hover: #{$color-slate};

--- a/projects/novo-elements/src/styles/typography.scss
+++ b/projects/novo-elements/src/styles/typography.scss
@@ -56,15 +56,6 @@ p {
   padding: 0.25rem 0 0.55rem;
 }
 
-// h1,
-// h2,
-// h3,
-// h4,
-// h5,
-// h6,
-// strong {
-//   color: var(--text-bright);
-// }
 
 q::before {
   content: none;


### PR DESCRIPTION
Updated css variable for light theme.

```css
/* Changed main text color to charcoal  */
--text-main: var(--color-charcoal);
/* Changed muted text color to neutral, used for secondary text like labels and captions  */
--text-muted: var(--color-neutral);
/* Added for disabled and placeholder text*/
--text-disabled: var(--color-slate);
```

![image](https://user-images.githubusercontent.com/1056055/163222060-c4a87fc1-f3c5-4bda-a832-797c45981c60.png)
