### PR TITLE
fix(Overlay): add safety check to nested overlay check method

### DIFF
--- a/projects/novo-elements/src/elements/common/overlay/Overlay.ts
+++ b/projects/novo-elements/src/elements/common/overlay/Overlay.ts
@@ -30,6 +30,7 @@ import {
 // Vendor
 import { fromEvent, merge, Observable, of as observableOf, Subscription } from 'rxjs';
 import { filter, first, switchMap } from 'rxjs/operators';
+import {Helpers} from "../../../utils";
 
 @Component({
   selector: 'novo-overlay-template',
@@ -324,7 +325,10 @@ export class NovoOverlayTemplateComponent implements OnDestroy {
 
   protected elementIsInNestedOverlay(el): boolean {
     while (el.parentNode) {
-      if (el.id?.includes('novo-overlay-') || el.id?.includes('modal-container-')) {
+      if (Helpers.isString(el.id) &&
+        (el.id?.includes('novo-overlay-') || el.id?.includes('modal-container-'))) {
+        // checking to see if the current overlay is newer (in front of the parent overlay)
+        // example text novo-overlay-1666291728835
         return this.id.split('-')[2] < el.id.split('-')[2];
       }
       el = el.parentNode;


### PR DESCRIPTION
## **Description**

Adding a safety check to the elementIsInNestedOverlay. On the off chance that el.id is something other than a string, this will ensure we don't try to execute the el.id?.includes() which breaks in this situation. 

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**