### PR TITLE
feat(Field): adding data-auto-ids to the new novo-field elements

### DIFF
--- a/projects/novo-elements/src/elements/field/field-control.ts
+++ b/projects/novo-elements/src/elements/field/field-control.ts
@@ -10,6 +10,7 @@ export abstract class NovoFieldControl<T> {
 
   /** The last key pressed. */
   lastKeyValue: string | null;
+
   /** The last cursor position. */
   lastCaretPosition: number | null;
 

--- a/projects/novo-elements/src/elements/field/field.ts
+++ b/projects/novo-elements/src/elements/field/field.ts
@@ -128,7 +128,7 @@ export class NovoFieldElement implements AfterContentInit, OnDestroy {
     }
 
     if (control.ngControl?.name) {
-      this._elementRef.nativeElement.setAttribute('data-automation-id', control.ngControl.name);
+      this._elementRef.nativeElement.setAttribute('data-control-key', control.ngControl.name);
     }
 
     // Subscribe to changes in the child control state in order to update the form field UI.

--- a/projects/novo-elements/src/elements/field/field.ts
+++ b/projects/novo-elements/src/elements/field/field.ts
@@ -118,7 +118,6 @@ export class NovoFieldElement implements AfterContentInit, OnDestroy {
     this._validateControlChild();
 
     const control = this._control;
-
     if (control.controlType) {
       this._elementRef.nativeElement.classList.add(`novo-field-type-${control.controlType}`);
       this._elementRef.nativeElement.setAttribute('data-control-type', control.controlType);
@@ -126,6 +125,10 @@ export class NovoFieldElement implements AfterContentInit, OnDestroy {
 
     if (control.id) {
       this._elementRef.nativeElement.setAttribute('data-control-id', control.id);
+    }
+
+    if (control.ngControl?.name) {
+      this._elementRef.nativeElement.setAttribute('data-automation-id', control.ngControl.name);
     }
 
     // Subscribe to changes in the child control state in order to update the form field UI.

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
@@ -18,7 +18,7 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
       <novo-field *novoConditionInputDef="let formGroup; fieldMeta as meta" [formGroup]="formGroup">
         <novo-select formControlName="value" [placeholder]="labels.select" [multiple]="true">
           <!-- WHat about optionUrl/optionType -->
-          <novo-option *ngFor="let option of meta?.options" [value]="option.value" [attr.data-automation-value]="option.value">
+          <novo-option *ngFor="let option of meta?.options" [value]="option.value" [attr.data-automation-value]="option.label">
             {{ option.label }}
           </novo-option>
         </novo-select>

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
@@ -18,7 +18,7 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
       <novo-field *novoConditionInputDef="let formGroup; fieldMeta as meta" [formGroup]="formGroup">
         <novo-select formControlName="value" [placeholder]="labels.select" [multiple]="true">
           <!-- WHat about optionUrl/optionType -->
-          <novo-option *ngFor="let option of meta?.options" [value]="option.value">
+          <novo-option *ngFor="let option of meta?.options" [value]="option.value" [attr.data-automation-value]="option.value">
             {{ option.label }}
           </novo-option>
         </novo-select>


### PR DESCRIPTION
## **Description**

if a field has an ngControl, it looks like we can pull the name of the control to use as the data-automation-id. 

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**