### PR TITLE
feat(AppBridge): When handling AppBridge events, pass origin to handler

### DIFF
--- a/projects/novo-elements/src/utils/app-bridge/AppBridge.spec.ts
+++ b/projects/novo-elements/src/utils/app-bridge/AppBridge.spec.ts
@@ -1,0 +1,342 @@
+import { AppBridge } from './AppBridge';
+import { AppBridgeHandler, MessageType } from './interfaces';
+
+class MockPostrobot {
+
+    responders: { [msg in MessageType]?: (event) => Promise<any>} = {};
+
+    lastRobotOpts: any;
+
+    CONFIG = {};
+
+    // In actual code these will be Window objects, but with cross-origin access blocked, all we
+    // can do is compare their equality.
+    mockSource = Symbol();
+
+    static allPostRobots: MockPostrobot[] = [];
+
+    constructor(public mockOrigin: string, public parent?: MockPostrobot) {
+        MockPostrobot.allPostRobots.push(this);
+    }
+
+    on(msg: MessageType, cb: (event) => Promise<any>) {
+        this.responders[msg] = cb;
+    }
+
+    sendToParent(msg: MessageType, packet: any, robotOpts: any) {
+        this.lastRobotOpts = robotOpts;
+        if (!this.parent) {
+            debugger;
+            throw new Error(`Tried to send message "${msg}" to parent from host`);
+        }
+        return this.parent.mockSendToMe(msg, packet, this);
+    }
+
+    protected mockSendToMe(msg: MessageType, data: any, from: MockPostrobot): Promise<any> {
+        if (!(this.responders[msg])) {
+            throw new Error(`No responder for "${msg}".`);
+        }
+        const mockRobotEvent = {
+            data: {...data},
+            source: from.mockSource,
+            origin: from.mockOrigin
+        };
+        return Promise.resolve(this.responders[msg]!(mockRobotEvent))
+            .then(replyData => ({ data: {...replyData } }));
+    }
+
+    send(frameSource: Symbol, eventType: MessageType, data: any): Promise<any> {
+        if (!frameSource) {
+            throw new Error('Null frameSource on send()');
+        }
+        const recipient = MockPostrobot.allPostRobots.find(c => c.mockSource === frameSource);
+        if (recipient) {
+            return recipient.mockSendToMe(eventType, data, this);
+        } else {
+            throw new Error('Could not locate child to send to');
+        }
+    }
+}
+
+describe('AppBridge', () => {
+
+    let hostBridge: AppBridge;
+    let frame1Bridge: AppBridge;
+    let frame2Bridge: AppBridge;
+
+    let hostRobot: MockPostrobot;
+    let frame1Robot: MockPostrobot;
+    let frame2Robot: MockPostrobot;
+
+    let handleFn: jest.Mock<any, [AppBridgeHandler, any]>;
+
+    beforeEach(() => {
+
+        hostRobot = new MockPostrobot('localhost:111');
+        frame1Robot = new MockPostrobot('localhost:222', hostRobot);
+        frame2Robot = new MockPostrobot('localhost:333', frame1Robot);
+
+        // Simulate a top-level app with two nested iframes
+        hostBridge = new AppBridge('Jest Host', hostRobot);
+        hostBridge.id = 'hostapp';
+        frame1Bridge = new AppBridge('Jest Frame1', frame1Robot);
+        frame1Bridge.id = 'childapp1';
+        frame2Bridge = new AppBridge('Jest Frame2', frame2Robot);
+        frame2Bridge.id = 'childapp2';
+        hostBridge['windowOrigin'] = frame1Bridge['windowOrigin'] = frame2Bridge['windowOrigin'] = function() { return this.postRobot.mockOrigin };
+
+        handleFn = jest.fn();
+
+        // setup handlers
+        for (let handlerKey of (Object.values(AppBridgeHandler)) as AppBridgeHandler[]) {
+            hostBridge.handle(handlerKey, (event, cb) => {
+                try {
+                    return cb(handleFn(handlerKey, event));
+                } catch(err) {
+                    cb(null, err);
+                }
+            })
+        }
+    });
+
+    it('should register a new app', async () => {
+        handleFn.mockReturnValue('terry');
+        await frame1Bridge.register();
+        expect(handleFn).toHaveBeenCalledWith(AppBridgeHandler.REGISTER, jasmine.objectContaining({ id: 'childapp1' }));
+        expect(hostBridge['_registeredFrames'].length).toBe(1);
+        expect(frame1Bridge.windowName).toBe('terry');
+    });
+
+    it('opens a window', async () => {
+        // TODO
+    });
+
+    it('opens a list', async () => {
+        // TODO
+    });
+
+    it('closes a window', async () => {
+        // TODO
+    });
+
+    it('refreshes a window', async () => {
+        // TODO
+    });
+
+    it('pins a window', async () => {
+        // TODO
+    });
+
+    it('pings a window', async () => {
+        // TODO
+    });
+
+    it('updates app title', async () => {
+        // TODO
+    });
+
+    it('should perform an httpGET from a sub-child to the parent', async () => {
+        handleFn.mockReturnValue('chips');
+        const result = await frame2Bridge.httpGET('snack', 500);
+        expect(handleFn).toHaveBeenCalledWith(AppBridgeHandler.HTTP, { verb: 'get', relativeURL: 'snack', origin: ['localhost:222', 'localhost:333'] });
+        expect(frame2Robot.lastRobotOpts).toEqual({ timeout: 500 });
+        expect(result).toEqual({ data: 'chips', error: undefined });
+    });
+
+    it('should correctly handle an httpGET failure', async () => {
+        const err = new Error('chip bin empty');
+        handleFn.mockImplementation(() => { throw err; });
+        const result = await frame2Bridge.httpGET('snack', 500);
+        expect(handleFn).toHaveBeenCalledWith(AppBridgeHandler.HTTP, { verb: 'get', relativeURL: 'snack', origin: ['localhost:222', 'localhost:333'] });
+        expect(frame2Robot.lastRobotOpts).toEqual({ timeout: 500 });
+        expect(result.error).toEqual(err);
+        expect(result.data).toBeFalsy();
+    });
+
+    // Should this behavior change? Won't bother testing it for other HTTP actions
+    it('should reject with null when postrobot transmission to parent fails', async () => {
+        const err = new Error('Something about postMessage isn\'t working');
+        spyOn(frame2Robot, 'sendToParent').and.returnValue(Promise.reject(err));
+        try {
+            await frame2Bridge.httpGET('snack');
+            fail('expected promise rejection');
+        } catch(err) {
+            expect(err).toBeNull();
+        }
+    });
+
+    it('should perform an httpPOST from a sub-child to the parent', async () => {
+        handleFn.mockReturnValue('received');
+        const result = await frame2Bridge.httpPOST('mail', { bill: '$5000' }, 500);
+        expect(handleFn).toHaveBeenCalledWith(AppBridgeHandler.HTTP,
+            { verb: 'post', relativeURL: 'mail', data: { bill: '$5000' }, origin: ['localhost:222', 'localhost:333'] });
+        expect(frame2Robot.lastRobotOpts).toEqual({ timeout: 500 });
+        expect(result).toEqual({ data: 'received', error: undefined });
+    });
+
+    it('should report the bridge\'s traceName when the origins match', async () => {
+        handleFn.mockReturnValue('received');
+        // imitate one server talking to itself through appbridge
+        frame1Robot.mockOrigin = hostRobot.mockOrigin;
+        const result = await frame1Bridge.httpPOST('mail', { bill: '$5000' }, 500);
+        expect(handleFn).toHaveBeenCalledWith(AppBridgeHandler.HTTP,
+            { verb: 'post', relativeURL: 'mail', data: { bill: '$5000' }, origin: [frame1Bridge.traceName] });
+        expect(result).toEqual({ data: 'received', error: undefined });
+    });
+
+    it('should use traceName instead of origin if calling httpGet from the home frame', async () => {
+        handleFn.mockReturnValue('received');
+        const result = await hostBridge.httpPOST('mail', { bill: '$5000' }, 500);
+        expect(handleFn).toHaveBeenCalledWith(AppBridgeHandler.HTTP,
+            { verb: 'post', relativeURL: 'mail', data: { bill: '$5000' }, origin: [hostBridge.traceName] });
+        expect(result).toEqual({ data: 'received', error: undefined });
+    });
+
+    it('should correctly handle an httpPOST failure', async () => {
+        const err = new Error('no mailbox');
+        handleFn.mockImplementation(() => { throw err; });
+        const result = await frame2Bridge.httpPOST('mail', { bill: '$5000' }, 500);
+        expect(handleFn).toHaveBeenCalledWith(AppBridgeHandler.HTTP, { verb: 'post', data: { bill: '$5000' }, relativeURL: 'mail',
+            origin: ['localhost:222', 'localhost:333'] });
+        expect(frame2Robot.lastRobotOpts).toEqual({ timeout: 500 });
+        expect(result.error).toEqual(err);
+        expect(result.data).toBeFalsy();
+    });
+
+    it('should perform an httpPUT from a sub-child to the parent', async () => {
+        handleFn.mockReturnValue('received');
+        const result = await frame2Bridge.httpPUT('mail', { bill: '$5000' }, 500);
+        expect(handleFn).toHaveBeenCalledWith(AppBridgeHandler.HTTP,
+            { verb: 'put', relativeURL: 'mail', data: { bill: '$5000' }, origin: ['localhost:222', 'localhost:333'] });
+        expect(frame2Robot.lastRobotOpts).toEqual({ timeout: 500 });
+        expect(result).toEqual({ data: 'received', error: undefined });
+    });
+
+    it('should correctly handle an httpPUT failure', async () => {
+        const err = new Error('no mailbox');
+        handleFn.mockImplementation(() => { throw err; });
+        const result = await frame2Bridge.httpPUT('mail', { bill: '$5000' }, 500);
+        expect(handleFn).toHaveBeenCalledWith(AppBridgeHandler.HTTP, { verb: 'put', data: { bill: '$5000' }, relativeURL: 'mail',
+            origin: ['localhost:222', 'localhost:333'] });
+        expect(frame2Robot.lastRobotOpts).toEqual({ timeout: 500 });
+        expect(result.error).toEqual(err);
+        expect(result.data).toBeFalsy();
+    });
+
+    it('should perform an httpDELETE from a sub-child to the parent', async () => {
+        handleFn.mockReturnValue('received');
+        const result = await frame2Bridge.httpDELETE('searchHistory', 500);
+        expect(handleFn).toHaveBeenCalledWith(AppBridgeHandler.HTTP,
+            { verb: 'delete', relativeURL: 'searchHistory', origin: ['localhost:222', 'localhost:333'] });
+        expect(frame2Robot.lastRobotOpts).toEqual({ timeout: 500 });
+        expect(result).toEqual({ data: 'received', error: undefined });
+    });
+
+    it('should correctly handle an httpDELETE failure', async () => {
+        const err = new Error('currently being accessed by user: FBI');
+        handleFn.mockImplementation(() => { throw err; });
+        const result = await frame2Bridge.httpDELETE('searchHistory', 500);
+        expect(handleFn).toHaveBeenCalledWith(AppBridgeHandler.HTTP, { verb: 'delete', relativeURL: 'searchHistory', origin: ['localhost:222', 'localhost:333'] });
+        expect(frame2Robot.lastRobotOpts).toEqual({ timeout: 500 });
+        expect(result.error).toEqual(err);
+        expect(result.data).toBeFalsy();
+    });
+
+    it('forwards REQUEST_DATA', async () => {
+        const handleResponse = { meta: '123' };
+        handleFn.mockReturnValue(handleResponse);
+        const result = await frame2Bridge.requestData({ type: 'all' });
+        expect(result.data).toEqual(handleResponse);
+    })
+
+    it('handles REQUEST_DATA failure', async () => {
+        const err = new Error('chip bin empty');
+        handleFn.mockImplementation(() => { throw err; });
+        try {
+            await frame2Bridge.requestData({ type: 'all' });
+            fail('Should not request data successfully');
+        } catch(err2) {
+            expect(err2).toBeFalsy();
+        }
+    });
+
+    it('should process a callback', async () => {
+        handleFn.mockReturnValue({ dataObj: 3 });
+        const result = await frame2Bridge.callback({
+            key: 'callbackTest',
+            generic: false,
+            options: {
+                switch: 'on'
+            }
+        });
+        expect(result).toBe(true);
+    });
+
+    it('should handle a callback failure without giving process details', async () => {
+        const err = new Error('Exception in proprietary secret db');
+        handleFn.mockImplementation(() => { throw err; });
+        try {
+            await frame2Bridge.callback({
+                key: 'callbackTest',
+                generic: false,
+                options: {
+                    switch: 'on'
+                }
+            });
+            fail('Expected exception');
+        } catch(succeed) {
+            expect(succeed).toBe(false);
+        }
+    });
+
+    it('should report callback failure when event.data is null', async () => {
+        handleFn.mockReturnValue(null);
+        try {
+            await frame2Bridge.callback({
+                key: 'callbackTest',
+                generic: false,
+                options: {
+                    switch: 'on'
+                }
+            });
+            fail('Expected exception');
+        } catch(succeed) {
+            expect(succeed).toBe(false);
+        }
+    });
+
+    it('should fire events to children', async () => {
+        await frame1Bridge.register();
+        await frame2Bridge.register();
+        const data = { dataContent: 1000 };
+        let receivedData1, receivedData2: any;
+        frame1Bridge.addEventListener('test', eventData => {
+            receivedData1 = eventData;
+        });
+        frame2Bridge.addEventListener('test', eventData => {
+            receivedData2 = eventData;
+        });
+        hostBridge.fireEventToChildren('test', data);
+        expect(receivedData1).toEqual(data);
+        expect(receivedData2).toEqual(data);
+    });
+
+    it('should fire custom events to parents', async () => {
+        let receivedEvent = false;
+        frame1Bridge.addEventListener('custom', () => {
+            receivedEvent = true;
+        });
+        await frame2Bridge.fireEvent('custom', { dataContent: 1000 });
+        expect(receivedEvent).toBeTruthy();
+    });
+
+    // This behavior theoretically should be expected, but is not working yet.
+    xit('should fire custom events to parents of parents', async () => {
+        let receivedEvent = false;
+        hostBridge.addEventListener('custom', () => {
+            receivedEvent = true;
+        });
+        await frame2Bridge.fireEvent('custom', { dataContent: 1000 });
+        expect(receivedEvent).toBeTruthy();
+    });
+});

