### PR TITLE
feat(Data Tables): Add applied search type

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -487,6 +487,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
             globalSearch: event.globalSearch,
             where: event.where,
             savedSearchName: event.savedSearchName,
+            appliedSearchType: event.appliedSearchType,
           });
           this.performInteractions('change');
         } else {

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -16,6 +16,7 @@ export interface IDataTablePreferences {
 export enum APPLIED_SEARCH_TYPE {
   SAVED = 'saved',
   RECENT = 'recent',
+  NONE = 'none',
 }
 
 export interface IDataTableColumn<T> {

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -10,13 +10,13 @@ export interface IDataTablePreferences {
   displayedColumns?: string[];
   columnWidths?: { id: string; width: number }[];
   savedSearchName?: string;
-  appliedSearchType?: APPLIED_SEARCH_TYPE;
+  appliedSearchType?: AppliedSearchType;
 }
 
-export enum APPLIED_SEARCH_TYPE {
-  SAVED = 'saved',
-  RECENT = 'recent',
-  NONE = 'none',
+export enum AppliedSearchType {
+  Saved = 'saved',
+  Recent = 'recent',
+  None = 'none',
 }
 
 export interface IDataTableColumn<T> {
@@ -122,7 +122,7 @@ export interface IDataTableChangeEvent {
   where?: { query: string; form: any };
   savedSearchName?: string;
   displayedColumns?: string[];
-  appliedSearchType?: APPLIED_SEARCH_TYPE;
+  appliedSearchType?: AppliedSearchType;
 }
 
 export interface IDataTableSelectionChangeEvent {

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -10,6 +10,12 @@ export interface IDataTablePreferences {
   displayedColumns?: string[];
   columnWidths?: { id: string; width: number }[];
   savedSearchName?: string;
+  appliedSearchType?: APPLIED_SEARCH_TYPE;
+}
+
+export enum APPLIED_SEARCH_TYPE {
+  SAVED = 'saved',
+  RECENT = 'recent',
 }
 
 export interface IDataTableColumn<T> {
@@ -115,6 +121,7 @@ export interface IDataTableChangeEvent {
   where?: { query: string; form: any };
   savedSearchName?: string;
   displayedColumns?: string[];
+  appliedSearchType?: APPLIED_SEARCH_TYPE;
 }
 
 export interface IDataTableSelectionChangeEvent {

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.spec.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.spec.ts
@@ -426,7 +426,7 @@ describe('Service: DataTableState', () => {
       where: { query: 'updated', form: 'query' },
       savedSearchName: 'new saved search',
       displayedColumns: ['column 3', 'column 4'],
-      appliedSearchType: AppliedSearchType.None,
+      appliedSearchType: AppliedSearchType.Saved,
     };
     beforeEach(() => {
       spyOn(service.selectedRows, 'clear');
@@ -438,7 +438,7 @@ describe('Service: DataTableState', () => {
       service.where = { query: 'mock query', form: 'mock form' };
       service.savedSearchName = 'old saved search';
       service.displayedColumns = ['column 1', 'column 2'];
-      service.appliedSearchType = AppliedSearchType.Saved;
+      service.appliedSearchType = AppliedSearchType.None;
     });
     it('should call selectedRows.clear, resetSource.next and onSortFilterChange if retainSelected is true', () => {
       service.retainSelected = false;
@@ -462,7 +462,7 @@ describe('Service: DataTableState', () => {
       expect(service.where).toEqual({ query: 'updated', form: 'query' });
       expect(service.savedSearchName).toEqual('new saved search');
       expect(service.displayedColumns).toEqual(['column 3', 'column 4']);
-      expect(service.appliedSearchType).toEqual(AppliedSearchType.None);
+      expect(service.appliedSearchType).toEqual(AppliedSearchType.Saved);
       expect(service.page).toEqual(0);
       expect(service.retainSelected).toBeFalsy();
     });
@@ -474,7 +474,7 @@ describe('Service: DataTableState', () => {
       expect(service.where).toEqual({ query: 'mock query', form: 'mock form' });
       expect(service.savedSearchName).toEqual('old saved search');
       expect(service.displayedColumns).toEqual(['column 1', 'column 2']);
-      expect(service.appliedSearchType).toEqual(AppliedSearchType.Saved);
+      expect(service.appliedSearchType).toEqual(AppliedSearchType.None);
     });
     it('should not set displayedColumns if displayedColumns property is undefined', () => {
       service.setState({ name: 'undefined columns', displayedColumns: undefined });

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.spec.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.spec.ts
@@ -1,4 +1,5 @@
 // APP
+import { AppliedSearchType } from '../interfaces';
 import { DataTableState } from './data-table-state.service';
 
 describe('Service: DataTableState', () => {
@@ -425,6 +426,7 @@ describe('Service: DataTableState', () => {
       where: { query: 'updated', form: 'query' },
       savedSearchName: 'new saved search',
       displayedColumns: ['column 3', 'column 4'],
+      appliedSearchType: AppliedSearchType.None,
     };
     beforeEach(() => {
       spyOn(service.selectedRows, 'clear');
@@ -436,6 +438,7 @@ describe('Service: DataTableState', () => {
       service.where = { query: 'mock query', form: 'mock form' };
       service.savedSearchName = 'old saved search';
       service.displayedColumns = ['column 1', 'column 2'];
+      service.appliedSearchType = AppliedSearchType.Saved;
     });
     it('should call selectedRows.clear, resetSource.next and onSortFilterChange if retainSelected is true', () => {
       service.retainSelected = false;
@@ -459,6 +462,7 @@ describe('Service: DataTableState', () => {
       expect(service.where).toEqual({ query: 'updated', form: 'query' });
       expect(service.savedSearchName).toEqual('new saved search');
       expect(service.displayedColumns).toEqual(['column 3', 'column 4']);
+      expect(service.appliedSearchType).toEqual(AppliedSearchType.None);
       expect(service.page).toEqual(0);
       expect(service.retainSelected).toBeFalsy();
     });
@@ -470,6 +474,7 @@ describe('Service: DataTableState', () => {
       expect(service.where).toEqual({ query: 'mock query', form: 'mock form' });
       expect(service.savedSearchName).toEqual('old saved search');
       expect(service.displayedColumns).toEqual(['column 1', 'column 2']);
+      expect(service.appliedSearchType).toEqual(AppliedSearchType.Saved);
     });
     it('should not set displayedColumns if displayedColumns property is undefined', () => {
       service.setState({ name: 'undefined columns', displayedColumns: undefined });

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
@@ -2,7 +2,7 @@ import { EventEmitter, Injectable } from '@angular/core';
 import { Subject } from 'rxjs';
 import { Helpers } from 'novo-elements/utils';
 import {
-  APPLIED_SEARCH_TYPE,
+  AppliedSearchType,
   IDataTableChangeEvent,
   IDataTableFilter,
   IDataTablePreferences,
@@ -36,7 +36,7 @@ export class DataTableState<T> {
   updates: EventEmitter<IDataTableChangeEvent> = new EventEmitter<IDataTableChangeEvent>();
   retainSelected: boolean = false;
   savedSearchName: string = undefined;
-  appliedSearchType: APPLIED_SEARCH_TYPE;
+  appliedSearchType: AppliedSearchType;
   displayedColumns: string[] = undefined;
 
   get userFiltered(): boolean {

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
@@ -1,7 +1,14 @@
 import { EventEmitter, Injectable } from '@angular/core';
 import { Subject } from 'rxjs';
 import { Helpers } from 'novo-elements/utils';
-import { IDataTableChangeEvent, IDataTableFilter, IDataTablePreferences, IDataTableSelectionOption, IDataTableSort } from '../interfaces';
+import {
+  APPLIED_SEARCH_TYPE,
+  IDataTableChangeEvent,
+  IDataTableFilter,
+  IDataTablePreferences,
+  IDataTableSelectionOption,
+  IDataTableSort
+} from '../interfaces';
 import { NovoDataTableFilterUtils } from '../services/data-table-filter-utils';
 
 @Injectable()
@@ -29,6 +36,7 @@ export class DataTableState<T> {
   updates: EventEmitter<IDataTableChangeEvent> = new EventEmitter<IDataTableChangeEvent>();
   retainSelected: boolean = false;
   savedSearchName: string = undefined;
+  appliedSearchType: APPLIED_SEARCH_TYPE;
   displayedColumns: string[] = undefined;
 
   get userFiltered(): boolean {
@@ -135,6 +143,7 @@ export class DataTableState<T> {
       globalSearch: this.globalSearch,
       where: this.where,
       savedSearchName: this.savedSearchName,
+      appliedSearchType: this.appliedSearchType,
     });
   }
 
@@ -159,6 +168,9 @@ export class DataTableState<T> {
       if (preferences.savedSearchName) {
         this.savedSearchName = preferences.savedSearchName;
       }
+      if (preferences.appliedSearchType) {
+        this.appliedSearchType = preferences.appliedSearchType;
+      }
     }
   }
 
@@ -172,6 +184,7 @@ export class DataTableState<T> {
       if (preferences.displayedColumns?.length) {
         this.displayedColumns = preferences.displayedColumns;
       }
+      this.appliedSearchType = preferences.appliedSearchType;
     }
 
     this.page = 0;
@@ -191,6 +204,7 @@ export class DataTableState<T> {
         where: this.where,
         savedSearchName: this.savedSearchName,
         displayedColumns: this.displayedColumns,
+        appliedSearchType: this.appliedSearchType,
       });
     }
   }

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
@@ -7,7 +7,7 @@ import {
   IDataTableFilter,
   IDataTablePreferences,
   IDataTableSelectionOption,
-  IDataTableSort
+  IDataTableSort,
 } from '../interfaces';
 import { NovoDataTableFilterUtils } from '../services/data-table-filter-utils';
 
@@ -168,6 +168,7 @@ export class DataTableState<T> {
       if (preferences.savedSearchName) {
         this.savedSearchName = preferences.savedSearchName;
       }
+
       if (preferences.appliedSearchType) {
         this.appliedSearchType = preferences.appliedSearchType;
       }


### PR DESCRIPTION
## **Description**

Adds appliedSearchType allowing searches to be sorted by type

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**