### PR TITLE
feat(picker): add maxlength parameter for characters on input

### DIFF
--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -56,6 +56,7 @@ const PICKER_VALUE_ACCESSOR = {
       (focus)="onFocus($event)"
       (click)="onFocus($event)"
       (blur)="onTouched($event)"
+      [maxlength]="maxlength"
       autocomplete="off"
       #input
       [disabled]="disablePickerInput"
@@ -108,6 +109,8 @@ export class NovoPickerElement implements OnInit {
   autoSelectFirstOption: boolean = true;
   @Input()
   overrideElement: ElementRef;
+  @Input()
+  maxlength: number;
 
   // Disable from typing into the picker (result template does everything)
   @Input()

--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -110,7 +110,7 @@ export class NovoPickerElement implements OnInit {
   @Input()
   overrideElement: ElementRef;
   @Input()
-  maxlength: number = 150;
+  maxlength: number;
 
   // Disable from typing into the picker (result template does everything)
   @Input()

--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -110,7 +110,7 @@ export class NovoPickerElement implements OnInit {
   @Input()
   overrideElement: ElementRef;
   @Input()
-  maxlength: number;
+  maxlength: number = 150;
 
   // Disable from typing into the picker (result template does everything)
   @Input()


### PR DESCRIPTION
## **Description**

Add maxlength parameter for novo-picker

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**