--- a/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
+++ b/projects/novo-elements/src/utils/app-bridge/AppBridge.ts
@@ -80,32 +80,45 @@ export interface IAppBridgeRequestDataEvent {
   type: NovoDataType;
 }
 
-const HTTP_VERBS = {
-  GET: 'get',
-  POST: 'post',
-  PUT: 'put',
-  DELETE: 'delete',
+namespace HTTP_VERBS {
+  export const GET = 'get';
+  export const POST = 'post';
+  export const PUT = 'put';
+  export const DELETE = 'delete';
 };
 
-const MESSAGE_TYPES = {
-  REGISTER: 'register',
-  OPEN: 'open',
-  OPEN_LIST: 'openList',
-  CLOSE: 'close',
-  REFRESH: 'refresh',
-  PIN: 'pin',
-  PING: 'ping',
-  UPDATE: 'update',
-  HTTP_GET: 'httpGET',
-  HTTP_POST: 'httpPOST',
-  HTTP_PUT: 'httpPUT',
-  HTTP_DELETE: 'httpDELETE',
-  CUSTOM_EVENT: 'customEvent',
-  REQUEST_DATA: 'requestData',
-  CALLBACK: 'callback',
+namespace MESSAGE_TYPES {
+  export const REGISTER = 'register';
+  export const OPEN = 'open';
+  export const OPEN_LIST = 'openList';
+  export const CLOSE = 'close';
+  export const REFRESH = 'refresh';
+  export const PIN = 'pin';
+  export const PING = 'ping';
+  export const UPDATE = 'update';
+  export const HTTP_GET = 'httpGET';
+  export const HTTP_POST = 'httpPOST';
+  export const HTTP_PUT = 'httpPUT';
+  export const HTTP_DELETE = 'httpDELETE';
+  export const CUSTOM_EVENT = 'customEvent';
+  export const REQUEST_DATA = 'requestData';
+  export const CALLBACK = 'callback';
 };
+
+type ValueOf<T> = T[keyof T];
+
+type MessageType = ValueOf<typeof MESSAGE_TYPES>;
+type HttpVerb = ValueOf<typeof HTTP_VERBS>;
 
 declare const postRobot: any;
+
+export interface PostRobotEvent<T> {
+  data: T;
+  // the URL of the origin window
+  origin: string;
+  // the Window object this event was sent from (be warned, you may not be able to access its properties)
+  source: Window;
+}
 
 export class AppBridgeService {
   create(name: string) {
@@ -158,122 +171,155 @@ export class AppBridge {
   }
 
   protected _setupHandlers(): void {
-    // Register
-    postRobot.on(MESSAGE_TYPES.REGISTER, (event) => {
-      this._trace(MESSAGE_TYPES.REGISTER, event);
-      this._registeredFrames.push(event);
-      return this.register(event.data).then((windowName) => {
-        return { windowName };
-      });
-    });
-    // Update
-    postRobot.on(MESSAGE_TYPES.UPDATE, (event) => {
-      this._trace(MESSAGE_TYPES.UPDATE, event);
-      return this.update(event.data).then((success) => {
-        return { success };
-      });
-    });
-    // Open
-    postRobot.on(MESSAGE_TYPES.OPEN, (event) => {
-      this._trace(MESSAGE_TYPES.OPEN, event);
-      return this.open(event.data).then((success) => {
-        return { success };
-      });
-    });
-    postRobot.on(MESSAGE_TYPES.OPEN_LIST, (event) => {
-      this._trace(MESSAGE_TYPES.OPEN_LIST, event);
-      return this.openList(event.data).then((success) => {
-        return { success };
-      });
-    });
-    // Close
-    postRobot.on(MESSAGE_TYPES.CLOSE, (event) => {
-      this._trace(MESSAGE_TYPES.CLOSE, event);
-      const index = this._registeredFrames.findIndex((frame) => frame.data.id === event.data.id);
-      if (index !== -1) {
-        this._registeredFrames.splice(index, 1);
-      }
-      return this.close(event.data).then((success) => {
-        return { success };
-      });
-    });
-    // Refresh
-    postRobot.on(MESSAGE_TYPES.REFRESH, (event) => {
-      this._trace(MESSAGE_TYPES.REFRESH, event);
-      return this.refresh(event.data).then((success) => {
-        return { success };
-      });
-    });
-    // PIN
-    postRobot.on(MESSAGE_TYPES.PIN, (event) => {
-      this._trace(MESSAGE_TYPES.PIN, event);
-      return this.pin(event.data).then((success) => {
-        return { success };
-      });
-    });
-    // PING
-    postRobot.on(MESSAGE_TYPES.PING, (event) => {
-      this._trace(MESSAGE_TYPES.PING, event);
-      return this.httpGET('ping').then((result) => {
-        return { data: result.data, error: result.error };
-      });
-    });
-    // REQUEST_DATA
-    postRobot.on(MESSAGE_TYPES.REQUEST_DATA, (event) => {
-      this._trace(MESSAGE_TYPES.REQUEST_DATA, event);
-      return this.requestData(event.data).then((result) => {
-        return { data: result.data, error: result.error };
-      });
-    });
-    // CALLBACKS
-    postRobot.on(MESSAGE_TYPES.CALLBACK, (event) => {
-      this._trace(MESSAGE_TYPES.CALLBACK, event);
-      return this.callback(event.data).then((success) => {
-        return { success };
-      });
-    });
-    // HTTP-GET
-    postRobot.on(MESSAGE_TYPES.HTTP_GET, (event) => {
-      this._trace(MESSAGE_TYPES.HTTP_GET, event);
-      return this.httpGET(event.data.relativeURL).then((result) => {
-        return { data: result.data, error: result.error };
-      });
-    });
-    // HTTP-POST
-    postRobot.on(MESSAGE_TYPES.HTTP_POST, (event) => {
-      this._trace(MESSAGE_TYPES.HTTP_POST, event);
-      return this.httpPOST(event.data.relativeURL, event.data.data).then((result) => {
-        return { data: result.data, error: result.error };
-      });
-    });
-    // HTTP-PUT
-    postRobot.on(MESSAGE_TYPES.HTTP_PUT, (event) => {
-      this._trace(MESSAGE_TYPES.HTTP_PUT, event);
-      return this.httpPUT(event.data.relativeURL, event.data.data).then((result) => {
-        return { data: result.data, error: result.error };
-      });
-    });
-    // HTTP-DELETE
-    postRobot.on(MESSAGE_TYPES.HTTP_DELETE, (event) => {
-      this._trace(MESSAGE_TYPES.HTTP_DELETE, event);
-      return this.httpDELETE(event.data.relativeURL).then((result) => {
-        return { data: result.data, error: result.error };
-      });
-    });
-    // Custom Events
-    postRobot.on(MESSAGE_TYPES.CUSTOM_EVENT, (event) => {
-      this._trace(MESSAGE_TYPES.CUSTOM_EVENT, event);
-      if (this._eventListeners[event.data.event]) {
-        this._eventListeners[event.data.event].forEach((listener) => {
-          listener(event.data.data);
+
+    // map an object for all handlers, so that we can run some other actions before each of them
+    const defaultMsgHandlers: { [msgType in MessageType]?: (evt: PostRobotEvent<any>) => Promise<unknown> } = {
+      // Register
+      [MESSAGE_TYPES.REGISTER]: async (event) => {
+        this._registeredFrames.push(event);
+        const windowName = await this.register(event.data);
+        return {windowName};
+      },
+
+      // Update
+      [MESSAGE_TYPES.UPDATE]: (event: PostRobotEvent<any>) => {
+        return this.update(event.data).then((success) => {
+          return { success };
         });
-      }
-      if (this._registeredFrames.length > 0) {
-        this._registeredFrames.forEach((frame) => {
-          postRobot.send(frame.source, MESSAGE_TYPES.CUSTOM_EVENT, event.data);
+      },
+      // Open
+      [MESSAGE_TYPES.OPEN]: (event: PostRobotEvent<any>) => {
+        return this.open(event.data).then((success) => {
+          return { success };
         });
+      },
+      [MESSAGE_TYPES.OPEN_LIST]: (event: PostRobotEvent<any>) => {
+        return this.openList(event.data).then((success) => {
+          return { success };
+        });
+      },
+      // Close
+      [MESSAGE_TYPES.CLOSE]: (event: PostRobotEvent<any>) => {
+        const index = this._registeredFrames.findIndex((frame) => frame.data.id === event.data.id);
+        if (index !== -1) {
+          this._registeredFrames.splice(index, 1);
+        }
+        return this.close(event.data).then(success => ({ success }));
+      },
+      // Refresh
+      [MESSAGE_TYPES.REFRESH]: (event: PostRobotEvent<any>) => {
+        return this.refresh(event.data).then((success) => {
+          return { success };
+        });
+      },
+      // PIN
+      [MESSAGE_TYPES.PIN]: (event: PostRobotEvent<any>) => {
+        return this.pin(event.data).then((success) => {
+          return { success };
+        });
+      },
+      // PING
+      [MESSAGE_TYPES.PING]: (event: PostRobotEvent<any>) => {
+        return this.httpGET('ping', undefined, event.data.origin).then((result) => {
+          return { data: result.data, error: result.error };
+        });
+      },
+      // REQUEST_DATA
+      [MESSAGE_TYPES.REQUEST_DATA]: (event: PostRobotEvent<any>) => {
+        return this.requestData(event.data).then((result) => {
+          return { data: result.data, error: result.error };
+        });
+      },
+      // CALLBACKS
+      [MESSAGE_TYPES.CALLBACK]: (event: PostRobotEvent<any>) => {
+        return this.callback(event.data).then((success) => {
+          return { success };
+        });
+      },
+      // HTTP-GET
+      [MESSAGE_TYPES.HTTP_GET]: (event: PostRobotEvent<any>) => {
+        return this.httpGET(event.data.relativeURL, undefined, event.data.origin).then((result) => {
+          return { data: result.data, error: result.error };
+        });
+      },
+      // HTTP-POST
+      [MESSAGE_TYPES.HTTP_POST]: (event: PostRobotEvent<any>) => {
+        return this.httpPOST(event.data.relativeURL, event.data.data, undefined, event.data.origin).then((result) => {
+          return { data: result.data, error: result.error };
+        });
+      },
+      // HTTP-PUT
+      [MESSAGE_TYPES.HTTP_PUT]: (event: PostRobotEvent<any>) => {
+        return this.httpPUT(event.data.relativeURL, event.data.data, undefined, event.data.origin).then((result) => {
+          return { data: result.data, error: result.error };
+        });
+      },
+      // HTTP-DELETE
+      [MESSAGE_TYPES.HTTP_DELETE]: (event: PostRobotEvent<any>) => {
+        return this.httpDELETE(event.data.relativeURL, undefined, event.data.origin).then((result) => {
+          return { data: result.data, error: result.error };
+        });
+      },
+      // Custom Events
+      [MESSAGE_TYPES.CUSTOM_EVENT]: async (event: PostRobotEvent<any>) => {
+        if (this._eventListeners[event.data.event]) {
+          this._eventListeners[event.data.event].forEach((listener) => {
+            listener(event.data.data);
+          });
+        }
+        if (this._registeredFrames.length > 0) {
+          this._registeredFrames.forEach((frame) => {
+            // TODO: Should this make sure it doesn't echo the custom event back to the author?
+            postRobot.send(frame.source, MESSAGE_TYPES.CUSTOM_EVENT, event.data);
+          });
+        }
       }
+    };
+
+    Object.keys(defaultMsgHandlers).forEach(msgType => {
+      postRobot.on(msgType, event => {
+        this._trace(msgType, event);
+        const origin: string[] = Array.isArray(event.data.origin) ? event.data.origin : [];
+        if (event.origin !== window.location.origin) {
+        origin.push(event.origin);
+        }
+        event.data.origin = origin;
+        event.data.source = event.source;
+        return defaultMsgHandlers[msgType](event);
+      })
     });
+  }
+
+  handleMessage<T>({ msgType, handler, packet, echoPacket, resolveEventData }: {
+    msgType: MessageType,
+    handler: AppBridgeHandler,
+    packet: T,
+    echoPacket: any,
+    resolveEventData: (any) => boolean,
+  }): Promise<boolean> {
+    let returnPromise: Promise<any>;
+    if (this._handlers[handler]) {
+      // Should be directly returning a promise. However, as a fallback, provide callback arguments
+      let callbackSuccess, callbackFail;
+      returnPromise = new Promise((s, f) => {
+        callbackSuccess = s;
+        callbackFail = f;
+      });
+      const handlerResult = this._handlers[handler](packet, callbackArg => {
+        if (callbackArg) {
+          callbackSuccess(true);
+        } else {
+          callbackFail(false);
+        }
+      });
+      if (handlerResult && 'then' in handlerResult) {
+        returnPromise = handlerResult;
+      }
+      return returnPromise.then(result => true, () => false);
+    } else {
+      return postRobot.sendToParent(msgType, echoPacket || packet);
+    }
+    
   }
 
   /**
@@ -606,16 +652,18 @@ export class AppBridge {
   /**
    * Fires or responds to an HTTP_GET event
    * @param packet any - packet of data to send with the event
+   * @param timeout - how long to attempt the request before reporting an error
+   * @param origin - the domain of the frame the request originated from
    */
-  public httpGET(relativeURL: string, timeout: number = 10000): Promise<any> {
+  public httpGET(relativeURL: string, timeout: number = 10000, origin: string = this.traceName): Promise<any> {
     return new Promise<any>((resolve, reject) => {
       if (this._handlers[AppBridgeHandler.HTTP]) {
-        this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.GET, relativeURL }, (data: any, error: any) => {
+        this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.GET, relativeURL, origin }, (data: any, error: any) => {
           resolve({ data, error });
         });
       } else {
         postRobot
-          .sendToParent(MESSAGE_TYPES.HTTP_GET, { relativeURL }, { timeout })
+          .sendToParent(MESSAGE_TYPES.HTTP_GET, { relativeURL, origin: [origin] })
           .then((event: any) => {
             resolve({ data: event.data.data, error: event.data.error });
           })
@@ -630,15 +678,15 @@ export class AppBridge {
    * Fires or responds to an HTTP_POST event
    * @param packet any - packet of data to send with the event
    */
-  public httpPOST(relativeURL: string, postData: any, timeout: number = 10000): Promise<any> {
+  public httpPOST(relativeURL: string, postData: any, timeout: number = 10000, origin: string = this.traceName): Promise<any> {
     return new Promise<any>((resolve, reject) => {
       if (this._handlers[AppBridgeHandler.HTTP]) {
-        this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.POST, relativeURL, data: postData }, (data: any, error: any) => {
+        this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.POST, relativeURL, data: postData, origin }, (data: any, error: any) => {
           resolve({ data, error });
         });
       } else {
         postRobot
-          .sendToParent(MESSAGE_TYPES.HTTP_POST, { relativeURL, data: postData }, { timeout })
+          .sendToParent(MESSAGE_TYPES.HTTP_POST, { relativeURL, data: postData, origin: [ origin ] }, { timeout })
           .then((event: any) => {
             resolve({ data: event.data.data, error: event.data.error });
           })
@@ -653,15 +701,15 @@ export class AppBridge {
    * Fires or responds to an HTTP_PUT event
    * @param packet any - packet of data to send with the event
    */
-  public httpPUT(relativeURL: string, putData: any, timeout: number = 10000): Promise<any> {
+  public httpPUT(relativeURL: string, putData: any, timeout: number = 10000, origin: string = this.traceName): Promise<any> {
     return new Promise<any>((resolve, reject) => {
       if (this._handlers[AppBridgeHandler.HTTP]) {
-        this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.PUT, relativeURL, data: putData }, (data: any, error: any) => {
+        this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.PUT, relativeURL, data: putData, origin }, (data: any, error: any) => {
           resolve({ data, error });
         });
       } else {
         postRobot
-          .sendToParent(MESSAGE_TYPES.HTTP_PUT, { relativeURL, data: putData }, { timeout })
+          .sendToParent(MESSAGE_TYPES.HTTP_PUT, { relativeURL, data: putData, origin: [ origin ] }, { timeout })
           .then((event: any) => {
             resolve({ data: event.data.data, error: event.data.error });
           })
@@ -676,15 +724,15 @@ export class AppBridge {
    * Fires or responds to an HTTP_DELETE event
    * @param packet any - packet of data to send with the event
    */
-  public httpDELETE(relativeURL: string, timeout: number = 10000): Promise<any> {
+  public httpDELETE(relativeURL: string, timeout: number = 10000, origin: string = this.traceName): Promise<any> {
     return new Promise<any>((resolve, reject) => {
       if (this._handlers[AppBridgeHandler.HTTP]) {
-        this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.DELETE, relativeURL }, (data: any, error: any) => {
+        this._handlers[AppBridgeHandler.HTTP]({ verb: HTTP_VERBS.DELETE, relativeURL, origin }, (data: any, error: any) => {
           resolve({ data, error });
         });
       } else {
         postRobot
-          .sendToParent(MESSAGE_TYPES.HTTP_DELETE, { relativeURL }, { timeout })
+          .sendToParent(MESSAGE_TYPES.HTTP_DELETE, { relativeURL, origin: [ origin ] }, { timeout })
           .then((event: any) => {
             resolve({ data: event.data.data, error: event.data.error });
           })

--- a/projects/novo-elements/src/utils/app-bridge/index.ts
+++ b/projects/novo-elements/src/utils/app-bridge/index.ts
@@ -1,1 +1,2 @@
 export * from './AppBridge';
+export * from './interfaces';

--- a/projects/novo-elements/src/utils/app-bridge/interfaces.ts
+++ b/projects/novo-elements/src/utils/app-bridge/interfaces.ts
@@ -1,0 +1,107 @@
+export enum AppBridgeHandler {
+  HTTP,
+  OPEN,
+  OPEN_LIST,
+  CLOSE,
+  REFRESH,
+  PIN,
+  REGISTER,
+  UPDATE,
+  REQUEST_DATA,
+  CALLBACK,
+  PING,
+}
+
+// record       - an individual entity record
+// add/fast-add - the add page for a new record
+// custom       - custom action that opens the url provided in data.url
+// preview      - the preview slideout available only in Novo
+export type NovoApps = 'record' | 'add' | 'fast-add' | 'slide-out-add' | 'custom' | 'preview';
+
+export type AlleyLinkColors =
+  | 'purple'
+  | 'green'
+  | 'blue'
+  | 'lead'
+  | 'candidate'
+  | 'contact'
+  | 'company'
+  | 'opportunity'
+  | 'job'
+  | 'billable-charge'
+  | 'earn-code'
+  | 'invoice-statement'
+  | 'job-code'
+  | 'payable-charge'
+  | 'sales-tax-rate'
+  | 'tax-rules'
+  | 'submission'
+  | 'placement'
+  | 'navigation'
+  | 'canvas'
+  | 'neutral'
+  | 'neutral-italic'
+  | 'initial'
+  | 'distributionList'
+  | 'contract';
+
+export interface IAppBridgeOpenEvent {
+  type: NovoApps;
+  entityType: string;
+  entityId?: string;
+  tab?: string;
+  data?: any;
+  passthrough?: string;
+}
+
+export type MosaicLists =
+  | 'Candidate'
+  | 'ClientContact'
+  | 'ClientCorporation'
+  | 'JobOrder'
+  | 'JobSubmission'
+  | 'JobPosting'
+  | 'Placement'
+  | 'Lead'
+  | 'Opportunity';
+
+export interface IAppBridgeOpenListEvent {
+  type: MosaicLists;
+  keywords: Array<string>;
+  criteria: any;
+}
+
+export type NovoDataType = 'entitlements' | 'settings' | 'user';
+
+export interface IAppBridgeRequestDataEvent {
+  type: NovoDataType;
+}
+
+export type HttpVerb = 'get' | 'post' | 'put' | 'delete';
+
+export const HTTP_VERBS = {
+  GET: 'get',
+  POST: 'post',
+  PUT: 'put',
+  DELETE: 'delete',
+};
+
+export type MessageType = 'register' | 'open' | 'openList' | 'close' | 'refresh' | 'pin' | 'ping' | 'update' | 'httpGET' | 'httpPOST' | 'httpPUT' | 'httpDELETE' | 'customEvent' | 'requestData' | 'callback';
+
+export const MESSAGE_TYPES = {
+  REGISTER: 'register',
+  OPEN: 'open',
+  OPEN_LIST: 'openList',
+  CLOSE: 'close',
+  REFRESH: 'refresh',
+  PIN: 'pin',
+  PING: 'ping',
+  UPDATE: 'update',
+  HTTP_GET: 'httpGET',
+  HTTP_POST: 'httpPOST',
+  HTTP_PUT: 'httpPUT',
+  HTTP_DELETE: 'httpDELETE',
+  CUSTOM_EVENT: 'customEvent',
+  REQUEST_DATA: 'requestData',
+  CALLBACK: 'callback',
+};


### PR DESCRIPTION
## **Description**

This change takes the raw "origin" value from postrobot event handlers and appends it to the message data, making it easier for the host frame to record information on different senders. This comes in natively as part of the iframe message event, so the child instance of AppBridge doesn't need to implement it.

This also changes the types around MessageTypes so that they are definitively typed towards each string, rather than all being of type "string". Thus, a coder providing a value that doesn't match the options will get a compilation error.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**