### PR TITLE
fix(Collection): fixing a strict=true TS compilation error

### DIFF
--- a/projects/novo-elements/src/services/data-provider/ArrayCollection.ts
+++ b/projects/novo-elements/src/services/data-provider/ArrayCollection.ts
@@ -172,7 +172,7 @@ export class ArrayCollection<T> implements Collection<T> {
    *
    * @memberOf ArrayCollection
    */
-  getItemIndex(item: T): number {
+  getItemIndex(item: T): number { // here
     return this.isEditing ? this.editData.indexOf(item) : this.source.indexOf(item);
   }
 

--- a/projects/novo-elements/src/services/data-provider/ArrayCollection.ts
+++ b/projects/novo-elements/src/services/data-provider/ArrayCollection.ts
@@ -172,7 +172,7 @@ export class ArrayCollection<T> implements Collection<T> {
    *
    * @memberOf ArrayCollection
    */
-  getItemIndex(item: T): number { // here
+  getItemIndex(item: T): number {
     return this.isEditing ? this.editData.indexOf(item) : this.source.indexOf(item);
   }
 

--- a/projects/novo-elements/src/services/data-provider/Collection.ts
+++ b/projects/novo-elements/src/services/data-provider/Collection.ts
@@ -60,7 +60,7 @@ export interface Collection<T> {
    *  @param item The item to find.
    *  @return The index of the item, or -1 if the item is not in the list.
    */
-  getItemIndex(item: Object): number;
+  getItemIndex(item: T): number; // here
 
   /**
    *  Notifies the view that an item has been updated.

--- a/projects/novo-elements/src/services/data-provider/Collection.ts
+++ b/projects/novo-elements/src/services/data-provider/Collection.ts
@@ -60,7 +60,7 @@ export interface Collection<T> {
    *  @param item The item to find.
    *  @return The index of the item, or -1 if the item is not in the list.
    */
-  getItemIndex(item: T): number; // here
+  getItemIndex(item: T): number;
 
   /**
    *  Notifies the view that an item has been updated.


### PR DESCRIPTION
## **Description**

just a quick typing update to correctly pass the generic type `T` into the getItemIndex function in the Collection service. this brings it in line with other functions and the types of existing functions that call it.

the purpose for this update is to fix a typescript compilation error when an app is importing novo-elements as a dependency and that app's tsconfig has the `strict = true` compiler option enabled.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**