### PR TITLE
style(picker): Add data-automation-id to picker

### DIFF
--- a/projects/novo-elements/src/elements/picker/extras/picker-results/PickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/picker-results/PickerResults.ts
@@ -17,6 +17,7 @@ import { BasePickerResults } from '../base-picker-results/BasePickerResults';
         [class.active]="match === activeMatch"
         (mouseenter)="selectActive(match)"
         [class.disabled]="preselected(match)"
+        data-automation-id="picker-result-list-item"
       >
         <item-content> <span [innerHtml]="highlight(match.label, term)"></span> </item-content>
       </novo-list-item>


### PR DESCRIPTION
## **Description**

Added data-automation-id to picker result list items so picker element location is consistent in the automation 

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**