### PR TITLE
fix(): DatePicker remove hard-coded width from styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ npm install --save novo-elements@6
 ng update novo-elements --migrate-only --from=0.0.0 --to=6.0.0 --force --allow-dirty  
 ```
 
-
 ## Contribute
 
 There are many ways to **[contribute](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)** to our OpenSource projects.

--- a/projects/novo-elements/src/elements/date-picker/DatePicker.scss
+++ b/projects/novo-elements/src/elements/date-picker/DatePicker.scss
@@ -3,7 +3,6 @@ input[type="calendar"] {
   font-size: 14px;
   line-height: 14px;
   color: #333;
-  width: 140px;
   display: inline-block;
   border: 2px solid #ddd;
   border-radius: 4px;


### PR DESCRIPTION
## **Description**

Removes hard coded width styling for date picker input[type="calendar"]

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**
![calendar datepicker with current styling](https://user-images.githubusercontent.com/46942213/184194330-3a481449-3288-489a-8cd9-f90291e49d9a.png)
![calendar datepicker without hardcoded width](https://user-images.githubusercontent.com/46942213/184194333-c4eac5a2-db22-4f26-b74e-5f3ff0e63bd1.png)
