### PR TITLE
fix(Dropdown): fixing a styling bug with data table dropdown cell lists

### DIFF
--- a/projects/novo-elements/src/elements/dropdown/Dropdown.scss
+++ b/projects/novo-elements/src/elements/dropdown/Dropdown.scss
@@ -49,4 +49,29 @@
       background: $light;
     }
   }
+  &.novo-table-dropdown-cell {
+    ::ng-deep list {
+      max-height: 400px;
+      display: block;
+      overflow: auto;
+      padding: 5px 0;
+    }
+    ::ng-deep item {
+      height: 30px !important;
+      padding: 0 16px !important;
+      span {
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        display: inline-block;
+        max-width: 80%;
+      }
+      &.active {
+        font-weight: 500;
+      }
+    }
+    ::ng-deep dropdown-item-header {
+      padding: 0 10px !important;
+    }
+  }
 }


### PR DESCRIPTION
## **Description**

certain DataTable cell dropdowns were relying on styles located in a stylesheet for the Table component, so after we went through and encapsulated styles properly they were no longer getting applied. The Table component is deprecated so the best fix for this was just to copy these styles from that component stylesheet and put them in the appropriate Dropdown component stylesheet.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**