### PR TITLE
feat(NovoDataTable): Update pagination with loading state, refresh button, and ability to override total

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -66,7 +66,7 @@ import { DataTableState } from './state/data-table-state.service';
       <novo-data-table-pagination
         *ngIf="paginationOptions"
         [theme]="paginationOptions.theme"
-        [length]="null !== overrideTotal ? overrideTotal : dataSource?.currentTotal"
+        [length]="null !== overrideTotal && overrideTotal >= 0 ? overrideTotal : dataSource?.currentTotal"
         [page]="paginationOptions.page"
         [pageSize]="paginationOptions.pageSize"
         [pageSizeOptions]="paginationOptions.pageSizeOptions"

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -17,7 +17,7 @@ import {
   ViewChild,
   ViewChildren,
 } from '@angular/core';
-import {Subject, Subscription} from 'rxjs';
+import { Subject, Subscription } from 'rxjs';
 import { NovoLabelService } from '../../services/novo-label-service';
 import { notify } from '../../utils/notifier/notifier.util';
 import { NovoTemplate } from '../common/novo-template/novo-template.directive';

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -73,8 +73,8 @@ import { DataTableState } from './state/data-table-state.service';
         [dataFeatureId]="paginatorDataFeatureId"
         [canSelectAll]="canSelectAll"
         [allMatchingSelected]="allMatchingSelected"
-        [isHidden]="paginationOptions.isHidden"
-        [isLoading]="paginationOptions.isLoading"
+        [loading]="paginationOptions.loading"
+        [errorLoading]="paginationOptions.errorLoading"
         [paginationRefreshSubject] = "paginationRefreshSubject"
       >
       </novo-data-table-pagination>

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -66,7 +66,7 @@ import { DataTableState } from './state/data-table-state.service';
       <novo-data-table-pagination
         *ngIf="paginationOptions"
         [theme]="paginationOptions.theme"
-        [length]="null !== overrideTotal && overrideTotal >= 0 ? overrideTotal : dataSource?.currentTotal"
+        [length]="null !== overrideTotal && overrideTotal !== undefined ? overrideTotal : dataSource?.currentTotal"
         [page]="paginationOptions.page"
         [pageSize]="paginationOptions.pageSize"
         [pageSizeOptions]="paginationOptions.pageSizeOptions"

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -75,7 +75,7 @@ import { DataTableState } from './state/data-table-state.service';
         [allMatchingSelected]="allMatchingSelected"
         [loading]="paginationOptions.loading"
         [errorLoading]="paginationOptions.errorLoading"
-        [paginationRefreshSubject] = "paginationRefreshSubject"
+        [paginationRefreshSubject]="paginationRefreshSubject"
       >
       </novo-data-table-pagination>
       <div class="novo-data-table-actions" *ngIf="templates['customActions']">

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -17,7 +17,7 @@ import {
   ViewChild,
   ViewChildren,
 } from '@angular/core';
-import { Subscription } from 'rxjs';
+import {Subject, Subscription} from 'rxjs';
 import { NovoLabelService } from '../../services/novo-label-service';
 import { notify } from '../../utils/notifier/notifier.util';
 import { NovoTemplate } from '../common/novo-template/novo-template.directive';
@@ -74,6 +74,8 @@ import { DataTableState } from './state/data-table-state.service';
         [canSelectAll]="canSelectAll"
         [allMatchingSelected]="allMatchingSelected"
         [isHidden]="paginationOptions.isHidden"
+        [isLoading]="paginationOptions.isLoading"
+        [overrideTotalSubject] = "overrideTotalSubject"
       >
       </novo-data-table-pagination>
       <div class="novo-data-table-actions" *ngIf="templates['customActions']">
@@ -332,6 +334,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   @Input() canSelectAll: boolean = false;
   @Input() allMatchingSelected = false;
   @Input() overrideTotal: number;
