### PR TITLE
fix(DatePickerInput): Default mask to a permissive number/separator

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -29,6 +29,7 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_NOVO_ELEMENTS }}'
           projectId: novo-elements
           expires: 7d
+          firebaseToolsVersion: 12.9.1
 
 concurrency:
   group: firebase-${{ github.head_ref }}

--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -161,7 +161,7 @@ export class NovoDatePickerInputElement implements OnInit, OnChanges, AfterViewI
   _initFormatOptions() {
     this.userDefinedFormat = this.format ? !this.format.match(/^(DD\/MM\/YYYY|MM\/DD\/YYYY)$/g) : false;
     if (!this.userDefinedFormat && this.textMaskEnabled && !this.allowInvalidDate) {
-      this.maskOptions = this.maskOptions || this.dateFormatService.getDateMask(this.format);
+      this.maskOptions = this.maskOptions || this.dateFormatService.getDateMask();
     } else {
       this.maskOptions = undefined;
     }

--- a/projects/novo-elements/src/elements/date-picker/DateRangeInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DateRangeInput.ts
@@ -170,7 +170,7 @@ export class NovoDateRangeInputElement implements OnInit, OnChanges, ControlValu
   _initFormatOptions() {
     this.userDefinedFormat = this.format ? !this.format.match(/^(DD\/MM\/YYYY|MM\/DD\/YYYY)$/g) : false;
     if (!this.userDefinedFormat && this.textMaskEnabled && !this.allowInvalidDate) {
-      this.maskOptions = this.maskOptions || this.dateFormatService.getDateMask(this.format);
+      this.maskOptions = this.maskOptions || this.dateFormatService.getDateMask();
     } else {
       this.maskOptions = undefined;
     }

--- a/projects/novo-elements/src/services/date-format/DateFormat.spec.ts
+++ b/projects/novo-elements/src/services/date-format/DateFormat.spec.ts
@@ -10,34 +10,25 @@ describe('Service: DateFormatService', () => {
   });
 
   describe('Function: getDateMask()', () => {
-    it('should be defined', () => {
-      expect(service.getDateMask).toBeDefined();
-    });
-    it('should return a default mask', () => {
-      service.labels.dateFormat = '';
-      const actual = service.getDateMask();
-      expect(actual.mask).toBeDefined();
-      expect(actual.pattern).toBeDefined();
-    });
     it('should return a mask that supports a date with format dd-MM-yyyy', () => {
       const value = '11-02-2017';
-      const dateMask = service.getDateMask(value);
-      expect(value.match(dateMask[0])).toBeTruthy();
+      const dateMask = service.getDateMask();
+      expect(value.match(dateMask.mask)).toBeTruthy();
     });
     it('should return a mask that supports dd.MM.yyyy', () => {
       const value = '11.02.2017';
-      const dateMask = service.getDateMask(value);
-      expect(value.match(dateMask[0])).toBeTruthy();
+      const dateMask = service.getDateMask();
+      expect(value.match(dateMask.mask)).toBeTruthy();
     });
     it('should return a mask that supports d/M/yyyy', () => {
       const value = '1/2/2017';
-      const dateMask = service.getDateMask(value);
-      expect(value.match(dateMask[0])).toBeTruthy();
+      const dateMask = service.getDateMask();
+      expect(value.match(dateMask.mask)).toBeTruthy();
     });
     it('should return a mask that supports M/d/yyyy', () => {
       const value = '11/2/2017';
-      const dateMask = service.getDateMask(value);
-      expect(value.match(dateMask[0])).toBeTruthy();
+      const dateMask = service.getDateMask();
+      expect(value.match(dateMask.mask)).toBeTruthy();
     });
   });
 

--- a/projects/novo-elements/src/services/date-format/DateFormat.ts
+++ b/projects/novo-elements/src/services/date-format/DateFormat.ts
@@ -3,14 +3,14 @@ import { Injectable } from '@angular/core';
 import { NovoLabelService } from '../novo-label-service';
 // APP
 import { format, parse } from 'date-fns';
-import { MaskedEnum, MaskedRange } from 'imask';
+import { AnyMaskedOptions, MaskedEnum, MaskedRange } from 'imask';
 import { DateUtil, Helpers, convertTokens } from 'novo-elements/utils';
 
 @Injectable()
 export class DateFormatService {
   constructor(private labels: NovoLabelService) {}
 
-  getTimeMask(militaryTime: boolean) {
+  getTimeMask(militaryTime: boolean): AnyMaskedOptions {
     const amFormat = this.labels.timeFormatAM.toUpperCase();
     const pmFormat = this.labels.timeFormatPM.toUpperCase();
     const mask = {
@@ -63,25 +63,10 @@ export class DateFormatService {
     return mask;
   }
 
-  getDateMask(format?: string) {
-    const mask = {
-      mask: Date,
-      pattern: 'm/`d/`Y',
-      overwrite: true,
-      autofix: 'pad',
-      min: new Date(1970, 0, 1),
-      max: new Date(2030, 0, 1),
-      prepare(str) {
-        return str.toUpperCase();
-      },
-      format(date) {
-        return DateUtil.format(date, format || 'MM/DD/YYYY');
-      },
-      parse: (str) => {
-        return DateUtil.parse(str);
-      },
-    }
-    return mask;
+  getDateMask(): AnyMaskedOptions {
+    return {
+      mask: /^((\d)(\d|\/|\.|\-){0,7})?(\d){0,2}$/
+    };
   }
 
   getDateTimeMask(militaryTime: boolean = false): Array<any> {


### PR DESCRIPTION


## **Description**

Since imask doesn't yet receive information on user date formatting settings, it's been changed from a date formatter to a regex that is only confirming the user is putting numbers and separators into the field.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**