### PR TITLE
feat(Chips): remove close icon, update color and opacity on disabled …

### DIFF
--- a/projects/novo-elements/src/elements/chips/Chip.scss
+++ b/projects/novo-elements/src/elements/chips/Chip.scss
@@ -93,7 +93,7 @@ $chip-spacing: (
   }
 
   &.novo-chip-disabled {
-    opacity: 0.4;
+    color: var(--text-main);
     pointer-events: none;
     &::after {
       opacity: 0;

--- a/projects/novo-elements/src/elements/chips/Chips.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.ts
@@ -32,7 +32,7 @@ const CHIPS_VALUE_ACCESSOR = {
       >
         <novo-icon *ngIf="getAvatarType(item)" class="txc-{{ getAvatarType(item) }}" novoChipAvatar>circle</novo-icon>
         {{ item.label }}
-        <novo-icon novoChipRemove>x</novo-icon>
+        <novo-icon novoChipRemove *ngIf="!disablePickerInput">x</novo-icon>
       </novo-chip>
     </div>
     <div class="chip-input-container" *ngIf="!maxlength || (maxlength && items.length < maxlength)">


### PR DESCRIPTION
## **Description**

Chips on disabled fields were difficult to read due to the opacity on the disabled chips. To address this I removed that opacity. Working with UX they also suggested removing the close icon and setting the text color to the main text color to further clue the user that the field is not editable. In summary:

Removed close icon on disabled chips.
Set text color to main text color on disabled chips.
Removed css that was setting the opacity on disabled chips so it reset to default.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

<img width="385" alt="image" src="https://user-images.githubusercontent.com/1056055/175649272-c61dcb4a-c940-489f-8cdf-47074b4a37a6.png">