+  @Input() overrideTotalSubject: Subject<any>;
 
   @Input()
   set dataTableService(service: IDataTableService<T>) {

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -66,7 +66,7 @@ import { DataTableState } from './state/data-table-state.service';
       <novo-data-table-pagination
         *ngIf="paginationOptions"
         [theme]="paginationOptions.theme"
-        [length]="dataSource?.currentTotal"
+        [length]="paginationOptions.asyncListCountEnabled? paginationOptions.length : dataSource?.currentTotal"
         [page]="paginationOptions.page"
         [pageSize]="paginationOptions.pageSize"
         [pageSizeOptions]="paginationOptions.pageSizeOptions"

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -66,7 +66,7 @@ import { DataTableState } from './state/data-table-state.service';
       <novo-data-table-pagination
         *ngIf="paginationOptions"
         [theme]="paginationOptions.theme"
-        [length]="paginationOptions.asyncListCountEnabled? paginationOptions.length : dataSource?.currentTotal"
+        [length]="paginationOptions.asyncListCountEnabled? length : dataSource?.currentTotal"
         [page]="paginationOptions.page"
         [pageSize]="paginationOptions.pageSize"
         [pageSizeOptions]="paginationOptions.pageSizeOptions"
@@ -331,6 +331,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   @Input() maxSelected: number = undefined;
   @Input() canSelectAll: boolean = false;
   @Input() allMatchingSelected = false;
+  @Input() length: number;
 
   @Input()
   set dataTableService(service: IDataTableService<T>) {

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -75,7 +75,7 @@ import { DataTableState } from './state/data-table-state.service';
         [allMatchingSelected]="allMatchingSelected"
         [isHidden]="paginationOptions.isHidden"
         [isLoading]="paginationOptions.isLoading"
-        [overrideTotalSubject] = "overrideTotalSubject"
+        [paginationRefreshSubject] = "paginationRefreshSubject"
       >
       </novo-data-table-pagination>
       <div class="novo-data-table-actions" *ngIf="templates['customActions']">
@@ -334,7 +334,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   @Input() canSelectAll: boolean = false;
   @Input() allMatchingSelected = false;
   @Input() overrideTotal: number;
-  @Input() overrideTotalSubject: Subject<any>;
+  @Input() paginationRefreshSubject: Subject<void>;
 
   @Input()
   set dataTableService(service: IDataTableService<T>) {

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -66,7 +66,7 @@ import { DataTableState } from './state/data-table-state.service';
       <novo-data-table-pagination
         *ngIf="paginationOptions"
         [theme]="paginationOptions.theme"
-        [length]="asyncListCountEnabled ? length : dataSource?.currentTotal"
+        [length]="null !== overrideTotal ? overrideTotal : dataSource?.currentTotal"
         [page]="paginationOptions.page"
         [pageSize]="paginationOptions.pageSize"
         [pageSizeOptions]="paginationOptions.pageSizeOptions"
@@ -331,8 +331,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   @Input() maxSelected: number = undefined;
   @Input() canSelectAll: boolean = false;
   @Input() allMatchingSelected = false;
-  @Input() length: number;
-  @Input() asyncListCountEnabled: boolean = false;
+  @Input() overrideTotal: number;
 
   @Input()
   set dataTableService(service: IDataTableService<T>) {

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -73,6 +73,7 @@ import { DataTableState } from './state/data-table-state.service';
         [dataFeatureId]="paginatorDataFeatureId"
         [canSelectAll]="canSelectAll"
         [allMatchingSelected]="allMatchingSelected"
+        [isHidden]="paginationOptions.isHidden"
       >
       </novo-data-table-pagination>
       <div class="novo-data-table-actions" *ngIf="templates['customActions']">

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -66,7 +66,7 @@ import { DataTableState } from './state/data-table-state.service';
       <novo-data-table-pagination
         *ngIf="paginationOptions"
         [theme]="paginationOptions.theme"
-        [length]="paginationOptions.asyncListCountEnabled? length : dataSource?.currentTotal"
+        [length]="asyncListCountEnabled ? length : dataSource?.currentTotal"
         [page]="paginationOptions.page"
         [pageSize]="paginationOptions.pageSize"
         [pageSizeOptions]="paginationOptions.pageSizeOptions"
@@ -332,6 +332,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   @Input() canSelectAll: boolean = false;
   @Input() allMatchingSelected = false;
   @Input() length: number;
+  @Input() asyncListCountEnabled: boolean = false;
 
   @Input()
   set dataTableService(service: IDataTableService<T>) {

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -68,8 +68,8 @@ export interface IDataTablePaginationOptions {
   page?: number;
   pageSize: number;
   pageSizeOptions: number[] | { value: string; label: string }[];
-  isHidden?: boolean;
-  isLoading?: boolean;
+  loading?: boolean;
+  errorLoading?: boolean;
 }
 
 export interface IDataTableColumnSortConfig {

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -69,6 +69,8 @@ export interface IDataTablePaginationOptions {
   pageSize: number;
   pageSizeOptions: number[] | { value: string; label: string }[];
   isHidden?: boolean;
+  asyncListCountEnabled?: boolean;
+  length?: number;
 }
 
 export interface IDataTableColumnSortConfig {

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -69,8 +69,6 @@ export interface IDataTablePaginationOptions {
   pageSize: number;
   pageSizeOptions: number[] | { value: string; label: string }[];
   isHidden?: boolean;
-  asyncListCountEnabled?: boolean;
-  length?: number;
 }
 
 export interface IDataTableColumnSortConfig {

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -68,7 +68,7 @@ export interface IDataTablePaginationOptions {
   page?: number;
   pageSize: number;
   pageSizeOptions: number[] | { value: string; label: string }[];
-  isHidden: boolean;
+  isHidden?: boolean;
 }
 
 export interface IDataTableColumnSortConfig {

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -69,6 +69,7 @@ export interface IDataTablePaginationOptions {
   pageSize: number;
   pageSizeOptions: number[] | { value: string; label: string }[];
   isHidden?: boolean;
+  isLoading?: boolean;
 }
 
 export interface IDataTableColumnSortConfig {

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -68,6 +68,7 @@ export interface IDataTablePaginationOptions {
   page?: number;
   pageSize: number;
   pageSizeOptions: number[] | { value: string; label: string }[];
+  isHidden: boolean;
 }
 
 export interface IDataTableColumnSortConfig {

--- a/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
+++ b/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
@@ -76,7 +76,7 @@ const MAX_PAGES_DISPLAYED = 5;
       >
       </novo-select>
       <span class="spacer"></span>
-      <ul *ngIf="!isHidden" class="pager" data-automation-id="pager">
+      <ul *ngIf="!loading && !errorLoading" class="pager" data-automation-id="pager">
         <li class="page" (click)="selectPage(page - 1)" [ngClass]="{ disabled: page === 0 }">
           <i class="bhi-previous" data-automation-id="pager-previous"></i>
         </li>
@@ -87,14 +87,12 @@ const MAX_PAGES_DISPLAYED = 5;
           <i class="bhi-next" data-automation-id="pager-next"></i>
         </li>
       </ul>
-      <div *ngIf="isHidden">
-        <novo-loading *ngIf="isLoading"></novo-loading>
-        <button *ngIf="!isLoading"
-                theme="primary"
-                color="negative"
-                icon="refresh"
-                (click)="paginationRefreshSubject.next()">{{ labels.refreshPagination }}</button>
-      </div>
+      <novo-loading *ngIf="loading"></novo-loading>
+      <button *ngIf="errorLoading"
+              theme="primary"
+              color="negative"
+              icon="refresh"
+              (click)="paginationRefreshSubject.next()">{{ labels.refreshPagination }}</button>
     </ng-container>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -144,9 +142,9 @@ export class NovoDataTablePagination<T> implements OnInit, OnDestroy {
   @Input()
   public allMatchingSelected: boolean = false;
   @Input()
-  public isHidden: boolean = false;
+  public loading: boolean = false;
   @Input()
-  public isLoading: boolean = false;
+  public errorLoading: boolean = false;
   @Input()
   public paginationRefreshSubject = new Subject();
 

--- a/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
+++ b/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
@@ -9,7 +9,7 @@ import {
   OnInit,
   Output,
 } from '@angular/core';
-import { Subscription } from 'rxjs';
+import {Subject, Subscription} from 'rxjs';
 import { NovoLabelService } from '../../../services/novo-label-service';
 import { IDataTablePaginationEvent } from '../interfaces';
 import { DataTableState } from '../state/data-table-state.service';
@@ -87,6 +87,14 @@ const MAX_PAGES_DISPLAYED = 5;
           <i class="bhi-next" data-automation-id="pager-next"></i>
         </li>
       </ul>
+      <div *ngIf="isHidden">
+        <novo-loading *ngIf="isLoading"></novo-loading>
+        <button *ngIf="!isLoading"
+                theme="primary"
+                color="negative"
+                icon="refresh"
+                (click)="overrideTotalSubject.next()">{{ labels.refreshPagination }}</button>
+      </div>
     </ng-container>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -137,6 +145,10 @@ export class NovoDataTablePagination<T> implements OnInit, OnDestroy {
   public allMatchingSelected: boolean = false;
   @Input()
   public isHidden: boolean = false;
+  @Input()
+  public isLoading: boolean = false;
+  @Input()
+  public overrideTotalSubject: Subject<any> = new Subject<any>();
 
   @Input()
   get length(): number {

--- a/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
+++ b/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
@@ -93,7 +93,7 @@ const MAX_PAGES_DISPLAYED = 5;
                 theme="primary"
                 color="negative"
                 icon="refresh"
-                (click)="overrideTotalSubject.next()">{{ labels.refreshPagination }}</button>
+                (click)="paginationRefreshSubject.next()">{{ labels.refreshPagination }}</button>
       </div>
     </ng-container>
   `,
@@ -148,7 +148,7 @@ export class NovoDataTablePagination<T> implements OnInit, OnDestroy {
   @Input()
   public isLoading: boolean = false;
   @Input()
-  public overrideTotalSubject: Subject<any> = new Subject<any>();
+  public paginationRefreshSubject = new Subject();
 
   @Input()
   get length(): number {

--- a/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
+++ b/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
@@ -76,7 +76,7 @@ const MAX_PAGES_DISPLAYED = 5;
       >
       </novo-select>
       <span class="spacer"></span>
-      <ul class="pager" data-automation-id="pager">
+      <ul *ngIf="!isHidden" class="pager" data-automation-id="pager">
         <li class="page" (click)="selectPage(page - 1)" [ngClass]="{ disabled: page === 0 }">
           <i class="bhi-previous" data-automation-id="pager-previous"></i>
         </li>
@@ -135,6 +135,8 @@ export class NovoDataTablePagination<T> implements OnInit, OnDestroy {
   public canSelectAll: boolean = false;
   @Input()
   public allMatchingSelected: boolean = false;
+  @Input()
+  public isHidden: boolean = false;
 
   @Input()
   get length(): number {

--- a/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
+++ b/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
@@ -9,7 +9,7 @@ import {
   OnInit,
   Output,
 } from '@angular/core';
-import {Subject, Subscription} from 'rxjs';
+import { Subject, Subscription } from 'rxjs';
 import { NovoLabelService } from '../../../services/novo-label-service';
 import { IDataTablePaginationEvent } from '../interfaces';
 import { DataTableState } from '../state/data-table-state.service';

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -134,6 +134,7 @@ export class NovoLabelService {
   after = 'After';
   between = 'Between';
   within = 'Within';
+  refreshPagination = 'Refresh Pagination';
 
   constructor(
     @Optional()


### PR DESCRIPTION
## **Description**

NovoDataTablePagination: update with a loading state (loading dots) and an error state (with button that can be wired up to handle refreshing data)

NovoDataTable: update with pass throughs for the new pagination loading state and refresh button, and add overrideTotal input to enable manually setting pagination length

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**