### PR TITLE
fix(Demo): fixing a few issues with the examples and their components

### DIFF
--- a/projects/novo-elements/src/elements/form/DynamicForm.ts
+++ b/projects/novo-elements/src/elements/form/DynamicForm.ts
@@ -191,7 +191,7 @@ export class NovoDynamicFormElement implements OnChanges, OnInit, AfterContentIn
     this.form.fieldsets.forEach((fieldset) => {
       fieldset.controls.forEach((control) => {
         const ctl = this.form.controls[control.key];
-        if (!this.fieldsAlreadyHidden.includes(control.key)) {
+        if (!this.fieldsAlreadyHidden?.includes(control.key)) {
           ctl.hidden = false;
         }
       });

--- a/projects/novo-elements/src/elements/stepper/stepper.component.ts
+++ b/projects/novo-elements/src/elements/stepper/stepper.component.ts
@@ -12,6 +12,7 @@ import {
   forwardRef,
   Inject,
   Input,
+  OnDestroy,
   Optional,
   QueryList,
   TemplateRef,
@@ -55,7 +56,7 @@ export class NovoStep extends CdkStep {
     { provide: CdkStepper, useExisting: NovoStepper },
   ],
 })
-export class NovoStepper extends CdkStepper implements AfterContentInit {
+export class NovoStepper extends CdkStepper implements AfterContentInit, OnDestroy {
   /** The list of step headers of the steps in the stepper. */
   @ViewChildren(NovoStepHeader)
   _stepHeader: QueryList<CdkStepHeader>;
@@ -85,6 +86,8 @@ export class NovoStepper extends CdkStepper implements AfterContentInit {
     // Mark the component for change detection whenever the content children query changes
     this.steps.changes.pipe(takeUntil(this._destroyed)).subscribe(() => this._stateChanged());
   }
+
+  ngOnDestroy() {}
 
   complete() {
     try {

--- a/projects/novo-examples/src/form-controls/dynamic-form/dynamic-form-field-sets/dynamic-form-field-sets-example.ts
+++ b/projects/novo-examples/src/form-controls/dynamic-form/dynamic-form-field-sets/dynamic-form-field-sets-example.ts
@@ -11,27 +11,10 @@ import { MockMeta, MockMetaHeaders } from '../MockMeta';
   styleUrls: ['dynamic-form-field-sets-example.css'],
 })
 export class DynamicFormFieldSetsExample {
-  public dynamic: any;
-  public dynamicForm: any;
   public fieldsets: Array<any>;
   public fieldsetsForm: any;
 
   constructor(private formUtils: FormUtils) {
-    // Dynamic
-    this.dynamic = formUtils.toFieldSets(
-      MockMeta,
-      '$ USD',
-      {},
-      { token: 'TOKEN', military: true },
-      {
-        customfield: {
-          template: 'custom-demo-component',
-        },
-      },
-    );
-    formUtils.setInitialValuesFieldsets(this.dynamic, { firstName: 'Initial F Name', number: 12 });
-    this.dynamicForm = formUtils.toFormGroupFromFieldset(this.dynamic);
-
     // Dynamic + Fieldsets
     this.fieldsets = formUtils.toFieldSets(
       MockMetaHeaders,
@@ -57,8 +40,10 @@ export class DynamicFormFieldSetsExample {
   }
 
   clear() {
-    this.dynamic.forEach((control) => {
-      control.forceClear.emit();
+    this.fieldsets.forEach((fieldset) => {
+      fieldset.controls.forEach((control) => {
+        control.forceClear.emit();
+      });
     });
   }
 

--- a/projects/novo-examples/src/form-controls/dynamic-form/dynamic-form/dynamic-form-example.ts
+++ b/projects/novo-examples/src/form-controls/dynamic-form/dynamic-form/dynamic-form-example.ts
@@ -40,7 +40,7 @@ export class DynamicFormExample {
   }
 
   clear() {
-    this.dynamic.forEach((control) => {
+    this.dynamic[0].controls.forEach((control) => {
       control.forceClear.emit();
     });
   }

--- a/projects/novo-examples/src/layouts/sidenav/basic-sidenav/basic-sidenav-example.html
+++ b/projects/novo-examples/src/layouts/sidenav/basic-sidenav/basic-sidenav-example.html
@@ -76,7 +76,7 @@
         </novo-stack>
       </novo-toolbar>
       <novo-toolbar gap="md">
-        <novo-nav outlet="pages">
+        <novo-nav [outlet]="pages">
           <novo-tab>Overview</novo-tab>
           <novo-tab>Activity</novo-tab>
           <novo-tab>Files</novo-tab>
@@ -92,6 +92,9 @@
         </novo-nav-content>
         <novo-nav-content>
           <h1>Tab 2 Content</h1>
+        </novo-nav-content>
+        <novo-nav-content>
+          <h1>Tab 3 Content</h1>
         </novo-nav-content>
       </novo-nav-outlet>
 


### PR DESCRIPTION
## **Description**

There were a few issues with the examples called out by some issues:
- #1482
  - DynamicForm - this was actually an issue in the component itself. added an undefined check on a property reference.
- #1198
  - DynamicForm - we were not referencing the form objects properly in the clear functions implemented in the demos.
- #1440 
  - SideNav - the outlet on the novo-nav in the example template needed to be bracketed to properly pass it in.
- #1440 
  - Stepper - we were subscribing to a state change until 'this._destroyed' without using the OnDestroy lifecycle hook. implemented OnDestroy.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**