### PR TITLE
refactor(dragula): deprecating dragula directive and service

### DIFF
--- a/projects/elements/addons/dragula/dragula-service.ts
+++ b/projects/elements/addons/dragula/dragula-service.ts
@@ -3,6 +3,14 @@ import { EventEmitter, Injectable } from '@angular/core';
 // Vendor
 import dragula from '@bullhorn/dragula';
 
+/**
+* @deprecated since v8.0.0 - slated for deletion.
+*
+* Moving away from all CommonJS dependencies to improve tree-shaking.
+*
+* Please look at built-in ng or third party drag-drop libraries like
+* angular-draggable-droppable, ngx-drag-drop, ngx-sortablejs, ng2-dragula.
+*/
 @Injectable({
   providedIn: `root`,
 })

--- a/projects/elements/addons/dragula/dragula.module.ts
+++ b/projects/elements/addons/dragula/dragula.module.ts
@@ -2,6 +2,14 @@
 import { NgModule } from '@angular/core';
 import { NovoDragulaElement } from './dragula';
 
+/**
+* @deprecated since v8.0.0 - slated for deletion.
+*
+* Moving away from all CommonJS dependencies to improve tree-shaking.
+*
+* Please look at built-in ng or third party drag-drop libraries like
+* angular-draggable-droppable, ngx-drag-drop, ngx-sortablejs, ng2-dragula.
+*/
 @NgModule({
   declarations: [NovoDragulaElement],
   exports: [NovoDragulaElement],

--- a/projects/elements/addons/dragula/dragula.ts
+++ b/projects/elements/addons/dragula/dragula.ts
@@ -2,8 +2,17 @@
 import { Directive, ElementRef, Input, OnChanges, OnInit } from '@angular/core';
 // Vendor
 import dragula from '@bullhorn/dragula';
+import { notify } from 'novo-elements/utils';
 import { NovoDragulaService } from './dragula-service';
 
+/**
+* @deprecated since v8.0.0 - slated for deletion.
+*
+* Moving away from all CommonJS dependencies to improve tree-shaking.
+*
+* Please look at built-in ng or third party drag-drop libraries like
+* angular-draggable-droppable, ngx-drag-drop, ngx-sortablejs, ng2-dragula.
+*/
 @Directive({
   selector: '[dragula]',
 })
@@ -16,6 +25,7 @@ export class NovoDragulaElement implements OnInit, OnChanges {
   container: any;
 
   constructor(element: ElementRef, private dragulaService: NovoDragulaService) {
+    notify('[dragula] has been deprecated - please look at built-in ng or third party drag-drop libraries instead');
     this.container = element.nativeElement;
   }
 


### PR DESCRIPTION
## **Description**

deprecating novo-elements dragula implementation in anticipation of deleting it in a future release.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**