### PR TITLE
fix: avoid checking for method on possibly undefined object

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -751,7 +751,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
     if (this.listInteractions) {
       for (const column of this.columns) {
         const allListColumnInteractions = this.listInteractions[column.id];
-        const listColumnInteraction = allListColumnInteractions && allListColumnInteractions.find((int) => int.event.includes(event));
+        const listColumnInteraction = !!allListColumnInteractions && allListColumnInteractions.find((int) => int.event.includes(event));
         if (listColumnInteraction) {
           listColumnInteraction.script(this, column.id);
         }


### PR DESCRIPTION
## **Description**

Fix a statement that could throw an error if the object it was checking was undefined

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**