### PR TITLE
feat(NonIdealState): Non Ideal Loading

### DIFF
--- a/projects/novo-elements/src/elements/non-ideal-state/NonIdealState.ts
+++ b/projects/novo-elements/src/elements/non-ideal-state/NonIdealState.ts
@@ -6,7 +6,9 @@ import { Component, HostBinding, Input } from '@angular/core';
   styleUrls: ['./NonIdealState.scss'],
   template: `
     <novo-icon class="novo-non-ideal-state-icon" *ngIf="icon" [color]="theme">{{ icon }}</novo-icon>
+    <ng-content select="novo-icon,novo-loading,novo-avatar"></ng-content>
     <novo-title class="novo-non-ideal-state-title" *ngIf="title" marginBefore>{{ title }}</novo-title>
+    <ng-content select="novo-title"></ng-content>
     <novo-text *ngIf="description" block marginBefore marginAfter>{{ description }}</novo-text>
     <ng-content></ng-content>
   `,

--- a/projects/novo-examples/src/components/non-ideal-state/non-ideal-state-examples.md
+++ b/projects/novo-examples/src/components/non-ideal-state/non-ideal-state-examples.md
@@ -14,3 +14,4 @@ Basic use-case is to display an icon, message, and reason for this state to occu
 The call to action doesn't necessarily need to be a button, for example:
 
 <code-example example="non-ideal-state-search-usage"></code-example>
+<code-example example="non-ideal-state-loading-usage"></code-example>

--- a/projects/novo-examples/src/components/non-ideal-state/non-ideal-state-loading-usage/index.ts
+++ b/projects/novo-examples/src/components/non-ideal-state/non-ideal-state-loading-usage/index.ts
@@ -1,0 +1,1 @@
+export * from './non-ideal-state-loading-usage-example';

--- a/projects/novo-examples/src/components/non-ideal-state/non-ideal-state-loading-usage/non-ideal-state-loading-usage-example.css
+++ b/projects/novo-examples/src/components/non-ideal-state/non-ideal-state-loading-usage/non-ideal-state-loading-usage-example.css
@@ -1,0 +1,3 @@
+span[tooltip]{
+  margin-left: 10px;
+}

--- a/projects/novo-examples/src/components/non-ideal-state/non-ideal-state-loading-usage/non-ideal-state-loading-usage-example.html
+++ b/projects/novo-examples/src/components/non-ideal-state/non-ideal-state-loading-usage/non-ideal-state-loading-usage-example.html
@@ -1,0 +1,7 @@
+<novo-non-ideal-state>
+  <novo-loading></novo-loading>
+  <novo-text lineLength="large" marginAfter>We are currently experiencing technical difficulites and your wait time is
+    taking a bit
+    longer than expected. Please be patient. </novo-text>
+  <button theme="primary" icon="refresh-o">Refresh</button>
+</novo-non-ideal-state>

--- a/projects/novo-examples/src/components/non-ideal-state/non-ideal-state-loading-usage/non-ideal-state-loading-usage-example.html
+++ b/projects/novo-examples/src/components/non-ideal-state/non-ideal-state-loading-usage/non-ideal-state-loading-usage-example.html
@@ -1,6 +1,6 @@
 <novo-non-ideal-state>
   <novo-loading></novo-loading>
   <novo-text lineLength="large" marginAfter>We are currently experiencing technical difficulites and your wait time is
-    taking a bit longer than expected. Please be patient. </novo-text>
+    taking a bit longer than expected. Thank you for your patience. </novo-text>
   <button theme="primary" icon="refresh-o">Refresh</button>
 </novo-non-ideal-state>

--- a/projects/novo-examples/src/components/non-ideal-state/non-ideal-state-loading-usage/non-ideal-state-loading-usage-example.html
+++ b/projects/novo-examples/src/components/non-ideal-state/non-ideal-state-loading-usage/non-ideal-state-loading-usage-example.html
@@ -1,7 +1,6 @@
 <novo-non-ideal-state>
   <novo-loading></novo-loading>
   <novo-text lineLength="large" marginAfter>We are currently experiencing technical difficulites and your wait time is
-    taking a bit
-    longer than expected. Please be patient. </novo-text>
+    taking a bit longer than expected. Please be patient. </novo-text>
   <button theme="primary" icon="refresh-o">Refresh</button>
 </novo-non-ideal-state>

--- a/projects/novo-examples/src/components/non-ideal-state/non-ideal-state-loading-usage/non-ideal-state-loading-usage-example.ts
+++ b/projects/novo-examples/src/components/non-ideal-state/non-ideal-state-loading-usage/non-ideal-state-loading-usage-example.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+/**
+ * @title Non Ideal State Alt Usage
+ */
+@Component({
+  selector: 'non-ideal-state-loading-usage-example',
+  templateUrl: './non-ideal-state-loading-usage-example.html',
+  styleUrls: ['./non-ideal-state-loading-usage-example.css'],
+})
+export class NonIdealStateLoadingUsageExample {}

--- a/projects/novo-examples/src/examples.routes.ts
+++ b/projects/novo-examples/src/examples.routes.ts
@@ -2305,8 +2305,8 @@ export class NonIdealStateDevelopPage {
 <p>Basic use-case is to display an icon, message, and reason for this state to occur. And provide a call to action for the user.</p>
 <p><code-example example="non-ideal-state-usage"></code-example></p>
 <p>The call to action doesn't necessarily need to be a button, for example:</p>
-<p><code-example example="non-ideal-state-search-usage"></code-example></p>
-<p><code-example example="non-ideal-state-loading-usage"></code-example></p>
+<p><code-example example="non-ideal-state-search-usage"></code-example>
+<code-example example="non-ideal-state-loading-usage"></code-example></p>
 `,
   host: { class: 'markdown-page' }
 })

--- a/projects/novo-examples/src/examples.routes.ts
+++ b/projects/novo-examples/src/examples.routes.ts
@@ -2306,6 +2306,7 @@ export class NonIdealStateDevelopPage {
 <p><code-example example="non-ideal-state-usage"></code-example></p>
 <p>The call to action doesn't necessarily need to be a button, for example:</p>
 <p><code-example example="non-ideal-state-search-usage"></code-example></p>
+<p><code-example example="non-ideal-state-loading-usage"></code-example></p>
 `,
   host: { class: 'markdown-page' }
 })


### PR DESCRIPTION
## **Description**

Adding a message next to the novo-loading component is not a known pattern. This could be used to display a message while loading with the flag controlled at implementation. This can be used for a loading message displaying all the time for a loading screen, or having a timer flipping the flag to show a message during a long long loading screen.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**
![image](https://user-images.githubusercontent.com/73492464/181272237-66468bd6-7b3c-443a-b5df-ae87a8cdae54.png)
![image](https://user-images.githubusercontent.com/73492464/181272305-689554f1-2cb5-434d-af7c-8fbe10724728.png)
