### PR TITLE
fix(Dropdown): increasing debounce time for type-ahead

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "novo-elements",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/novo-elements/src/elements/dropdown/Dropdown.ts
+++ b/projects/novo-elements/src/elements/dropdown/Dropdown.ts
@@ -293,7 +293,7 @@ export class NovoDropdownElement extends NovoDropdowMixins implements OnInit, Af
 
   /** Sets up a key manager to listen to keyboard events on the overlay panel. */
   private _initKeyManager() {
-    this._keyManager = new ActiveDescendantKeyManager<NovoOption>(this.options).withTypeAhead(300).withHomeAndEnd();
+    this._keyManager = new ActiveDescendantKeyManager<NovoOption>(this.options).withTypeAhead(250).withHomeAndEnd();
     // .withAllowedModifierKeys(['shiftKey']);
 
     this._keyManager.tabOut.pipe(takeUntil(this._onDestroy)).subscribe(() => {

--- a/projects/novo-elements/src/elements/dropdown/Dropdown.ts
+++ b/projects/novo-elements/src/elements/dropdown/Dropdown.ts
@@ -293,7 +293,7 @@ export class NovoDropdownElement extends NovoDropdowMixins implements OnInit, Af
 
   /** Sets up a key manager to listen to keyboard events on the overlay panel. */
   private _initKeyManager() {
-    this._keyManager = new ActiveDescendantKeyManager<NovoOption>(this.options).withTypeAhead(100).withHomeAndEnd();
+    this._keyManager = new ActiveDescendantKeyManager<NovoOption>(this.options).withTypeAhead(300).withHomeAndEnd();
     // .withAllowedModifierKeys(['shiftKey']);
 
     this._keyManager.tabOut.pipe(takeUntil(this._onDestroy)).subscribe(() => {

--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -728,7 +728,7 @@ export class NovoSelectElement
 
   /** Sets up a key manager to listen to keyboard events on the overlay panel. */
   private _initKeyManager() {
-    this._keyManager = new ActiveDescendantKeyManager<NovoOption>(this._getOptions()).withTypeAhead(300).withHomeAndEnd();
+    this._keyManager = new ActiveDescendantKeyManager<NovoOption>(this._getOptions()).withTypeAhead(250).withHomeAndEnd();
     // .withAllowedModifierKeys(['shiftKey']);
 
     this._keyManager.tabOut.pipe(takeUntil(this._destroy)).subscribe(() => {

--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -728,7 +728,7 @@ export class NovoSelectElement
 
   /** Sets up a key manager to listen to keyboard events on the overlay panel. */
   private _initKeyManager() {
-    this._keyManager = new ActiveDescendantKeyManager<NovoOption>(this._getOptions()).withTypeAhead(100).withHomeAndEnd();
+    this._keyManager = new ActiveDescendantKeyManager<NovoOption>(this._getOptions()).withTypeAhead(300).withHomeAndEnd();
     // .withAllowedModifierKeys(['shiftKey']);
 
     this._keyManager.tabOut.pipe(takeUntil(this._destroy)).subscribe(() => {


### PR DESCRIPTION
## **Description**

when using type-ahead in dropdown and select components, debounce time was very low (100ms) so the user would have to type extremely fast to avoid each keystroke being registered as a separate search, each one overriding the last.

This is being done to address issue https://github.com/bullhorn/novo-elements/issues/1291

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**