### PR TITLE
fix(WorkersCompCodesPickerResults): - fix buggy picker behaviour for w…

### DIFF
--- a/projects/novo-elements/src/elements/picker/Picker.scss
+++ b/projects/novo-elements/src/elements/picker/Picker.scss
@@ -404,10 +404,17 @@ distribution-list-picker-results {
       justify-content: center;
     }
   }
+  .picker-loader,
+  .picker-error,
+  .picker-null-results {
+    border: none;
+  }
+
   .picker-null,
   .picker-error,
   .picker-loading,
-  .picker-no-recents {
+  .picker-no-recents,
+  .picker-error{
     text-align: center;
     padding: 1em 0 4em;
     > i {

--- a/projects/novo-elements/src/elements/picker/Picker.scss
+++ b/projects/novo-elements/src/elements/picker/Picker.scss
@@ -332,6 +332,7 @@ picker-results {
 }
 
 // Shared specialty picker styles
+workers-comp-codes-picker-results,
 distribution-list-picker-results {
   display: block;
   color: black;

--- a/projects/novo-elements/src/elements/picker/Picker.scss
+++ b/projects/novo-elements/src/elements/picker/Picker.scss
@@ -332,7 +332,6 @@ picker-results {
 }
 
 // Shared specialty picker styles
-workers-comp-codes-picker-results,
 distribution-list-picker-results {
   display: block;
   color: black;

--- a/projects/novo-elements/src/elements/picker/extras/workers-comp-codes-picker-results/WorkersCompCodesPickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/workers-comp-codes-picker-results/WorkersCompCodesPickerResults.ts
@@ -3,7 +3,7 @@ import { ChangeDetectorRef, Component, ElementRef, HostBinding } from '@angular/
 import { DomSanitizer } from '@angular/platform-browser';
 import { NovoLabelService } from '../../../../services/novo-label-service';
 // Vendor
-import {PickerResults} from "../picker-results";
+import {PickerResults} from '../picker-results';
 
 @Component({
   selector: 'workers-comp-codes-picker-results',

--- a/projects/novo-elements/src/elements/picker/extras/workers-comp-codes-picker-results/WorkersCompCodesPickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/workers-comp-codes-picker-results/WorkersCompCodesPickerResults.ts
@@ -4,9 +4,13 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { NovoLabelService } from '../../../../services/novo-label-service';
 // Vendor
 import { BasePickerResults } from '../base-picker-results/BasePickerResults';
+import {PickerResults} from "../picker-results";
 
 @Component({
   selector: 'workers-comp-codes-picker-results',
+  host: {
+    class: 'active',
+  },
   template: `
     <section class="picker-loading" *ngIf="isLoading && !matches?.length">
       <novo-loading theme="line"></novo-loading>
@@ -45,23 +49,15 @@ import { BasePickerResults } from '../base-picker-results/BasePickerResults';
       </novo-list-item>
       <novo-loading theme="line" *ngIf="isLoading && matches?.length > 0"></novo-loading>
     </novo-list>
+    <div class="picker-loader" *ngIf="isLoading && matches.length === 0"><novo-loading theme="line"></novo-loading></div>
+    <p class="picker-error" *ngIf="hasError">{{ labels.pickerError }}</p>
+    <p class="picker-null-results" *ngIf="hasNonErrorMessage">{{ getEmptyMessage() }}</p>
   `,
 })
-export class WorkersCompCodesPickerResults extends BasePickerResults {
-  @HostBinding('class.active')
-  active: boolean = true;
-  @HostBinding('hidden')
-  get isHidden(): boolean {
-    return this.matches.length === 0;
-  }
+export class WorkersCompCodesPickerResults extends PickerResults {
 
   constructor(element: ElementRef, private sanitizer: DomSanitizer, public labels: NovoLabelService, ref: ChangeDetectorRef) {
-    super(element, ref);
-    this.sanitizer = sanitizer;
-  }
-
-  getListElement() {
-    return this.element.nativeElement.querySelector('novo-list');
+    super(element, labels, ref);
   }
 
   sanitizeHTML(compCode: string, name: string) {

--- a/projects/novo-elements/src/elements/picker/extras/workers-comp-codes-picker-results/WorkersCompCodesPickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/workers-comp-codes-picker-results/WorkersCompCodesPickerResults.ts
@@ -3,7 +3,6 @@ import { ChangeDetectorRef, Component, ElementRef, HostBinding } from '@angular/
 import { DomSanitizer } from '@angular/platform-browser';
 import { NovoLabelService } from '../../../../services/novo-label-service';
 // Vendor
-import { BasePickerResults } from '../base-picker-results/BasePickerResults';
 import {PickerResults} from "../picker-results";
 
 @Component({


### PR DESCRIPTION
Fix Buggy picker behavior for workers comp code pickers

## **Description**

Make the workers comp code picker results behave like the regular picker results
-Show the 'Begin typing to see results message'
-Show the 'Empty results message'
-Show loading dots while search is still processing
-Delete empty scss file

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**