### PR TITLE
fix(pagination): refresh pagination on clear filter

### DIFF
--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
@@ -591,6 +591,9 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
         this.allowMultipleFilters,
         selectedOption,
       );
+      if (!actualFilter) {
+        this.paginationRefreshSubject?.next();
+      }
       this.changeDetectorRef.markForCheck();
     }, 300);
   }
@@ -600,7 +603,6 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
     this.multiSelectedOptions = [];
     this.activeDateFilter = undefined;
     this.filterData(undefined);
-    this.paginationRefreshSubject?.next();
     this.clearOptionFilter();
     this.dropdown.closePanel();
   }

--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
@@ -16,7 +16,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import { Key } from '../../../utils';
-import { fromEvent, Subscription } from 'rxjs';
+import { fromEvent, Subject, Subscription } from 'rxjs';
 import { NovoLabelService } from '../../../services/novo-label-service';
 import { Helpers } from '../../../utils/Helpers';
 import { NovoDropdownElement } from '../../dropdown/Dropdown';
@@ -215,8 +215,13 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
 
   @Input()
   resized: EventEmitter<IDataTableColumn<T>>;
+
   @Input()
   filterTemplate: TemplateRef<any>;
+
+  @Input()
+  paginationRefreshSubject: Subject<void>;
+
   @HostBinding('class.resizable')
   public resizable: boolean;
 
@@ -595,6 +600,7 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
     this.multiSelectedOptions = [];
     this.activeDateFilter = undefined;
     this.filterData(undefined);
+    this.paginationRefreshSubject?.next();
     this.clearOptionFilter();
     this.dropdown.closePanel();
   }

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -126,6 +126,7 @@ import { DataTableState } from './state/data-table-state.service';
               [resized]="resized"
               [defaultSort]="defaultSort"
               [allowMultipleFilters]="allowMultipleFilters"
+              [paginationRefreshSubject]="paginationRefreshSubject"
               [class.empty]="column?.type === 'action' && !column?.label"
               [class.button-header-cell]="column?.type === 'expand' || (column?.type === 'action' && !column?.action?.options)"
               [class.dropdown-header-cell]="column?.type === 'action' && column?.action?.options"


### PR DESCRIPTION
## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

Call paginationRefreshSubject.next() when column filter gets called

#### **Verify that...**

- [X] Any related demos were added and `npm start` and `npm run build` still works
- [X] New demos work in `Safari`, `Chrome` and `Firefox`
- [X] `npm run lint` passes
- [X] `npm test` passes and code coverage is increased
- [X] `npm run build` still works

#### **Bullhorn Internal Developers**
- [X] Run `Novo Automation`

##### **Screenshots**