### PR TITLE
fix(Criteria): Added criteria operator types

### DIFF
--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -9,6 +9,7 @@ export interface IDataTablePreferences {
   pageSize?: number;
   displayedColumns?: string[];
   columnWidths?: { id: string; width: number }[];
+  savedSearchId?: number;
   savedSearchName?: string;
   appliedSearchType?: AppliedSearchType;
 }

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/abstract-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/abstract-condition.definition.ts
@@ -1,5 +1,6 @@
 import { Directive, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
+import { Operator } from 'novo-elements/elements';
 import { NovoLabelService } from 'novo-elements/services';
 import { NovoConditionFieldDef } from '../query-builder.directives';
 
@@ -18,7 +19,7 @@ export abstract class AbstractConditionFieldDef implements OnDestroy, OnInit {
   }
   _name: string;
 
-  defaultOperator: string;
+  defaultOperator: Operator;
 
   @ViewChild(NovoConditionFieldDef, { static: true }) fieldDef: NovoConditionFieldDef;
 

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/abstract-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/abstract-condition.definition.ts
@@ -19,7 +19,7 @@ export abstract class AbstractConditionFieldDef implements OnDestroy, OnInit {
   }
   _name: string;
 
-  defaultOperator: Operator;
+  defaultOperator: Operator | string;
 
   @ViewChild(NovoConditionFieldDef, { static: true }) fieldDef: NovoConditionFieldDef;
 

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/abstract-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/abstract-condition.definition.ts
@@ -1,8 +1,8 @@
 import { Directive, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
-import { Operator } from 'novo-elements/elements';
 import { NovoLabelService } from 'novo-elements/services';
 import { NovoConditionFieldDef } from '../query-builder.directives';
+import { Operator } from '../query-builder.types';
 
 @Directive()
 export abstract class AbstractConditionFieldDef implements OnDestroy, OnInit {

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
@@ -1,11 +1,11 @@
 import { ChangeDetectionStrategy, Component, ElementRef, QueryList, ViewChild, ViewChildren, ViewEncapsulation } from '@angular/core';
 import { AbstractControl } from '@angular/forms';
-import { Operator } from 'novo-elements/elements';
 import { NovoPickerToggleElement } from 'novo-elements/elements/field';
 import { PlacesListComponent } from 'novo-elements/elements/places';
 import { NovoLabelService } from 'novo-elements/services';
 import { Key } from 'novo-elements/utils';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
+import { Operator } from '../query-builder.types';
 
 /**
  * Handle selection of field values when a list of options is provided.

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, ElementRef, QueryList, ViewChild, ViewChildren, ViewEncapsulation } from '@angular/core';
 import { AbstractControl } from '@angular/forms';
+import { Operator } from 'novo-elements/elements';
 import { NovoPickerToggleElement } from 'novo-elements/elements/field';
 import { PlacesListComponent } from 'novo-elements/elements/places';
 import { NovoLabelService } from 'novo-elements/services';
@@ -50,7 +51,7 @@ export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef {
   @ViewChildren('addressInput') inputChildren: QueryList<ElementRef>;
   @ViewChild('placesPicker') placesPicker: PlacesListComponent;
 
-  defaultOperator = 'includeAny';
+  defaultOperator = Operator.includeAny;
   chipListModel: any = '';
   term: string = '';
 

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/boolean-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/boolean-condition.definition.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { Operator } from 'novo-elements/elements';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
 
 /**
@@ -27,5 +28,5 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class NovoDefaultBooleanConditionDef extends AbstractConditionFieldDef {
-  defaultOperator = 'include';
+  defaultOperator = Operator.include;
 }

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/boolean-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/boolean-condition.definition.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
-import { Operator } from 'novo-elements/elements';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
+import { Operator } from '../query-builder.types';
 
 /**
  * When constructing a query using a field that is a boolean with only true/false as possible values.

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, QueryList, ViewChildren, ViewEncapsulation } from '@angular/core';
-import { Operator } from 'novo-elements/elements';
 import { NovoPickerToggleElement } from 'novo-elements/elements/field';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
+import { Operator } from '../query-builder.types';
 
 /**
  * Most complicated of the default conditions defs, a date needs to provide a different

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, QueryList, ViewChildren, ViewEncapsulation } from '@angular/core';
+import { Operator } from 'novo-elements/elements';
 import { NovoPickerToggleElement } from 'novo-elements/elements/field';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
 
@@ -56,7 +57,7 @@ export class NovoDefaultDateConditionDef extends AbstractConditionFieldDef {
   @ViewChildren(NovoPickerToggleElement)
   overlayChildren: QueryList<NovoPickerToggleElement>;
 
-  defaultOperator = 'within';
+  defaultOperator = Operator.within;
 
   closePanel(event, viewIndex): void {
     const overlay = this.overlayChildren.find(item => item.overlayId === viewIndex);

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/date-time-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/date-time-condition.definition.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, QueryList, ViewChildren, ViewEncapsulation } from '@angular/core';
+import { Operator } from 'novo-elements/elements';
 import { NovoPickerToggleElement } from 'novo-elements/elements/field';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
 
@@ -55,7 +56,7 @@ export class NovoDefaultDateTimeConditionDef extends AbstractConditionFieldDef {
   @ViewChildren(NovoPickerToggleElement)
   overlayChildren: QueryList<NovoPickerToggleElement>;
 
-  defaultOperator = 'within';
+  defaultOperator = Operator.within;
 
   closePanel(event, viewIndex): void {
     const overlay = this.overlayChildren.find(item => item.overlayId === viewIndex);

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/date-time-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/date-time-condition.definition.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, QueryList, ViewChildren, ViewEncapsulation } from '@angular/core';
-import { Operator } from 'novo-elements/elements';
 import { NovoPickerToggleElement } from 'novo-elements/elements/field';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
+import { Operator } from '../query-builder.types';
 
 /**
  * Most complicated of the default conditions defs, a date needs to provide a different

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/id-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/id-condition.definition.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
-import { Operator } from 'novo-elements/elements';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
+import { Operator } from '../query-builder.types';
 
 /**
  * Any condition that has a type of ID usually only is queried by ID.

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/id-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/id-condition.definition.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { Operator } from 'novo-elements/elements';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
 
 /**
@@ -23,5 +24,5 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class NovoDefaultIdConditionDef extends AbstractConditionFieldDef {
-  defaultOperator = 'equalTo';
+  defaultOperator = Operator.equalTo;
 }

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/number-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/number-condition.definition.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
-import { Operator } from 'novo-elements/elements';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
+import { Operator } from '../query-builder.types';
 
 /**
  * When constructing a query using a field that is an Int, Double, Number ...etc.

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/number-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/number-condition.definition.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { Operator } from 'novo-elements/elements';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
 
 /**
@@ -34,5 +35,5 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class NovoDefaultNumberConditionDef extends AbstractConditionFieldDef {
-  defaultOperator = 'equalTo';
+  defaultOperator = Operator.equalTo;
 }

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
-import { Operator } from 'novo-elements/elements';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
+import { Operator } from '../query-builder.types';
 
 /**
  * Handle selection of field values when a list of options is provided.

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { Operator } from 'novo-elements/elements';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
 
 /**
@@ -38,5 +39,5 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class NovoDefaultPickerConditionDef extends AbstractConditionFieldDef {
-  defaultOperator = 'includeAny';
+  defaultOperator = Operator.includeAny;
 }

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 import { AbstractControl } from '@angular/forms';
-import { Operator } from 'novo-elements/elements';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
+import { Operator } from '../query-builder.types';
 
 /**
  * Constructing filters against String fields can be complex. Each "chip" added to the

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 import { AbstractControl } from '@angular/forms';
+import { Operator } from 'novo-elements/elements';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
 
 /**
@@ -56,7 +57,7 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class NovoDefaultStringConditionDef extends AbstractConditionFieldDef {
-  defaultOperator = 'includeAny';
+  defaultOperator = Operator.includeAny;
 
   getValue(formGroup: AbstractControl): any[] {
     return formGroup.value?.value || [];

--- a/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.spec.ts
+++ b/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.spec.ts
@@ -16,7 +16,7 @@ const condition1: Condition = {
 
 const condition2: Condition = {
   field: 'Candidate.status',
-  operator: 'equalTo',
+  operator: 'includeAll',
   value: 'New Lead',
 };
 

--- a/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.spec.ts
+++ b/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ControlContainer, UntypedFormBuilder } from '@angular/forms';
 import { NovoLabelService } from '../../../services';
-import { Condition, Criteria, NovoFlexModule, NovoQueryBuilderModule } from '../../index';
+import { Condition, Criteria, NovoFlexModule, NovoQueryBuilderModule, Operator } from '../../index';
 import { QueryBuilderService } from '../query-builder.service';
 import { CriteriaBuilderComponent } from './criteria-builder.component';
 
@@ -16,13 +16,13 @@ const condition1: Condition = {
 
 const condition2: Condition = {
   field: 'Candidate.status',
-  operator: 'includeAll',
+  operator: Operator.equalTo,
   value: 'New Lead',
 };
 
 const condition3: Condition = {
   field: 'Candidate.email',
-  operator: 'includeAny',
+  operator: Operator.includeAny,
   value: [
     'abc',
     'def',

--- a/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
@@ -14,13 +14,16 @@ export enum Operator {
   after = 'after',
   before = 'before',
   between = 'between',
+  equalTo = 'equalTo',
   exclude = 'exclude',
   excludeAny = 'excludeAny',
+  greaterThan = 'greaterThan',
   include = 'include',
   includeAll = 'includeAll',
   includeAny = 'includeAny',
   isEmpty = 'isEmpty',
   isNull = 'isNull',
+  lessThan = 'lessThan',
   within = 'within',
 }
 

--- a/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
@@ -31,7 +31,7 @@ export type OperatorName = keyof typeof Operator;
 
 export interface Condition {
   field: string;
-  operator: OperatorName;
+  operator: OperatorName | string;
   value: any;
 }
 

--- a/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
@@ -10,9 +10,25 @@ export type ConditionGroup = {
   [K in Conjunction as `$${K}`]?: Condition[]
 };
 
+export enum Operator {
+  after = 'after',
+  before = 'before',
+  between = 'between',
+  exclude = 'exclude',
+  excludeAny = 'excludeAny',
+  include = 'include',
+  includeAll = 'includeAll',
+  includeAny = 'includeAny',
+  isEmpty = 'isEmpty',
+  isNull = 'isNull',
+  within = 'within',
+}
+
+export type OperatorName = keyof typeof Operator;
+
 export interface Condition {
   field: string;
-  operator: string;
+  operator: OperatorName;
   value: any;
 }
 

--- a/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.ts
+++ b/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
 import { AbstractControl, UntypedFormBuilder, UntypedFormControl } from '@angular/forms';
-import { AbstractConditionFieldDef, Conjunction, CriteriaBuilderComponent, NovoLabelService } from 'novo-elements';
+import { AbstractConditionFieldDef, Conjunction, CriteriaBuilderComponent, NovoLabelService, Operator } from 'novo-elements';
 import { ReplaySubject, Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
 import { MockMeta } from './MockMeta';
@@ -33,7 +33,7 @@ import { MockMeta } from './MockMeta';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class CustomPickerConditionDef extends AbstractConditionFieldDef implements OnInit {
-  defaultOperator = 'includeAny';
+  defaultOperator = Operator.includeAny;
   searchCtrl: UntypedFormControl = new UntypedFormControl();
   /** list of results filtered by search keyword */
   remoteResults: ReplaySubject<any[]> = new ReplaySubject<any[]>(1);


### PR DESCRIPTION
## **Description**

Our typescript types could be stricter, since we have a limited number of operations. 

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**