### PR TITLE
refactor(FileInput): Removed Dragula from FileInput.ts

### DIFF
--- a/projects/novo-elements/src/elements/form/extras/FormExtras.module.ts
+++ b/projects/novo-elements/src/elements/form/extras/FormExtras.module.ts
@@ -1,15 +1,15 @@
 // NG2
+import { DragDropModule } from '@angular/cdk/drag-drop';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { NovoPipesModule } from 'novo-elements/pipes';
-import { NovoDragulaModule, NovoDragulaService } from 'novo-elements/addons/dragula';
 import { NovoButtonModule } from 'novo-elements/elements/button';
 import { NovoCheckboxModule } from 'novo-elements/elements/checkbox';
 import { NovoLoadingModule } from 'novo-elements/elements/loading';
 import { NovoPickerModule } from 'novo-elements/elements/picker';
 import { NovoSelectModule } from 'novo-elements/elements/select';
 import { NovoTooltipModule } from 'novo-elements/elements/tooltip';
+import { NovoPipesModule } from 'novo-elements/pipes';
 import { NovoAddressElement } from './address/Address';
 import { NovoFileInputElement } from './file/FileInput';
 
@@ -22,12 +22,11 @@ import { NovoFileInputElement } from './file/FileInput';
     NovoSelectModule,
     NovoPickerModule,
     NovoLoadingModule,
-    NovoDragulaModule,
     NovoTooltipModule,
     NovoCheckboxModule,
+    DragDropModule
   ],
   declarations: [NovoAddressElement, NovoFileInputElement],
   exports: [NovoAddressElement, NovoFileInputElement],
-  providers: [NovoDragulaService],
 })
 export class NovoFormExtrasModule {}

--- a/projects/novo-elements/src/elements/form/extras/file/FileInput.html
+++ b/projects/novo-elements/src/elements/form/extras/file/FileInput.html
@@ -1,0 +1,106 @@
+<div #container></div>
+<ng-template #fileInput>
+  <div class="file-input-group" [class.disabled]="disabled" [class.active]="active">
+    <input
+      #inputElement
+      *ngIf="!layoutOptions.customActions"
+      type="file"
+      [name]="name"
+      [attr.id]="name"
+      (change)="check($event)"
+      [attr.multiple]="multiple"
+      tabindex="-1"
+      [attr.data-feature-id]="dataFeatureId"
+    />
+    <input
+      #inputElement
+      *ngIf="layoutOptions.customActions"
+      type="file"
+      [name]="name"
+      [attr.id]="name"
+      (change)="customCheck($event)"
+      [attr.multiple]="multiple"
+      tabindex="-1"
+      [attr.data-feature-id]="dataFeatureId"
+    />
+    <section [ngSwitch]="layoutOptions.labelStyle">
+      <label *ngSwitchCase="'no-box'" [attr.for]="name" class="no-box">
+        <div>
+          <i class="bhi-dropzone"></i>{{ placeholder || labels.chooseAFile }} {{ labels.or }}
+          <strong class="link">{{ labels.clickToBrowse }}</strong>
+        </div>
+      </label>
+      <label *ngSwitchDefault [attr.for]="name" class="boxed">
+        <span>{{ placeholder || labels.chooseAFile }}</span>
+        <small
+          >{{ labels.or }} <strong class="link">{{ labels.clickToBrowse }}</strong></small
+        >
+      </label>
+    </section>
+  </div>
+</ng-template>
+<ng-template #fileOutput>
+  <div class="file-output-group" cdkDropList [cdkDropListDisabled]="outputFileDraggingDisabled" (cdkDropListDropped)="dropOutputItem($event)">
+    <div class="file-item" cdkDrag *ngFor="let file of files" [class.disabled]="disabled">
+      <i *ngIf="layoutOptions.draggable" class="bhi-move"></i>
+      <label *ngIf="file.link"
+        ><span
+          ><a href="{{ file.link }}" target="_blank">{{ file.name | decodeURI }}</a></span
+        ><span *ngIf="file.description">||</span><span>{{ file.description }}</span></label
+      >
+      <label *ngIf="!file.link">{{ file.name | decodeURI }}</label>
+      <div class="actions" [attr.data-automation-id]="'file-actions'" *ngIf="file.loaded">
+        <div *ngIf="!layoutOptions.customActions">
+          <button
+            *ngIf="layoutOptions.download"
+            type="button"
+            theme="icon"
+            icon="save"
+            (click)="download(file)"
+            [attr.data-automation-id]="'file-download'"
+            tabindex="-1"
+          ></button>
+          <button
+            *ngIf="!disabled && (layoutOptions.removable || (!layoutOptions.removable && layoutOptions.removableWhenNew && !file.link))"
+            type="button"
+            theme="icon"
+            icon="close"
+            (click)="remove(file)"
+            [attr.data-automation-id]="'file-remove'"
+            tabindex="-1"
+          ></button>
+        </div>
+        <div *ngIf="layoutOptions.customActions">
+          <button
+            *ngIf="layoutOptions.edit && !disabled"
+            type="button"
+            theme="icon"
+            icon="edit"
+            (click)="customEdit(file)"
+            [attr.data-automation-id]="'file-edit'"
+            tabindex="-1"
+          ></button>
+          <button
+            *ngIf="layoutOptions.download"
+            type="button"
+            theme="icon"
+            icon="save"
+            (click)="customSave(file)"
+            [attr.data-automation-id]="'file-download'"
+            tabindex="-1"
+          ></button>
+          <button
+            *ngIf="!disabled"
+            type="button"
+            theme="icon"
+            icon="close"
+            (click)="customDelete(file)"
+            [attr.data-automation-id]="'file-remove'"
+            tabindex="-1"
+          ></button>
+        </div>
+      </div>
+      <novo-loading *ngIf="!file.loaded"></novo-loading>
+    </div>
+  </div>
+</ng-template>

