### PR TITLE
fix(Picker): setting min-width on novo entity picker results

### DIFF
--- a/projects/novo-elements/src/elements/picker/Picker.scss
+++ b/projects/novo-elements/src/elements/picker/Picker.scss
@@ -196,6 +196,7 @@ entity-picker-result.active {
   width: 100%;
   .novo-list {
     background: $white;
+    min-width: 30rem;
     .novo-item-content {
       margin-top: $spacing-sm;
       margin-left: 1.8rem;

--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -136,7 +136,7 @@ export class NovoPickerElement implements OnInit {
   @ViewChild(NovoOverlayTemplateComponent, { static: true })
   public container: NovoOverlayTemplateComponent;
   @ViewChild('input', { static: true })
-  private input: ElementRef;
+  public input: ElementRef;
 
   term: string = '';
   resultsComponent: any;


### PR DESCRIPTION
## **Description**

We have a few different picker results templates which can still display text when their width is pretty small, but the `novo-entity-picker-results` template specifically displays lots of sub data points for each result which requires some space to be able to display properly. We're implementing some of these pickers in a place where the initial field width is pretty narrow, but has room around it for the picker to expand over, so we want to set a min-width here to give it room to display properly.

We're also making the `input` ViewChild property on the NovoPickerElement public so that we can call `focus` on it from a consuming component, since we want to load the pickers conditionally after the template has already been initialized.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**