### PR TITLE
feat(): next-major

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7070,7 +7070,8 @@
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -13140,6 +13141,19 @@
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
+    "moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+    },
+    "moment-timezone": {
+      "version": "0.5.39",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.39.tgz",
+      "integrity": "sha512-hoB6suq4ISDj7BDgctiOy6zljBsdYT0++0ZzZm9rtxIvJhIbQ3nmbgSWe7dNFGurl6/7b1OUkHlmN9JWgXVz7w==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
     "mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -18953,11 +18967,11 @@
       "integrity": "sha512-RX35iq/D+lrsqhcPWIazM9ELkjOe30MSeoBHQHSsRwd1YuhJO5ui1K1/R0r7N3mFvbLBs33idw+eR6j+w6i/DA=="
     },
     "timezone-support": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/timezone-support/-/timezone-support-2.0.2.tgz",
-      "integrity": "sha512-J/1PyHCX76vOPuJzCyHMQMH2wTjXCJ30R5EXaS/QTi+xYsL0thS0pubDrHCWnfG4zU1jpPJtctnBBRCOpcJZeQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/timezone-support/-/timezone-support-3.1.0.tgz",
+      "integrity": "sha512-N04dOzxt7Bw3PZ5ts8ofkQx6RsqWDo8cUQ/a8fdtywB58NIctmdbUUDWZSrgtI7c2jzA6MZ1Z6jY6OtBvc+CUQ==",
       "requires": {
-        "commander": "2.20.0"
+        "moment-timezone": "0.5.39"
       }
     },
     "tmp": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "resize-observer-polyfill": "^1.5.1",
     "rxjs": "~7.8.1",
     "text-mask-addons": "^3.8.0",
-    "timezone-support": "^2.0.2",
+    "timezone-support": "^3.1.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.11.4"
   },

