### PR TITLE
fix(DatePickerInput): removing value update on accept mask event

### DIFF
--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -190,8 +190,7 @@ export class NovoDatePickerInputElement implements OnInit, OnChanges, AfterViewI
   }
 
   _handleInput(event: KeyboardEvent): void {
-    // if maskOptions is enabled, then we do not want to process inputs until the mask has accepted them
-    if (document.activeElement === event.target && !this.maskOptions) {
+    if (document.activeElement === event.target) {
       this._handleValueUpdate((event.target as HTMLInputElement).value, false);
     }
   }

--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -43,7 +43,6 @@ const DATE_VALUE_ACCESSOR = {
       (keydown)="_handleKeydown($event)"
       (input)="_handleInput($event)"
       (blur)="_handleBlur($event)"
-      (accept)="handleMaskAccept($event)"
       #input
       data-automation-id="date-input"
       [disabled]="disabled"
@@ -191,8 +190,7 @@ export class NovoDatePickerInputElement implements OnInit, OnChanges, AfterViewI
   }
 
   _handleInput(event: KeyboardEvent): void {
-    // if maskOptions is enabled, then we do not want to process inputs until the mask has accepted them - so those events will be
-    // handled by the (accept) event.
+    // if maskOptions is enabled, then we do not want to process inputs until the mask has accepted them
     if (document.activeElement === event.target && !this.maskOptions) {
       this._handleValueUpdate((event.target as HTMLInputElement).value, false);
     }
@@ -224,10 +222,6 @@ export class NovoDatePickerInputElement implements OnInit, OnChanges, AfterViewI
       this.formatDate(value, blur);
       this.openPanel();
     }
-  }
-
-  handleMaskAccept(maskValue: string): void {
-    this._handleValueUpdate(maskValue, false);
   }
 
   protected formatDate(value: string, blur: boolean) {


### PR DESCRIPTION
## **Description**

with #1473 - specifically this commit: https://github.com/bullhorn/novo-elements/pull/1473/commits/30ad8fb7e43b25b50dc1f581338159f509af5e64
we attached an update value call to the input's `accept` event. this was done to handle the case where we don't want to handle keydown events before the mask is set, but this was throwing update events when an international mask was set which resulted in save calls being fired on load.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**