### PR TITLE
fix(quickNote): Allow placeholder to hide when clicking in text field to write a note

### DIFF
--- a/projects/novo-elements/src/elements/quick-note/QuickNote.ts
+++ b/projects/novo-elements/src/elements/quick-note/QuickNote.ts
@@ -644,7 +644,7 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
       this._placeholderElement = document.createElement('div');
       this._placeholderElement.className = 'placeholder';
       this._placeholderElement.style.cssText =
-        'margin: 20px; color: #AAAAAA; font-family: sans-serif; font-size: 13px; line-height: 20px; position: absolute; top: 0';
+        'margin: 20px; color: #AAAAAA; font-family: sans-serif; font-size: 13px; line-height: 20px; position: absolute; top: 0; pointer-events: none';
       this._placeholderElement.textContent = this.placeholder;
     }
     return this._placeholderElement;


### PR DESCRIPTION
## **Description**

Currently when you click on the placeholder/help text in a Notes Textbox you are unable to enter a comment/note. You have to click outside of the placeholder to be able to write a comment/note. I am adding `pointer-events: none` to the quickNote placeholder to prevent the placeholder from being the target of click events.

#### **Verify that...**

- [X] Any related demos were added and `npm start` and `npm run build` still works
- [X] New demos work in `Safari`, `Chrome` and `Firefox`
- [X] `npm run lint` passes
- [X] `npm test` passes and code coverage is increased
- [X] `npm run build` still works

#### **Bullhorn Internal Developers**
- [X] Run `Novo Automation`

##### **Screenshots**