--- a/projects/novo-elements/src/elements/form/extras/file/FileInput.scss
+++ b/projects/novo-elements/src/elements/form/extras/file/FileInput.scss
@@ -1,5 +1,38 @@
 @import "../../../../styles/variables.scss";
 
+@mixin file-item-style() {
+  background-color: $white;
+  box-shadow: 0 1px 4px rgba(#000, 0.15), 0 2px 10px rgba(#000, 0.09);
+  padding: 4px 12px;
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  i.bhi-move {
+    color: $grey;
+    padding-right: 0.75em;
+    padding-bottom: 4px;
+    font-size: 2em;
+    cursor: -webkit-grab;
+    cursor: grab;
+  }
+  label {
+    flex: 1;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    span {
+      margin: 0 8px;
+    }
+  }
+  button {
+    font-size: 1.4rem;
+    width: 42px;
+    height: 42px;
+    padding: 4px;
+    color: $grey;
+  }
+}
+
 novo-file-input {
   display: flex;
   flex-flow: row wrap;
@@ -10,39 +43,10 @@ novo-file-input {
     width: 100%;
     margin-top: 15px;
     .file-item {
-      background-color: $white;
-      box-shadow: 0 1px 4px rgba(#000, 0.15), 0 2px 10px rgba(#000, 0.09);
+      @include file-item-style;
       margin-bottom: 15px;
       position: relative; //border-radius: 3px;
-      display: flex;
-      flex-flow: row nowrap;
-      align-items: center;
-      padding: 4px 12px;
       width: 100%;
-      i.bhi-move {
-        color: $grey;
-        padding-right: 0.75em;
-        padding-bottom: 4px;
-        font-size: 2em;
-        cursor: -webkit-grab;
-        cursor: grab;
-      }
-      label {
-        flex: 1;
-        white-space: nowrap;
-        text-overflow: ellipsis;
-        overflow: hidden;
-        span {
-          margin: 0 8px;
-        }
-      }
-      button {
-        font-size: 1.4rem;
-        width: 42px;
-        height: 42px;
-        padding: 4px;
-        color: $grey;
-      }
       button:hover,
       button:focus,
       button.active {
@@ -52,6 +56,12 @@ novo-file-input {
       &.disabled {
         box-shadow: none;
         border: 2px dashed $grey;
+      }
+    }
+    &.cdk-drop-list-dragging {
+      cursor: grabbing;
+      .file-item {
+        transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
       }
     }
   }
@@ -119,3 +129,21 @@ novo-file-input {
     }
   }
 }
+
+// Configuration for CDK Drag/Drop
+// https://material.angular.io/cdk/drag-drop/overview
+
+.cdk-drag-preview.file-item {
+  cursor: grab;
+  @include file-item-style;
+}
+
+.cdk-drag-placeholder.file-item {
+  opacity: 0;
+}
+
+// This element will be outside of component layout, at the DOM root
+.cdk-drag-animating.file-item {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}
+

--- a/projects/novo-elements/src/elements/form/extras/file/FileInput.spec.ts
+++ b/projects/novo-elements/src/elements/form/extras/file/FileInput.spec.ts
@@ -1,25 +1,29 @@
 // NG
-import { async, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { NovoDragulaElement, NovoDragulaService } from 'novo-elements/addons/dragula';
-import { DecodeURIPipe } from 'novo-elements/pipes';
-import { NovoLabelService } from 'novo-elements/services';
 import { NovoLoadingElement } from 'novo-elements/elements/loading';
+import { DecodeURIPipe } from 'novo-elements/pipes';
+import { GlobalRef, NovoLabelService } from 'novo-elements/services';
 // App
+import { DragDropModule } from '@angular/cdk/drag-drop';
 import { NovoFileInputElement } from './FileInput';
 
 describe('Elements: NovoFileInputElement', () => {
-  let fixture;
-  let component;
-
-  const FakeEvent = () => {};
+  let fixture: ComponentFixture<NovoFileInputElement>;
+  let component: NovoFileInputElement;
+  let mockGlobal: {
+    nativeWindow: {
+      open: (url, target) => {}
+    }
+  };
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [NovoFileInputElement, NovoLoadingElement, NovoDragulaElement, DecodeURIPipe],
+      imports: [DragDropModule],
+      declarations: [NovoFileInputElement, NovoLoadingElement, DecodeURIPipe],
       providers: [
         { provide: NovoLabelService, useClass: NovoLabelService },
-        { provide: NovoDragulaService, useClass: NovoDragulaService },
+        { provide: GlobalRef, useValue: mockGlobal }
       ],
     }).compileComponents();
     fixture = TestBed.createComponent(NovoFileInputElement);
@@ -30,12 +34,6 @@ describe('Elements: NovoFileInputElement', () => {
   });
 
   describe('Method: ngOnInit()', () => {
-    it('should setup drag events', () => {
-      expect(component.ngOnInit).toBeDefined();
-      jest.spyOn(component.element.nativeElement, 'addEventListener');
-      component.ngOnInit();
-      expect(component.element.nativeElement.addEventListener).toHaveBeenCalled();
-    });
     it('should update layout', () => {
       expect(component.ngOnInit).toBeDefined();
       jest.spyOn(component, 'updateLayout');
@@ -43,16 +41,9 @@ describe('Elements: NovoFileInputElement', () => {
       expect(component.updateLayout).toHaveBeenCalled();
     });
     it('should setup initial files list', () => {
-      expect(component.ngOnInit).toBeDefined();
-      jest.spyOn(component, 'setInitialFileList');
+      component.value = [{name: 'TestFile1'}];
       component.ngOnInit();
-      expect(component.setInitialFileList).toHaveBeenCalled();
-    });
-    it('should initialize dragula', () => {
-      expect(component.ngOnInit).toBeDefined();
-      jest.spyOn(component, 'initializeDragula');
-      component.ngOnInit();
-      expect(component.initializeDragula).toHaveBeenCalled();
+      expect(component.files[0].name).toBe('TestFile1');
     });
   });
   describe('Method: updateLayout()', () => {
@@ -70,21 +61,6 @@ describe('Elements: NovoFileInputElement', () => {
         draggable: false,
       });
       expect(component.insertTemplatesBasedOnLayout).toHaveBeenCalled();
-    });
-  });
-  describe('Method: initializeDragula()', () => {
-    it('should correctly initialize dragula', () => {
-      const expectedBag = 'file-output-1';
-      component.dragula = {
-        bags: [{ name: 'TEST', drake: {} }],
-        setOptions: () => {},
-      };
-      expect(component.initializeDragula).toBeDefined();
-      expect(component.fileOutputBag).not.toBeDefined();
-      jest.spyOn(component.dragula, 'setOptions');
-      component.initializeDragula();
-      expect(component.fileOutputBag).toBe(expectedBag);
-      expect(component.dragula.setOptions).toHaveBeenCalled();
     });
   });
   describe('Method: insertTemplatesBasedOnLayout()', () => {
@@ -107,15 +83,6 @@ describe('Elements: NovoFileInputElement', () => {
       const insertedOrder = component.insertTemplatesBasedOnLayout();
       expect(component.container.createEmbeddedView).toHaveBeenCalled();
       expect(insertedOrder).toEqual(expected);
-    });
-  });
-
-  describe('Method: ngOnDestroy()', () => {
-    it('should destroy events.', () => {
-      expect(component.ngOnDestroy).toBeDefined();
-      jest.spyOn(component.element.nativeElement, 'removeEventListener');
-      component.ngOnDestroy();
-      expect(component.element.nativeElement.removeEventListener).toHaveBeenCalled();
     });
   });
 
@@ -170,7 +137,7 @@ describe('Elements: NovoFileInputElement', () => {
     it('should return true if null custom validation', () => {
       component.layoutOptions = {
         customValidation: null,
-      };
+      } as any;
       const result = component.validate([]);
       expect(result).toBeTruthy();
     });
@@ -196,35 +163,15 @@ describe('Elements: NovoFileInputElement', () => {
       expect(result).toBeFalsy();
     });
   });
-  //
-  // describe('Method: dragEnterHandler(event)', () => {
-  //     it('should set active to true.', () => {
-  //         expect(component.dragEnterHandler).toBeDefined();
-  //         let evt = new FakeEvent();
-  //         component.dragEnterHandler(evt);
-  //         expect(evt.dataTransfer.dropEffect).toBe('copy');
-  //         expect(component.active).toBe(true);
-  //     });
-  // });
-  //
-  // describe('Method: dragLeaveHandler(event)', () => {
-  //     it('should set active to false.', () => {
-  //         expect(component.dragLeaveHandler).toBeDefined();
-  //         let evt = new FakeEvent();
-  //         component.dragLeaveHandler(evt);
-  //         expect(component.active).toBe(false);
-  //     });
-  // });
-  //
-  // describe('Method: dropHandler(event)', () => {
-  //     it('should set active to false.', () => {
-  //         expect(component.dropHandler).toBeDefined();
-  //         let evt = new FakeEvent();
-  //         component.dropHandler(evt);
-  //         expect(component.active).toBe(false);
-  //     });
-  // });
-  //
+
+  describe('Drag events', () => {
+    it('should rearrange items when dragged across', () => {
+      component.value = [{name: 'TestFile1'}, {name: 'TestFile2'}] as any;
+      fixture.detectChanges();
+      fixture.debugElement.query(By.css('.file-output-group')).triggerEventHandler('cdkDropListDropped', {previousIndex: 1, currentIndex: 0});
+      expect(component.files[0].name).toBe('TestFile2');
+    });
+  });
   describe('Method: writeValue()', () => {
       it('should change the value', () => {
         component.writeValue(10);
@@ -252,16 +199,4 @@ describe('Elements: NovoFileInputElement', () => {
       });
     });
 });
-  //
-  // describe('Method: registerOnChange()', () => {
-  //     it('should be defined.', () => {
-  //         expect(component.registerOnChange).toBeDefined();
-  //     });
-  // });
-  //
-  // describe('Method: registerOnTouched()', () => {
-  //     it('should be defined.', () => {
-  //         expect(component.registerOnTouched).toBeDefined();
-  //     });
-  // });
 });

--- a/projects/novo-elements/src/elements/form/extras/file/FileInput.ts
+++ b/projects/novo-elements/src/elements/form/extras/file/FileInput.ts
@@ -1,13 +1,14 @@
 // NG2
 import { FocusKeyManager } from '@angular/cdk/a11y';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
+import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import {
   Component,
   ElementRef,
   EventEmitter,
   HostBinding,
+  HostListener,
   Input,
-  OnDestroy,
   OnInit,
   Optional,
   Output,
@@ -15,13 +16,12 @@ import {
   TemplateRef,
   ViewChild,
   ViewContainerRef,
-  ViewEncapsulation,
+  ViewEncapsulation
 } from '@angular/core';
 import { ControlValueAccessor, FormGroupDirective, NgControl, NgForm } from '@angular/forms';
-import { NovoDragulaService } from 'novo-elements/addons/dragula';
-import { NovoLabelService } from 'novo-elements/services';
 import { CanUpdateErrorStateCtor, ErrorStateMatcher, mixinErrorState } from 'novo-elements/elements/common';
 import { NovoFieldControl } from 'novo-elements/elements/field';
+import { GlobalRef, NovoLabelService } from 'novo-elements/services';
 import { NovoFile } from './extras/file/File';
 
 // Value accessor for the component (supports ngModel)
@@ -48,118 +48,11 @@ const NovoFileInputMixins: CanUpdateErrorStateCtor & typeof NovoFileInputBase = 
 @Component({
   selector: 'novo-file-input',
   providers: [{ provide: NovoFieldControl, useExisting: NovoFileInputElement }],
-  template: `
-    <div #container></div>
-    <ng-template #fileInput>
-      <div class="file-input-group" [class.disabled]="disabled" [class.active]="active">
-        <input
-          #inputElement
-          *ngIf="!layoutOptions.customActions"
-          type="file"
-          [name]="name"
-          [attr.id]="name"
-          (change)="check($event)"
-          [attr.multiple]="multiple"
-          tabindex="-1"
-          [attr.data-feature-id]="dataFeatureId"
-        />
-        <input
-          #inputElement
-          *ngIf="layoutOptions.customActions"
-          type="file"
-          [name]="name"
-          [attr.id]="name"
-          (change)="customCheck($event)"
-          [attr.multiple]="multiple"
-          tabindex="-1"
-          [attr.data-feature-id]="dataFeatureId"
-        />
-        <section [ngSwitch]="layoutOptions.labelStyle">
-          <label *ngSwitchCase="'no-box'" [attr.for]="name" class="no-box">
-            <div>
-              <i class="bhi-dropzone"></i>{{ placeholder || labels.chooseAFile }} {{ labels.or }}
-              <strong class="link">{{ labels.clickToBrowse }}</strong>
-            </div>
-          </label>
-          <label *ngSwitchDefault [attr.for]="name" class="boxed">
-            <span>{{ placeholder || labels.chooseAFile }}</span>
-            <small
-              >{{ labels.or }} <strong class="link">{{ labels.clickToBrowse }}</strong></small
-            >
-          </label>
-        </section>
-      </div>
-    </ng-template>
-    <ng-template #fileOutput>
-      <div class="file-output-group" [dragula]="fileOutputBag" [dragulaModel]="files">
-        <div class="file-item" *ngFor="let file of files" [class.disabled]="disabled">
-          <i *ngIf="layoutOptions.draggable" class="bhi-move"></i>
-          <label *ngIf="file.link"
-            ><span
-              ><a href="{{ file.link }}" target="_blank">{{ file.name | decodeURI }}</a></span
-            ><span *ngIf="file.description">||</span><span>{{ file.description }}</span></label
-          >
-          <label *ngIf="!file.link">{{ file.name | decodeURI }}</label>
-          <div class="actions" [attr.data-automation-id]="'file-actions'" *ngIf="file.loaded">
-            <div *ngIf="!layoutOptions.customActions">
-              <button
-                *ngIf="layoutOptions.download"
-                type="button"
-                theme="icon"
-                icon="save"
-                (click)="download(file)"
-                [attr.data-automation-id]="'file-download'"
-                tabindex="-1"
-              ></button>
-              <button
-                *ngIf="!disabled && (layoutOptions.removable || (!layoutOptions.removable && layoutOptions.removableWhenNew && !file.link))"
-                type="button"
-                theme="icon"
-                icon="close"
-                (click)="remove(file)"
-                [attr.data-automation-id]="'file-remove'"
-                tabindex="-1"
-              ></button>
-            </div>
-            <div *ngIf="layoutOptions.customActions">
-              <button
-                *ngIf="layoutOptions.edit && !disabled"
-                type="button"
-                theme="icon"
-                icon="edit"
-                (click)="customEdit(file)"
-                [attr.data-automation-id]="'file-edit'"
-                tabindex="-1"
-              ></button>
-              <button
-                *ngIf="layoutOptions.download"
-                type="button"
-                theme="icon"
-                icon="save"
-                (click)="customSave(file)"
-                [attr.data-automation-id]="'file-download'"
-                tabindex="-1"
-              ></button>
-              <button
-                *ngIf="!disabled"
-                type="button"
-                theme="icon"
-                icon="close"
-                (click)="customDelete(file)"
-                [attr.data-automation-id]="'file-remove'"
-                tabindex="-1"
-              ></button>
-            </div>
-          </div>
-          <novo-loading *ngIf="!file.loaded"></novo-loading>
-        </div>
-      </div>
-    </ng-template>
-  `,
+  templateUrl: './FileInput.html',
   styleUrls: ['./FileInput.scss'],
   encapsulation: ViewEncapsulation.None,
 })
-export class NovoFileInputElement extends NovoFileInputMixins implements NovoFieldControl<any>, ControlValueAccessor, OnInit, OnDestroy {
+export class NovoFileInputElement extends NovoFileInputMixins implements NovoFieldControl<any>, ControlValueAccessor, OnInit {
   private _uniqueId: string = `novo-file-input-${++nextId}`;
   /** The aria-describedby attribute on the chip list for improved a11y. */
   _ariaDescribedby: string;
@@ -200,7 +93,7 @@ export class NovoFileInputElement extends NovoFileInputMixins implements NovoFie
     edit?: boolean;
     labelStyle?: string;
     draggable?: boolean;
-    customActions: boolean;
+    customActions?: boolean;
     removable?: boolean;
     customValidation?: { action: string; fn: Function }[];
     removableWhenNew?: boolean;
@@ -219,8 +112,7 @@ export class NovoFileInputElement extends NovoFileInputMixins implements NovoFie
   @Output()
   upload: EventEmitter<any> = new EventEmitter();
 
-  elements: Array<any> = [];
-  files: Array<any> = [];
+  files: NovoFile[] = [];
   model: any;
   active: boolean = false;
   commands: any;
@@ -278,9 +170,8 @@ export class NovoFileInputElement extends NovoFileInputMixins implements NovoFie
   protected _placeholder: string;
 
   constructor(
-    private element: ElementRef,
     public labels: NovoLabelService,
-    private dragula: NovoDragulaService,
+    private globalRef: GlobalRef,
     _defaultErrorStateMatcher: ErrorStateMatcher,
     @Optional() _parentForm: NgForm,
     @Optional() _parentFormGroup: FormGroupDirective,
@@ -290,33 +181,12 @@ export class NovoFileInputElement extends NovoFileInputMixins implements NovoFie
     if (_ngControl) {
       _ngControl.valueAccessor = this;
     }
-    this.commands = {
-      dragenter: this.dragEnterHandler.bind(this),
-      dragleave: this.dragLeaveHandler.bind(this),
-      dragover: this.dragOverHandler.bind(this),
-      drop: this.dropHandler.bind(this),
-    };
   }
 
   ngOnInit() {
-    ['dragenter', 'dragleave', 'dragover', 'drop'].forEach((type) => {
-      this.element.nativeElement.addEventListener(type, this.commands[type]);
-    });
     this.updateLayout();
-    this.initializeDragula();
     this.setInitialFileList();
     this.dataFeatureId = this.dataFeatureId ? this.dataFeatureId : this.name;
-  }
-
-  ngOnDestroy() {
-    ['dragenter', 'dragleave', 'dragover', 'drop'].forEach((type) => {
-      this.element.nativeElement.removeEventListener(type, this.commands[type]);
-    });
-    const dragulaHasFileOutputBag =
-      this.dragula.bags.length > 0 && this.dragula.bags.filter((x) => x.name === this.fileOutputBag).length > 0;
-    if (dragulaHasFileOutputBag) {
-      this.dragula.destroy(this.fileOutputBag);
-    }
   }
 
   updateLayout() {
@@ -339,21 +209,18 @@ export class NovoFileInputElement extends NovoFileInputMixins implements NovoFie
     return order;
   }
 
-  initializeDragula() {
-    this.fileOutputBag = `file-output-${this.dragula.bags.length}`;
-    this.dragula.setOptions(this.fileOutputBag, {
-      moves: (el, container, handle) => {
-        return this.layoutOptions.draggable;
-      },
-    });
+  get outputFileDraggingDisabled(): boolean {
+    const draggable = this.layoutOptions?.draggable;
+    return draggable != null && !draggable;
   }
 
-  setInitialFileList() {
+  private setInitialFileList() {
     if (this.value) {
       this.files = this.value;
     }
   }
 
+  @HostListener('dragenter', ['$event'])
   dragEnterHandler(event) {
     event.preventDefault();
     event.dataTransfer.dropEffect = 'copy';
@@ -361,6 +228,7 @@ export class NovoFileInputElement extends NovoFileInputMixins implements NovoFie
     this.active = true;
   }
 
+  @HostListener('dragleave', ['$event'])
   dragLeaveHandler(event) {
     event.preventDefault();
     if (this.target === event.target) {
@@ -368,11 +236,13 @@ export class NovoFileInputElement extends NovoFileInputMixins implements NovoFie
     }
   }
 
+  @HostListener('dragover', ['$event'])
   dragOverHandler(event) {
     event.preventDefault();
     // no-op
   }
 
+  @HostListener('drop', ['$event'])
   dropHandler(event) {
     event.preventDefault();
     this.visible = false;
@@ -387,6 +257,10 @@ export class NovoFileInputElement extends NovoFileInputMixins implements NovoFie
       this.process(this.multiple ? filelist : [filelist[0]]);
     }
     this.active = false;
+  }
+
+  dropOutputItem(event: CdkDragDrop<NovoFile[]>) {
+    moveItemInArray(this.files, event.previousIndex, event.currentIndex);
   }
 
   writeValue(model: any): void {
@@ -421,7 +295,7 @@ export class NovoFileInputElement extends NovoFileInputMixins implements NovoFie
     return passedValidation;
   }
 
-  process(filelist) {
+  private process(filelist) {
     if (this.validate(filelist)) {
       Promise.all(filelist.map((file) => this.readFile(file))).then((files) => {
         if (this.multiple) {
@@ -436,7 +310,8 @@ export class NovoFileInputElement extends NovoFileInputMixins implements NovoFie
   }
 
   download(file) {
-    window.open(file.dataURL, '_blank');
+    // Using an injected instance of window to make sure that unit tests do not open a new window, even accidentally
+    this.globalRef.nativeWindow.open(file.dataURL, '_blank');
   }
 
   remove(file) {
@@ -448,7 +323,7 @@ export class NovoFileInputElement extends NovoFileInputMixins implements NovoFie
     this.onModelChange(this.model);
   }
 
-  readFile(file) {
+  private readFile(file) {
     return new NovoFile(file).read();
   }
 

--- a/projects/novo-elements/src/services/global/global.service.ts
+++ b/projects/novo-elements/src/services/global/global.service.ts
@@ -4,6 +4,7 @@ export interface Global {}
 
 export abstract class GlobalRef {
   abstract get nativeGlobal(): Global;
+  abstract get nativeWindow(): Window;
 }
 
 @Injectable()
@@ -11,10 +12,16 @@ export class BrowserGlobalRef extends GlobalRef {
   get nativeGlobal(): Global {
     return window as Global;
   }
+  get nativeWindow(): Window {
+    return window;
+  }
 }
 export class NodeGlobalRef extends GlobalRef {
   get nativeGlobal(): Global {
     throw new Error(`global doesn't compile for some reason`);
     // return global as Global;
+  }
+  get nativeWindow(): Window {
+    throw new Error('Node does not have a window object');
   }
 }


### PR DESCRIPTION
## **Description**

Removes use of Dragula from FileInput in favor of Angular CDK drag-drop module (progressing towards removal of the Dragula module)

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**