### PR TITLE
feat(Chips): added new hidden chips feature to Chips picker

### DIFF
--- a/projects/novo-elements/src/elements/chips/Chip.spec.ts
+++ b/projects/novo-elements/src/elements/chips/Chip.spec.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { NovoChipElement } from './Chip';
 import { NovoChipsModule } from './Chips.module';
 
-fdescribe('Elements: NovoChipElement', () => {
+describe('Elements: NovoChipElement', () => {
   let fixture;
   let component;
 

--- a/projects/novo-elements/src/elements/chips/Chip.spec.ts
+++ b/projects/novo-elements/src/elements/chips/Chip.spec.ts
@@ -1,0 +1,41 @@
+import { async, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { NovoChipElement } from './Chip';
+import { NovoChipsModule } from './Chips.module';
+
+fdescribe('Elements: NovoChipElement', () => {
+  let fixture;
+  let component;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [FormsModule, NovoChipsModule],
+    }).compileComponents();
+    fixture = TestBed.createComponent(NovoChipElement);
+    component = fixture.debugElement.componentInstance;
+  }));
+
+  describe('Method: ngOnInit()', () => {
+    it('should initialize correctly', () => {
+      expect(component).toBeTruthy();
+      expect(component.select).toBeDefined();
+      expect(component.remove).toBeDefined();
+      expect(component.entity).toBeUndefined();
+    });
+  });
+
+  describe('Method: remove()', () => {
+    it('should emit remove event if removable', () => {
+      jest.spyOn(component.removed, 'emit').mockImplementation(() => { });
+      component.removable = true;
+      component.remove();
+      expect(component.removed.emit).toHaveBeenCalled();
+    });
+    it('should not emit remove event if not removable', () => {
+      jest.spyOn(component.removed, 'emit').mockImplementation(() => { });
+      component.removable = false;
+      component.remove();
+      expect(component.removed.emit).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/projects/novo-elements/src/elements/chips/Chips.module.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.module.ts
@@ -4,7 +4,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 // APP
 import { Key } from 'novo-elements/utils';
-import { ErrorStateMatcher } from 'novo-elements/elements/common';
+import { ErrorStateMatcher, NovoCommonModule } from 'novo-elements/elements/common';
 import { NovoFieldModule } from 'novo-elements/elements/field';
 import { NovoIconModule } from 'novo-elements/elements/icon';
 import { NovoPickerModule } from 'novo-elements/elements/picker';
@@ -16,7 +16,7 @@ import { NovoChipsElement } from './Chips';
 import { NovoRowChipElement, NovoRowChipsElement } from './RowChips';
 import { AvatarTypePipe } from './pipe/AvatarType.pipe';
 @NgModule({
-  imports: [CommonModule, FormsModule, NovoPickerModule, NovoIconModule, NovoFieldModule],
+  imports: [CommonModule, FormsModule, NovoPickerModule, NovoIconModule, NovoFieldModule, NovoCommonModule],
   declarations: [
     NovoChipElement,
     NovoChipAvatar,

--- a/projects/novo-elements/src/elements/chips/Chips.module.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.module.ts
@@ -14,6 +14,7 @@ import { NovoChipInput } from './ChipInput';
 import { NovoChipList } from './ChipList';
 import { NovoChipsElement } from './Chips';
 import { NovoRowChipElement, NovoRowChipsElement } from './RowChips';
+import { AvatarTypePipe } from './pipe/AvatarType.pipe';
 @NgModule({
   imports: [CommonModule, FormsModule, NovoPickerModule, NovoIconModule, NovoFieldModule],
   declarations: [
@@ -25,6 +26,7 @@ import { NovoRowChipElement, NovoRowChipsElement } from './RowChips';
     NovoChipsElement,
     NovoRowChipElement,
     NovoRowChipsElement,
+    AvatarTypePipe
   ],
   exports: [
     NovoChipElement,
@@ -35,6 +37,7 @@ import { NovoRowChipElement, NovoRowChipsElement } from './RowChips';
     NovoChipsElement,
     NovoRowChipElement,
     NovoRowChipsElement,
+    AvatarTypePipe
   ],
   providers: [
     ErrorStateMatcher,

--- a/projects/novo-elements/src/elements/chips/Chips.scss
+++ b/projects/novo-elements/src/elements/chips/Chips.scss
@@ -13,7 +13,7 @@
 
   .hidden-chips-toggle {
     cursor: pointer;
-    padding: 0 1rem 0 .5rem;
+    padding-left: .5rem;
     line-height: 2.7rem;
   }
 
@@ -35,6 +35,7 @@
   }
   .chip-input-container {
     flex-grow: 4;
+    padding-left: 1rem;
     input {
       padding-top: 0;
       border: none;

--- a/projects/novo-elements/src/elements/chips/Chips.scss
+++ b/projects/novo-elements/src/elements/chips/Chips.scss
@@ -10,6 +10,13 @@
   transition: all 200ms ease-in-out;
   position: relative;
   padding: 2px 0;
+
+  .hidden-chips-toggle {
+    cursor: pointer;
+    padding: 0 1rem 0 .5rem;
+    line-height: 2.7rem;
+  }
+
   &.with-value {
     margin-bottom: 20px;
   }

--- a/projects/novo-elements/src/elements/chips/Chips.scss
+++ b/projects/novo-elements/src/elements/chips/Chips.scss
@@ -33,6 +33,13 @@
   &.disabled {
     border-bottom-style: dashed !important;
   }
+  .novo-chip-container {
+    flex: 1;
+    display: flex;
+    flex-flow: row wrap;
+    gap: 0.4rem;
+    align-items: center;
+  }
   .chip-input-container {
     flex: 1 15rem;
     padding-left: 1rem;
@@ -45,12 +52,6 @@
         outline: none;
       }
     }
-  }
-  .novo-chip-container {
-    display: flex;
-    flex-flow: row wrap;
-    gap: 0.4rem;
-    align-items: center;
   }
   label.clear-all {
     flex: 1 100%;

--- a/projects/novo-elements/src/elements/chips/Chips.scss
+++ b/projects/novo-elements/src/elements/chips/Chips.scss
@@ -34,7 +34,7 @@
     border-bottom-style: dashed !important;
   }
   .chip-input-container {
-    flex-grow: 4;
+    flex: 1 15rem;
     padding-left: 1rem;
     input {
       padding-top: 0;
@@ -50,6 +50,7 @@
     display: flex;
     flex-flow: row wrap;
     gap: 0.4rem;
+    align-items: center;
   }
   label.clear-all {
     flex: 1 100%;

--- a/projects/novo-elements/src/elements/chips/Chips.spec.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.spec.ts
@@ -76,6 +76,7 @@ describe('Elements: NovoChipsElement', () => {
     it('should update the hiddenChips object based on the maxChipsShown property', () => {
       component.items = ['A','B','C','D','E','F'];
       component.maxChipsShown = 4;
+      component._maxChipsShown = component.maxChipsShown;
       component.updateHiddenChips();
       expect(component.hiddenChips.type).toBe('items');
       expect(component.hiddenChips.count).toBe(2);

--- a/projects/novo-elements/src/elements/chips/Chips.spec.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.spec.ts
@@ -73,10 +73,10 @@ describe('Elements: NovoChipsElement', () => {
   });
 
   describe('Method: updateHiddenChips()', () => {
-    it('should update the hiddenChips object based on the maxChipsShown property', () => {
+    it('should update the hiddenChips object based on the hideChipsLimit property', () => {
       component.items = ['A','B','C','D','E','F'];
-      component.maxChipsShown = 4;
-      component._maxChipsShown = component.maxChipsShown;
+      component.hideChipsLimit = 4;
+      component._hideChipsLimit = component.hideChipsLimit;
       component.updateHiddenChips();
       expect(component.hiddenChips.type).toBe('items');
       expect(component.hiddenChips.count).toBe(2);
@@ -88,13 +88,13 @@ describe('Elements: NovoChipsElement', () => {
   });
 
   describe('Method: toggleHiddenChips()', () => {
-    it('should flip the maxChipsShown count between the original set at init and the CHIPS_SHOWN_MAX const', () => {
-      component.maxChipsShown = 3;
-      component._maxChipsShown = component.maxChipsShown;
+    it('should flip the hideChipsLimit count between the original set at init and the CHIPS_SHOWN_MAX const', () => {
+      component.hideChipsLimit = 3;
+      component._hideChipsLimit = component.hideChipsLimit;
       component.CHIPS_SHOWN_MAX = 999;
-      expect(component.maxChipsShown).toBe(3);
+      expect(component.hideChipsLimit).toBe(3);
       component.toggleHiddenChips();
-      expect(component.maxChipsShown).toBe(999);
+      expect(component.hideChipsLimit).toBe(999);
     });
   });
 

--- a/projects/novo-elements/src/elements/chips/Chips.spec.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.spec.ts
@@ -73,10 +73,10 @@ describe('Elements: NovoChipsElement', () => {
   });
 
   describe('Method: updateHiddenChips()', () => {
-    it('should update hiddenChipsCount based on the items length and the hideChipsLimit property', () => {
+    it('should update hiddenChipsCount based on the items length and the hiddenChipsLimit property', () => {
       component.items = ['A','B','C','D','E','F'];
-      component.hideChipsLimit = 4;
-      component._hideChipsLimit = component.hideChipsLimit;
+      component.hiddenChipsLimit = 4;
+      component._hiddenChipsLimit = component.hiddenChipsLimit;
       component.updateHiddenChips();
       expect(component.hiddenChipsCount).toBe(2);
       component.items.pop();
@@ -84,24 +84,24 @@ describe('Elements: NovoChipsElement', () => {
       expect(component.hiddenChipsCount).toBe(1);
     });
 
-    it('should reset the hideChipsLimit to the original limit if: currently showing all chips BUT there are no longer any extra chips to hide', () => {
+    it('should reset the hiddenChipsLimit to the original limit if: currently showing all chips BUT there are no longer any extra chips to hide', () => {
       component.items = ['A','B','C','D'];
-      component._hideChipsLimit = 3;
-      component.hideChipsLimit = component.CHIPS_SHOWN_MAX; // currently showing all chips
+      component._hiddenChipsLimit = 3;
+      component.hiddenChipsLimit = component.CHIPS_SHOWN_MAX; // currently showing all chips
       component.items.pop(); // ['A', 'B', 'C']
       component.updateHiddenChips();
-      expect(component.hideChipsLimit).toBe(component._hideChipsLimit);
+      expect(component.hiddenChipsLimit).toBe(component._hiddenChipsLimit);
 
     });
   });
 
   describe('Method: toggleHiddenChips()', () => {
-    it('should flip the hideChipsLimit count between the original set at init and the CHIPS_SHOWN_MAX const', () => {
-      component.hideChipsLimit = 3;
-      component._hideChipsLimit = component.hideChipsLimit;
-      expect(component.hideChipsLimit).toBe(3);
+    it('should flip the hiddenChipsLimit count between the original set at init and the CHIPS_SHOWN_MAX const', () => {
+      component.hiddenChipsLimit = 3;
+      component._hiddenChipsLimit = component.hiddenChipsLimit;
+      expect(component.hiddenChipsLimit).toBe(3);
       component.toggleHiddenChips();
-      expect(component.hideChipsLimit).toBe(999);
+      expect(component.hiddenChipsLimit).toBe(999);
     });
   });
 

--- a/projects/novo-elements/src/elements/chips/Chips.spec.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.spec.ts
@@ -6,7 +6,7 @@ import { ComponentUtils, NovoLabelService } from 'novo-elements/services';
 import { NovoChipsElement } from './Chips';
 import { NovoChipsModule } from './Chips.module';
 
-fdescribe('Elements: NovoChipsElement', () => {
+describe('Elements: NovoChipsElement', () => {
   let fixture;
   let component;
 

--- a/projects/novo-elements/src/elements/chips/Chips.spec.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.spec.ts
@@ -3,48 +3,10 @@ import { async, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { ComponentUtils, NovoLabelService } from 'novo-elements/services';
 // App
-import { NovoChipElement } from './Chip';
 import { NovoChipsElement } from './Chips';
 import { NovoChipsModule } from './Chips.module';
 
-xdescribe('Elements: NovoChipElement', () => {
-  let fixture;
-  let component;
-
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [FormsModule, NovoChipsModule],
-    }).compileComponents();
-    fixture = TestBed.createComponent(NovoChipElement);
-    component = fixture.debugElement.componentInstance;
-  }));
-
-  describe('Method: ngOnInit()', () => {
-    it('should initialize correctly', () => {
-      expect(component).toBeTruthy();
-      expect(component.select).toBeDefined();
-      expect(component.remove).toBeDefined();
-      expect(component.entity).toBeUndefined();
-    });
-  });
-
-  describe('Method: remove()', () => {
-    it('should emit remove event if removable', () => {
-      jest.spyOn(component.removed, 'emit').mockImplementation(() => {});
-      component.removable = true;
-      component.remove();
-      expect(component.removed.emit).toHaveBeenCalled();
-    });
-    it('should not emit remove event if not removable', () => {
-      jest.spyOn(component.removed, 'emit').mockImplementation(() => {});
-      component.removable = false;
-      component.remove();
-      expect(component.removed.emit).toHaveBeenCalled();
-    });
-  });
-});
-
-describe('Elements: NovoChipsElement', () => {
+fdescribe('Elements: NovoChipsElement', () => {
   let fixture;
   let component;
 
@@ -109,6 +71,32 @@ describe('Elements: NovoChipsElement', () => {
       expect(component.value).toBe('Test (test)');
     });
   });
+
+  describe('Method: updateHiddenChips()', () => {
+    it('should update the hiddenChips object based on the maxChipsShown property', () => {
+      component.items = ['A','B','C','D','E','F'];
+      component.maxChipsShown = 4;
+      component.updateHiddenChips();
+      expect(component.hiddenChips.type).toBe('items');
+      expect(component.hiddenChips.count).toBe(2);
+      component.items.pop();
+      component.updateHiddenChips();
+      expect(component.hiddenChips.type).toBe('item');
+      expect(component.hiddenChips.count).toBe(1);
+    });
+  });
+
+  describe('Method: toggleHiddenChips()', () => {
+    it('should flip the maxChipsShown count between the original set at init and the CHIPS_SHOWN_MAX const', () => {
+      component.maxChipsShown = 3;
+      component._maxChipsShown = component.maxChipsShown;
+      component.CHIPS_SHOWN_MAX = 999;
+      expect(component.maxChipsShown).toBe(3);
+      component.toggleHiddenChips();
+      expect(component.maxChipsShown).toBe(999);
+    });
+  });
+
 
   describe('Method: remove(event, item)', () => {
     it('should remove an item', () => {
@@ -239,7 +227,7 @@ describe('Elements: NovoChipsElement', () => {
         ],
       };
       const result = component.getLabelFromOptions({ id: 2 });
-      expect(result).toStrictEqual({ value: 2, label: 'option 2' });
+      expect(result).toEqual({ value: 2, label: 'option 2' });
     });
     it('should return a proper response if passed an number as value', () => {
       component.source = {
@@ -259,7 +247,7 @@ describe('Elements: NovoChipsElement', () => {
         ],
       };
       const result = component.getLabelFromOptions(2);
-      expect(result).toStrictEqual({ value: 2, label: 'option 2' });
+      expect(result).toEqual({ value: 2, label: 'option 2' });
     });
   });
 

--- a/projects/novo-elements/src/elements/chips/Chips.spec.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.spec.ts
@@ -73,17 +73,25 @@ describe('Elements: NovoChipsElement', () => {
   });
 
   describe('Method: updateHiddenChips()', () => {
-    it('should update the hiddenChips object based on the hideChipsLimit property', () => {
+    it('should update hiddenChipsCount based on the items length and the hideChipsLimit property', () => {
       component.items = ['A','B','C','D','E','F'];
       component.hideChipsLimit = 4;
       component._hideChipsLimit = component.hideChipsLimit;
       component.updateHiddenChips();
-      expect(component.hiddenChips.type).toBe('items');
-      expect(component.hiddenChips.count).toBe(2);
+      expect(component.hiddenChipsCount).toBe(2);
       component.items.pop();
       component.updateHiddenChips();
-      expect(component.hiddenChips.type).toBe('item');
-      expect(component.hiddenChips.count).toBe(1);
+      expect(component.hiddenChipsCount).toBe(1);
+    });
+
+    it('should reset the hideChipsLimit to the original limit if: currently showing all chips BUT there are no longer any extra chips to hide', () => {
+      component.items = ['A','B','C','D'];
+      component._hideChipsLimit = 3;
+      component.hideChipsLimit = component.CHIPS_SHOWN_MAX; // currently showing all chips
+      component.items.pop(); // ['A', 'B', 'C']
+      component.updateHiddenChips();
+      expect(component.hideChipsLimit).toBe(component._hideChipsLimit);
+
     });
   });
 
@@ -91,7 +99,6 @@ describe('Elements: NovoChipsElement', () => {
     it('should flip the hideChipsLimit count between the original set at init and the CHIPS_SHOWN_MAX const', () => {
       component.hideChipsLimit = 3;
       component._hideChipsLimit = component.hideChipsLimit;
-      component.CHIPS_SHOWN_MAX = 999;
       expect(component.hideChipsLimit).toBe(3);
       component.toggleHiddenChips();
       expect(component.hideChipsLimit).toBe(999);

--- a/projects/novo-elements/src/elements/chips/Chips.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.ts
@@ -32,7 +32,7 @@ const CHIPS_VALUE_ACCESSOR = {
         {{ item.label }}
         <novo-icon *ngIf="!disablePickerInput" novoChipRemove>x</novo-icon>
       </novo-chip>
-      <div *ngIf="items.length > maxChipsShown || items.length > _maxChipsShown && maxChipsShown === CHIPS_SHOWN_MAX" class="hidden-chips-toggle" (click)="toggleHiddenChips()">
+      <div *ngIf="items.length > _maxChipsShown" class="hidden-chips-toggle" (click)="toggleHiddenChips()">
         <novo-label *ngIf="maxChipsShown !== CHIPS_SHOWN_MAX" color="positive">+ {{ hiddenChips.count }} {{ labels.more }} {{ hiddenChips.type }}</novo-label>
         <novo-label *ngIf="maxChipsShown === CHIPS_SHOWN_MAX" color="positive"> {{labels.showLess}}</novo-label>
       </div>
@@ -250,17 +250,17 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
   }
 
   updateHiddenChips() {
-    this.hiddenChips = <{ type, count }>{};
-    const chipsToHide = this.items.slice(this.maxChipsShown);
-    const numChipsToHide = chipsToHide.length;
-    if (numChipsToHide > 0) {
+    const numChipsToHide = this.items.length - this._maxChipsShown;
+    if (numChipsToHide) {
       this.hiddenChips = { count: numChipsToHide, type: numChipsToHide > 1 ? this.labels.items : this.labels.item };
+    } else {
+      this.hiddenChips = <{ type, count }>{};
+      if (this.maxChipsShown === this.CHIPS_SHOWN_MAX) this.maxChipsShown = this._maxChipsShown; // reset maxChipsShown to original count
     }
   }
 
   toggleHiddenChips() {
-    this.maxChipsShown = this.maxChipsShown == this.CHIPS_SHOWN_MAX ? this._maxChipsShown : this.CHIPS_SHOWN_MAX;
-    this.updateHiddenChips();
+    this.maxChipsShown = this.maxChipsShown === this.CHIPS_SHOWN_MAX ? this._maxChipsShown : this.CHIPS_SHOWN_MAX;
   }
 
   remove(event, item) {

--- a/projects/novo-elements/src/elements/chips/Chips.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.ts
@@ -20,7 +20,7 @@ const CHIPS_VALUE_ACCESSOR = {
   template: `
     <div class="novo-chip-container">
       <novo-chip
-        *ngFor="let item of _items | async | slice: 0:maxChipsShown"
+        *ngFor="let item of _items | async | slice: 0:hideChipsLimit"
         [class.selected]="item == selected"
         [selectable]="true"
         [disabled]="disablePickerInput"
@@ -32,9 +32,9 @@ const CHIPS_VALUE_ACCESSOR = {
         {{ item.label }}
         <novo-icon *ngIf="!disablePickerInput" novoChipRemove>x</novo-icon>
       </novo-chip>
-      <div *ngIf="items.length > _maxChipsShown" class="hidden-chips-toggle" (click)="toggleHiddenChips()">
-        <novo-label *ngIf="maxChipsShown !== CHIPS_SHOWN_MAX" color="positive">+ {{ hiddenChips.count }} {{ labels.more }} {{ hiddenChips.type }}</novo-label>
-        <novo-label *ngIf="maxChipsShown === CHIPS_SHOWN_MAX" color="positive"> {{labels.showLess}}</novo-label>
+      <div *ngIf="items.length > _hideChipsLimit" class="hidden-chips-toggle" (click)="toggleHiddenChips()">
+        <novo-label *ngIf="hideChipsLimit !== CHIPS_SHOWN_MAX" color="positive">+ {{ hiddenChips.count }} {{ labels.more }} {{ hiddenChips.type }}</novo-label>
+        <novo-label *ngIf="hideChipsLimit === CHIPS_SHOWN_MAX" color="positive"> {{labels.showLess}}</novo-label>
       </div>
     </div>
     <div class="chip-input-container" *ngIf="!maxlength || (maxlength && items.length < maxlength)">
@@ -111,12 +111,12 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
   model: any;
   itemToAdd: any;
   popup: any;
-  maxChipsShown: number;
+  hideChipsLimit: number;
   hiddenChips: { type, count };
   // private data model
   _value: any = '';
   _items = new ReplaySubject<any[]>(1);
-  _maxChipsShown: number;
+  _hideChipsLimit: number;
   // Placeholders for the callbacks
   onModelChange: Function = () => {};
   onModelTouched: Function = () => {};
@@ -124,8 +124,8 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
   constructor(public element: ElementRef, private componentUtils: ComponentUtils, public labels: NovoLabelService) {}
 
   ngOnInit() {
-    this.maxChipsShown = this.source.maxChipsShown;
-    this._maxChipsShown = this.maxChipsShown; // copy of original max count
+    this.hideChipsLimit = this.source.hideChipsLimit;
+    this._hideChipsLimit = this.hideChipsLimit; // copy of original max count
     this.setItems();
   }
 
@@ -250,17 +250,17 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
   }
 
   updateHiddenChips() {
-    const numChipsToHide = this.items.length - this._maxChipsShown;
+    const numChipsToHide = this.items.length - this._hideChipsLimit;
     if (numChipsToHide) {
       this.hiddenChips = { count: numChipsToHide, type: numChipsToHide > 1 ? this.labels.items : this.labels.item };
     } else {
       this.hiddenChips = <{ type, count }>{};
-      if (this.maxChipsShown === this.CHIPS_SHOWN_MAX) this.maxChipsShown = this._maxChipsShown; // reset maxChipsShown to original count
+      if (this.hideChipsLimit === this.CHIPS_SHOWN_MAX) this.hideChipsLimit = this._hideChipsLimit; // reset hideChipsLimit to original count
     }
   }
 
   toggleHiddenChips() {
-    this.maxChipsShown = this.maxChipsShown === this.CHIPS_SHOWN_MAX ? this._maxChipsShown : this.CHIPS_SHOWN_MAX;
+    this.hideChipsLimit = this.hideChipsLimit === this.CHIPS_SHOWN_MAX ? this._hideChipsLimit : this.CHIPS_SHOWN_MAX;
   }
 
   remove(event, item) {

--- a/projects/novo-elements/src/elements/chips/Chips.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.ts
@@ -20,7 +20,7 @@ const CHIPS_VALUE_ACCESSOR = {
   template: `
     <div class="novo-chip-container">
       <novo-chip
-        *ngFor="let item of _items | async | slice: 0:hideChipsLimit"
+        *ngFor="let item of _items | async | slice: 0:hiddenChipsLimit"
         [class.selected]="item == selected"
         [selectable]="true"
         [disabled]="disablePickerInput"
@@ -33,8 +33,8 @@ const CHIPS_VALUE_ACCESSOR = {
         <novo-icon *ngIf="!disablePickerInput" novoChipRemove>x</novo-icon>
       </novo-chip>
       <div *ngIf="hiddenChipsCount" class="hidden-chips-toggle" (click)="toggleHiddenChips()">
-        <novo-label *ngIf="hideChipsLimit !== CHIPS_SHOWN_MAX" color="positive">+ {{ hiddenChipsCount }} {{ labels.more }} </novo-label>
-        <novo-label *ngIf="hideChipsLimit === CHIPS_SHOWN_MAX" color="positive"><novo-icon>sort-asc</novo-icon> {{labels.showLess}}</novo-label>
+        <novo-label *ngIf="hiddenChipsLimit !== CHIPS_SHOWN_MAX" color="positive">+ {{ hiddenChipsCount }} {{ labels.more }} </novo-label>
+        <novo-label *ngIf="hiddenChipsLimit === CHIPS_SHOWN_MAX" color="positive"><novo-icon>sort-asc</novo-icon> {{labels.showLess}}</novo-label>
       </div>
       <div class="chip-input-container" *ngIf="!maxlength || (maxlength && items.length < maxlength)">
         <novo-picker
@@ -111,12 +111,12 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
   model: any;
   itemToAdd: any;
   popup: any;
-  hideChipsLimit: number;
+  hiddenChipsLimit: number;
   hiddenChipsCount: number;
   // private data model
   _value: any = '';
   _items = new ReplaySubject<any[]>(1);
-  _hideChipsLimit: number;
+  _hiddenChipsLimit: number;
   // Placeholders for the callbacks
   onModelChange: Function = () => {};
   onModelTouched: Function = () => {};
@@ -124,8 +124,8 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
   constructor(public element: ElementRef, private componentUtils: ComponentUtils, public labels: NovoLabelService) {}
 
   ngOnInit() {
-    this.hideChipsLimit = this.source.hideChipsLimit;
-    this._hideChipsLimit = this.hideChipsLimit; // copy of original max count
+    this.hiddenChipsLimit = this.source.hiddenChipsLimit;
+    this._hiddenChipsLimit = this.hiddenChipsLimit; // copy of original max count
     this.setItems();
   }
 
@@ -250,13 +250,13 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
   }
 
   updateHiddenChips() {
-    this.hiddenChipsCount = Math.max(0, this.items.length - this._hideChipsLimit);
-    if (!this.hiddenChipsCount && this.hideChipsLimit === this.CHIPS_SHOWN_MAX)
-      this.hideChipsLimit = this._hideChipsLimit; // reset hideChipsLimit to original count
+    this.hiddenChipsCount = Math.max(0, this.items.length - this._hiddenChipsLimit);
+    if (!this.hiddenChipsCount && this.hiddenChipsLimit === this.CHIPS_SHOWN_MAX)
+      this.hiddenChipsLimit = this._hiddenChipsLimit; // reset hiddenChipsLimit to original count
   }
 
   toggleHiddenChips() {
-    this.hideChipsLimit = this.hideChipsLimit === this.CHIPS_SHOWN_MAX ? this._hideChipsLimit : this.CHIPS_SHOWN_MAX;
+    this.hiddenChipsLimit = this.hiddenChipsLimit === this.CHIPS_SHOWN_MAX ? this._hiddenChipsLimit : this.CHIPS_SHOWN_MAX;
   }
 
   remove(event, item) {

--- a/projects/novo-elements/src/elements/chips/Chips.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.ts
@@ -32,9 +32,9 @@ const CHIPS_VALUE_ACCESSOR = {
         {{ item.label }}
         <novo-icon *ngIf="!disablePickerInput" novoChipRemove>x</novo-icon>
       </novo-chip>
-      <div *ngIf="items.length > _hideChipsLimit" class="hidden-chips-toggle" (click)="toggleHiddenChips()">
-        <novo-label *ngIf="hideChipsLimit !== CHIPS_SHOWN_MAX" color="positive">+ {{ hiddenChips.count }} {{ labels.more }} {{ hiddenChips.type }}</novo-label>
-        <novo-label *ngIf="hideChipsLimit === CHIPS_SHOWN_MAX" color="positive"> {{labels.showLess}}</novo-label>
+      <div *ngIf="hiddenChipsCount" class="hidden-chips-toggle" (click)="toggleHiddenChips()">
+        <novo-label *ngIf="hideChipsLimit !== CHIPS_SHOWN_MAX" color="positive">+ {{ hiddenChipsCount }} {{ labels.more | lowercase }} </novo-label>
+        <novo-label *ngIf="hideChipsLimit === CHIPS_SHOWN_MAX" color="positive"> {{labels.showLess | lowercase}}</novo-label>
       </div>
     </div>
     <div class="chip-input-container" *ngIf="!maxlength || (maxlength && items.length < maxlength)">
@@ -112,7 +112,7 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
   itemToAdd: any;
   popup: any;
   hideChipsLimit: number;
-  hiddenChips: { type, count };
+  hiddenChipsCount: number;
   // private data model
   _value: any = '';
   _items = new ReplaySubject<any[]>(1);
@@ -250,13 +250,9 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
   }
 
   updateHiddenChips() {
-    const numChipsToHide = this.items.length - this._hideChipsLimit;
-    if (numChipsToHide) {
-      this.hiddenChips = { count: numChipsToHide, type: numChipsToHide > 1 ? this.labels.items : this.labels.item };
-    } else {
-      this.hiddenChips = <{ type, count }>{};
-      if (this.hideChipsLimit === this.CHIPS_SHOWN_MAX) this.hideChipsLimit = this._hideChipsLimit; // reset hideChipsLimit to original count
-    }
+    this.hiddenChipsCount = Math.max(0, this.items.length - this._hideChipsLimit);
+    if (!this.hiddenChipsCount && this.hideChipsLimit === this.CHIPS_SHOWN_MAX)
+      this.hideChipsLimit = this._hideChipsLimit; // reset hideChipsLimit to original count
   }
 
   toggleHiddenChips() {

--- a/projects/novo-elements/src/elements/chips/Chips.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.ts
@@ -28,7 +28,7 @@ const CHIPS_VALUE_ACCESSOR = {
         (selectionChange)="select($event, item)"
         (deselect)="deselect($event, item)"
       >
-        <novo-icon *ngIf="getAvatarType(item)" class="txc-{{ getAvatarType(item) }}" novoChipAvatar>circle</novo-icon>
+        <novo-icon *ngIf="item | avatarType:type as avatarType" class="txc-{{ avatarType }}" novoChipAvatar>circle</novo-icon>
         {{ item.label }}
         <novo-icon *ngIf="!disablePickerInput" novoChipRemove>x</novo-icon>
       </novo-chip>
@@ -195,10 +195,6 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
       value: id,
       label: optLabel ? optLabel.label : value,
     };
-  }
-
-  getAvatarType(item: any) {
-    return (this.type || item?.value?.searchEntity || '').toLowerCase();
   }
 
   deselectAll(event?) {

--- a/projects/novo-elements/src/elements/chips/Chips.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.ts
@@ -141,6 +141,7 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
 
   clearValue() {
     this.items = [];
+    this.updateHiddenChips();
     this._items.next(this.items);
     this.value = null;
     this._propagateChanges();

--- a/projects/novo-elements/src/elements/chips/Chips.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.ts
@@ -33,28 +33,28 @@ const CHIPS_VALUE_ACCESSOR = {
         <novo-icon *ngIf="!disablePickerInput" novoChipRemove>x</novo-icon>
       </novo-chip>
       <div *ngIf="hiddenChipsCount" class="hidden-chips-toggle" (click)="toggleHiddenChips()">
-        <novo-label *ngIf="hideChipsLimit !== CHIPS_SHOWN_MAX" color="positive">+ {{ hiddenChipsCount }} {{ labels.more | lowercase }} </novo-label>
-        <novo-label *ngIf="hideChipsLimit === CHIPS_SHOWN_MAX" color="positive"> {{labels.showLess | lowercase}}</novo-label>
+        <novo-label *ngIf="hideChipsLimit !== CHIPS_SHOWN_MAX" color="positive">+ {{ hiddenChipsCount }} {{ labels.more }} </novo-label>
+        <novo-label *ngIf="hideChipsLimit === CHIPS_SHOWN_MAX" color="positive"><novo-icon>sort-asc</novo-icon> {{labels.showLess}}</novo-label>
       </div>
-    </div>
-    <div class="chip-input-container" *ngIf="!maxlength || (maxlength && items.length < maxlength)">
-      <novo-picker
-        clearValueOnSelect="true"
-        [closeOnSelect]="closeOnSelect"
-        [config]="source"
-        [disablePickerInput]="disablePickerInput"
-        [placeholder]="placeholder"
-        [(ngModel)]="itemToAdd"
-        (select)="add($event)"
-        (keydown)="onKeyDown($event)"
-        (focus)="onFocus($event)"
-        (typing)="onTyping($event)"
-        (blur)="onTouched($event)"
-        [selected]="items"
-        [overrideElement]="element"
-        [allowCustomValues]="allowCustomValues"
-      >
-      </novo-picker>
+      <div class="chip-input-container" *ngIf="!maxlength || (maxlength && items.length < maxlength)">
+        <novo-picker
+          clearValueOnSelect="true"
+          [closeOnSelect]="closeOnSelect"
+          [config]="source"
+          [disablePickerInput]="disablePickerInput"
+          [placeholder]="placeholder"
+          [(ngModel)]="itemToAdd"
+          (select)="add($event)"
+          (keydown)="onKeyDown($event)"
+          (focus)="onFocus($event)"
+          (typing)="onTyping($event)"
+          (blur)="onTouched($event)"
+          [selected]="items"
+          [overrideElement]="element"
+          [allowCustomValues]="allowCustomValues"
+        >
+        </novo-picker>
+      </div>
     </div>
     <div class="preview-container">
       <span #preview></span>

--- a/projects/novo-elements/src/elements/chips/Chips.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.ts
@@ -125,7 +125,7 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
 
   ngOnInit() {
     this.hiddenChipsLimit = this.source.hiddenChipsLimit;
-    this._hiddenChipsLimit = this.hiddenChipsLimit; // copy of original max count
+    this._hiddenChipsLimit = this.hiddenChipsLimit; // copy of original chip limit
     this.setItems();
   }
 
@@ -252,7 +252,7 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
   updateHiddenChips() {
     this.hiddenChipsCount = Math.max(0, this.items.length - this._hiddenChipsLimit);
     if (!this.hiddenChipsCount && this.hiddenChipsLimit === this.CHIPS_SHOWN_MAX)
-      this.hiddenChipsLimit = this._hiddenChipsLimit; // reset hiddenChipsLimit to original count
+      this.hiddenChipsLimit = this._hiddenChipsLimit; // reset hiddenChipsLimit to original #
   }
 
   toggleHiddenChips() {

--- a/projects/novo-elements/src/elements/chips/index.ts
+++ b/projects/novo-elements/src/elements/chips/index.ts
@@ -6,3 +6,4 @@ export * from './Chips';
 export * from './Chips.module';
 export * from './ChipTextControl';
 export * from './RowChips';
+export * from './pipe';

--- a/projects/novo-elements/src/elements/chips/pipe/AvatarType.pipe.ts
+++ b/projects/novo-elements/src/elements/chips/pipe/AvatarType.pipe.ts
@@ -1,0 +1,8 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'avatarType' })
+export class AvatarTypePipe implements PipeTransform {
+  transform(item: any, type?: any): string {
+    return (type || item?.value?.searchEntity || '').toLowerCase();
+  }
+}

--- a/projects/novo-elements/src/elements/chips/pipe/index.ts
+++ b/projects/novo-elements/src/elements/chips/pipe/index.ts
@@ -1,0 +1,1 @@
+export * from './AvatarType.pipe';

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -96,6 +96,9 @@ export class NovoLabelService {
   yes = 'Yes';
   search = 'SEARCH';
   noItems = 'There are no items';
+  items = 'items';
+  item = 'item';
+  showLess = 'show less';
   dateFormat = 'MM/dd/yyyy';
   dateFormatPlaceholder = 'MM/DD/YYYY';
   localDatePlaceholder = 'mm/dd/yyyy';

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -137,7 +137,7 @@ export class NovoLabelService {
   isEmpty = 'Is Empty?';
   refreshPagination = 'Refresh Pagination';
   location = 'Location';
-  showLess = 'show less';
+  showLess = 'Show Less';
 
   constructor(
     @Optional()

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -96,9 +96,6 @@ export class NovoLabelService {
   yes = 'Yes';
   search = 'SEARCH';
   noItems = 'There are no items';
-  items = 'items';
-  item = 'item';
-  showLess = 'show less';
   dateFormat = 'MM/dd/yyyy';
   dateFormatPlaceholder = 'MM/DD/YYYY';
   localDatePlaceholder = 'mm/dd/yyyy';
@@ -140,6 +137,7 @@ export class NovoLabelService {
   isEmpty = 'Is Empty?';
   refreshPagination = 'Refresh Pagination';
   location = 'Location';
+  showLess = 'show less';
 
   constructor(
     @Optional()

--- a/projects/novo-examples/src/examples.routes.ts
+++ b/projects/novo-examples/src/examples.routes.ts
@@ -4033,7 +4033,7 @@ export class ChipsDevelopPage {
 <p>By clicking on the <code>row-chips</code> element, the options list will be displayed.  Select any of the options by clicking on the item in the list.  The value selected will be added to the list of selected values as a new row. By clicking the delete icon at the end of the row, the row will be removed from the list of selected values.</p>
 <p><code-example example="row-chips"></code-example></p>
 <h2>Hide Chips Example</h2>
-<p>Setting the <code>maxChipsShown</code> property via the <code>source</code> Input will limit the number of chips shown to the <code>maxChipsShown</code> set. A clickable suffix label will toggle the visibility of the hidden chips.</p>
+<p>Setting the <code>hideChipsLimit</code> property via the <code>source</code> Input will limit the number of chips shown to the <code>hideChipsLimit</code> set. A clickable suffix label will toggle the visibility of the hidden chips.</p>
 <p><code-example example="hide-chips"></code-example></p>
 `,
   host: { class: 'markdown-page' }

--- a/projects/novo-examples/src/examples.routes.ts
+++ b/projects/novo-examples/src/examples.routes.ts
@@ -3669,7 +3669,7 @@ export class IconographyPage {
     <pre><code>.box &#123;\n  &#64;include novo-padding-medium(); // use mixin \n  margin: $spacing-xs; // or use scss variables\n  padding: $spacing-xl;\n&#125; &#125;&#125;</code></pre>
   </typedef-snippet>
 </typedef-example>
-<!-- 
+<!--
 <typedef-example>
   <typedef-content>
     <novo-flex gap="1rem">
@@ -4032,6 +4032,9 @@ export class ChipsDevelopPage {
 <h2>Row Chips Example</h2>
 <p>By clicking on the <code>row-chips</code> element, the options list will be displayed.  Select any of the options by clicking on the item in the list.  The value selected will be added to the list of selected values as a new row. By clicking the delete icon at the end of the row, the row will be removed from the list of selected values.</p>
 <p><code-example example="row-chips"></code-example></p>
+<h2>Hide Chips Example</h2>
+<p>Setting the <code>maxChipsShown</code> property via the <code>source</code> Input will limit the number of chips shown to the <code>maxChipsShown</code> set. A clickable suffix label will toggle the visibility of the hidden chips.</p>
+<p><code-example example="hide-chips"></code-example></p>
 `,
   host: { class: 'markdown-page' }
 })
@@ -5773,7 +5776,7 @@ export class TemplatesPage {
 <p>First follow the steps to update your angular app to <a href="https://update.angular.io/?v=9.0-10.0">Version 10</a></p>
 <pre><code><span class="hljs-attribute">npm</span> install --save timezone-support&#64;<span class="hljs-number">2</span> novo-design-tokens&#64;<span class="hljs-number">0</span> angular-imask&#64;<span class="hljs-number">6</span> imask&#64;<span class="hljs-number">6</span>
 <span class="hljs-attribute">npm</span> install --save novo-elements&#64;<span class="hljs-number">6</span>
-<span class="hljs-attribute">ng</span> update novo-elements --migrate-only --from=<span class="hljs-number">0</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --to=<span class="hljs-number">6</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --force --<span class="hljs-literal">allow</span>-dirty  
+<span class="hljs-attribute">ng</span> update novo-elements --migrate-only --from=<span class="hljs-number">0</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --to=<span class="hljs-number">6</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --force --<span class="hljs-literal">allow</span>-dirty
 </code></pre>
 <p>For any issues that are not corrected with the above command, please ask questions in the <a href="https://github.com/bullhorn/novo-elements/discussions/categories/q-a">Q&amp;A Page</a> in github.</p>
 <p>Welcome to the February 2022 release of Novo Elements. There are many updates in this version that we hope you will like, some of the key highlights include:</p>
@@ -6151,7 +6154,7 @@ npm install novo-elements&#64;7.2.0-next.0
 <h2>Upgrading to V7</h2>
 <p>First follow the steps to update your angular app to <a href="https://update.angular.io/?v=10.0-13.0">Version 13</a></p>
 <pre><code><span class="hljs-attribute">npm</span> install --save novo-elements&#64;<span class="hljs-number">7</span>.x.x
-<span class="hljs-attribute">ng</span> update novo-elements --migrate-only --from=<span class="hljs-number">0</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --to=<span class="hljs-number">7</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --force --<span class="hljs-literal">allow</span>-dirty  
+<span class="hljs-attribute">ng</span> update novo-elements --migrate-only --from=<span class="hljs-number">0</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --to=<span class="hljs-number">7</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --force --<span class="hljs-literal">allow</span>-dirty
 </code></pre>
 <h2 id="notable-changes">Notable changes <a href="https://bullhorn.github.io/novo-elements/docs/#/updates/v7-announce#notable-changes">#</a></h2>
 <ul>
@@ -6188,7 +6191,7 @@ npm install novo-elements&#64;7.2.0-next.0
 <div class="p">Note: First follow the steps to update your angular app to <a href="https://update.angular.io/?v=10.0-13.0">Version 13</a> if you haven't already.</div>
 </blockquote>
 <pre><code><span class="hljs-attribute">npm</span> install --save novo-elements&#64;<span class="hljs-number">7</span>.x.x
-<span class="hljs-attribute">ng</span> update novo-elements --migrate-only --from=<span class="hljs-number">0</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --to=<span class="hljs-number">7</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --force --<span class="hljs-literal">allow</span>-dirty  
+<span class="hljs-attribute">ng</span> update novo-elements --migrate-only --from=<span class="hljs-number">0</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --to=<span class="hljs-number">7</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --force --<span class="hljs-literal">allow</span>-dirty
 </code></pre>
 <h1>📢  August 2022 (version 7.3.x)</h1>
 <p><strong>Announcement</strong>: New features and improvements!</p>

--- a/projects/novo-examples/src/examples.routes.ts
+++ b/projects/novo-examples/src/examples.routes.ts
@@ -3669,7 +3669,7 @@ export class IconographyPage {
     <pre><code>.box &#123;\n  &#64;include novo-padding-medium(); // use mixin \n  margin: $spacing-xs; // or use scss variables\n  padding: $spacing-xl;\n&#125; &#125;&#125;</code></pre>
   </typedef-snippet>
 </typedef-example>
-<!--
+<!-- 
 <typedef-example>
   <typedef-content>
     <novo-flex gap="1rem">
@@ -4033,7 +4033,7 @@ export class ChipsDevelopPage {
 <p>By clicking on the <code>row-chips</code> element, the options list will be displayed.  Select any of the options by clicking on the item in the list.  The value selected will be added to the list of selected values as a new row. By clicking the delete icon at the end of the row, the row will be removed from the list of selected values.</p>
 <p><code-example example="row-chips"></code-example></p>
 <h2>Hide Chips Example</h2>
-<p>Setting the <code>hideChipsLimit</code> property via the <code>source</code> Input will limit the number of chips shown to the <code>hideChipsLimit</code> set. A clickable suffix label will toggle the visibility of the hidden chips.</p>
+<p>Setting the <code>hiddenChipsLimit</code> property via the <code>source</code> Input will limit the number of chips shown to the <code>hiddenChipsLimit</code> set. A clickable suffix label will toggle the visibility of the hidden chips.</p>
 <p><code-example example="hide-chips"></code-example></p>
 `,
   host: { class: 'markdown-page' }
@@ -5776,7 +5776,7 @@ export class TemplatesPage {
 <p>First follow the steps to update your angular app to <a href="https://update.angular.io/?v=9.0-10.0">Version 10</a></p>
 <pre><code><span class="hljs-attribute">npm</span> install --save timezone-support&#64;<span class="hljs-number">2</span> novo-design-tokens&#64;<span class="hljs-number">0</span> angular-imask&#64;<span class="hljs-number">6</span> imask&#64;<span class="hljs-number">6</span>
 <span class="hljs-attribute">npm</span> install --save novo-elements&#64;<span class="hljs-number">6</span>
-<span class="hljs-attribute">ng</span> update novo-elements --migrate-only --from=<span class="hljs-number">0</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --to=<span class="hljs-number">6</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --force --<span class="hljs-literal">allow</span>-dirty
+<span class="hljs-attribute">ng</span> update novo-elements --migrate-only --from=<span class="hljs-number">0</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --to=<span class="hljs-number">6</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --force --<span class="hljs-literal">allow</span>-dirty  
 </code></pre>
 <p>For any issues that are not corrected with the above command, please ask questions in the <a href="https://github.com/bullhorn/novo-elements/discussions/categories/q-a">Q&amp;A Page</a> in github.</p>
 <p>Welcome to the February 2022 release of Novo Elements. There are many updates in this version that we hope you will like, some of the key highlights include:</p>
@@ -6154,7 +6154,7 @@ npm install novo-elements&#64;7.2.0-next.0
 <h2>Upgrading to V7</h2>
 <p>First follow the steps to update your angular app to <a href="https://update.angular.io/?v=10.0-13.0">Version 13</a></p>
 <pre><code><span class="hljs-attribute">npm</span> install --save novo-elements&#64;<span class="hljs-number">7</span>.x.x
-<span class="hljs-attribute">ng</span> update novo-elements --migrate-only --from=<span class="hljs-number">0</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --to=<span class="hljs-number">7</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --force --<span class="hljs-literal">allow</span>-dirty
+<span class="hljs-attribute">ng</span> update novo-elements --migrate-only --from=<span class="hljs-number">0</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --to=<span class="hljs-number">7</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --force --<span class="hljs-literal">allow</span>-dirty  
 </code></pre>
 <h2 id="notable-changes">Notable changes <a href="https://bullhorn.github.io/novo-elements/docs/#/updates/v7-announce#notable-changes">#</a></h2>
 <ul>
@@ -6191,7 +6191,7 @@ npm install novo-elements&#64;7.2.0-next.0
 <div class="p">Note: First follow the steps to update your angular app to <a href="https://update.angular.io/?v=10.0-13.0">Version 13</a> if you haven't already.</div>
 </blockquote>
 <pre><code><span class="hljs-attribute">npm</span> install --save novo-elements&#64;<span class="hljs-number">7</span>.x.x
-<span class="hljs-attribute">ng</span> update novo-elements --migrate-only --from=<span class="hljs-number">0</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --to=<span class="hljs-number">7</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --force --<span class="hljs-literal">allow</span>-dirty
+<span class="hljs-attribute">ng</span> update novo-elements --migrate-only --from=<span class="hljs-number">0</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --to=<span class="hljs-number">7</span>.<span class="hljs-number">0</span>.<span class="hljs-number">0</span> --force --<span class="hljs-literal">allow</span>-dirty  
 </code></pre>
 <h1>📢  August 2022 (version 7.3.x)</h1>
 <p><strong>Announcement</strong>: New features and improvements!</p>

--- a/projects/novo-examples/src/form-controls/chips/chips-examples.md
+++ b/projects/novo-examples/src/form-controls/chips/chips-examples.md
@@ -55,6 +55,6 @@ By clicking on the <code>row-chips</code> element, the options list will be disp
 
 ## Hide Chips Example
 
-Setting the `maxChipsShown` property via the `source` Input will limit the number of chips shown to the `maxChipsShown` set. A clickable suffix label will toggle the visibility of the hidden chips.
+Setting the `hideChipsLimit` property via the `source` Input will limit the number of chips shown to the `hideChipsLimit` set. A clickable suffix label will toggle the visibility of the hidden chips.
 
 <code-example example="hide-chips"></code-example>

--- a/projects/novo-examples/src/form-controls/chips/chips-examples.md
+++ b/projects/novo-examples/src/form-controls/chips/chips-examples.md
@@ -52,3 +52,9 @@ Having custom templates makes it easy to customize the functionality of the pick
 By clicking on the <code>row-chips</code> element, the options list will be displayed.  Select any of the options by clicking on the item in the list.  The value selected will be added to the list of selected values as a new row. By clicking the delete icon at the end of the row, the row will be removed from the list of selected values.
     
 <code-example example="row-chips"></code-example>
+
+## Hide Chips Example
+
+Setting the `maxChipsShown` property via the `source` Input will limit the number of chips shown to the `maxChipsShown` set. A clickable suffix label will toggle the visibility of the hidden chips.
+
+<code-example example="hide-chips"></code-example>

--- a/projects/novo-examples/src/form-controls/chips/chips-examples.md
+++ b/projects/novo-examples/src/form-controls/chips/chips-examples.md
@@ -55,6 +55,6 @@ By clicking on the <code>row-chips</code> element, the options list will be disp
 
 ## Hide Chips Example
 
-Setting the `hideChipsLimit` property via the `source` Input will limit the number of chips shown to the `hideChipsLimit` set. A clickable suffix label will toggle the visibility of the hidden chips.
+Setting the `hiddenChipsLimit` property via the `source` Input will limit the number of chips shown to the `hiddenChipsLimit` set. A clickable suffix label will toggle the visibility of the hidden chips.
 
 <code-example example="hide-chips"></code-example>

--- a/projects/novo-examples/src/form-controls/chips/hide-chips/hide-chips-example.css
+++ b/projects/novo-examples/src/form-controls/chips/hide-chips/hide-chips-example.css
@@ -1,0 +1,1 @@
+/** No CSS for this example */

--- a/projects/novo-examples/src/form-controls/chips/hide-chips/hide-chips-example.html
+++ b/projects/novo-examples/src/form-controls/chips/hide-chips/hide-chips-example.html
@@ -1,0 +1,2 @@
+<novo-chips [source]="hideDemo" [placeholder]="placeholder" [(ngModel)]="model" (changed)="onChanged($event)">
+</novo-chips>

--- a/projects/novo-examples/src/form-controls/chips/hide-chips/hide-chips-example.ts
+++ b/projects/novo-examples/src/form-controls/chips/hide-chips/hide-chips-example.ts
@@ -116,7 +116,7 @@ export class HideChipsExample {
     this.hideDemo = {
       format: '$firstName $lastName',
       options: collaborators,
-      maxChipsShown: 3
+      hideChipsLimit: 3
     };
 
     this.model = [];

--- a/projects/novo-examples/src/form-controls/chips/hide-chips/hide-chips-example.ts
+++ b/projects/novo-examples/src/form-controls/chips/hide-chips/hide-chips-example.ts
@@ -1,0 +1,128 @@
+import { Component } from '@angular/core';
+
+/**
+ * @title Hide Chips Example
+ */
+@Component({
+  selector: 'hide-chips-example',
+  templateUrl: 'hide-chips-example.html',
+  styleUrls: ['hide-chips-example.css'],
+})
+export class HideChipsExample {
+  public placeholder: string = 'Select...';
+  public value: any;
+  public hideDemo: any;
+  public model: any;
+
+  constructor() {
+    const collaborators = [
+      {
+        id: 1,
+        firstName: 'Brian',
+        lastName: 'Kimball',
+        searchEntity: 'candidate',
+      },
+      {
+        id: 2,
+        firstName: 'Josh',
+        lastName: 'Godi',
+        searchEntity: 'contact',
+      },
+      {
+        id: 3,
+        firstName: 'Alec',
+        lastName: 'Sibilia',
+        searchEntity: 'candidate',
+      },
+      {
+        id: 4,
+        firstName: 'Kameron',
+        lastName: 'Sween',
+        searchEntity: 'candidate',
+      },
+      {
+        id: 5,
+        firstName: 'Emily',
+        lastName: 'Jones',
+        searchEntity: 'candidate',
+      },
+      {
+        id: 6,
+        firstName: 'Michael',
+        lastName: 'Smith',
+        searchEntity: 'contact',
+      },
+      {
+        id: 7,
+        firstName: 'Sophia',
+        lastName: 'Johnson',
+        searchEntity: 'candidate',
+      },
+      {
+        id: 8,
+        firstName: 'Ethan',
+        lastName: 'Brown',
+        searchEntity: 'contact',
+      },
+      {
+        id: 9,
+        firstName: 'Isabella',
+        lastName: 'Williams',
+        searchEntity: 'candidate',
+      },
+      {
+        id: 10,
+        firstName: 'Jacob',
+        lastName: 'Davis',
+        searchEntity: 'contact',
+      },
+      {
+        id: 11,
+        firstName: 'Mia',
+        lastName: 'Miller',
+        searchEntity: 'candidate',
+      },
+      {
+        id: 12,
+        firstName: 'Alexander',
+        lastName: 'Wilson',
+        searchEntity: 'contact',
+      },
+      {
+        id: 13,
+        firstName: 'Charlotte',
+        lastName: 'Taylor',
+        searchEntity: 'candidate',
+      },
+      {
+        id: 14,
+        firstName: 'William',
+        lastName: 'Anderson',
+        searchEntity: 'contact',
+      },
+      {
+        id: 15,
+        firstName: 'Amelia',
+        lastName: 'Martinez',
+        searchEntity: 'candidate',
+      },
+      {
+        id: 16,
+        firstName: 'Daniel',
+        lastName: 'Jackson',
+        searchEntity: 'contact',
+      },
+    ];
+    this.hideDemo = {
+      format: '$firstName $lastName',
+      options: collaborators,
+      maxChipsShown: 3
+    };
+
+    this.model = [];
+  }
+
+  onChanged(event) {
+    console.log('EVENT', event);
+  }
+}

--- a/projects/novo-examples/src/form-controls/chips/hide-chips/hide-chips-example.ts
+++ b/projects/novo-examples/src/form-controls/chips/hide-chips/hide-chips-example.ts
@@ -116,7 +116,7 @@ export class HideChipsExample {
     this.hideDemo = {
       format: '$firstName $lastName',
       options: collaborators,
-      hideChipsLimit: 3
+      hiddenChipsLimit: 3
     };
 
     this.model = [];

--- a/projects/novo-examples/src/form-controls/chips/hide-chips/index.ts
+++ b/projects/novo-examples/src/form-controls/chips/hide-chips/index.ts
@@ -1,0 +1,1 @@
+export * from './hide-chips-example';


### PR DESCRIPTION
## **Description**

- Added optional `maxChipsShown` prop to the @Input `source` object. This will limit the number of chips shown in the picker input element. 
- A clickable suffix label was also added, to toggle the visibility of the hidden chips.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

##### **Screenshots**
![image](https://github.com/bullhorn/novo-elements/assets/102239533/9aea0a22-03ea-402b-a7f1-30067425459a)
![image](https://github.com/bullhorn/novo-elements/assets/102239533/b0b738a0-80b5-409a-96cb-843394b3e5de)
