### PR TITLE
fix(Tipwell): adjusting tipwell containers and width

### DIFF
--- a/projects/novo-elements/src/elements/tip-well/TipWell.scss
+++ b/projects/novo-elements/src/elements/tip-well/TipWell.scss
@@ -25,7 +25,6 @@
       > p {
         @include novo-body-text();
         width: 100%;
-        max-width: 40rem;
         padding: 0;
         text-align: left;
         white-space: pre-line;

--- a/projects/novo-elements/src/elements/tip-well/TipWell.ts
+++ b/projects/novo-elements/src/elements/tip-well/TipWell.ts
@@ -11,9 +11,9 @@ import { NovoLabelService } from 'novo-elements/services';
       <div>
         <i class="bhi-{{ icon }}" *ngIf="icon" [attr.data-automation-id]="'novo-tip-well-icon-' + name"></i>
         <ng-content select="novo-icon"></ng-content>
-        <p *ngIf="sanitize && tip.length" [attr.data-automation-id]="'novo-tip-well-tip-' + name">{{ tip }}</p>
-        <p *ngIf="!sanitize && tipWithStyles" [attr.data-automation-id]="'novo-tip-well-tip-' + name" [innerHTML]="tipWithStyles"></p>
-        <p [attr.data-automation-id]="'novo-tip-well-tip-' + name"><ng-content></ng-content></p>
+        <p *ngIf="sanitize && tip.length" [attr.data-automation-id]="'novo-tip-well-tip-1-' + name">{{ tip }}</p>
+        <p *ngIf="!sanitize && tipWithStyles" [attr.data-automation-id]="'novo-tip-well-tip-2-' + name" [innerHTML]="tipWithStyles"></p>
+        <p *ngIf="(sanitize && !tip.length) || (!sanitize && !tipWithStyles)" [attr.data-automation-id]="'novo-tip-well-tip-3-' + name"><ng-content></ng-content></p>
       </div>
       <button theme="dialogue" size="small" (click)="hideTip()" *ngIf="button" [attr.data-automation-id]="'novo-tip-well-button-' + name">
         {{ buttonText }}


### PR DESCRIPTION
## **Description**

- an extra container was added to tipwells in 7.4.0 here #1328 but there was no logic to not display this container if it was empty, so unless it was the only container being used, it would manifest as a blank container within the tipwell taking up half of the available space which squished the rest into the remaining half.
- a 40rem max width was also added to tipwell `p` elements which caused it to shrink in a lot of places, which may be undesirable.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**