### PR TITLE
feat(DataTable): pulling out column width setting logic to public function

### DIFF
--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
@@ -515,7 +515,6 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
       }
       this._column.width = width;
       this.setWidth(this._column.width)
-      this.resized.next(this._column);
     });
 
     const mouseUpSubscription: Subscription = fromEvent(window.document, 'mouseup').subscribe(() => {
@@ -532,6 +531,7 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
     this.renderer.setStyle(this.elementRef.nativeElement, 'max-width', `${width}px`);
     this.renderer.setStyle(this.elementRef.nativeElement, 'width', `${width}px`);
     this.changeDetectorRef.markForCheck();
+    this.resized.next(this._column);
   }
 
   public toggleCustomRange(event: Event, value: boolean): void {

--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
@@ -513,8 +513,7 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
       if (width < minimumWidth) {
         width = minimumWidth;
       }
-      this._column.width = width;
-      this.setWidth(this._column.width)
+      this.setWidth(width)
     });
 
     const mouseUpSubscription: Subscription = fromEvent(window.document, 'mouseup').subscribe(() => {
@@ -527,6 +526,7 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
   }
 
   public setWidth(width: number) {
+    this._column.width = width;
     this.renderer.setStyle(this.elementRef.nativeElement, 'min-width', `${width}px`);
     this.renderer.setStyle(this.elementRef.nativeElement, 'max-width', `${width}px`);
     this.renderer.setStyle(this.elementRef.nativeElement, 'width', `${width}px`);

--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
@@ -514,10 +514,7 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
         width = minimumWidth;
       }
       this._column.width = width;
-      this.renderer.setStyle(this.elementRef.nativeElement, 'min-width', `${this._column.width}px`);
-      this.renderer.setStyle(this.elementRef.nativeElement, 'max-width', `${this._column.width}px`);
-      this.renderer.setStyle(this.elementRef.nativeElement, 'width', `${this._column.width}px`);
-      this.changeDetectorRef.markForCheck();
+      this.setWidth(this._column.width)
       this.resized.next(this._column);
     });
 
@@ -528,6 +525,13 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
     });
     this.subscriptions.push(mouseMoveSubscription);
     this.subscriptions.push(mouseUpSubscription);
+  }
+
+  public setWidth(width: number) {
+    this.renderer.setStyle(this.elementRef.nativeElement, 'min-width', `${width}px`);
+    this.renderer.setStyle(this.elementRef.nativeElement, 'max-width', `${width}px`);
+    this.renderer.setStyle(this.elementRef.nativeElement, 'width', `${width}px`);
+    this.changeDetectorRef.markForCheck();
   }
 
   public toggleCustomRange(event: Event, value: boolean): void {

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -8,6 +8,7 @@ export interface IDataTablePreferences {
   globalSearch?: any;
   pageSize?: number;
   displayedColumns?: string[];
+  columnWidths?: { id: string; width: number }[];
   savedSearchName?: string;
 }
 

--- a/projects/novo-examples/src/components/data-table/data-table-rows/data-table-rows-example.ts
+++ b/projects/novo-examples/src/components/data-table/data-table-rows/data-table-rows-example.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ViewChild } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ViewChild } from '@angular/core';
 import * as dateFns from 'date-fns';
 import {
   IDataTableColumn,
@@ -21,9 +21,13 @@ import { ConfigureColumnsModal, MockData } from '../extras';
   styleUrls: ['data-table-rows-example.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DataTableRowsExample {
+export class DataTableRowsExample implements AfterViewInit {
   @ViewChild('basic')
   table: NovoDataTable<MockData>;
+
+  ngAfterViewInit() {
+    this.table.cellHeaders.get(2).setWidth(120);
+  }
 
   // Table configuration
   public dataSetOptions: any[] = [


### PR DESCRIPTION
## **Description**

In an effort to make dynamic column width settings able to be saved, persistent, and ultimately managed by the consumer of the data-table, I am pulling some logic out of the main resizing function to be able to be called independently. There is a width property on IDataTableColumn which can be used, but in order to use this we would need to know the width of the column before initializing the data table, and with the asynchronous way we handle loading data tables and their Preferences that may not always be the case.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**