### PR TITLE
feat(QueryBuilder): adding isEmpty operator to query builder field definitions

### DIFF
--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.scss
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.scss
@@ -41,6 +41,9 @@
           padding-left: 0 !important;
         }
       }
+      novo-radio-group {
+        padding: 0 !important;
+      }
     }
   }
 

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/abstract-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/abstract-condition.definition.ts
@@ -1,4 +1,5 @@
 import { Directive, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { FormGroup } from '@angular/forms';
 import { NovoLabelService } from '../../../services';
 import { NovoConditionFieldDef } from '../query-builder.directives';
 
@@ -32,6 +33,10 @@ export abstract class AbstractConditionFieldDef implements OnDestroy, OnInit {
 
   ngOnDestroy() {
     this.fieldDef?.unregister();
+  }
+
+  onOperatorSelect(formGroup: FormGroup): void {
+    formGroup.get('value').setValue(null);
   }
 
   /** Synchronizes the column definition name with the text column name. */

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
@@ -9,15 +9,24 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
   template: `
     <ng-container novoConditionFieldDef>
       <novo-field *novoConditionOperatorsDef="let formGroup" [formGroup]="formGroup">
-        <novo-select [placeholder]="labels.operator" formControlName="operator">
+        <novo-select [placeholder]="labels.operator" formControlName="operator" (onSelect)="onOperatorSelect(formGroup)">
           <novo-option value="includeAny">{{ labels.includeAny }}</novo-option>
           <novo-option value="excludeAny">{{ labels.exclude }}</novo-option>
           <novo-option value="radius">{{ labels.radius }}</novo-option>
+          <novo-option value="isEmpty">{{ labels.isEmpty }}</novo-option>
         </novo-select>
       </novo-field>
-      <novo-field *novoConditionInputDef="let formGroup; fieldMeta as meta" [formGroup]="formGroup">
-        <novo-select formControlName="value" [placeholder]="labels.select" [multiple]="true"> </novo-select>
-      </novo-field>
+      <ng-container *novoConditionInputDef="let formGroup; viewIndex as viewIndex; fieldMeta as meta" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">
+        <novo-field *novoSwitchCases="['includeAny', 'excludeAny', 'radius']">
+          <novo-select formControlName="value" [placeholder]="labels.select" [multiple]="true"> </novo-select>
+        </novo-field>
+        <novo-field *novoSwitchCases="['isEmpty']">
+          <novo-radio-group formControlName="value">
+            <novo-radio [value]="true">{{ labels.yes }}</novo-radio>
+            <novo-radio [value]="false">{{ labels.no }}</novo-radio>
+          </novo-radio-group>
+        </novo-field>
+      </ng-container>
     </ng-container>
   `,
   encapsulation: ViewEncapsulation.None,

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/boolean-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/boolean-condition.definition.ts
@@ -9,16 +9,17 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
   template: `
     <ng-container novoConditionFieldDef>
       <novo-field *novoConditionOperatorsDef="let formGroup" [formGroup]="formGroup">
-        <novo-select [placeholder]="labels.operator" formControlName="operator">
+        <novo-select [placeholder]="labels.operator" formControlName="operator" (onSelect)="onOperatorSelect(formGroup)">
           <novo-option value="include">{{ labels.equals }}</novo-option>
           <novo-option value="exclude">{{ labels.doesNotEqual }}</novo-option>
+          <novo-option value="isEmpty">{{ labels.isEmpty }}</novo-option>
         </novo-select>
       </novo-field>
-      <novo-field *novoConditionInputDef="let formGroup" [style.width.px]="100" [formGroup]="formGroup">
-        <novo-select [placeholder]="labels.value" formControlName="value">
-          <novo-option [value]="true">{{ labels.true }}</novo-option>
-          <novo-option [value]="false">{{ labels.false }}</novo-option>
-        </novo-select>
+      <novo-field *novoConditionInputDef="let formGroup" [style.width.px]="125" [formGroup]="formGroup">
+        <novo-radio-group formControlName="value">
+          <novo-radio [value]="true">{{ formGroup.value.operator === 'isEmpty' ? labels.yes : labels.true }}</novo-radio>
+          <novo-radio [value]="false">{{ formGroup.value.operator === 'isEmpty' ? labels.no : labels.false }}</novo-radio>
+        </novo-radio-group>
       </novo-field>
     </ng-container>
   `,

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
@@ -17,31 +17,36 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
           <novo-option value="after">{{ labels.after }}</novo-option>
           <novo-option value="between">{{ labels.between }}</novo-option>
           <novo-option value="within">{{ labels.within }}</novo-option>
+          <novo-option value="isEmpty">{{ labels.isEmpty }}</novo-option>
         </novo-select>
       </novo-field>
-      <ng-container *novoConditionInputDef="let formGroup; viewIndex as viewIndex">
-        <ng-container [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">
-          <novo-field *novoSwitchCases="['before', 'after']">
-            <input novoInput dateFormat="iso8601" [picker]="datepicker" formControlName="value" />
-            <novo-picker-toggle triggerOnFocus [overlayId]="viewIndex" novoSuffix icon="calendar">
-              <novo-date-picker (onSelect)="closePanel($event, viewIndex)" #datepicker></novo-date-picker>
-            </novo-picker-toggle>
-          </novo-field>
-          <novo-field *novoSwitchCases="['between']">
-            <input novoInput dateRangeFormat="date" [picker]="daterangepicker" formControlName="value" />
-            <novo-picker-toggle [for]="daterangepicker" triggerOnFocus [overlayId]="viewIndex" novoSuffix icon="calendar">
-              <novo-date-picker #daterangepicker (onSelect)="closePanel($event, viewIndex)" mode="range" numberOfMonths="2"></novo-date-picker>
-            </novo-picker-toggle>
-          </novo-field>
-          <novo-field *novoSwitchCases="['within']">
-            <novo-select [placeholder]="labels.selectDateRange" formControlName="value">
-              <novo-option value="7">{{ labels.next7Days }}</novo-option>
-              <novo-option value="-7">{{ labels.past7Days }}</novo-option>
-              <novo-option value="-30">{{ labels.past30Days }}</novo-option>
-              <novo-option value="-90">{{ labels.past90Days }}</novo-option>
-            </novo-select>
-          </novo-field>
-        </ng-container>
+      <ng-container *novoConditionInputDef="let formGroup; viewIndex as viewIndex" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">
+        <novo-field *novoSwitchCases="['before', 'after']">
+          <input novoInput dateFormat="iso8601" [picker]="datepicker" formControlName="value" />
+          <novo-picker-toggle triggerOnFocus [overlayId]="viewIndex" novoSuffix icon="calendar">
+            <novo-date-picker (onSelect)="closePanel($event, viewIndex)" #datepicker></novo-date-picker>
+          </novo-picker-toggle>
+        </novo-field>
+        <novo-field *novoSwitchCases="['between']">
+          <input novoInput dateRangeFormat="date" [picker]="daterangepicker" formControlName="value" />
+          <novo-picker-toggle [for]="daterangepicker" triggerOnFocus [overlayId]="viewIndex" novoSuffix icon="calendar">
+            <novo-date-picker #daterangepicker (onSelect)="closePanel($event, viewIndex)" mode="range" numberOfMonths="2"></novo-date-picker>
+          </novo-picker-toggle>
+        </novo-field>
+        <novo-field *novoSwitchCases="['within']">
+          <novo-select [placeholder]="labels.selectDateRange" formControlName="value">
+            <novo-option value="7">{{ labels.next7Days }}</novo-option>
+            <novo-option value="-7">{{ labels.past7Days }}</novo-option>
+            <novo-option value="-30">{{ labels.past30Days }}</novo-option>
+            <novo-option value="-90">{{ labels.past90Days }}</novo-option>
+          </novo-select>
+        </novo-field>
+        <novo-field *novoSwitchCases="['isEmpty']">
+          <novo-radio-group formControlName="value">
+            <novo-radio [value]="true">{{ labels.yes }}</novo-radio>
+            <novo-radio [value]="false">{{ labels.no }}</novo-radio>
+          </novo-radio-group>
+        </novo-field>
       </ng-container>
     </ng-container>
   `,
@@ -53,10 +58,6 @@ export class NovoDefaultDateConditionDef extends AbstractConditionFieldDef {
   overlayChildren: QueryList<NovoPickerToggleElement>;
 
   defaultOperator = 'within';
-
-  onOperatorSelect(formGroup: FormGroup): void {
-    formGroup.get('value').setValue(null);
-  }
 
   closePanel(event, viewIndex): void {
     const overlay = this.overlayChildren.find(item => item.overlayId === viewIndex);

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/number-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/number-condition.definition.ts
@@ -10,15 +10,24 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
   template: `
     <ng-container novoConditionFieldDef>
       <novo-field *novoConditionOperatorsDef="let formGroup" [formGroup]="formGroup">
-        <novo-select [placeholder]="labels.operator" formControlName="operator">
+        <novo-select [placeholder]="labels.operator" formControlName="operator" (onSelect)="onOperatorSelect(formGroup)">
           <novo-option value="greaterThan">{{ labels.greaterThan }}</novo-option>
           <novo-option value="lessThan">{{ labels.lessThan }}</novo-option>
           <novo-option value="equalTo">{{ labels.equalTo }}</novo-option>
+          <novo-option value="isEmpty">{{ labels.isEmpty }}</novo-option>
         </novo-select>
       </novo-field>
-      <novo-field *novoConditionInputDef="let formGroup" [formGroup]="formGroup">
-        <input novoInput type="number" formControlName="value" />
-      </novo-field>
+      <ng-container *novoConditionInputDef="let formGroup" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">
+        <novo-field *novoSwitchCases="['greaterThan', 'lessThan', 'equalTo']">
+          <input novoInput type="number" formControlName="value" />
+        </novo-field>
+        <novo-field *novoSwitchCases="['isEmpty']">
+          <novo-radio-group formControlName="value">
+            <novo-radio [value]="true">{{ labels.yes }}</novo-radio>
+            <novo-radio [value]="false">{{ labels.no }}</novo-radio>
+          </novo-radio-group>
+        </novo-field>
+      </ng-container>
     </ng-container>
   `,
   encapsulation: ViewEncapsulation.None,

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
@@ -9,20 +9,29 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
   template: `
     <ng-container novoConditionFieldDef>
       <novo-field *novoConditionOperatorsDef="let formGroup" [formGroup]="formGroup">
-        <novo-select [placeholder]="labels.operator" formControlName="operator">
+        <novo-select [placeholder]="labels.operator" formControlName="operator" (onSelect)="onOperatorSelect(formGroup)">
           <novo-option value="includeAny">{{ labels.includeAny }}</novo-option>
           <novo-option value="includeAll">{{ labels.includeAll }}</novo-option>
           <novo-option value="excludeAny">{{ labels.exclude }}</novo-option>
+          <novo-option value="isEmpty">{{ labels.isEmpty }}</novo-option>
         </novo-select>
       </novo-field>
-      <novo-field *novoConditionInputDef="let formGroup; fieldMeta as meta" [formGroup]="formGroup">
-        <novo-select formControlName="value" [placeholder]="labels.select" [multiple]="true">
-          <!-- WHat about optionUrl/optionType -->
-          <novo-option *ngFor="let option of meta?.options" [value]="option.value">
-            {{ option.label }}
-          </novo-option>
-        </novo-select>
-      </novo-field>
+      <ng-container *novoConditionInputDef="let formGroup; fieldMeta as meta" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">
+        <novo-field *novoSwitchCases="['includeAny', 'includeAll', 'excludeAny']">
+          <novo-select formControlName="value" [placeholder]="labels.select" [multiple]="true">
+            <!-- WHat about optionUrl/optionType -->
+            <novo-option *ngFor="let option of meta?.options" [value]="option.value">
+              {{ option.label }}
+            </novo-option>
+          </novo-select>
+        </novo-field>
+        <novo-field *novoSwitchCases="['isEmpty']">
+          <novo-radio-group formControlName="value">
+            <novo-radio [value]="true">{{ labels.yes }}</novo-radio>
+            <novo-radio [value]="false">{{ labels.no }}</novo-radio>
+          </novo-radio-group>
+        </novo-field>
+      </ng-container>
     </ng-container>
   `,
   encapsulation: ViewEncapsulation.None,

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
@@ -15,27 +15,36 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
     <!-- fieldTypes should be UPPERCASE -->
     <ng-container novoConditionFieldDef="STRING">
       <novo-field *novoConditionOperatorsDef="let formGroup" [formGroup]="formGroup">
-        <novo-select [placeholder]="labels.operator" formControlName="operator">
+        <novo-select [placeholder]="labels.operator" formControlName="operator" (onSelect)="onOperatorSelect(formGroup)">
           <novo-option value="includeAny">{{ labels.includeAny }}</novo-option>
           <novo-option value="includeAll">{{ labels.includeAll }}</novo-option>
           <novo-option value="excludeAny">{{ labels.exclude }}</novo-option>
+          <novo-option value="isEmpty">{{ labels.isEmpty }}</novo-option>
         </novo-select>
       </novo-field>
-      <novo-field *novoConditionInputDef="let formGroup" [formGroup]="formGroup">
-        <novo-chip-list #chipList aria-label="filter value" formControlName="value">
-          <novo-chip *ngFor="let chip of formGroup.value?.value || []" [value]="chip" (removed)="remove(chip, formGroup)">
-            {{ chip }}
-            <novo-icon novoChipRemove>close</novo-icon>
-          </novo-chip>
-          <input
-            novoChipInput
-            [placeholder]="labels.typeToAddChips"
-            autocomplete="off"
-            (novoChipInputTokenEnd)="add($event, formGroup)"
-          />
-        </novo-chip-list>
-        <novo-autocomplete></novo-autocomplete>
-      </novo-field>
+      <ng-container *novoConditionInputDef="let formGroup" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">
+        <novo-field *novoSwitchCases="['includeAny', 'includeAll', 'excludeAny']">
+          <novo-chip-list #chipList aria-label="filter value" formControlName="value">
+            <novo-chip *ngFor="let chip of formGroup.value?.value || []" [value]="chip" (removed)="remove(chip, formGroup)">
+              {{ chip }}
+              <novo-icon novoChipRemove>close</novo-icon>
+            </novo-chip>
+            <input
+              novoChipInput
+              [placeholder]="labels.typeToAddChips"
+              autocomplete="off"
+              (novoChipInputTokenEnd)="add($event, formGroup)"
+            />
+          </novo-chip-list>
+          <novo-autocomplete></novo-autocomplete>
+        </novo-field>
+        <novo-field *novoSwitchCases="['isEmpty']">
+          <novo-radio-group formControlName="value">
+            <novo-radio [value]="true">{{ labels.yes }}</novo-radio>
+            <novo-radio [value]="false">{{ labels.no }}</novo-radio>
+          </novo-radio-group>
+        </novo-field>
+      </ng-container>
     </ng-container>
   `,
   encapsulation: ViewEncapsulation.None,

--- a/projects/novo-elements/src/elements/query-builder/query-builder.module.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.module.ts
@@ -15,6 +15,7 @@ import { NovoFormModule } from '../form';
 import { NovoIconModule } from '../icon';
 import { NovoLoadingModule } from '../loading';
 import { NovoNonIdealStateModule } from '../non-ideal-state';
+import { NovoRadioModule } from '../radio'
 import { NovoSearchBoxModule } from '../search';
 import { NovoSelectModule } from '../select';
 import { NovoSelectSearchModule } from '../select-search';
@@ -52,6 +53,7 @@ import { NovoConditionFieldDef, NovoConditionInputDef, NovoConditionOperatorsDef
     NovoCardModule,
     NovoDatePickerModule,
     NovoIconModule,
+    NovoRadioModule,
     NovoSearchBoxModule,
     NovoSwitchModule,
     NovoChipsModule,

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -134,6 +134,7 @@ export class NovoLabelService {
   after = 'After';
   between = 'Between';
   within = 'Within';
+  isEmpty = 'Is Empty?';
   refreshPagination = 'Refresh Pagination';
 
   constructor(


### PR DESCRIPTION
## **Description**
- Adding isEmpty boolean radio operator to QueryBuilder field definitions.
- Updating boolean definition to use radio buttons instead of true/false select control.
- Updating all field definitions to clear out value on operator select.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**