### PR TITLE
feat(RowChips): Add flag to show chips at full height

### DIFF
--- a/projects/novo-elements/src/elements/chips/RowChips.scss
+++ b/projects/novo-elements/src/elements/chips/RowChips.scss
@@ -37,6 +37,14 @@
           border: none;
         }
       }
+      &.show-overflow {
+        height: unset;
+        span {
+          overflow: visible;
+          text-overflow: unset;
+          max-height: unset;
+        }
+       }
       &:first-of-type {
         flex: 0 0 275px;
       }

--- a/projects/novo-elements/src/elements/chips/RowChips.ts
+++ b/projects/novo-elements/src/elements/chips/RowChips.ts
@@ -66,6 +66,7 @@ export class NovoRowChipElement extends NovoChipElement {
     >
       <div
         class="column-data"
+        [class.show-overflow]="column.showOverflow"
         [class.editable]="column.editable"
         [style.flexBasis.px]="column.width || 200"
         *ngFor="let column of source.columns"


### PR DESCRIPTION
## **Description**

Adds a flag that can be passed into the control config/overrides to allow row chips to be shown at full height (instead of always having overflow hidden and height set at 2em).

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**