### PR TITLE
fix(dropdown): fixing a styling bug around dropdown icon cursors introduced in v8

### DIFF
--- a/projects/novo-elements/src/elements/dropdown/Dropdown.scss
+++ b/projects/novo-elements/src/elements/dropdown/Dropdown.scss
@@ -4,7 +4,7 @@
   display: inline-block;
   position: relative;
   outline: none;
-  .novo-dropdown-trigger {
+  ::ng-deep .novo-dropdown-trigger {
     cursor: pointer;
     -webkit-appearance: none;
   }


### PR DESCRIPTION
## **Description**

the style encapsulation changes made with the v8 release prevented this styling block from getting applied, which resulted in dropdown trigger icons not displaying the pointer cursor.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**