### PR TITLE
fix(css): another minor fix to a style encapsulation issue on the tabs component

### DIFF
--- a/projects/novo-elements/src/elements/tabs/Tabs.ts
+++ b/projects/novo-elements/src/elements/tabs/Tabs.ts
@@ -13,6 +13,7 @@ import {
   Optional,
   Output,
   ViewChild,
+  ViewEncapsulation,
 } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { BooleanInput } from 'novo-elements/utils';
@@ -273,6 +274,7 @@ export class NovoTabLinkElement implements OnInit {
   selector: 'novo-nav-outlet',
   template: '<ng-content></ng-content>',
   styleUrls: ['./tab-outlet.scss'],
+  encapsulation: ViewEncapsulation.None,
 })
 export class NovoNavOutletElement {
   items: Array<any> = [];
@@ -312,6 +314,7 @@ export class NovoNavOutletElement {
   },
   template: '<ng-content></ng-content>',
   styleUrls: ['./tab-content.scss'],
+  encapsulation: ViewEncapsulation.None,
 })
 export class NovoNavContentElement {
   @Input()

--- a/projects/novo-elements/src/elements/tabs/tab-content.scss
+++ b/projects/novo-elements/src/elements/tabs/tab-content.scss
@@ -1,4 +1,4 @@
-:host {
+novo-nav-content {
   display: none;
   &.active {
     display: block;

--- a/projects/novo-elements/src/elements/tabs/tab-outlet.scss
+++ b/projects/novo-elements/src/elements/tabs/tab-outlet.scss
@@ -1,3 +1,3 @@
-:host {
+novo-nav-outlet {
   display: block;
 }


### PR DESCRIPTION
## **Description**

encapsulating the styles for the tabs' outlet and content components caused the specificity on their styles to increase which overwrote some styles that novo needed to display the nested tab components properly. it would be preferable to encapsulate these styles, but in the interest of backwards compatibility we're going to not encapsulate them for now. we're still building them with their respective components with the styleUrls property so that's still a big step up from importing them into the root novo-elements stylesheet which is what we were doing before.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**