### PR TITLE
feat(Loading): Adding loading message to novo-loading component

### DIFF
--- a/projects/novo-elements/src/elements/loading/Loading.scss
+++ b/projects/novo-elements/src/elements/loading/Loading.scss
@@ -23,6 +23,11 @@ novo-loading {
     @include animationMapDelay($dot-colors, jump, 1600ms, ease-in-out, 70ms, forward, infinite, "", "");
   }
 
+  div.message {
+    position: absolute;
+    padding-top: 3em;
+}
+
   @each $analytics, $color in $analytics-colors {
     &.color-#{$analytics} {
       span.dot {

--- a/projects/novo-elements/src/elements/loading/Loading.ts
+++ b/projects/novo-elements/src/elements/loading/Loading.ts
@@ -20,7 +20,7 @@ import {
     <span class="dot"></span>
     <span class="dot"></span>
     <span class="dot"></span>
-    <div class="message" *ngIf="showLoadMessage">{{loadMessage}}</div>
+    <div class="message" *ngIf="showLoadMessage" ng-transclude></div>
   `,
 })
 export class NovoLoadingElement {
@@ -42,9 +42,6 @@ export class NovoLoadingElement {
 
   @Input()
   size: string = 'medium';
-
-  @Input()
-  loadMessage: string;
 
   @Input()
   showLoadMessage: boolean;

--- a/projects/novo-elements/src/elements/loading/Loading.ts
+++ b/projects/novo-elements/src/elements/loading/Loading.ts
@@ -20,7 +20,7 @@ import {
     <span class="dot"></span>
     <span class="dot"></span>
     <span class="dot"></span>
-    <div class="message" *ngIf="showLoadMessage" ng-transclude></div>
+    <div class="message" *ngIf="showLoadMessage"><ng-content></ng-content></div>
   `,
 })
 export class NovoLoadingElement {

--- a/projects/novo-elements/src/elements/loading/Loading.ts
+++ b/projects/novo-elements/src/elements/loading/Loading.ts
@@ -20,6 +20,7 @@ import {
     <span class="dot"></span>
     <span class="dot"></span>
     <span class="dot"></span>
+    <div class="message" *ngIf="showLoadMessage">{{loadMessage}}</div>
   `,
 })
 export class NovoLoadingElement {
@@ -41,6 +42,12 @@ export class NovoLoadingElement {
 
   @Input()
   size: string = 'medium';
+
+  @Input()
+  loadMessage: string;
+
+  @Input()
+  showLoadMessage: boolean;
 
   @HostBinding('class')
   get hb_class() {

--- a/projects/novo-examples/src/components/loading/loading-line/loading-line-example.html
+++ b/projects/novo-examples/src/components/loading/loading-line/loading-line-example.html
@@ -16,7 +16,6 @@
     <novo-radio name="color" value="ocean">ocean</novo-radio>
   </novo-radio-group>
 
-  <novo-label>Message</novo-label>
   <novo-form [form]="messageForm">
     <div class="novo-form-row">
       <novo-control [form]="messageForm" [control]="switchControl"></novo-control>

--- a/projects/novo-examples/src/components/loading/loading-line/loading-line-example.html
+++ b/projects/novo-examples/src/components/loading/loading-line/loading-line-example.html
@@ -1,4 +1,4 @@
-<novo-loading [size]="size.value" [color]="color.value" [showLoadMessage]="this.messageForm.value.switch" [loadMessage]="this.messageForm.value.text"></novo-loading>
+<novo-loading [size]="size.value" [color]="color.value" [showLoadMessage]="this.messageForm.value.switch">{{this.messageForm.value.text}}</novo-loading>
 
 <section>
   <novo-label>Size</novo-label>

--- a/projects/novo-examples/src/components/loading/loading-line/loading-line-example.html
+++ b/projects/novo-examples/src/components/loading/loading-line/loading-line-example.html
@@ -1,4 +1,4 @@
-<novo-loading [size]="size.value" [color]="color.value"></novo-loading>
+<novo-loading [size]="size.value" [color]="color.value" [showLoadMessage]="this.messageForm.value.switch" [loadMessage]="this.messageForm.value.text"></novo-loading>
 
 <section>
   <novo-label>Size</novo-label>
@@ -15,4 +15,16 @@
     <novo-radio name="color" value="mint">mint</novo-radio>
     <novo-radio name="color" value="ocean">ocean</novo-radio>
   </novo-radio-group>
+
+  <novo-label>Message</novo-label>
+  <novo-form [form]="messageForm">
+    <div class="novo-form-row">
+      <novo-control [form]="messageForm" [control]="switchControl"></novo-control>
+    </div>
+    <div class="novo-form-row">
+      <novo-control [form]="messageForm" [control]="textControl"></novo-control>
+  </div>
+  </novo-form>
+
+
 </section>

--- a/projects/novo-examples/src/components/loading/loading-line/loading-line-example.ts
+++ b/projects/novo-examples/src/components/loading/loading-line/loading-line-example.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { FormUtils, SwitchControl, TextBoxControl } from 'novo-elements';
 
 /**
  * @title Linear Loading Symbol
@@ -8,4 +9,24 @@ import { Component } from '@angular/core';
   templateUrl: 'loading-line-example.html',
   styleUrls: ['loading-line-example.css'],
 })
-export class LoadingLineExample {}
+export class LoadingLineExample {
+
+  public switchControl: any;
+  public textControl: any;
+  public messageForm: any;
+
+  constructor(private formUtils: FormUtils) {
+    this.switchControl = new SwitchControl({ key: 'switch', tooltip: 'Switch', label: 'Switch', checkboxLabel: 'Switch' });
+    this.textControl = new TextBoxControl({
+      key: 'text',
+      label: 'Text Box',
+      tooltip: 'Textbox',
+      value: 'Hang tight, still loading.',
+    });
+
+    this.messageForm = formUtils.toFormGroup([
+      this.textControl,
+      this.switchControl,
+    ]);
+  }
+}

--- a/projects/novo-examples/src/components/loading/loading-line/loading-line-example.ts
+++ b/projects/novo-examples/src/components/loading/loading-line/loading-line-example.ts
@@ -16,11 +16,11 @@ export class LoadingLineExample {
   public messageForm: any;
 
   constructor(private formUtils: FormUtils) {
-    this.switchControl = new SwitchControl({ key: 'switch', tooltip: 'Switch', label: 'Switch', checkboxLabel: 'Switch' });
+    this.switchControl = new SwitchControl({ key: 'switch', tooltip: 'Enable Message Switch', label: 'Enable Message', checkboxLabel: 'Switch' });
     this.textControl = new TextBoxControl({
       key: 'text',
-      label: 'Text Box',
-      tooltip: 'Textbox',
+      label: 'Loading Message',
+      tooltip: 'Loading Message Textbox',
       value: 'Hang tight, still loading.',
     });
 


### PR DESCRIPTION
## **Description**

Adding a message and flag for the novo-loading component. This could be used to display a message while loading with the flag controlled at implementation. This can be used for a loading message displaying all the time for a loading screen, or having a timer flipping the flag to show a message during a long long loading screen. 

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**

![loadingMessage](https://user-images.githubusercontent.com/73492464/180301184-41be3115-2566-4ca8-ab80-3784667dc9fa.gif)

