### PR TITLE
chore(demo): use different cdn for ckeditor

### DIFF
--- a/projects/demo/index.html
+++ b/projects/demo/index.html
@@ -19,7 +19,7 @@
     rel="stylesheet"
     type="text/css" />
 
-  <script src="//cdn.jsdelivr.net/npm/ckeditor@4.6.2/ckeditor.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/ckeditor-full@4.7.3/ckeditor.js"></script>
   <script src="//cdn.rawgit.com/krakenjs/post-robot/7da06445/dist/post-robot.js"></script>
   <script type="text/javascript"
     src="https://maps.google.com/maps/api/js?sensor=true&key=AIzaSyA7AU3UZXB5frMpSa0koWN096kb6MMtmN8&libraries=places&language=en-US"></script>

--- a/projects/demo/index.html
+++ b/projects/demo/index.html
@@ -19,7 +19,7 @@
     rel="stylesheet"
     type="text/css" />
 
-  <script src="//cdn.ckeditor.com/4.6.2/full/ckeditor.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/ckeditor@4.6.2/ckeditor.min.js"></script>
   <script src="//cdn.rawgit.com/krakenjs/post-robot/7da06445/dist/post-robot.js"></script>
   <script type="text/javascript"
     src="https://maps.google.com/maps/api/js?sensor=true&key=AIzaSyA7AU3UZXB5frMpSa0koWN096kb6MMtmN8&libraries=places&language=en-US"></script>


### PR DESCRIPTION
Using a new cdn for ckeditor to not impose on new license terms.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

