### PR TITLE
fix(NovoSelect): Fix issue with hints not displaying within Novo Sele…

### DIFF
--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -315,7 +315,7 @@ export class NovoSelectElement
 
   /** Implemented as part of NovoFieldControl. */
   get empty(): boolean {
-    return this._value === null;
+    return Helpers.isEmpty(this._value);
   }
 
   /** The currently selected option. */

--- a/projects/novo-examples/src/form-controls/form/MockMeta.ts
+++ b/projects/novo-examples/src/form-controls/form/MockMeta.ts
@@ -124,6 +124,8 @@ export const MockMeta = {
       dataType: 'String',
       maxLength: 200,
       confidential: false,
+      required: true,
+      hint: 'Placeholder Text',
       label: 'Status',
       options: [
         {


### PR DESCRIPTION
…ct controls.

## **Description**

Fixes an issue where the hint field on the drop down edit type in field maps does not show

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**