### PR TITLE
feat(DataTable): adding ability to explicitly set data-table state

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "copy:resources": "npm run copy:scss && npm run copy:schematics",
     "copy:schematics": "npx copyfiles -f projects/schematics/*.json dist/novo-elements/schematics/",
     "copy:scss": "node copy-scss.js",
-    "test": "jest projects/novo-elements/src/elements/data-table/state --no-coverage --max-workers=4",
+    "test": "jest projects/novo-elements --no-coverage --max-workers=4",
     "test:watch": "jest projects/chomsky projects/novo-elements --watch",
     "lint": "htmlhint \"projects\" --config .htmlhintrc",
     "lint:scss": "stylelint \"projects/**/*.scss\" --syntax scss",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "copy:resources": "npm run copy:scss && npm run copy:schematics",
     "copy:schematics": "npx copyfiles -f projects/schematics/*.json dist/novo-elements/schematics/",
     "copy:scss": "node copy-scss.js",
-    "test": "jest projects/novo-elements --no-coverage --max-workers=4",
+    "test": "jest projects/novo-elements/src/elements/data-table/state --no-coverage --max-workers=4",
     "test:watch": "jest projects/chomsky projects/novo-elements --watch",
     "lint": "htmlhint \"projects\" --config .htmlhintrc",
     "lint:scss": "stylelint \"projects/**/*.scss\" --syntax scss",

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -359,7 +359,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
       // Re-subscribe
       this.outsideFilterSubscription = outsideFilter.subscribe((filter: any) => {
         this.state.outsideFilter = filter;
-        this.state.updates.next({ globalSearch: this.state.globalSearch, filter: this.state.filter, sort: this.state.sort, where: this.state.where, savedSearchName: this.state.savedSearchName });
+        this.state.updates.next({ globalSearch: this.state.globalSearch, filter: this.state.filter, sort: this.state.sort, where: this.state.where });
         this.ref.markForCheck();
       });
     }
@@ -375,7 +375,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
       // Re-subscribe
       this.refreshSubscription = refreshSubject.subscribe((filter: any) => {
         this.state.isForceRefresh = true;
-        this.state.updates.next({ globalSearch: this.state.globalSearch, filter: this.state.filter, sort: this.state.sort, where: this.state.where, savedSearchName: this.state.savedSearchName });
+        this.state.updates.next({ globalSearch: this.state.globalSearch, filter: this.state.filter, sort: this.state.sort, where: this.state.where });
         this.ref.markForCheck();
       });
     }
@@ -575,7 +575,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   public onSearchChange(term: string): void {
     this.state.globalSearch = term;
     this.state.reset(false, true);
-    this.state.updates.next({ globalSearch: term, filter: this.state.filter, sort: this.state.sort, where: this.state.where, savedSearchName: this.state.savedSearchName });
+    this.state.updates.next({ globalSearch: term, filter: this.state.filter, sort: this.state.sort, where: this.state.where });
   }
 
   public trackColumnsBy(index: number, item: IDataTableColumn<T>) {

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -25,6 +25,7 @@ import { NovoDataTableCellHeader } from './cell-headers/data-table-header-cell.c
 import { DataTableSource } from './data-table.source';
 import { NOVO_DATA_TABLE_REF } from './data-table.token';
 import {
+  IDataTableChangeEvent,
   IDataTableColumn,
   IDataTableFilter,
   IDataTablePaginationOptions,
@@ -358,7 +359,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
       // Re-subscribe
       this.outsideFilterSubscription = outsideFilter.subscribe((filter: any) => {
         this.state.outsideFilter = filter;
-        this.state.updates.next({ globalSearch: this.state.globalSearch, filter: this.state.filter, sort: this.state.sort, where: this.state.where });
+        this.state.updates.next({ globalSearch: this.state.globalSearch, filter: this.state.filter, sort: this.state.sort, where: this.state.where, savedSearchName: this.state.savedSearchName });
         this.ref.markForCheck();
       });
     }
@@ -374,7 +375,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
       // Re-subscribe
       this.refreshSubscription = refreshSubject.subscribe((filter: any) => {
         this.state.isForceRefresh = true;
-        this.state.updates.next({ globalSearch: this.state.globalSearch, filter: this.state.filter, sort: this.state.sort, where: this.state.where });
+        this.state.updates.next({ globalSearch: this.state.globalSearch, filter: this.state.filter, sort: this.state.sort, where: this.state.where, savedSearchName: this.state.savedSearchName });
         this.ref.markForCheck();
       });
     }
