### PR TITLE
feat(Criteria Builder): Add criteria builder types and tests

### DIFF
--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -4,7 +4,7 @@ export interface IDataTablePreferences {
   name: string;
   sort?: IDataTableSort;
   filter?: IDataTableFilter | IDataTableFilter[];
-  where?: { query: string; criteria?: AdaptiveCriteria; form: any[] };
+  where?: { query: string; criteria?: AdaptiveCriteria; form: any };
   globalSearch?: any;
   pageSize?: number;
   displayedColumns?: string[];

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -173,6 +173,13 @@ export interface IDataTableCell<T> {}
  */
 export interface AdaptiveQuery {
   criteria: AdaptiveCriteria;
+  orderBy?: string | string[]; // a comma separated string, or a string array with the same data
+  pagination?: PaginationObject;
+}
+
+export interface PaginationObject {
+  page: number;
+  pageSize: number;
 }
 
 export type AdaptiveCriteria = AdaptiveCondition | AdaptiveConjunction;

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -5,6 +5,7 @@ export interface IDataTablePreferences {
   sort?: IDataTableSort;
   filter?: IDataTableFilter | IDataTableFilter[];
   where?: { query: string; form: any };
+  criteria?: any; // TODO: Add adaptive query criteria syntax here, coming from the Bullhorn Types repo
   globalSearch?: any;
   pageSize?: number;
   displayedColumns?: string[];

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -173,7 +173,13 @@ export interface IDataTableCell<T> {}
  */
 export interface AdaptiveQuery {
   criteria: AdaptiveCriteria;
-  orderBy?: string | string[]; // a comma separated string, or a string array with the same data
+
+  // a comma separated list of fields to requests
+  fields?: string;
+
+  // a comma separated string, or a string array with the same data
+  orderBy?: string | string[];
+
   pagination?: PaginationObject;
 }
 

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -4,8 +4,7 @@ export interface IDataTablePreferences {
   name: string;
   sort?: IDataTableSort;
   filter?: IDataTableFilter | IDataTableFilter[];
-  where?: { query: string; form: any };
-  criteria?: any; // TODO: Add adaptive query criteria syntax here, coming from the Bullhorn Types repo
+  where?: { query: string; criteria?: any; form: any }; // TODO: Add adaptive query criteria syntax here, coming from the Bullhorn Types repo
   globalSearch?: any;
   pageSize?: number;
   displayedColumns?: string[];

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -4,7 +4,7 @@ export interface IDataTablePreferences {
   name: string;
   sort?: IDataTableSort;
   filter?: IDataTableFilter | IDataTableFilter[];
-  where?: { query: string; criteria?: any; form: any }; // TODO: Add adaptive query criteria syntax here, coming from the Bullhorn Types repo
+  where?: { query: string; criteria?: AdaptiveCriteria; form: any[] };
   globalSearch?: any;
   pageSize?: number;
   displayedColumns?: string[];
@@ -167,3 +167,65 @@ export interface IDataTableService<T> {
 }
 
 export interface IDataTableCell<T> {}
+
+/**
+ * Adaptive criteria syntax is a json representation of a search or query string that supports all current and future search formats.
+ */
+export interface AdaptiveQuery {
+  criteria: AdaptiveCriteria;
+}
+
+export type AdaptiveCriteria = AdaptiveCondition | AdaptiveConjunction;
+
+/**
+ * Only a single field is valid.
+ * Combine multiple fields with conjunctions, not sibling properties.
+ * If multiple sibling properties are used in a condition, errors may occur in translation.
+ */
+export interface AdaptiveCondition {
+  [fieldName: string]: AdaptiveConditionOperatorObject;
+}
+
+/**
+ * Only a single operator for a condition is valid.
+ * Combine multiple operators with conjunctions, not sibling properties.
+ * If multiple sibling operators are used in a condition, only the first will be used.
+ */
+export type AdaptiveConditionOperatorObject = {
+  [K in AdaptiveOperator as `${K}`]?: AdaptiveValue;
+};
+
+export type AdaptiveValue = string | string[] | boolean | boolean[] | number | number[];
+
+export type AdaptiveConjunction = AdaptiveAnd | AdaptiveOr | AdaptiveNot;
+
+export interface AdaptiveAnd {
+  and: Array<AdaptiveCriteria>;
+}
+
+export interface AdaptiveOr {
+  or: Array<AdaptiveCriteria>;
+}
+
+export interface AdaptiveNot {
+  not: AdaptiveCriteria;
+}
+
+export enum AdaptiveConjunctionNames {
+  And = 'and',
+  Or = 'or',
+  Not = 'not',
+}
+
+export enum AdaptiveOperator {
+  EqualTo = 'equalTo',
+  In = 'in',
+  Is = 'is',
+  LessThan = 'lt',
+  LessThanEquals = 'lte',
+  GreaterThan = 'gt',
+  GreaterThanEquals = 'gte',
+  Like = 'like',
+  StartsWith = 'startsWith',
+  EndsWith = 'endsWith',
+}

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.spec.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.spec.ts
@@ -1,6 +1,25 @@
 // APP
-import { AppliedSearchType } from '../interfaces';
+import { AdaptiveQuery, AppliedSearchType } from '../interfaces';
 import { DataTableState } from './data-table-state.service';
+
+const mockAdaptiveQuery: AdaptiveQuery = {
+  criteria: {
+    and: [{
+      status: {
+        equalTo: 'New Lead'
+      }
+    }, {
+      isDeleted: {
+        equalTo: 0
+      }
+    }]
+  },
+  orderBy: ['-id', 'name'],
+  pagination: {
+    page: 2,
+    pageSize: 100
+  },
+};
 
 describe('Service: DataTableState', () => {
   let service = new DataTableState();
@@ -13,7 +32,7 @@ describe('Service: DataTableState', () => {
       service.filter = { id: 'test', value: 'value' };
       service.sort = { id: 'test', value: 'desc' };
       service.globalSearch = 'testing';
-      service.where = { query: 'mock query', form: 'mock form' };
+      service.where = { query: 'mock query', criteria: mockAdaptiveQuery.criteria, form: 'mock form' };
     });
     it('should call selectedRows.clear, resetSource.next and onSortFilterChange if retainSelected is true', () => {
       service.retainSelected = false;
@@ -43,7 +62,7 @@ describe('Service: DataTableState', () => {
       expect(service.filter).toEqual({ id: 'test', value: 'value' });
       expect(service.sort).toEqual({ id: 'test', value: 'desc' });
       expect(service.globalSearch).toEqual('testing');
-      expect(service.where).toEqual({ query: 'mock query', form: 'mock form' });
+      expect(service.where).toEqual({ query: 'mock query', criteria: mockAdaptiveQuery.criteria, form: 'mock form' });
     });
     it('should emit an update if fireUpdate is true', () => {
       const expected = {
@@ -68,7 +87,7 @@ describe('Service: DataTableState', () => {
       service.filter = { id: 'test', value: 'value' };
       service.sort = { id: 'test', value: 'desc' };
       service.globalSearch = 'testing';
-      service.where = { query: 'mock query', form: 'mock form' };
+      service.where = { query: 'mock query', criteria: mockAdaptiveQuery.criteria, form: 'mock form' };
     });
     afterAll(() => {
       service.reset();
@@ -86,7 +105,7 @@ describe('Service: DataTableState', () => {
       service.clearSort();
       expect(service.sort).toBeUndefined();
       expect(service.filter).toEqual({ id: 'test', value: 'value' });
-      expect(service.where).toEqual({ query: 'mock query', form: 'mock form' });
+      expect(service.where).toEqual({ query: 'mock query', criteria: mockAdaptiveQuery.criteria, form: 'mock form' });
       expect(service.globalSearch).toEqual('testing');
       expect(service.page).toEqual(0);
     });
@@ -95,7 +114,7 @@ describe('Service: DataTableState', () => {
         sort: undefined,
         filter: { id: 'test', value: 'value' },
         globalSearch: 'testing',
-        where: { query: 'mock query', form: 'mock form' },
+        where: { query: 'mock query', criteria: mockAdaptiveQuery.criteria, form: 'mock form' },
       };
       service.clearSort(true);
       expect(service.reset).toHaveBeenCalledWith(true, true);
@@ -115,7 +134,7 @@ describe('Service: DataTableState', () => {
       service.filter = { id: 'test', value: 'value' };
       service.sort = { id: 'test', value: 'desc' };
       service.globalSearch = 'testing';
-      service.where = { query: 'mock query', form: 'mock form' };
+      service.where = { query: 'mock query', criteria: mockAdaptiveQuery.criteria, form: 'mock form' };
     });
     afterAll(() => {
       service.reset();
@@ -133,7 +152,7 @@ describe('Service: DataTableState', () => {
       service.clearFilter();
       expect(service.sort).toEqual({ id: 'test', value: 'desc' });
       expect(service.filter).toBeUndefined();
-      expect(service.where).toEqual({ query: 'mock query', form: 'mock form' });
+      expect(service.where).toEqual({ query: 'mock query', criteria: mockAdaptiveQuery.criteria, form: 'mock form' });
       expect(service.globalSearch).toBeUndefined();
       expect(service.page).toEqual(0);
     });
@@ -142,7 +161,7 @@ describe('Service: DataTableState', () => {
         sort: { id: 'test', value: 'desc' },
         filter: undefined,
         globalSearch: undefined,
-        where: { query: 'mock query', form: 'mock form' },
+        where: { query: 'mock query', criteria: mockAdaptiveQuery.criteria, form: 'mock form' },
       };
       service.clearFilter(true);
       expect(service.reset).toHaveBeenCalledWith(true, true);
@@ -162,7 +181,7 @@ describe('Service: DataTableState', () => {
       service.filter = { id: 'test', value: 'value' };
       service.sort = { id: 'test', value: 'desc' };
       service.globalSearch = 'testing';
-      service.where = { query: 'mock query', form: 'mock form' };
+      service.where = { query: 'mock query', criteria: mockAdaptiveQuery.criteria, form: 'mock form' };
     });
     afterAll(() => {
       service.reset();
@@ -481,7 +500,7 @@ describe('Service: DataTableState', () => {
       expect(service.displayedColumns).toEqual(['column 1', 'column 2']);
     });
     it('should not set displayedColumns if displayedColumns array is empty', () => {
-      service.setState({  name: 'empty columns', displayedColumns: [] });
+      service.setState({ name: 'empty columns', displayedColumns: [] });
       expect(service.displayedColumns).toEqual(['column 1', 'column 2']);
     });
     it('should emit an update if fireUpdate is true', () => {

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
@@ -10,7 +10,7 @@ import {
   IDataTableSelectionOption,
   IDataTableSort,
 } from '../interfaces';
-import { NovoDataTableFilterUtils } from 'novo-elements/elements';
+import { NovoDataTableFilterUtils } from '../services/data-table-filter-utils';
 
 @Injectable()
 export class DataTableState<T> {

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
@@ -25,7 +25,7 @@ export class DataTableState<T> {
 
   sort: IDataTableSort = undefined;
   filter: IDataTableFilter | IDataTableFilter[] = undefined;
-  where: { query: string; criteria?: AdaptiveCriteria; form: any[] } = undefined;
+  where: { query: string; criteria?: AdaptiveCriteria; form: any } = undefined;
   page: number = 0;
   pageSize: number = undefined;
   globalSearch: string = undefined;

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
@@ -1,7 +1,8 @@
 import { EventEmitter, Injectable } from '@angular/core';
-import { Subject } from 'rxjs';
 import { Helpers } from 'novo-elements/utils';
+import { Subject } from 'rxjs';
 import {
+  AdaptiveCriteria,
   AppliedSearchType,
   IDataTableChangeEvent,
   IDataTableFilter,
@@ -9,7 +10,7 @@ import {
   IDataTableSelectionOption,
   IDataTableSort,
 } from '../interfaces';
-import { NovoDataTableFilterUtils } from '../services/data-table-filter-utils';
+import { NovoDataTableFilterUtils } from 'novo-elements/elements';
 
 @Injectable()
 export class DataTableState<T> {
@@ -24,7 +25,7 @@ export class DataTableState<T> {
 
   sort: IDataTableSort = undefined;
   filter: IDataTableFilter | IDataTableFilter[] = undefined;
-  where: { query: string; criteria?: any; form: any } = undefined; // TODO: Adaptive syntax
+  where: { query: string; criteria?: AdaptiveCriteria; form: any[] } = undefined;
   page: number = 0;
   pageSize: number = undefined;
   globalSearch: string = undefined;

--- a/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
+++ b/projects/novo-elements/src/elements/data-table/state/data-table-state.service.ts
@@ -24,7 +24,7 @@ export class DataTableState<T> {
 
   sort: IDataTableSort = undefined;
   filter: IDataTableFilter | IDataTableFilter[] = undefined;
-  where: { query: string; form: any } = undefined;
+  where: { query: string; criteria?: any; form: any } = undefined; // TODO: Adaptive syntax
   page: number = 0;
   pageSize: number = undefined;
   globalSearch: string = undefined;

--- a/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.html
+++ b/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.html
@@ -17,7 +17,7 @@
           </ng-template>
           <novo-condition-builder [groupIndex]="groupIndex" [andIndex]="andIndex" [isFirst]="isFirst"></novo-condition-builder>
           <novo-button theme="icon" icon="delete-o" color="negative" (click)="removeCondition(andIndex)"
-            [disabled]="cantRemoveRow(isFirst)">
+            [disabled]="cantRemoveRow()">
           </novo-button>
         </novo-flex>
       </ng-container>

--- a/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.ts
@@ -26,7 +26,6 @@ export class ConditionGroupComponent implements OnInit, OnDestroy {
   @Input() groupIndex: number;
 
   public parentForm: UntypedFormGroup;
-  public innerForm: UntypedFormGroup;
   /** Subject that emits when the component has been destroyed. */
   private readonly _onDestroy = new Subject<void>();
 
@@ -68,8 +67,8 @@ export class ConditionGroupComponent implements OnInit, OnDestroy {
   }
 
   addCondition(data?: any) {
-    const conditon = this.newCondition(data);
-    this.root.push(conditon);
+    const condition = this.newCondition(data);
+    this.root.push(condition);
     this.cdr.markForCheck();
   }
 
@@ -86,8 +85,10 @@ export class ConditionGroupComponent implements OnInit, OnDestroy {
     });
   }
 
-  cantRemoveRow(isFirst: boolean) {
-    if ((this.parentForm.parent as FormArray).length > 1) return false;
+  cantRemoveRow() {
+    if ((this.parentForm.parent as FormArray).length > 1) {
+      return false;
+    }
     return this.root.length <= 1;
   }
 }

--- a/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.ts
@@ -22,7 +22,7 @@ const EMPTY_CONDITION: Condition = {
   },
 })
 export class ConditionGroupComponent implements OnInit, OnDestroy {
-  @Input() controlName: string = '$' + Conjunction.AND;
+  @Input() controlName: string = '$' + Conjunction.And;
   @Input() groupIndex: number;
 
   public parentForm: UntypedFormGroup;

--- a/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.spec.ts
+++ b/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.spec.ts
@@ -1,0 +1,75 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ControlContainer, UntypedFormBuilder } from '@angular/forms';
+import { NovoLabelService } from '../../../services';
+import { Condition, Criteria, NovoFlexModule, NovoQueryBuilderModule } from '../../index';
+import { QueryBuilderService } from '../query-builder.service';
+import { CriteriaBuilderComponent } from './criteria-builder.component';
+
+const condition1: Condition = {
+  field: 'Candidate.email',
+  operator: 'excludeAny',
+  value: [
+    'cba',
+    'fed',
+  ],
+};
+
+const condition2: Condition = {
+  field: 'Candidate.status',
+  operator: 'equalTo',
+  value: 'New Lead',
+};
+
+const condition3: Condition = {
+  field: 'Candidate.email',
+  operator: 'includeAny',
+  value: [
+    'abc',
+    'def',
+  ],
+};
+
+const testCriteria: Criteria = {
+  criteria: [{
+    $and: [condition1, condition2, condition3],
+  }],
+};
+
+describe('CriteriaBuilderComponent', () => {
+  const formBuilder: UntypedFormBuilder = new UntypedFormBuilder();
+  const parentForm = formBuilder.group({ criteria: [] });
+  let fixture: ComponentFixture<CriteriaBuilderComponent>;
+  let component: CriteriaBuilderComponent;
+
+  class MockControlContainer {
+    public control = parentForm;
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [CriteriaBuilderComponent],
+      providers: [
+        { provide: QueryBuilderService, useClass: QueryBuilderService },
+        { provide: ControlContainer, useClass: MockControlContainer },
+        { provide: NovoLabelService, useClass: NovoLabelService },
+      ],
+      imports: [
+        NovoQueryBuilderModule,
+        NovoFlexModule
+      ]
+    }).compileComponents();
+    fixture = TestBed.createComponent(CriteriaBuilderComponent);
+    component = fixture.debugElement.componentInstance;
+    component.controlName = 'criteria';
+    component.config = [{
+      value: 'value',
+      label: 'label',
+    }];
+  });
+
+  it('should subscribe to changes in the parent form', () => {
+    expect(parentForm.value).toEqual({ criteria: null });
+    parentForm.setValue(testCriteria);
+    expect(parentForm.value).toEqual(testCriteria);
+  });
+});

--- a/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.ts
@@ -66,7 +66,7 @@ export class CriteriaBuilderComponent implements OnInit, OnDestroy, AfterContent
 
     this.parentForm.valueChanges.pipe(takeUntil(this._onDestroy)).subscribe((value) => {
       Promise.resolve().then(() => {
-        this.setInitalValue(value[this.controlName]);
+        this.setInitialValue(value[this.controlName]);
         this.cdr.markForCheck();
       });
     });
@@ -109,7 +109,7 @@ export class CriteriaBuilderComponent implements OnInit, OnDestroy, AfterContent
     return Object.keys(group).every((key) => ['$and', '$or', '$not'].includes(key));
   }
 
-  private setInitalValue(value: ConditionGroup[] | Condition[]) {
+  private setInitialValue(value: ConditionGroup[] | Condition[]) {
     if (value.length && this.isConditionGroup(value[0])) {
       value.forEach((it) => this.addConditionGroup(it));
     } else {

--- a/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.ts
@@ -41,7 +41,7 @@ const EMPTY_CONDITION: Condition = {
 export class CriteriaBuilderComponent implements OnInit, OnDestroy, AfterContentChecked, AfterViewInit {
   @Input() config: any;
   @Input() controlName: string;
-  @Input() allowedGroupings = [Conjunction.AND, Conjunction.OR, Conjunction.NOT];
+  @Input() allowedGroupings = [Conjunction.And, Conjunction.Or, Conjunction.Not];
   @Input() editTypeFn: (field: BaseFieldDef) => string;
 
   @ContentChildren(NovoConditionFieldDef, { descendants: true }) _contentFieldDefs: QueryList<NovoConditionFieldDef>;

--- a/projects/novo-elements/src/elements/query-builder/query-builder.service.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.service.ts
@@ -78,11 +78,11 @@ export class QueryBuilderService {
 
   getConjunctionLabel(conjunction: string) {
     switch (conjunction.replace('$', '').toLowerCase()) {
-      case Conjunction.OR:
+      case Conjunction.Or:
         return this.labels.or;
-      case Conjunction.NOT:
+      case Conjunction.Not:
         return this.labels.not;
-      case Conjunction.AND:
+      case Conjunction.And:
       default:
         return this.labels.and;
     }

--- a/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
@@ -5,13 +5,19 @@ export enum Conjunction {
   OR = 'or',
   NOT = 'not',
 }
+
 export type ConditionGroup = {
-  [key: string]: Condition[];
+  [K in Conjunction as `$${K}`]?: Condition[]
 };
+
 export interface Condition {
   field: string;
   operator: string;
   value: any;
+}
+
+export interface Criteria {
+  criteria: ConditionGroup[];
 }
 
 export interface BaseFieldDef {

--- a/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
@@ -1,9 +1,9 @@
 import { ViewContainerRef } from '@angular/core';
 
 export enum Conjunction {
-  AND = 'and',
-  OR = 'or',
-  NOT = 'not',
+  And = 'and',
+  Or = 'or',
+  Not = 'not',
 }
 
 export type ConditionGroup = {

--- a/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.ts
+++ b/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.ts
@@ -51,7 +51,7 @@ export class CustomPickerConditionDef extends AbstractConditionFieldDef implemen
         // filter((res) => res.length > 2),
         // Time in milliseconds between key events
         debounceTime(500),
-        // If previous query is diffent from current
+        // If previous query is different from current
         distinctUntilChanged(),
         takeUntil(this._onDestroy),
       )
@@ -79,9 +79,9 @@ export class JustCriteriaExample implements OnInit {
   queryForm: AbstractControl;
   config: any = null;
 
-  and = [Conjunction.AND];
-  andOr = [Conjunction.AND, Conjunction.OR];
-  andOrNot = [Conjunction.AND, Conjunction.OR, Conjunction.NOT];
+  and = [Conjunction.And];
+  andOr = [Conjunction.And, Conjunction.Or];
+  andOrNot = [Conjunction.And, Conjunction.Or, Conjunction.Not];
 
   editTypeFn = (field: any) => {
     if (field.optionsType === 'Brewery') return 'custom';


### PR DESCRIPTION
## **Description**

Cleaning up the types and tests for the criteria builder - non-functional changes

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**