### PR TITLE
fix(Criteria Types): Adding missing operator types

### DIFF
--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -234,6 +234,8 @@ export enum AdaptiveConjunctionNames {
 export enum AdaptiveOperator {
   EqualTo = 'equalTo',
   In = 'in',
+  IncludeAny = 'includeAny',
+  IncludeAll = 'includeAll',
   Is = 'is',
   LessThan = 'lt',
   LessThanEquals = 'lte',


### PR DESCRIPTION
## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**