### PR TITLE
feat(TabbedGroupPicker): Added option to disable item selection/checkboxes

### DIFF
--- a/projects/novo-elements/src/elements/common/option/option.component.ts
+++ b/projects/novo-elements/src/elements/common/option/option.component.ts
@@ -56,9 +56,13 @@ export class NovoOptionBase implements FocusableOption, AfterViewChecked, OnDest
   @Input()
   novoInert: boolean = false;
 
+  @BooleanInput()
+  @Input()
+  allowSelection = true;
+
   /** If there is no parent then nothing is managing the selection. */
   get selectable() {
-    return this._parent;
+    return this.allowSelection && this._parent;
   }
 
   /** Whether the wrapping component is in multiple selection mode. */

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
@@ -54,11 +54,11 @@ export class ConditionOperatorOutlet implements QueryFilterOutlet {
     {
       provide: QueryBuilderService,
       deps: [NovoLabelService, [new SkipSelf(), new Optional(), QueryBuilderService]],
-      useFactory: (labelService: NovoLabelService, qbs?: QueryBuilderService) => {
-        if (!qbs) {
-          qbs = new QueryBuilderService(labelService);
+      useFactory: (labelService: NovoLabelService, queryBuilderService?: QueryBuilderService) => {
+        if (!queryBuilderService) {
+          queryBuilderService = new QueryBuilderService(labelService);
         }
-        return qbs;
+        return queryBuilderService;
       }
     }
   ],

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
@@ -80,15 +80,15 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
   inputEditTypeFn = input<(field: BaseFieldDef) => string>(null, { alias: 'editTypeFn'});
   private config = computed<QueryBuilderConfig>(() => {
     if (this.isConditionHost) {
-      this.qbs.config = this.inputConfig();
+      this.queryBuilderService.config = this.inputConfig();
     }
-    return this.qbs.config;
+    return this.queryBuilderService.config;
   });
   private editTypeFn = computed<(field: BaseFieldDef) => string>(() => {
     if (this.isConditionHost) {
-      this.qbs.editTypeFn = this.inputEditTypeFn();
+      this.queryBuilderService.editTypeFn = this.inputEditTypeFn();
     }
-    return this.qbs.editTypeFn;
+    return this.queryBuilderService.editTypeFn;
   });
 
   public parentForm: FormGroup;
@@ -118,11 +118,11 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
   constructor(
     public labels: NovoLabelService,
     private cdr: ChangeDetectorRef,
-    private qbs: QueryBuilderService,
+    private queryBuilderService: QueryBuilderService,
     private controlContainer: ControlContainer,
   ) {
-    if (!qbs.componentHost) {
-      qbs.componentHost = this;
+    if (!queryBuilderService.componentHost) {
+      queryBuilderService.componentHost = this;
       this.isConditionHost = true;
       this.groupIndex = 0;
       this.andIndex = 0;
@@ -224,7 +224,7 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
     const editType = this.editTypeFn()(field);
     // Don't look at dataSpecialization it is no good, this misses currency, and percent
     const { name } = field;
-    const fieldDefsByName = this.qbs.getFieldDefsByName();
+    const fieldDefsByName = this.queryBuilderService.getFieldDefsByName();
     // Check Fields by priority for match Field Definition
     const key = [name, editType?.toUpperCase(), 'DEFAULT'].find((it) => fieldDefsByName.has(it));
     return fieldDefsByName.get(key);

--- a/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.html
+++ b/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.html
@@ -11,7 +11,7 @@
   <div class="tabbed-group-picker-search" data-automation-id="tabbed-group-picker-search" (keydown)="dropdown._handleKeydown($event)">
     <input #inputElement type="text" [placeholder]="labelService.search" [value]="filterText | async" (input)="onFilter($event)" />
     <i class="bhi-search" *ngIf="!(filterText | async)"></i>
-    <i class="bhi-times" *ngIf="(filterText | async)" (click)="onClearFilter($event)"></i>
+    <i class="bhi-times" *ngIf="(filterText | async)" (click)="onClearFilter($event)" (keydown.space)="onClearFilter($event)"></i>
   </div>
   <div class="tabbed-group-picker-column-container" (keydown)="dropdown._handleKeydown($event)">
     <div class="tabbed-group-picker-column left">
@@ -22,7 +22,7 @@
         </novo-tab>
       </novo-nav>
       <novo-button *ngIf="showClearAll && !showFooter" class="clear-all-button" theme="dialogue" icon="times" side="right"
-        color="grapefruit" (click)="deselectEverything($event)">{{ labelService.clear }}</novo-button>
+        color="grapefruit" (click)="deselectEverything($event)" (keydown.space)="deselectEverything($event)">{{ labelService.clear }}</novo-button>
     </div>
     <div class="tabbed-group-picker-column right">
       <div class="quick-select" *ngIf="quickSelectConfig && !(filterText | async)">
@@ -31,8 +31,10 @@
             class="quick-select-item"
             *ngFor="let quickSelect of quickSelectConfig.items"
             [attr.data-automation-id]="quickSelect.label"
+            [allowSelection]="selectionEnabled"
             [selected]="quickSelect.selected"
-            (click)="quickSelect.selected = !quickSelect.selected; onItemToggled(quickSelect)"
+            (click)="activateItem(quickSelect)"
+            (keydown.space)="activateItem(quickSelect)"
             novoInert>
             {{quickSelect.label}}
           </novo-option>
@@ -47,8 +49,10 @@
           <novo-option
             *cdkVirtualFor="let item of displayTab.data"
             [attr.data-automation-id]="item[displayTab.labelField]"
+            [allowSelection]="selectionEnabled"
             [selected]="item.selected"
-            (click)="item.selected = !item.selected; onItemToggled(item)"
+            (click)="activateItem(item)"
+            (keydown.space)="activateItem(item)"
             novoInert>
             {{item[displayTab.labelField]}}
           </novo-option>

--- a/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.scss
+++ b/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.scss
@@ -59,6 +59,7 @@
   .tabbed-group-picker-column-container {
     display: flex;
     flex-direction: row;
+    user-select: none;
 
     .tabbed-group-picker-column {
       display: flex;

--- a/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.spec.ts
+++ b/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.spec.ts
@@ -400,7 +400,7 @@ describe('Elements: NovoTabbedGroupPickerElement', () => {
       component.onItemToggled(chicken);
 
       const selectedItem = component.tabs[0].data[0];
-      const displayReference = component.displayTabs.find(({ typeName }) => typeName === 'chickens').data[0];
+      const displayReference = component.displayTabs.find((tab) => tab.typeName === 'chickens')!.data[0];
 
       expect(selectedItem.selected).toEqual(true);
       expect(displayReference.selected).toEqual(true);
@@ -429,10 +429,9 @@ describe('Elements: NovoTabbedGroupPickerElement', () => {
         },
       ];
       const chicken = component.tabs[0].data[0];
-      chicken.selected = true;
 
       component.createChildrenReferences();
-      component.onItemToggled(chicken);
+      component.activateItem(chicken);
 
       const selectedItem = component.tabs[0].data[0];
       expect(selectedItem.selected).toEqual(true);
@@ -456,11 +455,31 @@ describe('Elements: NovoTabbedGroupPickerElement', () => {
         },
       ];
       const chicken = component.tabs[0].data[0];
-      chicken.selected = true;
       const tRex = component.tabs[1].data[0];
 
-      component.onItemToggled(chicken);
+      component.activateItem(chicken);
       expect(tRex.selected).toEqual(true);
     });
   });
+
+  describe('Activation mode', () => {
+    it('should emit an activation, not selectionChange event when activation mode is enabled', () => {
+      let activation: any;
+      let selection: any;
+      component.activation.subscribe(item => {
+        activation = item;
+      });
+      component.selectionChange.subscribe(newSelection => {
+        selection = newSelection;
+      });
+      const chickenTab = getChickenTab();
+      component.selectionEnabled = false;
+      component.tabs = [chickenTab];
+      const chicken = component.tabs[0].data[0];
+
+      component.activateItem(chicken);
+      expect(selection).toBeUndefined();
+      expect(activation).toBe(chicken);
+    });
+  })
 });

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -123,6 +123,7 @@ export class NovoLabelService {
   includeAny = 'Include Any';
   includeAll = 'Include All';
   exclude = 'Exclude';
+  excludeAny = 'Exclude Any';
   radius = 'Radius';
   equals = 'Equals';
   equalTo = 'Equal To';

--- a/projects/novo-examples/src/components/tabbed-group-picker/index.ts
+++ b/projects/novo-examples/src/components/tabbed-group-picker/index.ts
@@ -1,3 +1,4 @@
+export * from './tabbed-group-picker-no-selection-example';
 export * from './tabbed-group-picker-basic';
 export * from './tabbed-group-picker-big-groups-example';
 export * from './tabbed-group-picker-groups-example';

--- a/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-no-selection-example/index.ts
+++ b/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-no-selection-example/index.ts
@@ -1,0 +1,1 @@
+export * from './tabbed-group-picker-no-selection-example';

--- a/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-no-selection-example/tabbed-group-picker-no-selection-example.html
+++ b/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-no-selection-example/tabbed-group-picker-no-selection-example.html
@@ -1,0 +1,12 @@
+<div class="tabbed-group-picker-example">
+  <novo-tabbed-group-picker
+    [tabs]="example_tab"
+    [selectionEnabled]="false"
+    [buttonConfig]="example_buttonConfig"
+    (activation)="onActivation($event)"
+  ></novo-tabbed-group-picker>
+  <div class="selected-data-wrapper">
+    <h6>Last selection:</h6>
+    <div>{{ lastSelection }}</div>
+  </div>
+</div>

--- a/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-no-selection-example/tabbed-group-picker-no-selection-example.ts
+++ b/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-no-selection-example/tabbed-group-picker-no-selection-example.ts
@@ -1,0 +1,43 @@
+import { Component } from '@angular/core';
+
+/**
+ * @title Tabbed Group Picker - Basic Example
+ */
+@Component({
+  selector: 'tabbed-group-picker-no-selection-example',
+  templateUrl: 'tabbed-group-picker-no-selection-example.html',
+  styleUrls: ['../tabbed-group-picker-example.scss'],
+})
+export class TabbedGroupPickerNoSelectionExample {
+  getActions = (): { actionId: number; name: string }[] =>
+    ['Run', 'Jump', 'Swim', 'Climb', 'Walk', 'Fly'].map((name, index) => ({
+      name,
+      actionId: index + 1
+    }));
+
+  actionsTab = {
+    typeName: 'actions',
+    typeLabel: 'Actions',
+    valueField: 'actionId',
+    labelField: 'name',
+    data: this.getActions(),
+  };
+
+  example_tab = [
+    this.actionsTab
+  ];
+
+  public example_buttonConfig = {
+    theme: 'select',
+    side: 'right',
+    icon: 'collapse',
+    label: 'Open action activation window',
+    selector: 'buttonConfig',
+  };
+
+  public lastSelection: string;
+
+  onActivation(selectedData: { actionId: number; name: string }) {
+    this.lastSelection = selectedData.name;
+  }
+}

--- a/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker.md
+++ b/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker.md
@@ -21,3 +21,9 @@ Tabbed Group Picker provides a configurable quick select interface. For each qui
 ## Big Groups
 
 <code-example example="tabbed-group-picker-big-groups"></code-example>
+
+## Selection Disabled
+
+When checkboxes are disabled in the activation picker, we can still listen for "activation" events when an item has been clicked.
+
+<code-example example="tabbed-group-picker-no-selection"></code-example>

--- a/projects/novo-examples/src/examples.routes.ts
+++ b/projects/novo-examples/src/examples.routes.ts
@@ -2828,6 +2828,9 @@ export class SwitchPage {
 <p><code-example example="tabbed-group-picker-groups"></code-example></p>
 <h2>Big Groups</h2>
 <p><code-example example="tabbed-group-picker-big-groups"></code-example></p>
+<h2>Selection Disabled</h2>
+<p>When checkboxes are disabled in the activation picker, we can still listen for &quot;activation&quot; events when an item has been clicked.</p>
+<p><code-example example="tabbed-group-picker-no-selection"></code-example></p>
 `,
   host: { class: 'markdown-page' }
 })


### PR DESCRIPTION
## **Description**

Added option to disable item selection/checkboxes.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**
![noselection](https://github.com/bullhorn/novo-elements/assets/130384363/6ef3688b-cf0d-430b-b8c9-a23229de0b22)

