### PR TITLE
fix: use correct comparison for dates in time picker input

### DIFF
--- a/projects/novo-elements/src/elements/time-picker/TimePickerInput.ts
+++ b/projects/novo-elements/src/elements/time-picker/TimePickerInput.ts
@@ -171,7 +171,12 @@ export class NovoTimePickerInputElement implements OnInit, OnChanges, ControlVal
   }
 
   onComplete(dt) {
-    if (this.value !== dt) {
+    if (this.value instanceof Date && dt instanceof Date) {
+      if (this.value.getTime() !== dt.getTime()) {
+        this.dispatchOnChange(dt);
+      }
+    }
+    else if (this.value !== dt) {
       this.dispatchOnChange(dt);
     }
   }


### PR DESCRIPTION
## **Description**

Fixed date comparisons to avoid incorrectly emitting change events

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**