### PR TITLE
fix(picker): fixed field interaction issue on picker

### DIFF
--- a/projects/novo-elements/src/elements/picker/Picker.spec.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.spec.ts
@@ -77,6 +77,21 @@ describe('Elements: NovoPickerElement', () => {
       expect(component.checkTerm).toBeDefined();
       component.checkTerm();
     });
+    it('sets the value to null when the picker input is cleared out', () => {
+      component._value = '123';
+      spyOn(component, 'onModelChange');
+      component.checkTerm('');
+      expect(component._value).toEqual(null);
+      expect(component.onModelChange).toHaveBeenCalled();
+    });
+    it('does not register a change if there is no value set', () => {
+      component._value = null;
+      spyOn(component, 'onModelChange');
+      spyOn(component.ref, 'markForCheck');
+      component.checkTerm('');
+      expect(component.onModelChange).not.toHaveBeenCalled();
+      expect(component.ref.markForCheck).toHaveBeenCalled();
+    });
   });
 
   describe('Method: onTouched()', () => {

--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -227,7 +227,7 @@ export class NovoPickerElement implements OnInit {
         return;
       }
 
-      if ((event.key === Key.Backspace || event.key === Key.Delete) && !Helpers.isBlank(this._value)) {
+      if ((event.key === Key.Backspace || event.key === Key.Delete) && !Helpers.isEmpty(this._value) && (this._value === this.term)) {
         this.clearValue(false);
         this.closePanel();
       }
@@ -318,6 +318,7 @@ export class NovoPickerElement implements OnInit {
         this.popup.instance.selected = this.selected;
       }
     } else {
+      this.term = this.clearValueOnSelect ? '' : selected.label;
       this.changed.emit({ value: selected.value, rawValue: { label: this.term, value: this._value } });
       this.select.emit(selected);
     }
@@ -327,7 +328,7 @@ export class NovoPickerElement implements OnInit {
   // Makes sure to clear the model if the user clears the text box
   checkTerm(event) {
     this.typing.emit(event);
-    if (!event || !event.length) {
+    if ((!event || !event.length) && !Helpers.isEmpty(this._value)) {
       this._value = null;
       this.onModelChange(this._value);
     }


### PR DESCRIPTION
## **Description**

Updating picker to only trigger events and field interactions when backspacing on picker values. Field interactions no longer trigger when backspacing on empty picker input, or non-select/non-chip input value.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**