### PR TITLE
fix(ExpansionPanelHeader): adding default heights to expansion-panel-header input properties

### DIFF
--- a/projects/novo-elements/src/elements/expansion/expansion-panel-header.ts
+++ b/projects/novo-elements/src/elements/expansion/expansion-panel-header.ts
@@ -69,11 +69,11 @@ export class NovoExpansionPanelHeader implements OnDestroy {
 
   /** Height of the header while the panel is expanded. */
   @Input()
-  expandedHeight: string;
+  expandedHeight: string = '56px';
 
   /** Height of the header while the panel is collapsed. */
   @Input()
-  collapsedHeight: string;
+  collapsedHeight: string = '48px';
 
   /** Toggles the expanded state of the panel. */
   _toggle(): void {


### PR DESCRIPTION
## **Description**

since these properties are used in an animation, they need to have a value as of angular 15. this fixes a compilation error and should not change any existing behavior.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**