### PR TITLE
chore(icons): Bump icons version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3686,9 +3686,9 @@
       "dev": true
     },
     "@bullhorn/bullhorn-icons": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/@bullhorn/bullhorn-icons/-/bullhorn-icons-2.21.0.tgz",
-      "integrity": "sha512-yQKADQQIJ31X8+fGwCguVhnHHU85thyBoYG4EeNsGnyx75ZKOGzszv20qDcuOIdui36CmlYcQ52LmOsgBxrdUg==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/@bullhorn/bullhorn-icons/-/bullhorn-icons-2.25.0.tgz",
+      "integrity": "sha512-ZFTM84ecgrWP5eqAYiYO+qnzmfell/i+sVvjyxwLAv9wiF7w+J3Egah4Fx4PuC52AQvV3wTgiq9whjZEYOLTpQ==",
       "dev": true
     },
     "@bullhorn/dragula": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@angular/cli": "^13.3.0",
     "@angular/compiler-cli": "~13.3.0",
     "@angular/language-service": "~13.3.0",
-    "@bullhorn/bullhorn-icons": "^2.21.0",
+    "@bullhorn/bullhorn-icons": "^2.25.0",
     "@github-docs/frontmatter": "^1.3.1",
     "@schematics/angular": "^13.3.0",
     "@semantic-release/changelog": "^6.0.1",


### PR DESCRIPTION
## **Description**

Bumping icons version to pull in some recently added icons

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**