### PR TITLE
fix(Picker): fixing bug preventing active match from resetting when results don't close

### DIFF
--- a/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.ts
+++ b/projects/novo-elements/src/elements/picker/extras/base-picker-results/BasePickerResults.ts
@@ -336,8 +336,8 @@ export class BasePickerResults {
       this.selectingMatches = true;
       if (this.parent.closeOnSelect) {
         this.parent.hideResults();
-        this.selectingMatches = false;
       }
+      this.selectingMatches = false;
     }
     this.ref.markForCheck();
     return false;


### PR DESCRIPTION
## **Description**

when the results component is set to not close on select (like in the case of a Chips multiselect picker), `selectingMatches` was never getting set back to false. this was preventing `activeMatch` from getting reset to the first match when a new search was carried out due to this if check in the `processSearch()` function:
```
if (this.matches.length > 0 && this.autoSelectFirstOption && !this.selectingMatches) {
  this.nextActiveMatch();
}
```

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**