### PR TITLE
feat(popOver): fix popover error with empty content

### DIFF
--- a/projects/novo-elements/src/elements/popover/PopOver.ts
+++ b/projects/novo-elements/src/elements/popover/PopOver.ts
@@ -98,7 +98,7 @@ export class PopOverDirective implements OnChanges {
   }
 
   show() {
-    if (this.visible) {
+    if (this.visible || !this.content) {
       return;
     }
 

--- a/projects/novo-elements/src/elements/popover/PopOver.ts
+++ b/projects/novo-elements/src/elements/popover/PopOver.ts
@@ -98,7 +98,7 @@ export class PopOverDirective implements OnChanges {
   }
 
   show() {
-    if (this.visible || !this.content) {
+    if (this.visible || (!this.content && !this.popoverHtmlContent)) {
       return;
     }
 


### PR DESCRIPTION
## **Description**

fix error when popover htmlcontent is empty

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**