### PR TITLE
build(): fixing the firebase preview script by upping node version

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v1
         with:
-          node-version: 14.19.1
+          node-version: 16.13.0
       
       - run: npm ci && npm run build:ci && npm run build:examples && npm run build:demo
       

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v1
         with:
-          node-version: 14.18.2
+          node-version: 16.13.0
       - name: Install Dependencies
         run: |
           npm install

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v1
         with:
-          node-version: 14.19.3
+          node-version: 16.13.0
       - name: Install Dependencies
         run: |
           npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v1
         with:
-          node-version: 14.19.3
+          node-version: 16.13.0
       - name: Install Dependencies
         run: |
           npm ci


### PR DESCRIPTION
## **Description**
our builds started failing with the error
`Firebase CLI v12.0.0 is incompatible with Node.js v14.19.1 Please upgrade Node.js to version >=16.13.0 || >=18.0.0`
during the deploy preview stage so i upped the node version in all of our workflow scripts.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**