### PR TITLE
fix(Chips): BH-77703 updates chips to show match object

### DIFF
--- a/projects/novo-elements/src/elements/chips/Chips.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.ts
@@ -311,7 +311,7 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
       if (!this.popup) {
         this.popup = this.componentUtils.append(this.source.previewTemplate, this.preview);
       }
-      this.popup.instance.match = { data: this.selected.data ?? this.selected.value };
+      this.popup.instance.match = this.selected;
     }
   }
 


### PR DESCRIPTION
## **Description**

Reverted Chips.ts match object to contain the full selected object instead of just the value. 
Needed to fix this bug: https://jira.bullhorn.com/browse/BH-77703
Novo code where bug is located: https://bhsource.bullhorn.com/NOVO/novo/-/blob/development/libs/bte/src/components/rule/add-edit-rule-form/holiday-picker-preview/holiday-picker-preview.ts#L30

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**
<img width="811" alt="Screenshot 2022-09-20 153642" src="https://user-images.githubusercontent.com/47579031/191348922-5b516404-4cf3-48d2-a101-cead9df13fc9.png">
