### PR TITLE
build(rxjs): updating rxjs to v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4896,6 +4896,15 @@
           "integrity": "sha512-6Pxgsrf0qF9iFFqmIcWmjJGkkCaCm6V5QNnxMy2KloO3SDq6QuMVRbN9RtC8Urmo25LP+eZ6ZgYqFYpdD8Hd9w==",
           "dev": true
         },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -15967,18 +15976,11 @@
       }
     },
     "rxjs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
-      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
+      "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
       "requires": {
-        "tslib": "^1.9.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "tslib": "^2.1.0"
       }
     },
     "safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "novo-design-tokens": "^0.0.9",
     "post-robot": "9.0.30",
     "resize-observer-polyfill": "^1.5.1",
-    "rxjs": "~6.5.5",
+    "rxjs": "^7.5.4",
     "text-mask-addons": "^3.8.0",
     "timezone-support": "^2.0.2",
     "tslib": "^2.0.0",

--- a/projects/novo-elements/src/elements/card/Card.ts
+++ b/projects/novo-elements/src/elements/card/Card.ts
@@ -153,9 +153,9 @@ export class CardElement implements OnChanges, OnInit {
   }
 
   @Output()
-  onClose: EventEmitter<any> = new EventEmitter();
+  onClose: EventEmitter<void> = new EventEmitter();
   @Output()
-  onRefresh: EventEmitter<any> = new EventEmitter();
+  onRefresh: EventEmitter<void> = new EventEmitter();
 
   cardAutomationId: string;
   labels: NovoLabelService;

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
@@ -6,13 +6,13 @@ import { NovoDataTableFilterUtils } from '../services/data-table-filter-utils';
 
 @Injectable()
 export class DataTableState<T> {
-  public selectionSource = new Subject();
+  public selectionSource = new Subject<void>();
   public paginationSource = new Subject();
   public sortFilterSource = new Subject();
-  public resetSource = new Subject();
+  public resetSource = new Subject<void>();
   public expandSource = new Subject();
   public allMatchingSelectedSource = new Subject();
-  public dataLoaded = new Subject();
+  public dataLoaded = new Subject<void>();
 
   sort: IDataTableSort = undefined;
   filter: IDataTableFilter | IDataTableFilter[] = undefined;

--- a/projects/novo-elements/src/elements/field/field.ts
+++ b/projects/novo-elements/src/elements/field/field.ts
@@ -103,7 +103,7 @@ export class NovoFieldElement implements AfterContentInit, OnDestroy {
   private _destroyed = new Subject<void>();
 
   @Output() valueChanges: EventEmitter<any> = new EventEmitter();
-  @Output() stateChanges: EventEmitter<any> = new EventEmitter();
+  @Output() stateChanges: EventEmitter<void> = new EventEmitter();
 
   constructor(public _elementRef: ElementRef, private _changeDetectorRef: ChangeDetectorRef) {}
   /**

--- a/projects/novo-examples/src/components/data-table/data-table-remote/data-table-remote-example.ts
+++ b/projects/novo-examples/src/components/data-table/data-table-remote/data-table-remote-example.ts
@@ -249,7 +249,7 @@ export class DataTableRemoteExample {
     value: 'asc',
   };
   public globalSearchEnabled: boolean = false;
-  public refreshSubject: Subject<boolean> = new Subject();
+  public refreshSubject: Subject<void> = new Subject();
 
   // Remote configuration
   public remoteService: RemoteDataTableService<MockData>;

--- a/projects/novo-examples/src/components/data-table/data-table-rows/data-table-rows-example.ts
+++ b/projects/novo-examples/src/components/data-table/data-table-rows/data-table-rows-example.ts
@@ -275,7 +275,7 @@ export class DataTableRowsExample {
     value: 'asc',
   };
   public globalSearchEnabled: boolean = false;
-  public refreshSubject: Subject<boolean> = new Subject();
+  public refreshSubject: Subject<void> = new Subject();
 
   // Basic configuration
   public basicRows: MockData[];

--- a/projects/novo-examples/src/components/data-table/data-table-service/data-table-service-example.ts
+++ b/projects/novo-examples/src/components/data-table/data-table-service/data-table-service-example.ts
@@ -247,7 +247,7 @@ export class DataTableServiceExample {
     value: 'asc',
   };
   public globalSearchEnabled: boolean = false;
-  public refreshSubject: Subject<boolean> = new Subject();
+  public refreshSubject: Subject<void> = new Subject();
 
   // Basic configuration
   public basicService: IDataTableService<MockData>;


### PR DESCRIPTION
## **Description**

updated rxjs from v6 to v7.5.4 due to alleged huge performance increase.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**