### PR TITLE
fix(DragDrop): Address dragdrop parenting issues

### DIFF
--- a/projects/novo-elements/src/elements/drag-drop/drag-drop-box.spec.ts
+++ b/projects/novo-elements/src/elements/drag-drop/drag-drop-box.spec.ts
@@ -27,6 +27,7 @@ class FakeEvent {
         }
     }
     preventDefault() {}
+    stopPropagation() {}
 
     dataTransfer = {
       effectAllowed: 'none',


### PR DESCRIPTION
## **Description**

Fixes to drag-drop module when regions are contained within each other (as in BhMenu in Novo)

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`
