### PR TITLE
fix(xmldom): removed unused xmldom dependency due to security concern

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3569,6 +3569,12 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@xmldom/xmldom": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.8.tgz",
+      "integrity": "sha512-PrJx38EfpitFhwmILRl37jAdBlsww6AZ6rRVK4QS7T7RHLhX7mSs647sTmgr9GIxe3qjXdesmomEgbgaokrVFg==",
+      "dev": true
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -18833,12 +18839,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
-    },
-    "xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
       "dev": true
     },
     "xtend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3569,12 +3569,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "@xmldom/xmldom": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.8.tgz",
-      "integrity": "sha512-PrJx38EfpitFhwmILRl37jAdBlsww6AZ6rRVK4QS7T7RHLhX7mSs647sTmgr9GIxe3qjXdesmomEgbgaokrVFg==",
-      "dev": true
-    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "@types/jasmine": "~3.6.0",
     "@types/jest": "^27.4.1",
     "@types/node": "^14.0.27",
-    "@xmldom/xmldom": "^0.7.6",
     "angular-split": "^5.0.0",
     "codelyzer": "^6.0.0",
     "conventional-changelog-cli": "~2.1.0",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@types/jasmine": "~3.6.0",
     "@types/jest": "^27.4.1",
     "@types/node": "^14.0.27",
+    "@xmldom/xmldom": "^0.7.6",
     "angular-split": "^5.0.0",
     "codelyzer": "^6.0.0",
     "conventional-changelog-cli": "~2.1.0",
@@ -126,8 +127,7 @@
     "tslint": "~6.1.3",
     "tslint-config-prettier": "^1.14.0",
     "typedoc": "^0.22.13",
-    "typescript": "4.6.2",
-    "xmldom": "^0.6.0"
+    "typescript": "4.6.2"
   },
   "lint-staged": {
     "*.{ts,json,scss,css,html}": [


### PR DESCRIPTION
## **Description**
Removed unused @xmldom dependency due to critical security flaw:
https://github.com/bullhorn/novo-elements/security/dependabot/60

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**