--- a/projects/novo-elements/src/elements/form/controls/timezone/TimezoneControl.spec.ts
+++ b/projects/novo-elements/src/elements/form/controls/timezone/TimezoneControl.spec.ts
@@ -13,7 +13,7 @@ describe('Control: TimezoneControl', () => {
   });
 
   it('should set the options', () => {
-    expect(control.options.length).toBe(387);
+    expect(control.options.length).toBe(351);
   });
 
   it('should set the placeholder', () => {

--- a/projects/novo-elements/src/elements/form/controls/timezone/TimezoneControl.ts
+++ b/projects/novo-elements/src/elements/form/controls/timezone/TimezoneControl.ts
@@ -1,6 +1,6 @@
 // APP
 import { findTimeZone, getZonedTime, listTimeZones } from 'timezone-support';
-import { formatZonedTime } from 'timezone-support/dist/parse-format';
+import { formatZonedTime } from 'novo-elements/utils';
 import { BaseControl, NovoControlConfig } from '../BaseControl';
 
 export class TimezoneControl extends BaseControl {

--- a/projects/novo-elements/src/package.json
+++ b/projects/novo-elements/src/package.json
@@ -18,7 +18,7 @@
     "post-robot": "^8.0.0",
     "rxjs": ">=7",
     "text-mask-addons": "^3.7.0",
-    "timezone-support": "^2.0.2"
+    "timezone-support": "^3.1.0"
   },
   "dependencies": {
     "tslib": "^2.0.0"

--- a/projects/novo-elements/src/utils/date/index.ts
+++ b/projects/novo-elements/src/utils/date/index.ts
@@ -2,3 +2,4 @@ export * from './convert-tokens';
 export * from './Date';
 export * from './Date.types';
 export * from './legacy-parse';
+export * from './timezone-support';

--- a/projects/novo-elements/src/utils/date/timezone-support.ts
+++ b/projects/novo-elements/src/utils/date/timezone-support.ts
@@ -1,0 +1,97 @@
+/** 
+ * Copyright © 2018-2022 Ferdinand Prantl
+ * https://www.npmjs.com/package/timezone-support
+ **/
+
+const formattingToken = /(\[[^[]*\])|([-:/.()\s]+)|(A|a|YYYY|YY?|MM?|DD?|d|hh?|HH?|mm?|ss?|S{1,3}|z|ZZ?)/g;
+const formatTokenFunctions = {};
+const formatters = {};
+
+export function formatZonedTime(time, format) {
+  let formatter = formatters[format];
+  if (!formatter) {
+    formatter = formatters[format] = makeFormatter(format);
+  }
+  return formatter(time);
+}
+
+function makeFormatter (format) {
+  const array = format.match(formattingToken);
+  const { length } = array;
+  for (let i = 0; i < length; ++i) {
+    const token = array[i];
+    const formatter = formatTokenFunctions[token];
+    if (formatter) {
+      array[i] = formatter;
+    } else {
+      array[i] = token.replace(/^\[|\]$/g, '');
+    }
+  }
+  return function (time) {
+    let output = '';
+    for (const token of array) {
+      output += typeof token === 'function' ? token.call(time) : token;
+    }
+    return output;
+  }
+}
+
+const addFormatToken = function (token, padded, property) {
+  const callback = typeof property === 'string' ? function () {
+    return this[property];
+  } : property;
+  if (token) {
+    formatTokenFunctions[token] = callback;
+  }
+  if (padded) {
+    formatTokenFunctions[padded[0]] = function () {
+      return padWithZeros(callback.call(this), padded[1]);
+    }
+  }
+}
+
+addFormatToken('A', 0, function () { return this.hours < 12 ? 'AM' : 'PM' });
+addFormatToken('a', 0, function () { return this.hours < 12 ? 'am' : 'pm' });
+addFormatToken('S', 0, function () { return Math.floor(this.milliseconds / 100) });
+addFormatToken(0, ['SS', 2], function () { return Math.floor(this.milliseconds / 10) });
+addFormatToken(0, ['SSS', 3], 'milliseconds');
+addFormatToken('s', ['ss', 2], 'seconds');
+addFormatToken('m', ['mm', 2], 'minutes');
+addFormatToken('h', ['hh', 2], function () { return (this.hours % 12) || 12 });
+addFormatToken('H', ['HH', 2], 'hours');
+addFormatToken('d', 0, 'dayOfWeek');
+addFormatToken('D', ['DD', 2], 'day');
+addFormatToken('M', ['MM', 2], 'month');
+addFormatToken(0, ['YY', 2], function () { return this.year % 100 });
+addFormatToken('Y', ['YYYY', 4], 'year');
+addFormatToken('z', 0, function () { return this.zone.abbreviation });
+
+function addTimeZoneFormatToken (token, separator) {
+  addFormatToken(token, 0, function () {
+    let offset = -this.zone.offset;
+    const sign = offset < 0 ? '-' : '+';
+    offset = Math.abs(offset);
+    return sign + padWithZeros(Math.floor(offset / 60), 2) + separator + padWithZeros(offset % 60, 2);
+  });
+}
+
+addTimeZoneFormatToken('Z', ':');
+addTimeZoneFormatToken('ZZ', '');
+
+const padToN = [ undefined, undefined, padToTwo, padToThree, padToFour ];
+
+function padWithZeros (number, length) {
+  return padToN[length](number);
+}
+
+function padToTwo (number) {
+  return number > 9 ? number : '0' + number;
+}
+
+function padToThree (number) {
+  return number > 99 ? number : number > 9 ? '0' + number : '00' + number;
+}
+
+function padToFour (number) {
+  return number > 999 ? number : number > 99 ? '0' + number : number > 9 ? '00' + number : '000' + number;
+}


### PR DESCRIPTION
## **Description**

refactor(timezone-support)!: upping version to avoid CommonJS optimization bailouts #1455

**BREAKING CHANGE**: consumers will need to update their timezone-support dependencies to 3.1.0.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**