### PR TITLE
feat(): next

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -29,6 +29,7 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_NOVO_ELEMENTS }}'
           projectId: novo-elements
           expires: 7d
+          firebaseToolsVersion: 12.9.1
 
 concurrency:
   group: firebase-${{ github.head_ref }}

--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -51,7 +51,7 @@ const DATE_VALUE_ACCESSOR = {
     <span class="error-text" *ngIf="showInvalidDateError">{{ invalidDateErrorMessage }}</span>
     <i *ngIf="!hasValue" (click)="openPanel()" class="bhi-calendar"></i>
     <i *ngIf="hasValue" (click)="clearValue()" class="bhi-times"></i>
-    <novo-overlay-template [parent]="element" position="above-below">
+    <novo-overlay-template [parent]="overlayElement" position="above-below">
       <novo-date-picker
         [start]="start"
         [end]="end"
@@ -109,16 +109,31 @@ export class NovoDatePickerInputElement implements OnInit, OnChanges, AfterViewI
    **/
   @Input()
   format: string;
+  /**
+   * Whether to apply a text mask to the date (see `maskOptions`). Only enabled if allowInvalidDate is false.
+   */
   @Input()
   textMaskEnabled: boolean = true;
+  /**
+   * Whether the input should emit values when the field does not yet constitute a valid date
+   */
   @Input()
   allowInvalidDate: boolean = false;
+  /**
+   * The element to use as the parent for the date picker's overlay (to determine bounds sizing). By default,
+   * this refers to the input element itself, but may be a container if it has a padded border.
+   */
+  @Input()
+  overlayOnElement: ElementRef;
   /**
    * Sets the field as to appear disabled, users will not be able to interact with the text field.
    **/
   @HostBinding('class.disabled')
   @Input()
   disabled: boolean = false;
+  /**
+   * A message to display in the picker overlay when a given date is disabled through minimum/maximum
+   */
   @Input()
   disabledDateMessage: string;
   /**
@@ -179,6 +194,10 @@ export class NovoDatePickerInputElement implements OnInit, OnChanges, AfterViewI
   }
   get panelOpen(): boolean {
     return this.overlay?.panelOpen;
+  }
+
+  get overlayElement(): ElementRef {
+    return this.overlayOnElement || this.element;
   }
   /** END: Convenient Panel Methods. */
 

--- a/projects/novo-elements/src/elements/field/field.ts
+++ b/projects/novo-elements/src/elements/field/field.ts
@@ -96,6 +96,10 @@ export class NovoFieldElement implements AfterContentInit, OnDestroy {
 
   @Input() layout: 'horizontal' | 'vertical' = 'vertical';
   @Input() appearance: 'standard' | 'outline' | 'fill' | 'list' = 'standard';
+  /**
+   * When this field has a picker element, express which element it should be parented to
+   */
+  @Input() customOverlayOrigin: ElementRef;
 
   @Input()
   width: string;
@@ -111,7 +115,7 @@ export class NovoFieldElement implements AfterContentInit, OnDestroy {
    * positioned relative to.
    */
   getConnectedOverlayOrigin(): ElementRef {
-    return this._inputContainerRef || this._elementRef;
+    return this.customOverlayOrigin || this._inputContainerRef || this._elementRef;
   }
 
   ngAfterContentInit(): any {

--- a/projects/novo-elements/src/elements/field/formats/date-format.ts
+++ b/projects/novo-elements/src/elements/field/formats/date-format.ts
@@ -43,7 +43,7 @@ export class NovoDateFormatDirective extends IMaskDirective<any> {
       autofix: true,
       lazy: false,
       min: new Date(1900, 0, 1),
-      max: new Date(2030, 0, 1),
+      max: new Date(2100, 0, 1),
       prepare: (str) => str.toUpperCase(),
       format: (date) => this.formatValue(date),
       parse: (str) => DateUtil.parse(str),

--- a/projects/novo-elements/src/elements/field/formats/date-time-format.ts
+++ b/projects/novo-elements/src/elements/field/formats/date-time-format.ts
@@ -53,7 +53,7 @@ export class NovoDateTimeFormatDirective extends IMaskDirective<any> implements 
       autofix: true,
       lazy: false,
       min: new Date(1900, 0, 1),
-      max: new Date(2030, 0, 1),
+      max: new Date(2100, 0, 1),
       prepare: (str) => str.toUpperCase(),
       format: (date) => this.formatValue(date),
       parse: (str) => DateUtil.parse(str),

--- a/projects/novo-elements/src/elements/field/formats/time-format.ts
+++ b/projects/novo-elements/src/elements/field/formats/time-format.ts
@@ -78,7 +78,7 @@ export class NovoTimeFormatDirective extends IMaskDirective<any> implements Novo
       autofix: true,
       lazy: false,
       min: new Date(1970, 0, 1),
-      max: new Date(2030, 0, 1),
+      max: new Date(2100, 0, 1),
       prepare: (str) => str.toUpperCase(),
       format: (value) => this.formatValue(value),
       parse: (str) => {

--- a/projects/novo-elements/src/elements/time-picker/TimePicker.module.ts
+++ b/projects/novo-elements/src/elements/time-picker/TimePicker.module.ts
@@ -7,11 +7,12 @@ import { IMaskDirectiveModule } from 'angular-imask';
 // APP
 import { NovoOverlayModule } from 'novo-elements/elements/common';
 import { NovoListModule } from 'novo-elements/elements/list';
+import { NovoButtonModule } from 'novo-elements/elements/button';
 import { NovoTimePickerElement } from './TimePicker';
 import { NovoTimePickerInputElement } from './TimePickerInput';
 
 @NgModule({
-  imports: [CommonModule, FormsModule, IMaskDirectiveModule, NovoOverlayModule, NovoListModule],
+  imports: [CommonModule, FormsModule, IMaskDirectiveModule, NovoOverlayModule, NovoListModule, NovoButtonModule],
   declarations: [NovoTimePickerElement, NovoTimePickerInputElement],
   exports: [NovoTimePickerElement, NovoTimePickerInputElement],
 })

--- a/projects/novo-elements/src/elements/time-picker/TimePicker.scss
+++ b/projects/novo-elements/src/elements/time-picker/TimePicker.scss
@@ -364,4 +364,25 @@
       }
     }
   }
+
+  &.hasButtons {
+    border-radius: 4px 4px 0 0;
+
+    &.military {
+      .increments--hour,
+      .increments--minute {
+        width: auto;
+      }
+    }
+    .save-cancel-buttons {
+      background: var(--background-main);
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      padding: 1rem;
+      gap: .5rem;
+      border-radius: 0 0 4px 4px;
+      box-shadow: 0 1px 3px #00000026, 0 2px 7px #0000001a;
+    }
+  }
 }

--- a/projects/novo-elements/src/elements/time-picker/TimePicker.ts
+++ b/projects/novo-elements/src/elements/time-picker/TimePicker.ts
@@ -14,7 +14,7 @@ import {
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { isValid } from 'date-fns';
 // APP
-import { DateFormatService, NovoLabelService } from 'novo-elements/services';
+import { NovoLabelService } from 'novo-elements/services';
 import { DateUtil, Helpers } from 'novo-elements/utils';
 
 // Value accessor for the component (supports ngModel)
@@ -119,6 +119,20 @@ export enum TIME_VALUE_FORMATS {
         </div>
       </div>
     </div>
+    <div class="save-cancel-buttons" *ngIf="hasButtons">
+      <novo-button
+          class="cancel-button"
+          theme="dialogue"
+          size="small"
+          (click)="cancel()">{{ labels.cancel }}</novo-button>
+      <novo-button
+          class="save-button"
+          theme="primary"
+          color="primary"
+          size="small"
+          [disabled]="saveDisabled"
+          (click)="save()">{{ labels.save }}</novo-button>
+    </div>
   `,
   styleUrls: ['./TimePicker.scss'],
   host: {
@@ -135,9 +149,17 @@ export class NovoTimePickerElement implements ControlValueAccessor, OnInit, OnCh
   inline: boolean = false;
   @Input()
   step: number = 1;
+  @Input()
+  hasButtons: boolean = false;
+  @Input()
+  saveDisabled: boolean = false;
 
   @Output()
   onSelect: EventEmitter<any> = new EventEmitter();
+  @Output()
+  onSave: EventEmitter<any> = new EventEmitter();
+  @Output()
+  onCancel: EventEmitter<any> = new EventEmitter();
 
   hours: number = 12;
   minutes: number = 0;
@@ -318,5 +340,13 @@ export class NovoTimePickerElement implements ControlValueAccessor, OnInit, OnCh
       hours = `${parseInt(hours, 10) + 12}`.padStart(2, '0');
     }
     return `${hours}:${minutes}`;
+  }
+
+  save(): void {
+    this.onSave.emit();
+  }
+
+  cancel(): void {
+    this.onCancel.emit();
   }
 }

--- a/projects/novo-elements/src/elements/time-picker/TimePickerInput.ts
+++ b/projects/novo-elements/src/elements/time-picker/TimePickerInput.ts
@@ -49,11 +49,16 @@ const DATE_VALUE_ACCESSOR = {
     <i *ngIf="!hasValue" (click)="openPanel()" class="bhi-clock"></i> <i *ngIf="hasValue" (click)="clearValue()" class="bhi-times"></i>
     <novo-overlay-template [parent]="element" position="above-below">
       <novo-time-picker
+        [ngClass]="{ 'hasButtons': hasButtons }"
+        [hasButtons]="hasButtons"
         inline="true"
         [analog]="analog"
         (onSelect)="setValue($event)"
         [ngModel]="value"
         [military]="military"
+        [saveDisabled]="saveDisabled"
+        (onCancel)="cancel()"
+        (onSave)="save()"
       ></novo-time-picker>
     </novo-overlay-template>
   `,
@@ -78,6 +83,10 @@ export class NovoTimePickerInputElement implements OnInit, OnChanges, ControlVal
   @HostBinding('class.disabled')
   @Input()
   disabled: boolean = false;
+  @Input()
+  hasButtons: boolean = false;
+  @Input()
+  saveDisabled: boolean = false;
 
   /**
    * @deprecated don't use
@@ -91,6 +100,10 @@ export class NovoTimePickerInputElement implements OnInit, OnChanges, ControlVal
   focusEvent: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
   @Output()
   changeEvent: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
+  @Output()
+  onSave: EventEmitter<any> = new EventEmitter();
+  @Output()
+  onCancel: EventEmitter<any> = new EventEmitter();
 
   /** Element for the panel containing the autocomplete options. */
   @ViewChild(NovoOverlayTemplateComponent)
@@ -297,5 +310,13 @@ export class NovoTimePickerInputElement implements OnInit, OnChanges, ControlVal
         this.dispatchOnChange(null);
       }
     } catch (err) {}
+  }
+
+  save(): void {
+    this.onSave.emit();
+  }
+
+  cancel(): void {
+    this.onCancel.emit();
   }
 }

