### PR TITLE
feat(): next

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3677,9 +3677,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+          "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -4106,9 +4106,9 @@
           }
         },
         "loader-utils": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.1.tgz",
+          "integrity": "sha512-1Qo97Y2oKaU+Ro2xnDMR26g1BwMT29jNbem1EvcujW2jqt+j5COXyscjM7bLQkM9HaxI7pkWeW7gnI072yMI9Q==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -15862,9 +15862,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+          "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18835,12 +18835,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
-    "xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
-      "dev": true
-    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3677,9 +3677,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
-          "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -4106,9 +4106,9 @@
           }
         },
         "loader-utils": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.1.tgz",
-          "integrity": "sha512-1Qo97Y2oKaU+Ro2xnDMR26g1BwMT29jNbem1EvcujW2jqt+j5COXyscjM7bLQkM9HaxI7pkWeW7gnI072yMI9Q==",
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+          "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -15862,9 +15862,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
-          "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -126,8 +126,7 @@
     "tslint": "~6.1.3",
     "tslint-config-prettier": "^1.14.0",
     "typedoc": "^0.22.13",
-    "typescript": "4.6.2",
-    "xmldom": "^0.6.0"
+    "typescript": "4.6.2"
   },
   "lint-staged": {
     "*.{ts,json,scss,css,html}": [

--- a/projects/novo-elements/src/elements/data-table/sort-filter/sort-button.animations.ts
+++ b/projects/novo-elements/src/elements/data-table/sort-filter/sort-button.animations.ts
@@ -1,8 +1,8 @@
 import { animate, AnimationTriggerMetadata, state, style, transition, trigger } from '@angular/animations';
 import { SortDirection } from './sort-direction';
 
-const activeStyle = { opacity: 1, pointerEvents: 'all', top: 0 };
-const inactiveStyle = { opacity: 0, pointerEvents: 'none' };
+const activeStyle = { opacity: 1, top: 0 };
+const inactiveStyle = { opacity: 0 };
 
 /** Animation that moves the sort indicator. */
 export const sortAscAnim: AnimationTriggerMetadata = trigger('sortAsc', [

--- a/projects/novo-elements/src/elements/data-table/sort-filter/sort-button.component.html
+++ b/projects/novo-elements/src/elements/data-table/sort-filter/sort-button.component.html
@@ -1,15 +1,18 @@
 <novo-icon
   class="novo-sort-asc-icon"
   [class.sort-active]="isActive"
+  [class.sort-hidden]="value !== SortDirection.ASC"
   [@sortAsc]="value"
   (click)="changeSort(SortDirection.DESC)">arrow-up</novo-icon>
 <novo-icon
   class="novo-sort-desc-icon"
   [class.sort-active]="isActive"
+  [class.sort-hidden]="value !== SortDirection.DESC"
   [@sortDesc]="value"
   (click)="changeSort(SortDirection.NONE)">arrow-down</novo-icon>
 <novo-icon
   class="novo-sortable-icon"
   [class.sort-active]="isActive"
+  [class.sort-hidden]="value !== SortDirection.NONE"
   [@sortNone]="value"
   (click)="changeSort(SortDirection.ASC)">sortable</novo-icon>

--- a/projects/novo-elements/src/elements/data-table/sort-filter/sort-button.component.scss
+++ b/projects/novo-elements/src/elements/data-table/sort-filter/sort-button.component.scss
@@ -13,6 +13,9 @@
     &:hover {
       color: var(--selection);
     }
+    &.sort-hidden {
+      pointer-events: none;
+    }
   }
 
   .novo-sort-asc-icon {

--- a/projects/novo-elements/src/elements/date-time-picker/DateTimePicker.ts
+++ b/projects/novo-elements/src/elements/date-time-picker/DateTimePicker.ts
@@ -117,7 +117,7 @@ const DATE_TIME_PICKER_VALUE_ACCESSOR = {
           ></novo-date-picker>
         </div>
         <div class="time-picker">
-          <novo-time-picker (onSelect)="onTimeSelected($event)" [(ngModel)]="model" [military]="military" inline="true"></novo-time-picker>
+          <novo-time-picker (onSelect)="onTimeSelected($event)" [(ngModel)]="model" (ngModelChange)="onModelChange($event)" [military]="military" inline="true"></novo-time-picker>
         </div>
       </div>
     </div>
@@ -158,6 +158,10 @@ export class NovoDateTimePickerElement implements ControlValueAccessor {
 
   toggleView(tab: string): void {
     this.componentTabState = tab;
+  }
+
+  onModelChange(event) {
+    this.model = this.createFullDateValue(this.datePickerValue, event);
   }
 
   setDateLabels(value: Date) {

--- a/projects/novo-elements/src/elements/date-time-picker/DateTimePicker.ts
+++ b/projects/novo-elements/src/elements/date-time-picker/DateTimePicker.ts
@@ -125,6 +125,8 @@ const DATE_TIME_PICKER_VALUE_ACCESSOR = {
 })
 export class NovoDateTimePickerElement implements ControlValueAccessor {
   @Input()
+  defaultTime: string;
+  @Input()
   minYear: any;
   @Input()
   maxYear: any;
@@ -195,6 +197,11 @@ export class NovoDateTimePickerElement implements ControlValueAccessor {
 
   onDateSelected(event: { month?: any; year?: any; day?: any; date?: Date }) {
     this.datePickerValue = event.date;
+    if (this.defaultTime === 'start') {
+      this.timePickerValue = new Date(this.timePickerValue.setHours(0, 0, 0));
+    } else if (this.defaultTime === 'end') {
+      this.timePickerValue = new Date(this.timePickerValue.setHours(23, 59, 59));
+    }
     this.model = this.createFullDateValue(this.datePickerValue, this.timePickerValue);
     this.setDateLabels(this.model);
     this.onSelect.emit({ date: this.model });
@@ -231,8 +238,8 @@ export class NovoDateTimePickerElement implements ControlValueAccessor {
     this.datePickerValue = this.model;
     this.timePickerValue = this.model;
     if (Helpers.isDate(this.model)) {
-      this.setDateLabels(this.model);
-      this.setTimeLabels(this.model);
+      this.setDateLabels(this.datePickerValue);
+      this.setTimeLabels(this.timePickerValue);
     }
   }
 

--- a/projects/novo-elements/src/elements/field/field-control.ts
+++ b/projects/novo-elements/src/elements/field/field-control.ts
@@ -10,6 +10,7 @@ export abstract class NovoFieldControl<T> {
 
   /** The last key pressed. */
   lastKeyValue: string | null;
+
   /** The last cursor position. */
   lastCaretPosition: number | null;
 

--- a/projects/novo-elements/src/elements/field/field.module.ts
+++ b/projects/novo-elements/src/elements/field/field.module.ts
@@ -11,6 +11,7 @@ import { NovoFieldElement, NovoFieldPrefixDirective, NovoFieldSuffixDirective } 
 import { NovoFieldsElement } from './fieldset';
 import { NovoDateFormatDirective } from './formats/date-format';
 import { NovoDateRangeFormatDirective } from './formats/date-range-format';
+import { NovoDateTimeFormatDirective } from './formats/date-time-format';
 import { NovoTimeFormatDirective } from './formats/time-format';
 import { NovoHintElement } from './hint/hint';
 import { NovoInput } from './input';
@@ -30,6 +31,7 @@ import { NovoPickerToggleElement } from './toggle/picker-toggle.component';
     NovoFieldsElement,
     NovoTimeFormatDirective,
     NovoDateFormatDirective,
+    NovoDateTimeFormatDirective,
     NovoDateRangeFormatDirective,
     NovoPickerToggleElement,
     NovoPickerDirective,
@@ -47,6 +49,7 @@ import { NovoPickerToggleElement } from './toggle/picker-toggle.component';
     NovoTimeFormatDirective,
     NovoDateFormatDirective,
     NovoDateRangeFormatDirective,
+    NovoDateTimeFormatDirective,
     NovoPickerToggleElement,
     NovoPickerDirective,
     NovoAutocompleteElement,

--- a/projects/novo-elements/src/elements/field/field.ts
+++ b/projects/novo-elements/src/elements/field/field.ts
@@ -118,7 +118,6 @@ export class NovoFieldElement implements AfterContentInit, OnDestroy {
     this._validateControlChild();
 
     const control = this._control;
-
     if (control.controlType) {
       this._elementRef.nativeElement.classList.add(`novo-field-type-${control.controlType}`);
       this._elementRef.nativeElement.setAttribute('data-control-type', control.controlType);
@@ -126,6 +125,10 @@ export class NovoFieldElement implements AfterContentInit, OnDestroy {
 
     if (control.id) {
       this._elementRef.nativeElement.setAttribute('data-control-id', control.id);
+    }
+
+    if (control.ngControl?.name) {
+      this._elementRef.nativeElement.setAttribute('data-control-key', control.ngControl.name);
     }
 
     // Subscribe to changes in the child control state in order to update the form field UI.

--- a/projects/novo-elements/src/elements/field/formats/date-time-format.ts
+++ b/projects/novo-elements/src/elements/field/formats/date-time-format.ts
@@ -160,7 +160,7 @@ export class NovoDateTimeFormatDirective extends IMaskDirective<any> implements 
     const dateTime =  text.split(', ');
     const hour: string = dateTime[1].slice(0, 2);
     if (!this.military) {
-      const input = dateTime[1].substr(17, 4).replace(/\-/g, '').trim().slice(0, 2);
+      const input = dateTime[1].substr(5, 4).replace(/\-/g, '').trim().slice(0, 2);
       const timePeriod = this.imask.blocks.aa.enum.find((it) => it[0] === input[0]);
       if (this.hourOneFormatRequired(hour)) {
         (event.target as HTMLInputElement).value = `${dateTime[0]}, 01:${dateTime[1].slice(3, dateTime[1].length)}`;

--- a/projects/novo-elements/src/elements/field/formats/date-time-format.ts
+++ b/projects/novo-elements/src/elements/field/formats/date-time-format.ts
@@ -1,0 +1,263 @@
+import { Directive, ElementRef, EventEmitter, forwardRef, Inject, Input, Optional, Renderer2, SimpleChanges, OnChanges, LOCALE_ID } from '@angular/core';
+import { COMPOSITION_BUFFER_MODE, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { IMaskDirective, IMaskFactory } from 'angular-imask';
+import { format, isValid, parse } from 'date-fns';
+import * as IMask from 'imask';
+import { NovoLabelService } from '../../../services/novo-label-service';
+import { NovoInputFormat, DATE_FORMATS, NOVO_INPUT_FORMAT } from './base-format';
+import { Key } from '../../../utils';
+
+export const DATETIMEFORMAT_VALUE_ACCESSOR = {
+  provide: NG_VALUE_ACCESSOR,
+  useExisting: forwardRef(() => NovoDateTimeFormatDirective),
+  multi: true,
+};
+
+@Directive({
+  selector: 'input[dateTimeFormat]',
+  host: {
+    class: 'novo-date-time-format',
+    '(input)': '_checkInput($event)',
+    '(blur)': '_handleBlur($event)',
+    '(keydown)': '_handleKeydown($event)',
+  },
+  providers: [DATETIMEFORMAT_VALUE_ACCESSOR, { provide: NOVO_INPUT_FORMAT, useExisting: NovoDateTimeFormatDirective }],
+})
+export class NovoDateTimeFormatDirective extends IMaskDirective<any> implements NovoInputFormat, OnChanges {
+  valueChange: EventEmitter<any> = new EventEmitter();
+
+  @Input() military: boolean = false;
+  @Input() dateTimeFormat: DATE_FORMATS = DATE_FORMATS.DATE;
+
+  constructor(
+    private _element: ElementRef,
+    _renderer: Renderer2,
+    _factory: IMaskFactory,
+    @Optional() @Inject(COMPOSITION_BUFFER_MODE) _compositionMode: boolean,
+    private labels: NovoLabelService,
+  ) {
+    super(_element, _renderer, _factory, _compositionMode);
+    this.initFormatOptions();
+    
+  }
+
+  initFormatOptions() {
+    const amFormat = this.labels.timeFormatAM.toUpperCase();
+    const pmFormat = this.labels.timeFormatPM.toUpperCase();
+
+    this.unmask = 'typed';
+    this.imask = {
+      mask: Date,
+      pattern: this.military ? 'm{/}`d{/}`Y, HH:mm' : 'm{/}`d{/}`Y, HH:mm aa',
+      overwrite: true,
+      autofix: true,
+      lazy: false,
+      min: new Date(1900, 0, 1),
+      max: new Date(2030, 0, 1),
+      prepare: (str) => str.toUpperCase(),
+      format: (date) => {
+        const test1 = this.formatValue(date)
+        return test1;
+    },
+      parse: (str) => {
+        const test = parse(str);
+
+        return test;
+      },
+      blocks: {
+        d: {
+          mask: IMask.MaskedRange,
+          placeholderChar: 'D',
+          from: 1,
+          to: 31,
+          maxLength: 2,
+        },
+        m: {
+          mask: IMask.MaskedRange,
+          placeholderChar: 'M',
+          from: 1,
+          to: 12,
+          maxLength: 2,
+        },
+        Y: {
+          mask: IMask.MaskedRange,
+          placeholderChar: 'Y',
+          from: 1900,
+          to: 9999,
+        },
+        HH: {
+            mask: IMask.MaskedRange,
+            placeholderChar: '-',
+            maxLength: 2,
+            from: 0,
+            to: 23,
+          },
+          hh: {
+            mask: IMask.MaskedRange,
+            placeholderChar: '-',
+            maxLength: 2,
+            from: 1,
+            to: 12,
+          },
+          mm: {
+            mask: IMask.MaskedRange,
+            placeholderChar: '-',
+            maxLength: 2,
+            from: 0,
+            to: 59,
+          },
+          ss: {
+            mask: IMask.MaskedRange,
+            placeholderChar: '-',
+            maxLength: 2,
+            from: 0,
+            to: 59,
+          },
+          aa: {
+            mask: IMask.MaskedEnum,
+            placeholderChar: '-',
+            enum: ['AM', 'PM', 'am', 'pm', amFormat, pmFormat],
+          },
+      },
+    };
+  }
+  
+  ngOnChanges(changes: SimpleChanges): void {
+    if (Object.keys(changes).some((key) => ['military', 'dateFormat'].includes(key))) {
+      this.initFormatOptions();
+    }
+  }
+
+  _checkInput(event: InputEvent): void {
+    if (document.activeElement === event.target) {
+      const text = (event.target as HTMLInputElement).value;
+      const dateTime =  text.split(', ');
+      const hour = dateTime[1].slice(0, 2);
+      if ((this.military && Number(dateTime[1][0]) > 2) || (!this.military && Number(dateTime[1][0]) > 1)) {
+        event.preventDefault();
+        const value = `0${dateTime[1]}`;
+        (event.target as HTMLInputElement).value = value;
+        // this.onChange(value);
+      }
+      if (!this.military) {
+        const input = dateTime[1].substr(5, 4).replace(/\-/g, '').trim().slice(0, 2);
+        const timePeriod = this.imask.blocks.aa.enum.find((it) => it[0] === input[0]);
+        if (timePeriod) {
+          (event.target as HTMLInputElement).value = `${dateTime[0]}, ${dateTime[1].slice(0, 5)} ${timePeriod}`;
+        }
+        if ((event.target as HTMLInputElement).selectionStart >= 3 && this.hourOneFormatRequired(hour)) {
+          (event.target as HTMLInputElement).value = `${dateTime[0]}, 01:${(event.target as HTMLInputElement).value.slice(
+            3,
+            (event.target as HTMLInputElement).value.length,
+          )}`;
+        }
+      }
+    }
+  }
+
+  _handleBlur(event: FocusEvent): void {
+    const text = (event.target as HTMLInputElement).value;
+    const dateTime =  text.split(', ');
+    const hour: string = dateTime[1].slice(0, 2);
+    if (!this.military) {
+      const input = dateTime[1].substr(17, 4).replace(/\-/g, '').trim().slice(0, 2);
+      const timePeriod = this.imask.blocks.aa.enum.find((it) => it[0] === input[0]);
+      if (this.hourOneFormatRequired(hour)) {
+        (event.target as HTMLInputElement).value = `${dateTime[0]}, 01:${dateTime[1].slice(3, dateTime[1].length)}`;
+      }
+      if (!timePeriod) {
+        (event.target as HTMLInputElement).value = `${dateTime[0]}, ${dateTime[1].slice(0, 5)} --`;
+      }
+    }
+  }
+
+  _handleKeydown(event: KeyboardEvent): void {
+    const input = event.target as HTMLInputElement;
+    const dateTime =  input.value.split(', ');
+    const hour: string = dateTime[1].slice(0, 2);
+
+    if (event.key === Key.Backspace && input.selectionStart === dateTime[1].length) {
+      (event.target as HTMLInputElement).value = `${dateTime[1].slice(0, 5)} --`;
+    } else if (event.key === Key.Tab && input.selectionStart <= 2 && this.hourOneFormatRequired(hour)) {
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      input.value = `${dateTime[0]}, 01:${dateTime[1].slice(3, dateTime[1].length)}`;
+      input.setSelectionRange(15, 15);
+    } else if (event.key === Key.ArrowRight && input.selectionStart >= 2 && this.hourOneFormatRequired(hour)) {
+      input.value = `${dateTime[0]}, 01:${dateTime[1].slice(3, dateTime[1].length)}`;
+      input.setSelectionRange(14, 14);
+    }
+  }
+
+  normalize(value: string) {
+    const pattern = this.labels.dateFormat.toUpperCase();
+    return format(parse(value), pattern);
+  }
+
+  formatAsIso(date: Date): string {
+    if (date && isValid(date)) {
+      return date.toISOString();
+    }
+    return null;
+  }
+
+  convertTime12to24(time12h: string) {
+    const pmFormat = this.labels.timeFormatPM.toUpperCase();
+    const [time, meridian] = time12h.split(' ');
+    let [hours, minutes] = time.split(':');
+    if (hours === '12') {
+      hours = '00';
+    }
+    if (['PM', pmFormat].includes(meridian)) {
+      hours = `${parseInt(hours, 10) + 12}`.padStart(2, '0');
+    }
+    return `${hours}:${minutes}`;
+  }
+
+  convertTime24to12(time24h: string) {
+    if (time24h.length === 5) {
+      const date = parse(`2020-01-01T${time24h}`);
+      return format(date, 'hh:mm A');
+    }
+    return time24h;
+  }
+
+  formatValue(value: any): string {
+    if (value == null) return '';
+    // Use `parse` because it keeps dates in locale
+    const date = parse(value);
+    if (isValid(date)) {
+      const dateFormat = `${this.labels.dateFormat.toUpperCase()}, ${this.military ? 'HH:mm' : 'hh:mm A'}`;
+      return format(date, dateFormat);
+    }
+    return this.normalize(value);
+  }
+
+  writeValue(value: any) {
+    super.writeValue(this.formatValue(value));
+  }
+
+  registerOnChange(fn: (_: any) => void): void {
+    this.onChange = (date: any) => {
+      let formatted = date;
+      switch (this.dateTimeFormat) {
+        case DATE_FORMATS.ISO8601:
+          formatted = this.formatAsIso(date);
+          break;
+        case DATE_FORMATS.STRING:
+          formatted = this.formatValue(date);
+          break;
+        default:
+          formatted = date;
+          break;
+      }
+      this.valueChange.emit(date);
+      fn(formatted);
+    };
+  }
+
+  hourOneFormatRequired(hourInput: string): boolean {
+    return hourInput === '-1' || hourInput === '1-';
+  }
+}

--- a/projects/novo-elements/src/elements/field/index.ts
+++ b/projects/novo-elements/src/elements/field/index.ts
@@ -8,6 +8,7 @@ export * from './formats/base-format';
 export * from './formats/date-format';
 export * from './formats/date-range-format';
 export * from './formats/time-format';
+export * from './formats/date-time-format';
 export * from './hint';
 export * from './input';
 export * from './picker.directive';

--- a/projects/novo-elements/src/elements/field/toggle/picker-toggle.component.html
+++ b/projects/novo-elements/src/elements/field/toggle/picker-toggle.component.html
@@ -7,6 +7,6 @@
   [disabled]="disabled"
   (click)="togglePanel($event)"></novo-button>
 
-<novo-overlay-template [parent]="element" position="above-below">
+<novo-overlay-template [width]="width" [parent]="element" position="above-below">
   <ng-content></ng-content>
 </novo-overlay-template>

--- a/projects/novo-elements/src/elements/field/toggle/picker-toggle.component.ts
+++ b/projects/novo-elements/src/elements/field/toggle/picker-toggle.component.ts
@@ -64,6 +64,9 @@ export class NovoPickerToggleElement<T = any> implements AfterContentInit, After
   /** An id to select the correct overlay.*/
   @Input() overlayId: string;
 
+  /** Width to pass to overlay.*/
+  @Input() width: string;
+
   /** Whether the toggle button is disabled. */
   @Input()
   get disabled(): boolean {

--- a/projects/novo-elements/src/elements/form/Form.module.ts
+++ b/projects/novo-elements/src/elements/form/Form.module.ts
@@ -49,6 +49,7 @@ import { NovoFormElement } from './Form';
     NovoChipsModule,
     NovoDatePickerModule,
     NovoTimePickerModule,
+    NovoDateTimePickerModule,
     NovoNovoCKEditorModule,
     NovoFormExtrasModule,
     NovoQuickNoteModule,

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.scss
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.scss
@@ -41,6 +41,9 @@
           padding-left: 0 !important;
         }
       }
+      novo-radio-group {
+        padding: 0 !important;
+      }
     }
   }
 

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/abstract-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/abstract-condition.definition.ts
@@ -1,4 +1,5 @@
 import { Directive, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { FormGroup } from '@angular/forms';
 import { NovoLabelService } from '../../../services';
 import { NovoConditionFieldDef } from '../query-builder.directives';
 
@@ -32,6 +33,10 @@ export abstract class AbstractConditionFieldDef implements OnDestroy, OnInit {
 
   ngOnDestroy() {
     this.fieldDef?.unregister();
+  }
+
+  onOperatorSelect(formGroup: FormGroup): void {
+    formGroup.get('value').setValue(null);
   }
 
   /** Synchronizes the column definition name with the text column name. */

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
@@ -9,15 +9,24 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
   template: `
     <ng-container novoConditionFieldDef>
       <novo-field *novoConditionOperatorsDef="let formGroup" [formGroup]="formGroup">
-        <novo-select [placeholder]="labels.operator" formControlName="operator">
+        <novo-select [placeholder]="labels.operator" formControlName="operator" (onSelect)="onOperatorSelect(formGroup)">
           <novo-option value="includeAny">{{ labels.includeAny }}</novo-option>
           <novo-option value="excludeAny">{{ labels.exclude }}</novo-option>
           <novo-option value="radius">{{ labels.radius }}</novo-option>
+          <novo-option value="isNull">{{ labels.isEmpty }}</novo-option>
         </novo-select>
       </novo-field>
-      <novo-field *novoConditionInputDef="let formGroup; fieldMeta as meta" [formGroup]="formGroup">
-        <novo-select formControlName="value" [placeholder]="labels.select" [multiple]="true"> </novo-select>
-      </novo-field>
+      <ng-container *novoConditionInputDef="let formGroup; viewIndex as viewIndex; fieldMeta as meta" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">
+        <novo-field *novoSwitchCases="['includeAny', 'excludeAny', 'radius']">
+          <novo-select formControlName="value" [placeholder]="labels.select" [multiple]="true"> </novo-select>
+        </novo-field>
+        <novo-field *novoSwitchCases="['isNull']">
+          <novo-radio-group formControlName="value">
+            <novo-radio [value]="true">{{ labels.yes }}</novo-radio>
+            <novo-radio [value]="false">{{ labels.no }}</novo-radio>
+          </novo-radio-group>
+        </novo-field>
+      </ng-container>
     </ng-container>
   `,
   encapsulation: ViewEncapsulation.None,

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/boolean-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/boolean-condition.definition.ts
@@ -9,16 +9,17 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
   template: `
     <ng-container novoConditionFieldDef>
       <novo-field *novoConditionOperatorsDef="let formGroup" [formGroup]="formGroup">
-        <novo-select [placeholder]="labels.operator" formControlName="operator">
+        <novo-select [placeholder]="labels.operator" formControlName="operator" (onSelect)="onOperatorSelect(formGroup)">
           <novo-option value="include">{{ labels.equals }}</novo-option>
           <novo-option value="exclude">{{ labels.doesNotEqual }}</novo-option>
+          <novo-option value="isNull">{{ labels.isEmpty }}</novo-option>
         </novo-select>
       </novo-field>
-      <novo-field *novoConditionInputDef="let formGroup" [style.width.px]="100" [formGroup]="formGroup">
-        <novo-select [placeholder]="labels.value" formControlName="value">
-          <novo-option [value]="true">{{ labels.true }}</novo-option>
-          <novo-option [value]="false">{{ labels.false }}</novo-option>
-        </novo-select>
+      <novo-field *novoConditionInputDef="let formGroup" [style.width.px]="125" [formGroup]="formGroup">
+        <novo-radio-group formControlName="value">
+          <novo-radio [value]="true">{{ formGroup.value.operator === 'isNull' ? labels.yes : labels.true }}</novo-radio>
+          <novo-radio [value]="false">{{ formGroup.value.operator === 'isNull' ? labels.no : labels.false }}</novo-radio>
+        </novo-radio-group>
       </novo-field>
     </ng-container>
   `,

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
@@ -1,5 +1,4 @@
-import { ChangeDetectionStrategy, Component, ContentChild, QueryList, ViewChild, ViewChildren, ViewEncapsulation } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, QueryList, ViewChildren, ViewEncapsulation } from '@angular/core';
 import { NovoPickerToggleElement } from './../../field/toggle/picker-toggle.component';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
 
@@ -17,31 +16,36 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
           <novo-option value="after">{{ labels.after }}</novo-option>
           <novo-option value="between">{{ labels.between }}</novo-option>
           <novo-option value="within">{{ labels.within }}</novo-option>
+          <novo-option value="isNull">{{ labels.isEmpty }}</novo-option>
         </novo-select>
       </novo-field>
-      <ng-container *novoConditionInputDef="let formGroup; viewIndex as viewIndex">
-        <ng-container [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">
-          <novo-field *novoSwitchCases="['before', 'after']">
-            <input novoInput dateFormat="iso8601" [picker]="datepicker" formControlName="value" />
-            <novo-picker-toggle triggerOnFocus [overlayId]="viewIndex" novoSuffix icon="calendar">
-              <novo-date-picker (onSelect)="closePanel($event, viewIndex)" #datepicker></novo-date-picker>
-            </novo-picker-toggle>
-          </novo-field>
-          <novo-field *novoSwitchCases="['between']">
-            <input novoInput dateRangeFormat="date" [picker]="daterangepicker" formControlName="value" />
-            <novo-picker-toggle [for]="daterangepicker" triggerOnFocus [overlayId]="viewIndex" novoSuffix icon="calendar">
-              <novo-date-picker #daterangepicker (onSelect)="closePanel($event, viewIndex)" mode="range" numberOfMonths="2"></novo-date-picker>
-            </novo-picker-toggle>
-          </novo-field>
-          <novo-field *novoSwitchCases="['within']">
-            <novo-select [placeholder]="labels.selectDateRange" formControlName="value">
-              <novo-option value="7">{{ labels.next7Days }}</novo-option>
-              <novo-option value="-7">{{ labels.past7Days }}</novo-option>
-              <novo-option value="-30">{{ labels.past30Days }}</novo-option>
-              <novo-option value="-90">{{ labels.past90Days }}</novo-option>
-            </novo-select>
-          </novo-field>
-        </ng-container>
+      <ng-container *novoConditionInputDef="let formGroup; viewIndex as viewIndex" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">
+        <novo-field *novoSwitchCases="['before', 'after']">
+          <input novoInput dateFormat="iso8601" [picker]="datepicker" formControlName="value" />
+          <novo-picker-toggle triggerOnFocus [overlayId]="viewIndex" novoSuffix icon="calendar">
+            <novo-date-picker (onSelect)="closePanel($event, viewIndex)" #datepicker></novo-date-picker>
+          </novo-picker-toggle>
+        </novo-field>
+        <novo-field *novoSwitchCases="['between']">
+          <input novoInput dateRangeFormat="date" [picker]="daterangepicker" formControlName="value" />
+          <novo-picker-toggle [for]="daterangepicker" triggerOnFocus [overlayId]="viewIndex" novoSuffix icon="calendar">
+            <novo-date-picker #daterangepicker (onSelect)="closePanel($event, viewIndex)" mode="range" numberOfMonths="2"></novo-date-picker>
+          </novo-picker-toggle>
+        </novo-field>
+        <novo-field *novoSwitchCases="['within']">
+          <novo-select [placeholder]="labels.selectDateRange" formControlName="value">
+            <novo-option value="7">{{ labels.next7Days }}</novo-option>
+            <novo-option value="-7">{{ labels.past7Days }}</novo-option>
+            <novo-option value="-30">{{ labels.past30Days }}</novo-option>
+            <novo-option value="-90">{{ labels.past90Days }}</novo-option>
+          </novo-select>
+        </novo-field>
+        <novo-field *novoSwitchCases="['isNull']">
+          <novo-radio-group formControlName="value">
+            <novo-radio [value]="true">{{ labels.yes }}</novo-radio>
+            <novo-radio [value]="false">{{ labels.no }}</novo-radio>
+          </novo-radio-group>
+        </novo-field>
       </ng-container>
     </ng-container>
   `,
@@ -53,10 +57,6 @@ export class NovoDefaultDateConditionDef extends AbstractConditionFieldDef {
   overlayChildren: QueryList<NovoPickerToggleElement>;
 
   defaultOperator = 'within';
-
-  onOperatorSelect(formGroup: FormGroup): void {
-    formGroup.get('value').setValue(null);
-  }
 
   closePanel(event, viewIndex): void {
     const overlay = this.overlayChildren.find(item => item.overlayId === viewIndex);

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/date-time-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/date-time-condition.definition.ts
@@ -1,0 +1,63 @@
+import { ChangeDetectionStrategy, Component, QueryList, ViewChildren, ViewEncapsulation } from '@angular/core';
+import { NovoPickerToggleElement } from './../../field/toggle/picker-toggle.component';
+import { AbstractConditionFieldDef } from './abstract-condition.definition';
+
+/**
+ * Most complicated of the default conditions defs, a date needs to provide a different
+ * input type depending on the operator selected.
+ */
+@Component({
+  selector: 'novo-date-time-condition-def',
+  template: `
+    <ng-container novoConditionFieldDef="DATE">
+      <novo-field *novoConditionOperatorsDef="let formGroup" [formGroup]="formGroup">
+        <novo-select [placeholder]="labels.operator" formControlName="operator" (onSelect)="onOperatorSelect(formGroup)">
+          <novo-option value="before">{{ labels.before }}</novo-option>
+          <novo-option value="after">{{ labels.after }}</novo-option>
+          <novo-option value="within">{{ labels.within }}</novo-option>
+          <novo-option value="isNull">{{ labels.isEmpty }}</novo-option>
+        </novo-select>
+      </novo-field>
+      <ng-container *novoConditionInputDef="let formGroup; viewIndex as viewIndex" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">
+        <novo-field *novoSwitchCases="['after']">
+          <input novoInput dateTimeFormat="iso8601" [picker]="datetimepicker" formControlName="value" />
+          <novo-picker-toggle triggerOnFocus [width]="-1" [overlayId]="viewIndex" novoSuffix icon="calendar">
+            <novo-date-time-picker defaultTime="end" (onSelect)="closePanel($event, viewIndex)" #datetimepicker></novo-date-time-picker>
+          </novo-picker-toggle>
+        </novo-field>
+        <novo-field *novoSwitchCases="['before']">
+          <input novoInput dateTimeFormat="iso8601" [picker]="datetimepickerbefore" formControlName="value" />
+          <novo-picker-toggle triggerOnFocus [width]="-1" [overlayId]="viewIndex" novoSuffix icon="calendar">
+            <novo-date-time-picker defaultTime="start" (onSelect)="closePanel($event, viewIndex)" #datetimepickerbefore></novo-date-time-picker>
+          </novo-picker-toggle>
+        </novo-field>
+        <novo-field *novoSwitchCases="['within']">
+          <novo-select [placeholder]="labels.selectDateRange" formControlName="value">
+            <novo-option value="7">{{ labels.next7Days }}</novo-option>
+            <novo-option value="-7">{{ labels.past7Days }}</novo-option>
+            <novo-option value="-30">{{ labels.past30Days }}</novo-option>
+            <novo-option value="-90">{{ labels.past90Days }}</novo-option>
+          </novo-select>
+        </novo-field>
+        <novo-field *novoSwitchCases="['isNull']">
+          <novo-radio-group formControlName="value">
+            <novo-radio [value]="true">{{ labels.yes }}</novo-radio>
+            <novo-radio [value]="false">{{ labels.no }}</novo-radio>
+          </novo-radio-group>
+        </novo-field>
+      </ng-container>
+    </ng-container>
+  `,
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.Default,
+})
+export class NovoDefaultDateTimeConditionDef extends AbstractConditionFieldDef {
+  @ViewChildren(NovoPickerToggleElement)
+  overlayChildren: QueryList<NovoPickerToggleElement>;
+
+  defaultOperator = 'within';
+
+  closePanel(event, viewIndex): void {
+    const overlay = this.overlayChildren.find(item => item.overlayId === viewIndex);
+  }
+}

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/number-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/number-condition.definition.ts
@@ -10,15 +10,24 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
   template: `
     <ng-container novoConditionFieldDef>
       <novo-field *novoConditionOperatorsDef="let formGroup" [formGroup]="formGroup">
-        <novo-select [placeholder]="labels.operator" formControlName="operator">
+        <novo-select [placeholder]="labels.operator" formControlName="operator" (onSelect)="onOperatorSelect(formGroup)">
           <novo-option value="greaterThan">{{ labels.greaterThan }}</novo-option>
           <novo-option value="lessThan">{{ labels.lessThan }}</novo-option>
           <novo-option value="equalTo">{{ labels.equalTo }}</novo-option>
+          <novo-option value="isNull">{{ labels.isEmpty }}</novo-option>
         </novo-select>
       </novo-field>
-      <novo-field *novoConditionInputDef="let formGroup" [formGroup]="formGroup">
-        <input novoInput type="number" formControlName="value" />
-      </novo-field>
+      <ng-container *novoConditionInputDef="let formGroup" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">
+        <novo-field *novoSwitchCases="['greaterThan', 'lessThan', 'equalTo']">
+          <input novoInput type="number" formControlName="value" />
+        </novo-field>
+        <novo-field *novoSwitchCases="['isNull']">
+          <novo-radio-group formControlName="value">
+            <novo-radio [value]="true">{{ labels.yes }}</novo-radio>
+            <novo-radio [value]="false">{{ labels.no }}</novo-radio>
+          </novo-radio-group>
+        </novo-field>
+      </ng-container>
     </ng-container>
   `,
   encapsulation: ViewEncapsulation.None,

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
@@ -18,7 +18,7 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
       <novo-field *novoConditionInputDef="let formGroup; fieldMeta as meta" [formGroup]="formGroup">
         <novo-select formControlName="value" [placeholder]="labels.select" [multiple]="true">
           <!-- WHat about optionUrl/optionType -->
-          <novo-option *ngFor="let option of meta?.options" [value]="option.value">
+          <novo-option *ngFor="let option of meta?.options" [value]="option.value" [attr.data-automation-value]="option.label">
             {{ option.label }}
           </novo-option>
         </novo-select>

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
@@ -9,20 +9,29 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
   template: `
     <ng-container novoConditionFieldDef>
       <novo-field *novoConditionOperatorsDef="let formGroup" [formGroup]="formGroup">
-        <novo-select [placeholder]="labels.operator" formControlName="operator">
+        <novo-select [placeholder]="labels.operator" formControlName="operator" (onSelect)="onOperatorSelect(formGroup)">
           <novo-option value="includeAny">{{ labels.includeAny }}</novo-option>
           <novo-option value="includeAll">{{ labels.includeAll }}</novo-option>
           <novo-option value="excludeAny">{{ labels.exclude }}</novo-option>
+          <novo-option value="isNull">{{ labels.isEmpty }}</novo-option>
         </novo-select>
       </novo-field>
-      <novo-field *novoConditionInputDef="let formGroup; fieldMeta as meta" [formGroup]="formGroup">
-        <novo-select formControlName="value" [placeholder]="labels.select" [multiple]="true">
-          <!-- WHat about optionUrl/optionType -->
-          <novo-option *ngFor="let option of meta?.options" [value]="option.value" [attr.data-automation-value]="option.label">
-            {{ option.label }}
-          </novo-option>
-        </novo-select>
-      </novo-field>
+      <ng-container *novoConditionInputDef="let formGroup; fieldMeta as meta" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">
+        <novo-field *novoSwitchCases="['includeAny', 'includeAll', 'excludeAny']">
+          <novo-select formControlName="value" [placeholder]="labels.select" [multiple]="true">
+            <!-- WHat about optionUrl/optionType -->
+            <novo-option *ngFor="let option of meta?.options" [value]="option.value" [attr.data-automation-value]="option.label">
+              {{ option.label }}
+            </novo-option>
+          </novo-select>
+        </novo-field>
+        <novo-field *novoSwitchCases="['isNull']">
+          <novo-radio-group formControlName="value">
+            <novo-radio [value]="true">{{ labels.yes }}</novo-radio>
+            <novo-radio [value]="false">{{ labels.no }}</novo-radio>
+          </novo-radio-group>
+        </novo-field>
+      </ng-container>
     </ng-container>
   `,
   encapsulation: ViewEncapsulation.None,

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
@@ -1,6 +1,6 @@
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
-import { AbstractControl, FormControl } from '@angular/forms';
+import { AbstractControl } from '@angular/forms';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
 
 /**
@@ -15,27 +15,36 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
     <!-- fieldTypes should be UPPERCASE -->
     <ng-container novoConditionFieldDef="STRING">
       <novo-field *novoConditionOperatorsDef="let formGroup" [formGroup]="formGroup">
-        <novo-select [placeholder]="labels.operator" formControlName="operator">
+        <novo-select [placeholder]="labels.operator" formControlName="operator" (onSelect)="onOperatorSelect(formGroup)">
           <novo-option value="includeAny">{{ labels.includeAny }}</novo-option>
           <novo-option value="includeAll">{{ labels.includeAll }}</novo-option>
           <novo-option value="excludeAny">{{ labels.exclude }}</novo-option>
+          <novo-option value="isEmpty">{{ labels.isEmpty }}</novo-option>
         </novo-select>
       </novo-field>
-      <novo-field *novoConditionInputDef="let formGroup" [formGroup]="formGroup">
-        <novo-chip-list #chipList aria-label="filter value" formControlName="value">
-          <novo-chip *ngFor="let chip of formGroup.value?.value || []" [value]="chip" (removed)="remove(chip, formGroup)">
-            {{ chip }}
-            <novo-icon novoChipRemove>close</novo-icon>
-          </novo-chip>
-          <input
-            novoChipInput
-            [placeholder]="labels.typeToAddChips"
-            autocomplete="off"
-            (novoChipInputTokenEnd)="add($event, formGroup)"
-          />
-        </novo-chip-list>
-        <novo-autocomplete></novo-autocomplete>
-      </novo-field>
+      <ng-container *novoConditionInputDef="let formGroup" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">
+        <novo-field *novoSwitchCases="['includeAny', 'includeAll', 'excludeAny']">
+          <novo-chip-list #chipList aria-label="filter value" formControlName="value">
+            <novo-chip *ngFor="let chip of formGroup.value?.value || []" [value]="chip" (removed)="remove(chip, formGroup)">
+              {{ chip }}
+              <novo-icon novoChipRemove>close</novo-icon>
+            </novo-chip>
+            <input
+              novoChipInput
+              [placeholder]="labels.typeToAddChips"
+              autocomplete="off"
+              (novoChipInputTokenEnd)="add($event, formGroup)"
+            />
+          </novo-chip-list>
+          <novo-autocomplete></novo-autocomplete>
+        </novo-field>
+        <novo-field *novoSwitchCases="['isEmpty']">
+          <novo-radio-group formControlName="value">
+            <novo-radio [value]="true">{{ labels.yes }}</novo-radio>
+            <novo-radio [value]="false">{{ labels.no }}</novo-radio>
+          </novo-radio-group>
+        </novo-field>
+      </ng-container>
     </ng-container>
   `,
   encapsulation: ViewEncapsulation.None,

--- a/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.html
+++ b/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.html
@@ -9,7 +9,8 @@
   </novo-stack>
 </form>
 <novo-id-condition-def name="ID"></novo-id-condition-def>
-<novo-date-condition-def name="TIMESTAMP"></novo-date-condition-def>
+<novo-date-condition-def name="DATE"></novo-date-condition-def>
+<novo-date-time-condition-def name="TIMESTAMP"></novo-date-time-condition-def>
 <novo-string-condition-def name="STRING"></novo-string-condition-def>
 <novo-number-condition-def name="FLOAT"></novo-number-condition-def>
 <novo-number-condition-def name="INTEGER"></novo-number-condition-def>

--- a/projects/novo-elements/src/elements/query-builder/index.ts
+++ b/projects/novo-elements/src/elements/query-builder/index.ts
@@ -3,6 +3,7 @@ export * from './condition-definitions/abstract-condition.definition';
 export * from './condition-definitions/address-condition.definition';
 export * from './condition-definitions/boolean-condition.definition';
 export * from './condition-definitions/date-condition.definition';
+export * from './condition-definitions/date-time-condition.definition';
 export * from './condition-definitions/id-condition.definition';
 export * from './condition-definitions/number-condition.definition';
 export * from './condition-definitions/picker-condition.definition';

--- a/projects/novo-elements/src/elements/query-builder/query-builder.module.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.module.ts
@@ -8,6 +8,7 @@ import { NovoCardModule } from '../card';
 import { NovoChipsModule } from '../chips';
 import { NovoCommonModule, NovoOptionModule } from '../common';
 import { NovoDatePickerModule } from '../date-picker';
+import { NovoDateTimePickerModule } from './../date-time-picker/DateTimePicker.module';
 import { NovoDropdownModule } from '../dropdown';
 import { NovoFieldModule } from '../field';
 import { NovoFlexModule } from '../flex';
@@ -25,6 +26,7 @@ import { ConditionBuilderComponent, ConditionInputOutlet, ConditionOperatorOutle
 import { NovoDefaultAddressConditionDef } from './condition-definitions/address-condition.definition';
 import { NovoDefaultBooleanConditionDef } from './condition-definitions/boolean-condition.definition';
 import { NovoDefaultDateConditionDef } from './condition-definitions/date-condition.definition';
+import { NovoDefaultDateTimeConditionDef } from './condition-definitions/date-time-condition.definition';
 import { NovoDefaultIdConditionDef } from './condition-definitions/id-condition.definition';
 import { NovoDefaultNumberConditionDef } from './condition-definitions/number-condition.definition';
 import { NovoDefaultPickerConditionDef } from './condition-definitions/picker-condition.definition';
@@ -52,6 +54,7 @@ import { NovoConditionFieldDef, NovoConditionInputDef, NovoConditionOperatorsDef
     NovoLoadingModule,
     NovoCardModule,
     NovoDatePickerModule,
+    NovoDateTimePickerModule,
     NovoIconModule,
     NovoRadioModule,
     NovoSearchBoxModule,
@@ -69,6 +72,7 @@ import { NovoConditionFieldDef, NovoConditionInputDef, NovoConditionOperatorsDef
     NovoDefaultAddressConditionDef,
     NovoDefaultBooleanConditionDef,
     NovoDefaultDateConditionDef,
+    NovoDefaultDateTimeConditionDef,
     NovoConditionOperatorsDef,
     NovoConditionInputDef,
     NovoConditionFieldDef,
@@ -83,6 +87,7 @@ import { NovoConditionFieldDef, NovoConditionInputDef, NovoConditionOperatorsDef
     NovoDefaultAddressConditionDef,
     NovoDefaultBooleanConditionDef,
     NovoDefaultDateConditionDef,
+    NovoDefaultDateTimeConditionDef,
     NovoConditionOperatorsDef,
     NovoConditionInputDef,
     NovoConditionFieldDef,

--- a/projects/novo-elements/src/elements/query-builder/query-builder.module.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.module.ts
@@ -15,6 +15,7 @@ import { NovoFormModule } from '../form';
 import { NovoIconModule } from '../icon';
 import { NovoLoadingModule } from '../loading';
 import { NovoNonIdealStateModule } from '../non-ideal-state';
+import { NovoRadioModule } from '../radio'
 import { NovoSearchBoxModule } from '../search';
 import { NovoSelectModule } from '../select';
 import { NovoSelectSearchModule } from '../select-search';
@@ -52,6 +53,7 @@ import { NovoConditionFieldDef, NovoConditionInputDef, NovoConditionOperatorsDef
     NovoCardModule,
     NovoDatePickerModule,
     NovoIconModule,
+    NovoRadioModule,
     NovoSearchBoxModule,
     NovoSwitchModule,
     NovoChipsModule,

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -134,6 +134,7 @@ export class NovoLabelService {
   after = 'After';
   between = 'Between';
   within = 'Within';
+  isEmpty = 'Is Empty?';
   refreshPagination = 'Refresh Pagination';
 
   constructor(

--- a/projects/novo-examples/src/components/field/form-usage/form-usage-example.html
+++ b/projects/novo-examples/src/components/field/form-usage/form-usage-example.html
@@ -30,28 +30,6 @@
       </novo-picker-toggle>
     </novo-field>
 
-    <!-- <novo-field>
-      <novo-label>Shift Needs?</novo-label>
-      <novo-association-table>
-        <ng-container novoColumnDef="position">
-          <th mat-header-cell *novoHeaderCellDef>No.</th>
-          <td mat-cell *novoCellDef="let element">{{element.position}}</td>
-        </ng-container>
-
-        <tr>
-          <td colspan="3">
-            <novo-field>
-              <novo-label>Date of Birth</novo-label>
-              <input novoInput dateFormat [picker]="datepicker" [formControl]="dateControl" />
-              <novo-picker-toggle novoSuffix icon="calendar">
-                <novo-date-picker #datepicker></novo-date-picker>
-              </novo-picker-toggle>
-            </novo-field>
-          </td>
-        </tr>
-      </novo-association-table>
-    </novo-field> -->
-
     <button theme="primary" [disabled]="!options.valid" (click)="onSubmit(options.value)">Submit
       Form</button>
   </novo-fields>

--- a/projects/novo-examples/src/components/field/form-usage/form-usage-example.html
+++ b/projects/novo-examples/src/components/field/form-usage/form-usage-example.html
@@ -22,6 +22,13 @@
       </novo-picker-toggle>
     </novo-field>
 
+    <novo-field>
+      <novo-label>Appointment</novo-label>
+      <input novoInput dateTimeFormat [picker]="datetimepicker" [military]="false" [formControl]="dateTimeControl" readonly />
+      <novo-picker-toggle novoSuffix icon="calendar">
+        <novo-date-time-picker #datetimepicker></novo-date-time-picker>
+      </novo-picker-toggle>
+    </novo-field>
 
     <!-- <novo-field>
       <novo-label>Shift Needs?</novo-label>

--- a/projects/novo-examples/src/components/field/form-usage/form-usage-example.ts
+++ b/projects/novo-examples/src/components/field/form-usage/form-usage-example.ts
@@ -14,6 +14,7 @@ export class FormUsageExample {
   numberControl = new FormControl(16, Validators.min(10));
   timeControl = new FormControl(new Date());
   dateControl = new FormControl(new Date());
+  dateTimeControl = new FormControl(new Date());
   post: any = '';
 
   constructor(fb: FormBuilder) {
@@ -21,6 +22,7 @@ export class FormUsageExample {
       number: this.numberControl,
       time: this.timeControl,
       date: this.dateControl,
+      dateTime: this.dateTimeControl,
     });
   }
 


### PR DESCRIPTION
## **Description**
feat(Field): adding data-auto-ids to the new novo-field elements #1349
feat(QueryBuilder): adding isNull/isEmpty operators to query builder field definitions #1358
feat(dateTimePicker): Added formatter for dateTimePicker #1361
fix(xmldom): removed unused xmldom dependency due to security concern #1357
chore(deps): bump loader-utils from 1.4.0 to 1.4.1 #1362
chore(deps): bump loader-utils from 1.4.1 to 1.4.2 #1366
fix(NovoDataTableSortButton): fixing ng14 warning caused by animating pointer-events #1368
feat(date-time-condition): Added default date-time condition definition #1364

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**