### PR TITLE
fix(GroupedMultiPickerResults): Remove horizontal scroll bar

### DIFF
--- a/projects/novo-elements/src/elements/picker/extras/grouped-multi-picker-results/GroupedMultiPickerResults.scss
+++ b/projects/novo-elements/src/elements/picker/extras/grouped-multi-picker-results/GroupedMultiPickerResults.scss
@@ -18,6 +18,9 @@ grouped-multi-picker-results {
       pointer-events: none;
       opacity: 0.75;
     }
+    div.list-item {
+      flex: 1 !important;
+    }
   }
   > .grouped-multi-picker-groups {
     flex: 1;


### PR DESCRIPTION
## **Description**

Remove horizontal scroll bar on GroupedMultiPickerResults

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**