### PR TITLE
fix(imports): fix utils imports

### DIFF
--- a/projects/novo-elements/src/elements/field/autocomplete/autocomplete.component.ts
+++ b/projects/novo-elements/src/elements/field/autocomplete/autocomplete.component.ts
@@ -22,7 +22,7 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import { Key } from 'projects/novo-elements/src/utils';
+import { Key } from '../../../utils';
 import { fromEvent, merge, of, Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
 import {

--- a/projects/novo-elements/src/elements/form/ControlTemplates.ts
+++ b/projects/novo-elements/src/elements/form/ControlTemplates.ts
@@ -245,6 +245,7 @@ import { NovoTemplate } from '../common/novo-template/novo-template.directive';
           [type]="control.config.type"
           [formControlName]="control.key"
           [placeholder]="control.placeholder"
+          [maxlength]="control?.maxlength"
           *ngIf="control.multiple && control.config.columns"
           [closeOnSelect]="control.closeOnSelect"
           (changed)="methods.modelChangeWithRaw($event)"

--- a/projects/novo-elements/src/elements/layout/sidenav/sidenav.component.ts
+++ b/projects/novo-elements/src/elements/layout/sidenav/sidenav.component.ts
@@ -21,7 +21,7 @@ import {
   Output,
   ViewEncapsulation,
 } from '@angular/core';
-import { Key } from 'projects/novo-elements/src/utils';
+import { Key } from '../../../utils';
 import { fromEvent, Observable, Subject } from 'rxjs';
 import { distinctUntilChanged, filter, map, mapTo, take, takeUntil } from 'rxjs/operators';
 // import type { NovoLayoutContainer } from '../container/layout-container.component';

--- a/projects/novo-elements/src/elements/table/extras/table-filter/TableFilter.ts
+++ b/projects/novo-elements/src/elements/table/extras/table-filter/TableFilter.ts
@@ -11,7 +11,7 @@ import {
   Renderer2,
   SimpleChanges,
 } from '@angular/core';
-import { Key } from 'projects/novo-elements/src/utils';
+import { Key } from '../../../../utils';
 import { Helpers } from './../../../../utils/Helpers';
 
 @Directive({


### PR DESCRIPTION
## **Description**

Fixing some import statements so that novo-elements can be run with the novo app locally

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**