### PR TITLE
fix(CriteriaTypes): Adding missing operator types

### DIFF
--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -234,6 +234,8 @@ export enum AdaptiveConjunctionNames {
 export enum AdaptiveOperator {
   EqualTo = 'equalTo',
   In = 'in',
+  IncludeAny = 'includeAny',
+  IncludeAll = 'includeAll',
   Is = 'is',
   LessThan = 'lt',
   LessThanEquals = 'lte',


### PR DESCRIPTION
## **Description**

Adding missing operator types

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**