### PR TITLE
fix(NovoDataTableSortButton): fixing ng14 warning caused by animating pointer-events

### DIFF
--- a/projects/novo-elements/src/elements/data-table/sort-filter/sort-button.animations.ts
+++ b/projects/novo-elements/src/elements/data-table/sort-filter/sort-button.animations.ts
@@ -1,8 +1,8 @@
 import { animate, AnimationTriggerMetadata, state, style, transition, trigger } from '@angular/animations';
 import { SortDirection } from './sort-direction';
 
-const activeStyle = { opacity: 1, pointerEvents: 'all', top: 0 };
-const inactiveStyle = { opacity: 0, pointerEvents: 'none' };
+const activeStyle = { opacity: 1, top: 0 };
+const inactiveStyle = { opacity: 0 };
 
 /** Animation that moves the sort indicator. */
 export const sortAscAnim: AnimationTriggerMetadata = trigger('sortAsc', [

--- a/projects/novo-elements/src/elements/data-table/sort-filter/sort-button.component.html
+++ b/projects/novo-elements/src/elements/data-table/sort-filter/sort-button.component.html
@@ -1,15 +1,18 @@
 <novo-icon
   class="novo-sort-asc-icon"
   [class.sort-active]="isActive"
+  [class.sort-hidden]="value !== SortDirection.ASC"
   [@sortAsc]="value"
   (click)="changeSort(SortDirection.DESC)">arrow-up</novo-icon>
 <novo-icon
   class="novo-sort-desc-icon"
   [class.sort-active]="isActive"
+  [class.sort-hidden]="value !== SortDirection.DESC"
   [@sortDesc]="value"
   (click)="changeSort(SortDirection.NONE)">arrow-down</novo-icon>
 <novo-icon
   class="novo-sortable-icon"
   [class.sort-active]="isActive"
+  [class.sort-hidden]="value !== SortDirection.NONE"
   [@sortNone]="value"
   (click)="changeSort(SortDirection.ASC)">sortable</novo-icon>

--- a/projects/novo-elements/src/elements/data-table/sort-filter/sort-button.component.scss
+++ b/projects/novo-elements/src/elements/data-table/sort-filter/sort-button.component.scss
@@ -13,6 +13,9 @@
     &:hover {
       color: var(--selection);
     }
+    &.sort-hidden {
+      pointer-events: none;
+    }
   }
 
   .novo-sort-asc-icon {


### PR DESCRIPTION
## **Description**

ng14 is now throwing console warnings when you try to animate non-animatable properties. ie:
```
browser.mjs:2541 Warning: The animation trigger "sortNone" is attempting to animate the following not animatable properties: pointerEvents
(to check the list of all animatable properties visit https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_animated_properties)
```
this is a fix for this behavior.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**