### PR TITLE
fix(NovoDataTablePagination): Recalculate pages when page is reset to zero

### DIFF
--- a/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
+++ b/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
@@ -106,6 +106,9 @@ export class NovoDataTablePagination<T> implements OnInit, OnDestroy {
     this.longRangeLabel = this.labels.getRangeText(this.page, this.pageSize, this.length, false);
     this.shortRangeLabel = this.labels.getRangeText(this.page, this.pageSize, this.length, true);
     this.state.page = this._page;
+    if (this._page === 0) {
+      this.pages = this.getPages(this.page, this.totalPages);
+    }
   }
   _page: number = 0;
 


### PR DESCRIPTION
## **Description**

Update NovoDataTablePagination so it recalculates pages when page is reset to zero. Fixes issue 1297.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**