### PR TITLE
fix(FormControl): Prevent input events from firing if a mask has reje…

### DIFF
--- a/projects/novo-elements/src/elements/form/ControlTemplates.ts
+++ b/projects/novo-elements/src/elements/form/ControlTemplates.ts
@@ -36,7 +36,8 @@ import { NovoTemplateService } from 'novo-elements/services';
           [id]="control.key"
           [type]="control?.type"
           [placeholder]="control?.placeholder"
-          (input)="methods.emitChange($event)"
+          (input)="methods.handleSimpleTextInput($event)"
+          (accept)="methods.handleAccept($event)"
           (focus)="methods.handleFocus($event)"
           (blur)="methods.handleBlur($event)"
           autocomplete

--- a/projects/novo-elements/src/elements/form/controls/BaseControl.spec.ts
+++ b/projects/novo-elements/src/elements/form/controls/BaseControl.spec.ts
@@ -1,6 +1,8 @@
 // APP
 import { BaseControl } from './BaseControl';
 
+const testTextMaskOptions = /^TEST_MASK_OPTIONS$/;
+
 describe('Control: BaseControl', () => {
   let control;
 
@@ -85,7 +87,7 @@ describe('Control: BaseControl', () => {
         layoutOptions: { removable: false },
         fileBrowserImageUploadUrl: '/foo/bar/baz',
         textMaskEnabled: true,
-        maskOptions: { mask: ['TEST_MASK_OPTIONS'], keepCharPositions: false, guide: true },
+        maskOptions: { mask: testTextMaskOptions, keepCharPositions: false, guide: true },
       });
     });
 
@@ -150,7 +152,7 @@ describe('Control: BaseControl', () => {
       expect(control.textMaskEnabled).toEqual(true);
     });
     it('should set maskOptions', () => {
-      expect(control.maskOptions).toEqual({ mask: ['TEST_MASK_OPTIONS'], keepCharPositions: false, guide: true });
+      expect(control.maskOptions).toEqual({ mask: testTextMaskOptions, keepCharPositions: false, guide: true });
     });
   });
 

--- a/projects/novo-examples/src/form-controls/form/text-based-controls/text-based-controls-example.html
+++ b/projects/novo-examples/src/form-controls/form/text-based-controls/text-based-controls-example.html
@@ -8,6 +8,9 @@
         <novo-control [form]="textForm" [control]="textControl"></novo-control>
     </div>
     <div class="novo-form-row">
+        <novo-control [form]="textForm" [control]="textMaskControl"></novo-control>
+    </div>
+    <div class="novo-form-row">
         <novo-control [autoFocus]="true" [form]="textForm" [control]="emailControl"></novo-control>
     </div>
     <div class="novo-form-row">

--- a/projects/novo-examples/src/form-controls/form/text-based-controls/text-based-controls-example.ts
+++ b/projects/novo-examples/src/form-controls/form/text-based-controls/text-based-controls-example.ts
@@ -12,6 +12,7 @@ import { AceEditorControl, FormUtils, QuickNoteControl, TextAreaControl, TextBox
 export class TextBasedControlsExample {
   public quickNoteConfig: any;
   public textControl: any;
+  public textMaskControl: any;
   public emailControl: any;
   public numberControl: any;
   public currencyControl: any;
@@ -56,6 +57,18 @@ export class TextBasedControlsExample {
       value: 'HI',
       required: true,
     });
+    this.textMaskControl = new TextBoxControl({
+      key: 'textmask',
+      maxlength: 10,
+      label: 'Text Control with Mask (hexadecimal)',
+      textMaskEnabled: true,
+      maskOptions: {
+        mask: /^[\da-fA-F]{0,10}$/,
+        keepCharPositions: false,
+        guide: false
+      },
+      value: '9F'
+    })
     this.textAreaControl = new TextAreaControl({
       key: 'textarea',
       label: 'Text Area',
@@ -90,6 +103,7 @@ export class TextBasedControlsExample {
     this.aceEditorControl = new AceEditorControl({ key: 'ace', label: 'CODE', tooltip: 'CODE', value: 'var i = 0;' });
     this.textForm = formUtils.toFormGroup([
       this.textControl,
+      this.textMaskControl,
       this.emailControl,
       this.textAreaControl,
       this.numberControl,


### PR DESCRIPTION
## **Description**

Adjust text controls so that they use the (accept) event for recognizing input changes if a mask is enabled.

Added a demo of form masking to the form examples page

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**