### PR TITLE
fix(NovoDefaultStringConditionDef): fixing bug with the model when loading multiple string defs

### DIFF
--- a/projects/novo-elements/src/elements/chips/ChipInput.ts
+++ b/projects/novo-elements/src/elements/chips/ChipInput.ts
@@ -158,7 +158,7 @@ export class NovoChipInput implements NovoChipTextControl, OnChanges {
     this._inputElement.focus(options);
   }
 
-  /** Focuses the input. */
+  /** Clears the input. */
   clearValue(): void {
     this._inputElement.value = '';
     this.ngControl?.control.setValue('');

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
@@ -21,15 +21,14 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
           <novo-option value="excludeAny">{{ labels.exclude }}</novo-option>
         </novo-select>
       </novo-field>
-      <novo-field *novoConditionInputDef="let formGroup">
-        <novo-chip-list #chipList aria-label="filter value">
+      <novo-field *novoConditionInputDef="let formGroup" [formGroup]="formGroup">
+        <novo-chip-list #chipList aria-label="filter value" formControlName="value">
           <novo-chip *ngFor="let chip of formGroup.value?.value || []" [value]="chip" (removed)="remove(chip, formGroup)">
             {{ chip }}
             <novo-icon novoChipRemove>close</novo-icon>
           </novo-chip>
           <input
             novoChipInput
-            [(ngModel)]="model"
             [placeholder]="labels.typeToAddChips"
             autocomplete="off"
             (novoChipInputTokenEnd)="add($event, formGroup)"
@@ -51,7 +50,6 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
 export class NovoDefaultStringConditionDef extends AbstractConditionFieldDef {
   separatorKeysCodes: number[] = [ENTER, COMMA];
   defaultOperator = 'includeAny';
-  model = '';
 
   getValue(formGroup: AbstractControl): any[] {
     return formGroup.value?.value || [];

--- a/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.ts
@@ -82,7 +82,7 @@ export class ConditionGroupComponent implements OnInit, OnDestroy {
     return this.formBuilder.group({
       field: [field, Validators.required],
       operator: [operator, Validators.required],
-      value: [value, Validators.required],
+      value: [value],
     });
   }
 

--- a/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.ts
@@ -140,7 +140,7 @@ export class CriteriaBuilderComponent implements OnInit, OnDestroy, AfterContent
     return this.formBuilder.group({
       field: [field, Validators.required],
       operator: [operator, Validators.required],
-      value: [value, Validators.required],
+      value: [value],
     });
   }
 


### PR DESCRIPTION
## **Description**

I added an ngModel to the input on the query builder's string definition to fix some errors being thrown about needing a provider for NgControl, but this created an issue where the model was effectively being shared between multiple string defs if they were loaded onto the form together. To fix this (and the original issue as well) I refactored the novo-field and chip-list on the string def to use a formGroup and ngControlName instead of ngModel.

Also making the value not required since it doesn't need to be.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**