### PR TITLE
fix(PickerResults): Fixing picker background in firefox/safari

### DIFF
--- a/projects/novo-elements/src/elements/picker/extras/picker-results/PickerResults.scss
+++ b/projects/novo-elements/src/elements/picker/extras/picker-results/PickerResults.scss
@@ -163,8 +163,7 @@ quick-note-results,
 }
 
 
-entity-picker-results,
-:host-context(entity-picker-results) {
+entity-picker-results {
   background: $white;
   width: 100%;
   min-width: 250px;


### PR DESCRIPTION
## **Description**

Making a small change for entity-picker background to fix transparency issues in firefox and safari. Entity-picker inside PickerResults should remain non-transparent in firefox and safari as it does in chrome.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**