### PR TITLE
feat(test): Configure SonarQube to inspect code coverage from jest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ novo-elements.iml
 
 # misc
 /.angular/cache
+/.scannerwork
 /.sass-cache
 /connect.lock
 /coverage

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,13 @@ module.exports = {
   },
   collectCoverage: true,
   coverageReporters: ['json', 'lcov', 'text', 'text-summary', 'html'],
-  coveragePathIgnorePatterns: ['/node_modules/', 'novo-elements/jest.setup.ts'],
+  coveragePathIgnorePatterns: [
+    '/node_modules/',
+    'novo-elements/jest.setup.ts',
+    '.spec.ts',
+    'projects/novo-examples',
+    'index.ts'
+  ],
   modulePathIgnorePatterns: ['/dist/', '/novo-elements/package.json'],
   testEnvironmentOptions: {
     url: 'http://localhost',

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "copy:schematics": "npx copyfiles -f projects/schematics/*.json dist/novo-elements/schematics/",
     "copy:scss": "node copy-scss.js",
     "test": "jest projects/novo-elements --no-coverage --max-workers=4",
+    "test:coverage": "jest projects/novo-elements --max-workers=4",
     "test:watch": "jest projects/novo-elements --watch",
     "lint": "htmlhint \"projects\" --config .htmlhintrc",
     "lint:scss": "stylelint \"projects/**/*.scss\" --syntax scss",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,10 @@
+sonar.projectKey=org.sonarqube:sonarqube-scanner
+sonar.projectName=Novo Elements
+sonar.projectVersion=1.0
+
+sonar.sources=projects/novo-elements/src
+
+sonar.sourceEncoding=UTF-8
+
+sonar.javascript.lcov.reportPaths=./coverage/lcov.info
+sonar.coverage.exclusions=**/*.spec.ts


### PR DESCRIPTION
## **Description**

Added SonarQube configuration and exclusions to generate code coverage reports

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**