### PR TITLE
fix(DataTable): restyling resizable column headers to make them more obvious

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.component.scss
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.scss
@@ -105,12 +105,17 @@ cdk-table {
 .novo-data-table-header-cell {
   &.resizable {
     padding-right: 0;
+    &:hover {
+      background-color: var(--background-muted, $neutral);
+    }
     .data-table-header-resizable {
       height: 100%;
 
       span {
         cursor: ew-resize;
-        width: 8px;
+        background-color: var(--border, $neutral);
+        width: 1px;
+        margin: 0 4px;
         display: block;
       }
     }

--- a/projects/novo-examples/src/components/data-table/data-table-rows/data-table-rows-example.ts
+++ b/projects/novo-examples/src/components/data-table/data-table-rows/data-table-rows-example.ts
@@ -91,6 +91,7 @@ export class DataTableRowsExample {
         type: 'number',
       },
       sortable: true,
+      resizable: true,
     },
     {
       id: 'telephone',
@@ -146,6 +147,7 @@ export class DataTableRowsExample {
       },
       sortable: true,
       format: '$year-$month-$day $hour:$minute',
+      resizable: true,
     },
     {
       id: 'dateTime',


### PR DESCRIPTION
## **Description**

Making resizable column more obvious by adding a vertical divider on the right, and adding a light gray background on hover. Also adding a few resizable columns to the DataTable demo to test them out.

![resizable styling update](https://user-images.githubusercontent.com/18195860/223422289-06219d7a-494a-418a-9f55-d192df115b4f.png)

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**