### PR TITLE
refactor(dragula): deprecating dragula directive and service

### DIFF
--- a/projects/novo-elements/src/elements/dragula/Dragula.module.ts
+++ b/projects/novo-elements/src/elements/dragula/Dragula.module.ts
@@ -3,6 +3,14 @@ import { NgModule } from '@angular/core';
 // APP
 import { NovoDragulaElement } from './Dragula';
 
+/**
+* @deprecated since v8.0.0 - slated for deletion.
+*
+* Moving away from all CommonJS dependencies to improve tree-shaking.
+*
+* Please look at built-in ng or third party drag-drop libraries like
+* angular-draggable-droppable, ngx-drag-drop, ngx-sortablejs, ng2-dragula.
+*/
 @NgModule({
   declarations: [NovoDragulaElement],
   exports: [NovoDragulaElement],

--- a/projects/novo-elements/src/elements/dragula/Dragula.ts
+++ b/projects/novo-elements/src/elements/dragula/Dragula.ts
@@ -3,8 +3,17 @@ import { Directive, ElementRef, Input, OnChanges, OnInit } from '@angular/core';
 // Vendor
 import dragula from '@bullhorn/dragula';
 // APP
+import { notify } from 'novo-elements/utils';
 import { NovoDragulaService } from './DragulaService';
 
+/**
+* @deprecated since v8.0.0 - slated for deletion.
+*
+* Moving away from all CommonJS dependencies to improve tree-shaking.
+*
+* Please look at built-in ng or third party drag-drop libraries like
+* angular-draggable-droppable, ngx-drag-drop, ngx-sortablejs, ng2-dragula.
+*/
 @Directive({
   selector: '[dragula]',
 })
@@ -17,6 +26,7 @@ export class NovoDragulaElement implements OnInit, OnChanges {
   container: any;
 
   constructor(element: ElementRef, private dragulaService: NovoDragulaService) {
+    notify('[dragula] has been deprecated - please look at built-in ng or third party drag-drop libraries instead');
     this.container = element.nativeElement;
   }
 

--- a/projects/novo-elements/src/elements/dragula/DragulaService.ts
+++ b/projects/novo-elements/src/elements/dragula/DragulaService.ts
@@ -3,6 +3,14 @@ import { EventEmitter, Injectable } from '@angular/core';
 // Vendor
 import dragula from '@bullhorn/dragula';
 
+/**
+* @deprecated since v8.0.0 - slated for deletion.
+*
+* Moving away from all CommonJS dependencies to improve tree-shaking.
+*
+* Please look at built-in ng or third party drag-drop libraries like
+* angular-draggable-droppable, ngx-drag-drop, ngx-sortablejs, ng2-dragula.
+*/
 @Injectable()
 export class NovoDragulaService {
   cancel: EventEmitter<any> = new EventEmitter();


### PR DESCRIPTION
## **Description**

deprecating novo-elements dragula implementation in anticipation of deleting it in a future release.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**