### PR TITLE
refactor(CKEditor): Do not encode special characters by default

### DIFF
--- a/projects/novo-elements/src/elements/ckeditor/CKEditor.spec.ts
+++ b/projects/novo-elements/src/elements/ckeditor/CKEditor.spec.ts
@@ -99,6 +99,7 @@ describe('Elements: NovoCKEditorElement', () => {
       component.minimal = false;
       expect(component.getBaseConfig()).toEqual({
         enterMode: window.CKEDITOR.ENTER_BR,
+        entities: false,
         shiftEnterMode: window.CKEDITOR.ENTER_P,
         disableNativeSpellChecker: false,
         removePlugins: 'liststyle,tabletools,contextmenu',
@@ -149,6 +150,7 @@ describe('Elements: NovoCKEditorElement', () => {
       component.fileBrowserImageUploadUrl = '/foo/bar/baz.cfm';
       expect(component.getBaseConfig()).toEqual({
         enterMode: window.CKEDITOR.ENTER_BR,
+        entities: false,
         shiftEnterMode: window.CKEDITOR.ENTER_P,
         disableNativeSpellChecker: false,
         removePlugins: 'liststyle,tabletools,contextmenu',
@@ -198,6 +200,7 @@ describe('Elements: NovoCKEditorElement', () => {
       component.minimal = true;
       expect(component.getBaseConfig()).toEqual({
         enterMode: window.CKEDITOR.ENTER_BR,
+        entities: false,
         shiftEnterMode: window.CKEDITOR.ENTER_P,
         disableNativeSpellChecker: false,
         removePlugins: 'liststyle,tabletools,contextmenu',

--- a/projects/novo-elements/src/elements/ckeditor/CKEditor.ts
+++ b/projects/novo-elements/src/elements/ckeditor/CKEditor.ts
@@ -163,6 +163,7 @@ export class NovoCKEditorElement implements OnDestroy, AfterViewInit, ControlVal
   getBaseConfig(): { [key: string]: any } {
     const baseConfig = {
       enterMode: CKEDITOR.ENTER_BR,
+      entities: false,
       shiftEnterMode: CKEDITOR.ENTER_P,
       disableNativeSpellChecker: false,
       removePlugins: 'liststyle,tabletools,contextmenu', // allows browser based spell checking


### PR DESCRIPTION
## **Description**

Change CKEditor config to no longer encode special and accented characters by default.

Example: `À Á Â` will now save as `À Á Â` instead of `&Agrave; &Aacute; &Acirc;`

https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html
#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**