--- a/projects/novo-elements/src/elements/time-picker/TimePickerInput.ts
+++ b/projects/novo-elements/src/elements/time-picker/TimePickerInput.ts
@@ -47,7 +47,7 @@ const DATE_VALUE_ACCESSOR = {
       [disabled]="disabled"
     />
     <i *ngIf="!hasValue" (click)="openPanel()" class="bhi-clock"></i> <i *ngIf="hasValue" (click)="clearValue()" class="bhi-times"></i>
-    <novo-overlay-template [parent]="element" position="above-below">
+    <novo-overlay-template [parent]="overlayElement" position="above-below">
       <novo-time-picker
         [ngClass]="{ 'hasButtons': hasButtons }"
         [hasButtons]="hasButtons"
@@ -87,6 +87,8 @@ export class NovoTimePickerInputElement implements OnInit, OnChanges, ControlVal
   hasButtons: boolean = false;
   @Input()
   saveDisabled: boolean = false;
+  @Input()
+  overlayOnElement: ElementRef;
 
   /**
    * @deprecated don't use
@@ -149,6 +151,10 @@ export class NovoTimePickerInputElement implements OnInit, OnChanges, ControlVal
 
   get panelOpen(): boolean {
     return this.overlay && this.overlay.panelOpen;
+  }
+
+  get overlayElement(): ElementRef {
+    return this.overlayOnElement || this.element;
   }
 
   /** END: Convenient Panel Methods. */

--- a/projects/novo-elements/src/services/date-format/DateFormat.ts
+++ b/projects/novo-elements/src/services/date-format/DateFormat.ts
@@ -20,7 +20,7 @@ export class DateFormatService {
       autofix: true,
       lazy: false,
       min: new Date(1970, 0, 1),
-      max: new Date(2030, 0, 1),
+      max: new Date(2100, 0, 1),
       prepare(str) {
         return str.toUpperCase();
       },
@@ -70,7 +70,7 @@ export class DateFormatService {
       overwrite: true,
       autofix: 'pad',
       min: new Date(1970, 0, 1),
-      max: new Date(2030, 0, 1),
+      max: new Date(2100, 0, 1),
       prepare(str) {
         return str.toUpperCase();
       },

--- a/projects/novo-examples/src/form-controls/time-picker/time-picker/time-picker-example.html
+++ b/projects/novo-examples/src/form-controls/time-picker/time-picker/time-picker-example.html
@@ -4,6 +4,7 @@
       [military]="display.value"
       [disabled]="disabled.value"
       [analog]="appearance.value"
+      [hasButtons]="hasButtons.value"
       [(ngModel)]="time1"></novo-time-picker-input>
     <novo-hint>value: {{time1}}</novo-hint>
   </div>
@@ -49,6 +50,13 @@
     <novo-radio-group #disabled appearance="vertical" [value]="false">
       <novo-radio name="disabled" [value]="false">Enabled</novo-radio>
       <novo-radio name="disabled" [value]="true">Disabled</novo-radio>
+    </novo-radio-group>
+  </novo-field>
+  <novo-field>
+    <novo-label>Save/Cancel Buttons?</novo-label>
+    <novo-radio-group #hasButtons appearance="vertical" [value]="false">
+      <novo-radio name="disabled" [value]="true">Enabled</novo-radio>
+      <novo-radio name="disabled" [value]="false">Disabled</novo-radio>
     </novo-radio-group>
   </novo-field>
 </novo-row>


### PR DESCRIPTION
## **Description**

feat(TimePicker): Add Save and Cancel buttons to Time Picker #1481
feat(Picker): Specify parent of picker components #1483
fix(imask): upping the max date on all date/text masks from 2030 to 2100 #1486

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**