### PR TITLE
fix(CKEditor): Also disable tableselection plugin

### DIFF
--- a/projects/novo-elements/src/elements/ckeditor/CKEditor.spec.ts
+++ b/projects/novo-elements/src/elements/ckeditor/CKEditor.spec.ts
@@ -102,7 +102,7 @@ describe('Elements: NovoCKEditorElement', () => {
         entities: false,
         shiftEnterMode: window.CKEDITOR.ENTER_P,
         disableNativeSpellChecker: false,
-        removePlugins: 'liststyle,tabletools,contextmenu',
+        removePlugins: 'liststyle,tabletools,contextmenu,tableselection',
         extraAllowedContent: '*(*){*};table tbody tr td th[*];',
         font_names:
           'Arial/Arial, Helvetica, sans-serif;' +
@@ -153,7 +153,7 @@ describe('Elements: NovoCKEditorElement', () => {
         entities: false,
         shiftEnterMode: window.CKEDITOR.ENTER_P,
         disableNativeSpellChecker: false,
-        removePlugins: 'liststyle,tabletools,contextmenu',
+        removePlugins: 'liststyle,tabletools,contextmenu,tableselection',
         extraAllowedContent: '*(*){*};table tbody tr td th[*];',
         font_names:
           'Arial/Arial, Helvetica, sans-serif;' +
@@ -203,7 +203,7 @@ describe('Elements: NovoCKEditorElement', () => {
         entities: false,
         shiftEnterMode: window.CKEDITOR.ENTER_P,
         disableNativeSpellChecker: false,
-        removePlugins: 'liststyle,tabletools,contextmenu',
+        removePlugins: 'liststyle,tabletools,contextmenu,tableselection',
         extraAllowedContent: '*(*){*};table tbody tr td th[*];',
         font_names:
           'Arial/Arial, Helvetica, sans-serif;' +

--- a/projects/novo-elements/src/elements/ckeditor/CKEditor.ts
+++ b/projects/novo-elements/src/elements/ckeditor/CKEditor.ts
@@ -166,7 +166,7 @@ export class NovoCKEditorElement implements OnDestroy, AfterViewInit, ControlVal
       entities: false,
       shiftEnterMode: CKEDITOR.ENTER_P,
       disableNativeSpellChecker: false,
-      removePlugins: 'liststyle,tabletools,contextmenu', // allows browser based spell checking
+      removePlugins: 'liststyle,tabletools,contextmenu,tableselection', // allows browser based spell checking
       extraAllowedContent: '*(*){*};table tbody tr td th[*];', // allows class names (*) and inline styles {*} for all and attributes [*] on tables
       font_names:
         'Arial/Arial, Helvetica, sans-serif;' +

--- a/projects/novo-elements/src/elements/quick-note/QuickNote.ts
+++ b/projects/novo-elements/src/elements/quick-note/QuickNote.ts
@@ -529,7 +529,7 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
       disableNativeSpellChecker: false,
       height: editorHeight,
       startupFocus: this.startupFocus,
-      removePlugins: 'liststyle,tabletools,contextmenu', // allows browser based spell checking
+      removePlugins: 'liststyle,tabletools,contextmenu,tableselection', // allows browser based spell checking
       toolbar: [
         {
           name: 'basicstyles',


### PR DESCRIPTION
Change list of removePlugins for CKEditor to include tableselection plugin

## **Description**

CKEditor is not disabling the plugins that we intend to disable in order to allow the browser to use its own right-click menu. This is because of a new plugin which includes some of the plugins we have disabled as a dependency. We also must disable this other plugin to maintain intended behavior.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**