### PR TITLE
style(Chips): remove max-width from novo-picker if a row chips picker

### DIFF
--- a/projects/novo-elements/src/elements/chips/Chips.scss
+++ b/projects/novo-elements/src/elements/chips/Chips.scss
@@ -276,9 +276,6 @@ novo-row-chips {
     font-style: italic;
     color: $grey;
   }
-  novo-picker {
-    max-width: 275px;
-  }
   i {
     cursor: pointer;
   }


### PR DESCRIPTION
## **Description**

Removing the novo-picker style when nested within novo-row-chips. We want the picker to expand to 100% of the size of the container, which is how it behaves in other areas. After these changes the picker will expand to be the standard width of our form fields.
#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**
BEFORE CHANGES:
![image](https://user-images.githubusercontent.com/21197268/167141045-74548bbc-9640-4753-aa14-a85f0102b7b5.png)

AFTER CHANGES:

![image](https://user-images.githubusercontent.com/21197268/167143367-3ba56ba3-65c8-442a-8073-d7f2c46d2699.png)
