### PR TITLE
fix(imask): upping the max date on all date/time masks from 2030 to 2100

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -29,7 +29,7 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_NOVO_ELEMENTS }}'
           projectId: novo-elements
           expires: 7d
-          node-version: 20
+          firebaseToolsVersion: 12.9.1
 
 concurrency:
   group: firebase-${{ github.head_ref }}

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -29,6 +29,7 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_NOVO_ELEMENTS }}'
           projectId: novo-elements
           expires: 7d
+          node-version: 20
 
 concurrency:
   group: firebase-${{ github.head_ref }}

--- a/projects/novo-elements/src/elements/field/formats/date-format.ts
+++ b/projects/novo-elements/src/elements/field/formats/date-format.ts
@@ -43,7 +43,7 @@ export class NovoDateFormatDirective extends IMaskDirective<any> {
       autofix: true,
       lazy: false,
       min: new Date(1900, 0, 1),
-      max: new Date(2030, 0, 1),
+      max: new Date(2100, 0, 1),
       prepare: (str) => str.toUpperCase(),
       format: (date) => this.formatValue(date),
       parse: (str) => DateUtil.parse(str),

--- a/projects/novo-elements/src/elements/field/formats/date-time-format.ts
+++ b/projects/novo-elements/src/elements/field/formats/date-time-format.ts
@@ -53,7 +53,7 @@ export class NovoDateTimeFormatDirective extends IMaskDirective<any> implements 
       autofix: true,
       lazy: false,
       min: new Date(1900, 0, 1),
-      max: new Date(2030, 0, 1),
+      max: new Date(2100, 0, 1),
       prepare: (str) => str.toUpperCase(),
       format: (date) => this.formatValue(date),
       parse: (str) => DateUtil.parse(str),

--- a/projects/novo-elements/src/elements/field/formats/time-format.ts
+++ b/projects/novo-elements/src/elements/field/formats/time-format.ts
@@ -78,7 +78,7 @@ export class NovoTimeFormatDirective extends IMaskDirective<any> implements Novo
       autofix: true,
       lazy: false,
       min: new Date(1970, 0, 1),
-      max: new Date(2030, 0, 1),
+      max: new Date(2100, 0, 1),
       prepare: (str) => str.toUpperCase(),
       format: (value) => this.formatValue(value),
       parse: (str) => {

--- a/projects/novo-elements/src/services/date-format/DateFormat.ts
+++ b/projects/novo-elements/src/services/date-format/DateFormat.ts
@@ -20,7 +20,7 @@ export class DateFormatService {
       autofix: true,
       lazy: false,
       min: new Date(1970, 0, 1),
-      max: new Date(2030, 0, 1),
+      max: new Date(2100, 0, 1),
       prepare(str) {
         return str.toUpperCase();
       },
@@ -70,7 +70,7 @@ export class DateFormatService {
       overwrite: true,
       autofix: 'pad',
       min: new Date(1970, 0, 1),
-      max: new Date(2030, 0, 1),
+      max: new Date(2100, 0, 1),
       prepare(str) {
         return str.toUpperCase();
       },


### PR DESCRIPTION
## **Description**

we need to allow dates to be set beyond 2030 so we're upping the default date/time masks to support dates up to 2100.

also setting the firebase tools version manually for the firebase build action due to this bug:
https://github.com/FirebaseExtended/action-hosting-deploy/issues/326

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**