### PR TITLE
fix(NovoButton): disabling enter/space keypresses on disabled/loading buttons

### DIFF
--- a/projects/novo-elements/src/elements/button/Button.ts
+++ b/projects/novo-elements/src/elements/button/Button.ts
@@ -1,6 +1,6 @@
 // NG2
-import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, Input } from '@angular/core';
-import { BooleanInput } from '../../utils/decorators';
+import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, HostListener, Input } from '@angular/core';
+import { BooleanInput, Helpers, Key } from '../../utils';
 
 @Component({
   selector: 'novo-button,button[theme]',
@@ -110,6 +110,13 @@ export class NovoButtonElement {
   private _icon: string;
 
   constructor(public element: ElementRef) {}
+
+  @HostListener('keydown', ['$event'])
+  handleKeydown(event: KeyboardEvent) {
+    if ((Key.Enter === event.key || Key.Space === event.key) && (this.disabled || this.loading)) {
+      Helpers.swallowEvent(event);
+    }
+  }
 
   /** Focuses the input. */
   focus(options?: FocusOptions): void {

--- a/projects/novo-examples/src/components/buttons/button-dynamic/button-dynamic-example.ts
+++ b/projects/novo-examples/src/components/buttons/button-dynamic/button-dynamic-example.ts
@@ -17,5 +17,6 @@ export class ButtonDynamicExample {
   changeTheme() {
     const i = Math.floor(Math.random() * 4);
     this.theme = ['primary', 'secondary', 'dialogue', 'standard', 'icon'][i];
+    console.log('changed theme to', this.theme);
   }
 }

--- a/projects/novo-examples/src/components/buttons/button-loading/button-loading-example.ts
+++ b/projects/novo-examples/src/components/buttons/button-loading/button-loading-example.ts
@@ -12,6 +12,7 @@ export class ButtonLoadingExample {
   loading: boolean = false;
   loadingButtonText: string = 'Delete';
   fakeRequest() {
+    console.log('making fake request');
     this.loading = true;
     this.loadingButtonText = this.loading ? 'Removing... ' : 'Delete';
     setTimeout(() => {


### PR DESCRIPTION
## **Description**

Disabled buttons and buttons in a 'loading' state were correctly swallowing click events, but they were not swallowing keyboard events which would call functions attached to them. This was resulting in a user being able to make multiple identical api requests when (for example) submitting a form by hitting enter/space multiple times or by holding either of those keys down.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**