@@ -466,7 +467,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   constructor(public labels: NovoLabelService, private ref: ChangeDetectorRef, public state: DataTableState<T>) {
     this.scrollListenerHandler = this.scrollListener.bind(this);
     this.sortFilterSubscription = this.state.sortFilterSource.subscribe(
-      (event: { sort: IDataTableSort; filter: IDataTableFilter | IDataTableFilter[]; globalSearch: string; where: { query: string; form: any } }) => {
+      (event: IDataTableChangeEvent) => {
         if (this.name !== 'novo-data-table') {
           this.preferencesChanged.emit({
             name: this.name,
@@ -474,6 +475,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
             filter: event.filter,
             globalSearch: event.globalSearch,
             where: event.where,
+            savedSearchName: event.savedSearchName,
           });
           this.performInteractions('change');
         } else {
@@ -571,7 +573,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
   public onSearchChange(term: string): void {
     this.state.globalSearch = term;
     this.state.reset(false, true);
-    this.state.updates.next({ globalSearch: term, filter: this.state.filter, sort: this.state.sort, where: this.state.where });
+    this.state.updates.next({ globalSearch: term, filter: this.state.filter, sort: this.state.sort, where: this.state.where, savedSearchName: this.state.savedSearchName });
   }
 
   public trackColumnsBy(index: number, item: IDataTableColumn<T>) {

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -109,6 +109,7 @@ export interface IDataTableChangeEvent {
   outsideFilter?: IDataTableFilter | IDataTableFilter[];
   where?: { query: string; form: any };
   savedSearchName?: string;
+  displayedColumns?: string[];
 }
 
 export interface IDataTableSelectionChangeEvent {

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.spec.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.spec.ts
@@ -67,7 +67,6 @@ describe('Service: DataTableState', () => {
       service.filter = { id: 'test', value: 'value' };
       service.sort = { id: 'test', value: 'desc' };
       service.globalSearch = 'testing';
-      service.savedSearchName = 'saved search';
       service.where = { query: 'mock query', form: 'mock form' };
     });
     afterAll(() => {
@@ -82,13 +81,12 @@ describe('Service: DataTableState', () => {
       expect(service.onSortFilterChange).toHaveBeenCalled();
       expect(service.updates.emit).toHaveBeenCalled();
     });
-    it('should only reset sort, savedSearchName, and page', () => {
+    it('should only reset sort and page', () => {
       service.clearSort();
       expect(service.sort).toBeUndefined();
       expect(service.filter).toEqual({ id: 'test', value: 'value' });
       expect(service.where).toEqual({ query: 'mock query', form: 'mock form' });
       expect(service.globalSearch).toEqual('testing');
-      expect(service.savedSearchName).toBeUndefined();
       expect(service.page).toEqual(0);
     });
     it('should emit an update if fireUpdate is true', () => {
@@ -96,7 +94,6 @@ describe('Service: DataTableState', () => {
         sort: undefined,
         filter: { id: 'test', value: 'value' },
         globalSearch: 'testing',
-        savedSearchName: undefined,
         where: { query: 'mock query', form: 'mock form' },
       };
       service.clearSort(true);
@@ -117,7 +114,6 @@ describe('Service: DataTableState', () => {
       service.filter = { id: 'test', value: 'value' };
       service.sort = { id: 'test', value: 'desc' };
       service.globalSearch = 'testing';
-      service.savedSearchName = 'saved search';
       service.where = { query: 'mock query', form: 'mock form' };
     });
     afterAll(() => {
@@ -132,13 +128,12 @@ describe('Service: DataTableState', () => {
       expect(service.onSortFilterChange).toHaveBeenCalled();
       expect(service.updates.emit).toHaveBeenCalled();
     });
-    it('should only reset page, globalSearch, savedSearchName, and filter', () => {
+    it('should only reset page, globalSearch, and filter', () => {
       service.clearFilter();
       expect(service.sort).toEqual({ id: 'test', value: 'desc' });
       expect(service.filter).toBeUndefined();
       expect(service.where).toEqual({ query: 'mock query', form: 'mock form' });
       expect(service.globalSearch).toBeUndefined();
-      expect(service.savedSearchName).toBeUndefined();
       expect(service.page).toEqual(0);
     });
     it('should emit an update if fireUpdate is true', () => {
@@ -146,7 +141,6 @@ describe('Service: DataTableState', () => {
         sort: { id: 'test', value: 'desc' },
         filter: undefined,
         globalSearch: undefined,
-        savedSearchName: undefined,
         where: { query: 'mock query', form: 'mock form' },
       };
       service.clearFilter(true);
@@ -167,7 +161,6 @@ describe('Service: DataTableState', () => {
       service.filter = { id: 'test', value: 'value' };
       service.sort = { id: 'test', value: 'desc' };
       service.globalSearch = 'testing';
-      service.savedSearchName = 'saved search';
       service.where = { query: 'mock query', form: 'mock form' };
     });
     afterAll(() => {
@@ -182,12 +175,11 @@ describe('Service: DataTableState', () => {
       expect(service.onSortFilterChange).toHaveBeenCalled();
       expect(service.updates.emit).toHaveBeenCalled();
     });
-    it('should only reset page, savedSearchName, and where', () => {
+    it('should only reset page and where', () => {
       service.clearQuery();
       expect(service.sort).toEqual({ id: 'test', value: 'desc' });
       expect(service.filter).toEqual({ id: 'test', value: 'value' });
       expect(service.globalSearch).toEqual('testing');
-      expect(service.savedSearchName).toBeUndefined();
       expect(service.where).toBeUndefined();
       expect(service.page).toEqual(0);
     });
@@ -196,7 +188,6 @@ describe('Service: DataTableState', () => {
         sort: { id: 'test', value: 'desc' },
         filter: { id: 'test', value: 'value' },
         globalSearch: 'testing',
-        savedSearchName: undefined,
         where: undefined,
       };
       service.clearQuery(true);

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.spec.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.spec.ts
@@ -41,7 +41,7 @@ describe('Service: DataTableState', () => {
       expect(service.sort).toEqual({ id: 'test', value: 'desc' });
       expect(service.globalSearch).toEqual('testing');
     });
-    it('should emit an update if fiedUpdate is true', () => {
+    it('should emit an update if fireUpdate is true', () => {
       const expected = {
         sort: undefined,
         filter: undefined,
@@ -50,7 +50,7 @@ describe('Service: DataTableState', () => {
       service.reset(true);
       expect(service.updates.emit).toHaveBeenCalledWith(expected);
     });
-    it('should not emit an update if fiedUpdate is false', () => {
+    it('should not emit an update if fireUpdate is false', () => {
       service.reset(false);
       expect(service.updates.emit).not.toHaveBeenCalled();
     });
@@ -77,7 +77,7 @@ describe('Service: DataTableState', () => {
       expect(service.sort).toBeUndefined();
       expect(service.page).toEqual(0);
     });
-    it('should emit an update if fiedUpdate is true', () => {
+    it('should emit an update if fireUpdate is true', () => {
       const expected = {
         sort: undefined,
         filter: { id: 'test', value: 'value' },
@@ -87,7 +87,7 @@ describe('Service: DataTableState', () => {
       expect(service.reset).toHaveBeenCalledWith(true, true);
       expect(service.updates.emit).toHaveBeenCalledWith(expected);
     });
-    it('should not emit an update if fiedUpdate is false', () => {
+    it('should not emit an update if fireUpdate is false', () => {
       service.clearSort(false);
       expect(service.reset).toHaveBeenCalledWith(false, true);
       expect(service.updates.emit).not.toHaveBeenCalled();
@@ -117,7 +117,7 @@ describe('Service: DataTableState', () => {
       expect(service.globalSearch).toBeUndefined();
       expect(service.page).toEqual(0);
     });
-    it('should emit an update if fiedUpdate is true', () => {
+    it('should emit an update if fireUpdate is true', () => {
       const expected = {
         sort: { id: 'test', value: 'desc' },
         filter: undefined,
@@ -127,7 +127,7 @@ describe('Service: DataTableState', () => {
       expect(service.reset).toHaveBeenCalledWith(true, true);
       expect(service.updates.emit).toHaveBeenCalledWith(expected);
     });
-    it('should not emit an update if fiedUpdate is false', () => {
+    it('should not emit an update if fireUpdate is false', () => {
       service.clearFilter(false);
       expect(service.reset).toHaveBeenCalledWith(false, true);
       expect(service.updates.emit).not.toHaveBeenCalled();
@@ -154,7 +154,7 @@ describe('Service: DataTableState', () => {
       expect(service.globalSearch).toBeUndefined();
       expect(service.page).toEqual(0);
     });
-    it('should emit an update if fiedUpdate is true', () => {
+    it('should emit an update if fireUpdate is true', () => {
       service.filter = { id: 'test', value: 'value' };
       service.sort = { id: 'test', value: 'desc' };
       const expected = {
@@ -166,7 +166,7 @@ describe('Service: DataTableState', () => {
       expect(service.reset).toHaveBeenCalledWith(true, true);
       expect(service.updates.emit).toHaveBeenCalledWith(expected);
     });
-    it('should not emit an update if fiedUpdate is false', () => {
+    it('should not emit an update if fireUpdate is false', () => {
       service.clearSelected(false);
       expect(service.reset).toHaveBeenCalledWith(false, true);
       expect(service.updates.emit).not.toHaveBeenCalled();

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.spec.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.spec.ts
@@ -12,6 +12,7 @@ describe('Service: DataTableState', () => {
       service.filter = { id: 'test', value: 'value' };
       service.sort = { id: 'test', value: 'desc' };
       service.globalSearch = 'testing';
+      service.where = { query: 'mock query', form: 'mock form' };
     });
     it('should call selectedRows.clear, resetSource.next and onSortFilterChange if retainSelected is true', () => {
       service.retainSelected = false;
@@ -27,25 +28,28 @@ describe('Service: DataTableState', () => {
       expect(service.resetSource.next).not.toHaveBeenCalled();
       expect(service.selectedRows.clear).not.toHaveBeenCalled();
     });
-    it('should reset page, globalSearch, filter and sort', () => {
+    it('should reset page, globalSearch, filter, sort, and where', () => {
       service.reset();
       expect(service.filter).toBeUndefined();
       expect(service.sort).toBeUndefined();
       expect(service.globalSearch).toBeUndefined();
+      expect(service.where).toBeUndefined();
       expect(service.page).toEqual(0);
       expect(service.retainSelected).toBeFalsy();
     });
-    it('should not reset globalSearch, filter and sort if persist filters is true', () => {
+    it('should not reset globalSearch, filter, sort, and where if persist filters is true', () => {
       service.reset(false, true);
       expect(service.filter).toEqual({ id: 'test', value: 'value' });
       expect(service.sort).toEqual({ id: 'test', value: 'desc' });
       expect(service.globalSearch).toEqual('testing');
+      expect(service.where).toEqual({ query: 'mock query', form: 'mock form' });
     });
     it('should emit an update if fireUpdate is true', () => {
       const expected = {
         sort: undefined,
         filter: undefined,
         globalSearch: undefined,
+        where: undefined,
       };
       service.reset(true);
       expect(service.updates.emit).toHaveBeenCalledWith(expected);
@@ -62,6 +66,12 @@ describe('Service: DataTableState', () => {
       spyOn(service.updates, 'emit');
       service.filter = { id: 'test', value: 'value' };
       service.sort = { id: 'test', value: 'desc' };
+      service.globalSearch = 'testing';
+      service.savedSearchName = 'saved search';
+      service.where = { query: 'mock query', form: 'mock form' };
+    });
+    afterAll(() => {
+      service.reset();
     });
     it('should call checkRetainment, reset and onSortFilterChange', () => {
       spyOn(service, 'checkRetainment');
@@ -72,16 +82,22 @@ describe('Service: DataTableState', () => {
       expect(service.onSortFilterChange).toHaveBeenCalled();
       expect(service.updates.emit).toHaveBeenCalled();
     });
-    it('should reset sort and page', () => {
+    it('should only reset sort, savedSearchName, and page', () => {
       service.clearSort();
       expect(service.sort).toBeUndefined();
+      expect(service.filter).toEqual({ id: 'test', value: 'value' });
+      expect(service.where).toEqual({ query: 'mock query', form: 'mock form' });
+      expect(service.globalSearch).toEqual('testing');
+      expect(service.savedSearchName).toBeUndefined();
       expect(service.page).toEqual(0);
     });
     it('should emit an update if fireUpdate is true', () => {
       const expected = {
         sort: undefined,
         filter: { id: 'test', value: 'value' },
-        globalSearch: undefined,
+        globalSearch: 'testing',
+        savedSearchName: undefined,
+        where: { query: 'mock query', form: 'mock form' },
       };
       service.clearSort(true);
       expect(service.reset).toHaveBeenCalledWith(true, true);
@@ -101,6 +117,11 @@ describe('Service: DataTableState', () => {
       service.filter = { id: 'test', value: 'value' };
       service.sort = { id: 'test', value: 'desc' };
       service.globalSearch = 'testing';
+      service.savedSearchName = 'saved search';
+      service.where = { query: 'mock query', form: 'mock form' };
+    });
+    afterAll(() => {
+      service.reset();
     });
     it('should call checkRetainment, reset and onSortFilterChange', () => {
       spyOn(service, 'checkRetainment');
@@ -111,10 +132,13 @@ describe('Service: DataTableState', () => {
       expect(service.onSortFilterChange).toHaveBeenCalled();
       expect(service.updates.emit).toHaveBeenCalled();
     });
-    it('should reset page, globalSearch and filter', () => {
+    it('should only reset page, globalSearch, savedSearchName, and filter', () => {
       service.clearFilter();
+      expect(service.sort).toEqual({ id: 'test', value: 'desc' });
       expect(service.filter).toBeUndefined();
+      expect(service.where).toEqual({ query: 'mock query', form: 'mock form' });
       expect(service.globalSearch).toBeUndefined();
+      expect(service.savedSearchName).toBeUndefined();
       expect(service.page).toEqual(0);
     });
     it('should emit an update if fireUpdate is true', () => {
@@ -122,6 +146,8 @@ describe('Service: DataTableState', () => {
         sort: { id: 'test', value: 'desc' },
         filter: undefined,
         globalSearch: undefined,
+        savedSearchName: undefined,
+        where: { query: 'mock query', form: 'mock form' },
       };
       service.clearFilter(true);
       expect(service.reset).toHaveBeenCalledWith(true, true);
@@ -134,11 +160,64 @@ describe('Service: DataTableState', () => {
     });
   });
 
+  describe('Method: clearQuery', () => {
+    beforeEach(() => {
+      spyOn(service, 'reset');
+      spyOn(service.updates, 'emit');
+      service.filter = { id: 'test', value: 'value' };
+      service.sort = { id: 'test', value: 'desc' };
+      service.globalSearch = 'testing';
+      service.savedSearchName = 'saved search';
+      service.where = { query: 'mock query', form: 'mock form' };
+    });
+    afterAll(() => {
+      service.reset();
+    });
+    it('should call checkRetainment, reset and onSortFilterChange', () => {
+      spyOn(service, 'checkRetainment');
+      spyOn(service, 'onSortFilterChange');
+      service.clearQuery();
+      expect(service.checkRetainment).toHaveBeenCalledWith('where');
+      expect(service.reset).toHaveBeenCalledWith(true, true);
+      expect(service.onSortFilterChange).toHaveBeenCalled();
+      expect(service.updates.emit).toHaveBeenCalled();
+    });
+    it('should only reset page, savedSearchName, and where', () => {
+      service.clearQuery();
+      expect(service.sort).toEqual({ id: 'test', value: 'desc' });
+      expect(service.filter).toEqual({ id: 'test', value: 'value' });
+      expect(service.globalSearch).toEqual('testing');
+      expect(service.savedSearchName).toBeUndefined();
+      expect(service.where).toBeUndefined();
+      expect(service.page).toEqual(0);
+    });
+    it('should emit an update if fireUpdate is true', () => {
+      const expected = {
+        sort: { id: 'test', value: 'desc' },
+        filter: { id: 'test', value: 'value' },
+        globalSearch: 'testing',
+        savedSearchName: undefined,
+        where: undefined,
+      };
+      service.clearQuery(true);
+      expect(service.reset).toHaveBeenCalledWith(true, true);
+      expect(service.updates.emit).toHaveBeenCalledWith(expected);
+    });
+    it('should not emit an update if fireUpdate is false', () => {
+      service.clearQuery(false);
+      expect(service.reset).toHaveBeenCalledWith(false, true);
+      expect(service.updates.emit).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Method: clearSelected', () => {
     beforeEach(() => {
       spyOn(service, 'reset');
       spyOn(service.updates, 'emit');
       service.globalSearch = 'testing';
+    });
+    afterAll(() => {
+      service.reset();
     });
     it('should call allMatchingSelectedSource.next, reset and onSelectionChange', () => {
       spyOn(service.allMatchingSelectedSource, 'next');
@@ -241,14 +320,186 @@ describe('Service: DataTableState', () => {
       service.filter = { id: 'test', value: 'value' };
       service.sort = { id: 'test', value: 'desc' };
       service.globalSearch = 'testing';
+      service.where = { query: 'mock query', form: 'mock form' };
+      service.savedSearchName = 'saved search';
       const expected = {
         sort: { id: 'test', value: 'desc' },
         filter: { id: 'test', value: 'value' },
         globalSearch: 'testing',
+        where: { query: 'mock query', form: 'mock form' },
+        savedSearchName: 'saved search',
       };
       service.onSortFilterChange();
       expect(service.sortFilterSource.next).toHaveBeenCalledWith(expected);
       expect(service.checkRetainment).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('Method: setInitialSortFilter', () => {
+    beforeEach(() => {
+      service.filter = { id: 'test', value: 'value' };
+      service.sort = { id: 'test', value: 'desc' };
+      service.globalSearch = 'testing';
+      service.where = { query: 'mock query', form: 'mock form' };
+      service.savedSearchName = 'old saved search';
+    });
+    it('should not do anything if preferences undefined', () => {
+      service.setInitialSortFilter(undefined);
+      expect(service.filter).toEqual({ id: 'test', value: 'value' });
+      expect(service.sort).toEqual({ id: 'test', value: 'desc' });
+      expect(service.globalSearch).toEqual('testing');
+      expect(service.where).toEqual({ query: 'mock query', form: 'mock form' });
+      expect(service.savedSearchName).toEqual('old saved search');
+    });
+    it('should set all values included in preferences', () => {
+      const updatedPreferences = {
+        filter: { id: 'updated', value: 'filter' },
+        sort: { id: 'new', value: 'asc' },
+        globalSearch: 'updated search',
+        where: { query: 'updated', form: 'query' },
+        savedSearchName: 'new saved search',
+      };
+      service.setInitialSortFilter(updatedPreferences);
+      expect(service.filter).toEqual([{ id: 'updated', value: 'filter' }]);
+      expect(service.sort).toEqual({ id: 'new', value: 'asc' });
+      expect(service.globalSearch).toEqual('updated search');
+      expect(service.where).toEqual({ query: 'updated', form: 'query' });
+      expect(service.savedSearchName).toEqual('new saved search');
+    });
+    it('should only set values included in preferences (where)', () => {
+      const updatedPreferences = {
+        where: { query: 'updated', form: 'query' },
+      };
+      service.setInitialSortFilter(updatedPreferences);
+      expect(service.filter).toEqual({ id: 'test', value: 'value' });
+      expect(service.sort).toEqual({ id: 'test', value: 'desc' });
+      expect(service.globalSearch).toEqual('testing');
+      expect(service.where).toEqual(updatedPreferences.where);
+      expect(service.savedSearchName).toEqual('old saved search');
+    });
+    it('should only set values included in preferences (sort)', () => {
+      const updatedPreferences = {
+        sort: { id: 'new', value: 'asc' },
+      };
+      service.setInitialSortFilter(updatedPreferences);
+      expect(service.filter).toEqual({ id: 'test', value: 'value' });
+      expect(service.sort).toEqual(updatedPreferences.sort);
+      expect(service.globalSearch).toEqual('testing');
+      expect(service.where).toEqual({ query: 'mock query', form: 'mock form' });
+      expect(service.savedSearchName).toEqual('old saved search');
+    });
+    it('should only set values included in preferences (filter)', () => {
+      spyOn((service as any), 'transformFilters').and.callThrough();
+      const updatedPreferences = {
+        filter: { id: 'updated', value: 'filter' },
+      };
+      service.setInitialSortFilter(updatedPreferences);
+      expect((service as any).transformFilters).toHaveBeenCalledWith(updatedPreferences.filter);
+      expect(service.filter).toEqual([updatedPreferences.filter]);
+      expect(service.sort).toEqual({ id: 'test', value: 'desc' });
+      expect(service.globalSearch).toEqual('testing');
+      expect(service.where).toEqual({ query: 'mock query', form: 'mock form' });
+      expect(service.savedSearchName).toEqual('old saved search');
+    });
+    it('should only set values included in preferences (globalSearch)', () => {
+      const updatedPreferences = {
+        globalSearch: 'updated search',
+      };
+      service.setInitialSortFilter(updatedPreferences);
+      expect(service.filter).toEqual({ id: 'test', value: 'value' });
+      expect(service.sort).toEqual({ id: 'test', value: 'desc' });
+      expect(service.globalSearch).toEqual(updatedPreferences.globalSearch);
+      expect(service.where).toEqual({ query: 'mock query', form: 'mock form' });
+      expect(service.savedSearchName).toEqual('old saved search');
+    });
+    it('should only set values included in preferences (savedSearchName)', () => {
+      const updatedPreferences = {
+        savedSearchName: 'new saved search',
+      };
+      service.setInitialSortFilter(updatedPreferences);
+      expect(service.filter).toEqual({ id: 'test', value: 'value' });
+      expect(service.sort).toEqual({ id: 'test', value: 'desc' });
+      expect(service.globalSearch).toEqual('testing');
+      expect(service.where).toEqual({ query: 'mock query', form: 'mock form' });
+      expect(service.savedSearchName).toEqual(updatedPreferences.savedSearchName);
+    });
+  });
+
+  describe('Method: setState', () => {
+    const updatedPreferences = {
+      name: 'table',
+      filter: { id: 'updated', value: 'filter' },
+      sort: { id: 'new', value: 'asc' },
+      globalSearch: 'updated search',
+      where: { query: 'updated', form: 'query' },
+      savedSearchName: 'new saved search',
+      displayedColumns: ['column 3', 'column 4'],
+    };
+    beforeEach(() => {
+      spyOn(service.selectedRows, 'clear');
+      spyOn(service.resetSource, 'next');
+      spyOn(service.updates, 'emit');
+      service.filter = { id: 'test', value: 'value' };
+      service.sort = { id: 'test', value: 'desc' };
+      service.globalSearch = 'testing';
+      service.where = { query: 'mock query', form: 'mock form' };
+      service.savedSearchName = 'old saved search';
+      service.displayedColumns = ['column 1', 'column 2'];
+    });
+    it('should call selectedRows.clear, resetSource.next and onSortFilterChange if retainSelected is true', () => {
+      service.retainSelected = false;
+      spyOn(service, 'onSortFilterChange');
+      service.setState(updatedPreferences);
+      expect(service.onSortFilterChange).toHaveBeenCalled();
+      expect(service.resetSource.next).toHaveBeenCalled();
+      expect(service.selectedRows.clear).toHaveBeenCalled();
+    });
+    it('should not call selectedRows.clear or resetSource.next if retainSelected is false', () => {
+      service.retainSelected = true;
+      service.setState(updatedPreferences);
+      expect(service.resetSource.next).not.toHaveBeenCalled();
+      expect(service.selectedRows.clear).not.toHaveBeenCalled();
+    });
+    it('should set page, globalSearch, filter, sort, and where', () => {
+      service.setState(updatedPreferences);
+      expect(service.filter).toEqual([{ id: 'updated', value: 'filter' }]);
+      expect(service.sort).toEqual({ id: 'new', value: 'asc' });
+      expect(service.globalSearch).toEqual('updated search');
+      expect(service.where).toEqual({ query: 'updated', form: 'query' });
+      expect(service.savedSearchName).toEqual('new saved search');
+      expect(service.displayedColumns).toEqual(['column 3', 'column 4']);
+      expect(service.page).toEqual(0);
+      expect(service.retainSelected).toBeFalsy();
+    });
+    it('should not set globalSearch, filter, sort, and where if persist filters is true', () => {
+      service.setState(updatedPreferences, true, true);
+      expect(service.filter).toEqual({ id: 'test', value: 'value' });
+      expect(service.sort).toEqual({ id: 'test', value: 'desc' });
+      expect(service.globalSearch).toEqual('testing');
+      expect(service.where).toEqual({ query: 'mock query', form: 'mock form' });
+      expect(service.savedSearchName).toEqual('old saved search');
+      expect(service.displayedColumns).toEqual(['column 1', 'column 2']);
+    });
+    it('should not set displayedColumns if displayedColumns property is undefined', () => {
+      service.setState({ name: 'undefined columns', displayedColumns: undefined });
+      expect(service.displayedColumns).toEqual(['column 1', 'column 2']);
+    });
+    it('should not set displayedColumns if displayedColumns array is empty', () => {
+      service.setState({  name: 'empty columns', displayedColumns: [] });
+      expect(service.displayedColumns).toEqual(['column 1', 'column 2']);
+    });
+    it('should emit an update if fireUpdate is true', () => {
+      service.setState(updatedPreferences, true);
+      const expectedUpdate = {
+        ...updatedPreferences,
+        name: undefined,
+        filter: [updatedPreferences.filter],
+      }
+      expect(service.updates.emit).toHaveBeenCalledWith(expectedUpdate);
+    });
+    it('should not emit an update if fireUpdate is false', () => {
+      service.setState(updatedPreferences, false);
+      expect(service.updates.emit).not.toHaveBeenCalled();
     });
   });
 });

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
@@ -48,6 +48,7 @@ export class DataTableState<T> {
 
   public clearSort(fireUpdate: boolean = true): void {
     this.sort = undefined;
+    this.savedSearchName = undefined;
     this.page = 0;
     this.checkRetainment('sort');
     this.reset(fireUpdate, true);
@@ -66,6 +67,7 @@ export class DataTableState<T> {
   public clearFilter(fireUpdate: boolean = true): void {
     this.filter = undefined;
     this.globalSearch = undefined;
+    this.savedSearchName = undefined;
     this.page = 0;
     this.checkRetainment('filter');
     this.reset(fireUpdate, true);
@@ -83,6 +85,7 @@ export class DataTableState<T> {
 
   public clearQuery(fireUpdate: boolean = true): void {
     this.where = undefined;
+    this.savedSearchName = undefined;
     this.page = 0;
     this.checkRetainment('where');
     this.reset(fireUpdate, true);

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
@@ -165,7 +165,7 @@ export class DataTableState<T> {
     }
   }
 
-  public setDataTableState(preferences: IDataTablePreferences, fireUpdate = true, persistUserFilters = true) {
+  public setDataTableState(preferences: IDataTablePreferences, fireUpdate = true, persistUserFilters = false) {
     if (!persistUserFilters) {
       this.where = preferences.where;
       this.sort = preferences.sort;

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
@@ -43,7 +43,7 @@ export class DataTableState<T> {
   }
 
   public reset(fireUpdate: boolean = true, persistUserFilters?): void {
-    this.setDataTableState({} as IDataTablePreferences, fireUpdate, persistUserFilters)
+    this.setState({} as IDataTablePreferences, fireUpdate, persistUserFilters)
   }
 
   public clearSort(fireUpdate: boolean = true): void {
@@ -165,7 +165,7 @@ export class DataTableState<T> {
     }
   }
 
-  public setDataTableState(preferences: IDataTablePreferences, fireUpdate = true, persistUserFilters = false) {
+  public setState(preferences: IDataTablePreferences, fireUpdate = true, persistUserFilters = false): void {
     if (!persistUserFilters) {
       this.where = preferences.where;
       this.sort = preferences.sort;

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
@@ -43,29 +43,7 @@ export class DataTableState<T> {
   }
 
   public reset(fireUpdate: boolean = true, persistUserFilters?): void {
-    if (!persistUserFilters) {
-      this.sort = undefined;
-      this.globalSearch = undefined;
-      this.filter = undefined;
-      this.where = undefined;
-      this.savedSearchName = undefined;
-    }
-    this.page = 0;
-    if (!this.retainSelected) {
-      this.selectedRows.clear();
-      this.resetSource.next();
-    }
-    this.onSortFilterChange();
-    this.retainSelected = false;
-    if (fireUpdate) {
-      this.updates.emit({
-        sort: this.sort,
-        filter: this.filter,
-        globalSearch: this.globalSearch,
-        where: this.where,
-        savedSearchName: this.savedSearchName,
-      });
-    }
+    this.setDataTableState({} as IDataTablePreferences, fireUpdate, persistUserFilters)
   }
 
   public clearSort(fireUpdate: boolean = true): void {
@@ -187,30 +165,37 @@ export class DataTableState<T> {
     }
   }
 
-  public setDataTableState(preferences: IDataTablePreferences) {
-    this.where = preferences.where;
-    this.sort = preferences.sort;
-    this.filter = this.transformFilters(preferences.filter);
-    this.globalSearch = preferences.globalSearch;
-    this.savedSearchName = preferences.savedSearchName;
-
-    if (preferences.displayedColumns?.length) {
-      this.displayedColumns = preferences.displayedColumns;
+  public setDataTableState(preferences: IDataTablePreferences, fireUpdate = true, persistUserFilters = true) {
+    if (!persistUserFilters) {
+      this.where = preferences.where;
+      this.sort = preferences.sort;
+      this.filter = preferences.filter ? this.transformFilters(preferences.filter) : undefined;
+      this.globalSearch = preferences.globalSearch;
+      this.savedSearchName = preferences.savedSearchName;
+      if (preferences.displayedColumns?.length) {
+        this.displayedColumns = preferences.displayedColumns;
+      }
     }
 
-    this.selectedRows.clear();
-    this.resetSource.next();
     this.page = 0;
+    if (!this.retainSelected) {
+      this.selectedRows.clear();
+      this.resetSource.next();
+    }
 
     this.onSortFilterChange();
-    this.updates.emit({
-      sort: this.sort,
-      filter: this.filter,
-      globalSearch: this.globalSearch,
-      where: this.where,
-      savedSearchName: this.savedSearchName,
-      displayedColumns: this.displayedColumns,
-    });
+    this.retainSelected = false;
+
+    if (fireUpdate) {
+      this.updates.emit({
+        sort: this.sort,
+        filter: this.filter,
+        globalSearch: this.globalSearch,
+        where: this.where,
+        savedSearchName: this.savedSearchName,
+        displayedColumns: this.displayedColumns,
+      });
+    }
   }
 
   public checkRetainment(caller: string, allMatchingSelected = false): void {

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
@@ -48,7 +48,6 @@ export class DataTableState<T> {
 
   public clearSort(fireUpdate: boolean = true): void {
     this.sort = undefined;
-    this.savedSearchName = undefined;
     this.page = 0;
     this.checkRetainment('sort');
     this.reset(fireUpdate, true);
@@ -59,7 +58,6 @@ export class DataTableState<T> {
         filter: this.filter,
         globalSearch: this.globalSearch,
         where: this.where,
-        savedSearchName: this.savedSearchName,
       });
     }
   }
@@ -67,7 +65,6 @@ export class DataTableState<T> {
   public clearFilter(fireUpdate: boolean = true): void {
     this.filter = undefined;
     this.globalSearch = undefined;
-    this.savedSearchName = undefined;
     this.page = 0;
     this.checkRetainment('filter');
     this.reset(fireUpdate, true);
@@ -78,14 +75,12 @@ export class DataTableState<T> {
         filter: this.filter,
         globalSearch: this.globalSearch,
         where: this.where,
-        savedSearchName: this.savedSearchName,
       });
     }
   }
 
   public clearQuery(fireUpdate: boolean = true): void {
     this.where = undefined;
-    this.savedSearchName = undefined;
     this.page = 0;
     this.checkRetainment('where');
     this.reset(fireUpdate, true);
@@ -96,7 +91,6 @@ export class DataTableState<T> {
         filter: this.filter,
         globalSearch: this.globalSearch,
         where: this.where,
-        savedSearchName: this.savedSearchName,
       });
     }
   }
@@ -113,7 +107,6 @@ export class DataTableState<T> {
         filter: this.filter,
         globalSearch: this.globalSearch,
         where: this.where,
-        savedSearchName: this.savedSearchName,
       });
     }
   }

--- a/projects/novo-examples/src/examples.routes.ts
+++ b/projects/novo-examples/src/examples.routes.ts
@@ -6225,7 +6225,7 @@ export class February2022Page {
 @Component({
   selector: 'june-2022-page',
   template: `<h1>📢  June 2022 (version 7.2.x)</h1>
-<p><strong>New Feature: Query Builder</strong>: We have added a new component to help with building complex and modern interfaces.  At Bullhorn we have to enable our users to create advanced and dynamic searches against there data.  We have built many iterations of a query builder in the past but we think this one is our best and most re-usable.</p>
+<p><strong>New Feature: Query Builder</strong>: We have added a new component to help with building complex and modern interfaces.  At Bullhorn we have to enable our users to create advanced and dynamic searches against their data.  We have built many iterations of a query builder in the past but we think this one is our best and most re-usable.</p>
 <p>Bullhorn is continually seeking to update and innovate our products, and leverage the latest features in the frameworks we use. In support of that mission, we are updating our Novo UI and its supporting novo-elements library to Angular 13.  This update  allows us to continue offering a streamlined and consistent experience across Bullhorn’s complete product portfolio.  This update includes both an Angular upgrade, as well as supporting the latest Typescript updates.  You can find more details in the Technical Release Notes section below.</p>
 <h2>Release Timeline</h2>
 <p>Bullhorn has released a Release Candidate v7 of Novo-elements. Bullhorn will update Novo to use Novo-Elements v7 in the 2022.6 release</p>


### PR DESCRIPTION
..and reset saved search name

## **Description**

most of the data-table state fns are additive, allowing the consumer to change, set, reset one property without affecting the others. the exception to this is the reset() fn, which sets everything to undefined and then fires an update event. we needed a fn that functions like this, but sets everything to a provided value whether it's defined or not so we can explicitly set the state of the data-table.

we also needed a way to store and reset the name of the currently applied saved search to avoid having to manage this state separately in lower level services. 

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**