### PR TITLE
feat(DataTable): Add ability to emit an event when data is loading fo…

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.source.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.source.ts
@@ -34,6 +34,7 @@ export class DataTableSource<T> extends DataSource<T> {
       switchMap(() => {
         this.pristine = false;
         this.loading = true;
+        this.state.dataLoadingSource.next(this.loading);
         return this.tableService.getTableResults(
           this.state.sort,
           this.state.filter,
@@ -66,6 +67,7 @@ export class DataTableSource<T> extends DataSource<T> {
           this.ref.markForCheck();
           setTimeout(() => {
             this.loading = false;
+            this.state.dataLoadingSource.next(this.loading);
             this.state.dataLoaded.next();
             this.ref.markForCheck();
           });

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
@@ -13,6 +13,7 @@ export class DataTableState<T> {
   public expandSource = new Subject();
   public allMatchingSelectedSource = new Subject();
   public dataLoaded = new Subject();
+  public dataLoadingSource = new Subject();
 
   sort: IDataTableSort = undefined;
   filter: IDataTableFilter | IDataTableFilter[] = undefined;


### PR DESCRIPTION
## **Description**

Created a subject on DataTableState for data loading (based on the Data Source). The data table component subscribes to this subject (only if enabled to do so via the alertOnLongRunningQuery input). After a configurable amount of time (default is 2 minutes) if the data source is still loading then data table emits an event which can be acted upon by an implementer of data table. If the data source is not loading emit an event that allows an implementer to act upon that info as well if necessary. The use case this was designed for was to show a modal on a data table when the data had been loading for over 2 minutes that informs the user that the call is still running but offers them the option to refresh the page. The table sends an even when data is finished loading so the implementing table can automatically close the modal if it has not been manually closed when the data is finished loading. 

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased (same test failures on next)
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**