### PR TITLE
docs(v9): Add v9 documentation page

### DIFF
--- a/projects/novo-examples/src/components/field/field-design.md
+++ b/projects/novo-examples/src/components/field/field-design.md
@@ -3,7 +3,6 @@ section: Components
 page: Field
 title: Design
 order: 2
-tag: experiment
 ---
 
 <novo-grid columns="2" align="start" gap="2rem">

--- a/projects/novo-examples/src/components/query-builder/query-builder-design.md
+++ b/projects/novo-examples/src/components/query-builder/query-builder-design.md
@@ -3,7 +3,6 @@ section: Components
 page: Query Builder
 title: Design
 order: 2
-tag: experiment
 ---
 
 ## Usage

--- a/projects/novo-examples/src/examples.routes.ts
+++ b/projects/novo-examples/src/examples.routes.ts
@@ -6364,9 +6364,36 @@ export class v8Page {
 
 @Component({
   selector: 'v9-page',
-  template: `<h1>📢  --Release month TBD-- (version 9)</h1>
-<p><strong>CommonJS library removal</strong>: Version 9 continues to remove some of the dependence on CommonJS libraries. The previous release deprecated Dragula, as well as some of our date-fns. This release has a new target.</p>
-<p><strong>Ace Editor removal / Code Editor</strong>: In V9, we have deprecated the <code>novo-ace-editor</code> component, and its reliance on the Ace Editor. It is being replaced with <code>novo-code-editor</code>, implemented using the <a href="https://codemirror.net/">CodeMirror</a> library.</p>
+  template: `<h1>📢  December 2023 (version 9)</h1>
+<h1>Continuing CommonJS library removal</h1>
+<p>The previous release of novo-elements, version 8, started to deprecate some modules that relied on CommonJS libraries. In version 9, we are introducing some new options to replace the tools that we've removed.</p>
+<h2>NovoDragDrop</h2>
+<p>While there are several third-party options to replace Dragula (deprecated in v8), our drag-and-drop utility, such as <a href="https://v7.material.angular.io/cdk/drag-drop/overview">cdkDrag</a> and <a href="https://www.npmjs.com/package/ngx-drag-drop">ngx-drag-drop</a>, we are also adding the <a href="https://bullhorn.github.io/novo-elements/docs/#/utils/drag%20and%20drop"><code>NovoDragDropModule</code></a>, which provides drag and drop capability with support for grid layouts. We have also added an example page to demonstrate its usage.</p>
+<p>We recommend that users switch from the dragula directive to novoDragDrop, cdkDrag, or a third-party solution in anticipation of future optimization strategies.</p>
+<h2>Code Editor</h2>
+<p>In version 8, we deprecated Ace Editor. This module has not been removed yet, but there is now a recommended option to replace it: <a href="https://bullhorn.github.io/novo-elements/docs/#/utils/code%20editor">The Novo Code Editor</a>, backed by <a href="https://codemirror.net/">Codemirror</a>. This supports basic syntax highlighting for JavaScript.</p>
+<h2>Text masks</h2>
+<p><code>angular2-text-mask</code>, a CommonJS dependency used for text masking support, has been exchanged for <code>imask</code>. This may affect the arguments provided to <code>maskOptions.mask</code> in the <code>TextBoxControl</code> type. The <a href="https://bullhorn.github.io/novo-elements/docs/#/form-controls/form">Form example</a> has been updated with a &quot;hexadecimal&quot; field to showcase its use. Further examples can be found on <a href="https://imask.js.org/guide.html#masked-base">imask's documentation page</a>.</p>
+<h1>Peer Dependencies</h1>
+<p>The following peer dependencies have been <em>removed</em> from novo-elements. If your core project does not use them, they can be safely removed.</p>
+<ul>
+<li>text-mask-addons</li>
+<li>angular2-text-mask</li>
+</ul>
+<p>The following peer dependencies have been <em>added</em> to support the novo-code-editor.</p>
+<ul>
+<li>@codemirror/commands</li>
+<li>@codemirror/state</li>
+<li>@codemirror/view</li>
+<li>@codemirror/lang-javascript</li>
+<li>codemirror</li>
+</ul>
+<p>Lastly, the <code>timezone-support</code> module has been upgraded from 2.0.2 to 3.1.0.</p>
+<h1>Upgrading to V9</h1>
+<p>The following commands will upgrade novo-elements, as well as its dependencies.</p>
+<pre><code><span class="hljs-attribute">npm</span> install --save  novo-elements@^<span class="hljs-number">9</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> @codemirror/commands@^<span class="hljs-number">6</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> @codemirror/state@^<span class="hljs-number">6</span>.<span class="hljs-number">2</span>.<span class="hljs-number">1</span> @codemirror/view@<span class="hljs-number">6</span>.<span class="hljs-number">16</span>.<span class="hljs-number">0</span> codemirror@<span class="hljs-number">6</span>.<span class="hljs-number">0</span>.<span class="hljs-number">1</span> timezone-support@^<span class="hljs-number">3</span>.<span class="hljs-number">1</span>.<span class="hljs-number">0</span>
+<span class="hljs-attribute">npm</span> uninstall --save text-mask-addons angular2-text-mask
+</code></pre>
 `,
   host: { class: 'markdown-page' }
 })
@@ -6378,7 +6405,7 @@ export class v9Page {
 @Component({
   selector: 'ace-editor-page',
   template: `<h1>Ace Editor <a href="https://github.com/bullhorn/novo-elements/blob/master/projects/novo-elements/src/addons/ace-editor">(source)</a></h1>
-<p>Basic code editor using Ace Editor.</p>
+<p>Basic code editor using <a href="https://ace.c9.io/">Ace Editor</a>.</p>
 <h5>Basic Example</h5>
 <p><code-example example="basic-ace"></code-example></p>
 `,
@@ -6647,7 +6674,7 @@ const routes: Routes = [
   {
     path: 'components/field',
     component: TabsLayout,
-    data: { title: 'Field', section: 'components', pages: [{ title: 'Design', route: './design'},{ title: 'Develop', route: './develop'},{ title: 'Examples', route: './examples'}], description: null, tag: 'experiment' },
+    data: { title: 'Field', section: 'components', pages: [{ title: 'Design', route: './design'},{ title: 'Develop', route: './develop'},{ title: 'Examples', route: './examples'}], description: null },
     children: [
       { path: 'design', component: FieldDesignPage },
       { path: 'develop', component: FieldDevelopPage },
@@ -6736,7 +6763,7 @@ const routes: Routes = [
   {
     path: 'components/query builder',
     component: TabsLayout,
-    data: { title: 'Query Builder', section: 'components', pages: [{ title: 'Design', route: './design'},{ title: 'Develop', route: './develop'},{ title: 'Examples', route: './examples'}], description: null, tag: 'experiment' },
+    data: { title: 'Query Builder', section: 'components', pages: [{ title: 'Design', route: './design'},{ title: 'Develop', route: './develop'},{ title: 'Examples', route: './examples'}], description: null },
     children: [
       { path: 'design', component: QueryBuilderDesignPage },
       { path: 'develop', component: QueryBuilderDevelopPage },
@@ -6875,7 +6902,7 @@ const routes: Routes = [
   { path: 'layouts/expansion', component: ExpansionPage, data: { title: 'Expansion', section: 'layouts' } },
   { path: 'layouts/header', component: HeaderPage, data: { title: 'Header', section: 'layouts' } },
   { path: 'layouts/list', component: ListPage, data: { title: 'List', section: 'layouts' } },
-  { path: 'layouts/sidenav', component: SidenavPage, data: { title: 'Sidenav', section: 'layouts', tag: 'new' } },
+  { path: 'layouts/sidenav', component: SidenavPage, data: { title: 'Sidenav', section: 'layouts' } },
   { path: 'layouts/stepper', component: StepperPage, data: { title: 'Stepper', section: 'layouts' } },
   {
     path: 'layouts/tabs',

--- a/projects/novo-examples/src/layouts/sidenav/sidenav.md
+++ b/projects/novo-examples/src/layouts/sidenav/sidenav.md
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 # SideNav [(source)](https://github.com/bullhorn/novo-elements/blob/master/projects/novo-elements/src/elements/layout)
 
 Components and elements for cards to make sure the loading/empty/layout views are all consistent.

--- a/projects/novo-examples/src/updates/v9.md
+++ b/projects/novo-examples/src/updates/v9.md
@@ -6,9 +6,42 @@ order: 4
 tag: new
 ---
 
-📢  --Release month TBD-- (version 9)
+📢  December 2023 (version 9)
 ===========================
 
-**CommonJS library removal**: Version 9 continues to remove some of the dependence on CommonJS libraries. The previous release deprecated Dragula, as well as some of our date-fns. This release has a new target.
+# Continuing CommonJS library removal
+The previous release of novo-elements, version 8, started to deprecate some modules that relied on CommonJS libraries. In version 9, we are introducing some new options to replace the tools that we've removed.
 
-**Ace Editor removal / Code Editor**: In V9, we have deprecated the `novo-ace-editor` component, and its reliance on the Ace Editor. It is being replaced with `novo-code-editor`, implemented using the [CodeMirror](https://codemirror.net/) library.
+## NovoDragDrop
+While there are several third-party options to replace Dragula (deprecated in v8), our drag-and-drop utility, such as [cdkDrag](https://v7.material.angular.io/cdk/drag-drop/overview) and [ngx-drag-drop](https://www.npmjs.com/package/ngx-drag-drop), we are also adding the [`NovoDragDropModule`](https://bullhorn.github.io/novo-elements/docs/#/utils/drag%20and%20drop), which provides drag and drop capability with support for grid layouts. We have also added an example page to demonstrate its usage.
+
+We recommend that users switch from the dragula directive to novoDragDrop, cdkDrag, or a third-party solution in anticipation of future optimization strategies.
+
+## Code Editor
+In version 8, we deprecated Ace Editor. This module has not been removed yet, but there is now a recommended option to replace it: [The Novo Code Editor](https://bullhorn.github.io/novo-elements/docs/#/utils/code%20editor), backed by [Codemirror](https://codemirror.net/). This supports basic syntax highlighting for JavaScript.
+
+## Text masks
+`angular2-text-mask`, a CommonJS dependency used for text masking support, has been exchanged for `imask`. This may affect the arguments provided to `maskOptions.mask` in the `TextBoxControl` type. The [Form example](https://bullhorn.github.io/novo-elements/docs/#/form-controls/form) has been updated with a "hexadecimal" field to showcase its use. Further examples can be found on [imask's documentation page](https://imask.js.org/guide.html#masked-base).
+
+# Peer Dependencies
+
+The following peer dependencies have been *removed* from novo-elements. If your core project does not use them, they can be safely removed.
+- text-mask-addons
+- angular2-text-mask
+
+The following peer dependencies have been *added* to support the novo-code-editor.
+- @codemirror/commands
+- @codemirror/state
+- @codemirror/view
+- @codemirror/lang-javascript
+- codemirror
+
+Lastly, the `timezone-support` module has been upgraded from 2.0.2 to 3.1.0.
+
+# Upgrading to V9
+
+The following commands will upgrade novo-elements, as well as its dependencies.
+```
+npm install --save  novo-elements@^9.0.0 @codemirror/commands@^6.0.0 @codemirror/state@^6.2.1 @codemirror/view@6.16.0 codemirror@6.0.1 timezone-support@^3.1.0
+npm uninstall --save text-mask-addons angular2-text-mask
+```

--- a/projects/novo-examples/src/utils/ace-editor/ace-editor.md
+++ b/projects/novo-examples/src/utils/ace-editor/ace-editor.md
@@ -9,7 +9,7 @@ tag: deprecated
 Ace Editor [(source)](https://github.com/bullhorn/novo-elements/blob/master/projects/novo-elements/src/addons/ace-editor)
 ====================================================================================================
 
-Basic code editor using Ace Editor.
+Basic code editor using [Ace Editor](https://ace.c9.io/).
 
 ##### Basic Example
 


### PR DESCRIPTION
## **Description**

Adds a screen that details the new changes in v9.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**