### PR TITLE
fix(picker): Fix field interaction issue on picker

### DIFF
--- a/projects/novo-elements/src/elements/picker/Picker.spec.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.spec.ts
@@ -77,6 +77,21 @@ describe('Elements: NovoPickerElement', () => {
       expect(component.checkTerm).toBeDefined();
       component.checkTerm();
     });
+    it('sets the value to null when the picker input is cleared out', () => {
+      component._value = '123';
+      spyOn(component, 'onModelChange');
+      component.checkTerm('');
+      expect(component._value).toEqual(null);
+      expect(component.onModelChange).toHaveBeenCalled();
+    });
+    it('does not register a change if there is no value set', () => {
+      component._value = null;
+      spyOn(component, 'onModelChange');
+      spyOn(component.ref, 'markForCheck');
+      component.checkTerm('');
+      expect(component.onModelChange).not.toHaveBeenCalled();
+      expect(component.ref.markForCheck).toHaveBeenCalled();
+    });
   });
 
   describe('Method: onTouched()', () => {

--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -329,10 +329,9 @@ export class NovoPickerElement implements OnInit {
     this.typing.emit(event);
     if ((!event || !event.length) && !Helpers.isEmpty(this._value)) {
       this._value = null;
-
       this.onModelChange(this._value);
     }
-      this.ref.markForCheck();
+    this.ref.markForCheck();
   }
 
   // Set touched on blur

--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -227,7 +227,7 @@ export class NovoPickerElement implements OnInit {
         return;
       }
 
-      if ((event.key === Key.Backspace || event.key === Key.Delete) && !Helpers.isEmpty(this._value) && Helpers.isEmpty(this.term)) {
+      if ((event.key === Key.Backspace || event.key === Key.Delete) && !Helpers.isEmpty(this._value) && (this._value === this.term)) {
         this.clearValue(false);
         this.closePanel();
       }
@@ -318,6 +318,7 @@ export class NovoPickerElement implements OnInit {
         this.popup.instance.selected = this.selected;
       }
     } else {
+      this.term = this.clearValueOnSelect ? '' : selected.label;
       this.changed.emit({ value: selected.value, rawValue: { label: this.term, value: this._value } });
       this.select.emit(selected);
     }

--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -327,11 +327,12 @@ export class NovoPickerElement implements OnInit {
   // Makes sure to clear the model if the user clears the text box
   checkTerm(event) {
     this.typing.emit(event);
-    if (!event || !event.length) {
+    if ((!event || !event.length) && !Helpers.isEmpty(this._value)) {
       this._value = null;
+
       this.onModelChange(this._value);
     }
-    this.ref.markForCheck();
+      this.ref.markForCheck();
   }
 
   // Set touched on blur

--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -227,7 +227,7 @@ export class NovoPickerElement implements OnInit {
         return;
       }
 
-      if ((event.key === Key.Backspace || event.key === Key.Delete) && !Helpers.isEmpty(this._value)) {
+      if ((event.key === Key.Backspace || event.key === Key.Delete) && !Helpers.isEmpty(this._value) && Helpers.isEmpty(this.term)) {
         this.clearValue(false);
         this.closePanel();
       }

--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -227,7 +227,7 @@ export class NovoPickerElement implements OnInit {
         return;
       }
 
-      if ((event.key === Key.Backspace || event.key === Key.Delete) && !Helpers.isBlank(this._value)) {
+      if ((event.key === Key.Backspace || event.key === Key.Delete) && !Helpers.isEmpty(this._value)) {
         this.clearValue(false);
         this.closePanel();
       }


### PR DESCRIPTION


## **Description**
Fix issue where backspacing within picker with an empty string value would trigger an unnecessary field interaction

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**