### PR TITLE
feat(QueryBuilder): Enabling nested search criteria via new types

### DIFF
--- a/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.ts
@@ -138,7 +138,7 @@ export class CriteriaBuilderComponent implements OnInit, OnDestroy, AfterContent
     const controls = Object.entries(data).reduce((obj, [key, val]) => {
       return {
         ...obj,
-        [key]: this.formBuilder.array(val.map((it) => this.newCondition(it))),
+        [key]: this.formBuilder.array(val.map((it: Condition) => this.newCondition(it))),
       };
     }, {});
     return this.formBuilder.group(controls);

--- a/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.ts
@@ -138,7 +138,7 @@ export class CriteriaBuilderComponent implements OnInit, OnDestroy, AfterContent
     const controls = Object.entries(data).reduce((obj, [key, val]) => {
       return {
         ...obj,
-        [key]: this.formBuilder.array(val.map((it: Condition) => this.newCondition(it))),
+        [key]: this.formBuilder.array(val.map((it) => this.newCondition(it))),
       };
     }, {});
     return this.formBuilder.group(controls);

--- a/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
@@ -11,10 +11,10 @@ export type ConditionGroup = {
 };
 
 export type NestedConditionGroup = {
-  [K in Conjunction as `$${K}`]?: ConditionOrConjunctionGroup[];
+  [K in Conjunction as `$${K}`]?: ConditionOrConditionGroup[];
 };
 
-export type ConditionOrConjunctionGroup = Condition | ConditionGroup;
+export type ConditionOrConditionGroup = Condition | ConditionGroup;
 
 export enum Operator {
   after = 'after',

--- a/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
@@ -14,7 +14,7 @@ export type NestedConditionGroup = {
   [K in Conjunction as `$${K}`]?: ConditionOrConditionGroup[];
 };
 
-export type ConditionOrConditionGroup = Condition | ConditionGroup;
+export type ConditionOrConditionGroup = Condition | NestedConditionGroup;
 
 export enum Operator {
   after = 'after',

--- a/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
@@ -45,6 +45,10 @@ export interface Criteria {
   criteria: ConditionGroup[];
 }
 
+export interface NestedCriteria {
+  criteria: NestedConditionGroup[];
+}
+
 export interface BaseFieldDef {
   name: string;
   label?: string;

--- a/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
@@ -7,6 +7,10 @@ export enum Conjunction {
 }
 
 export type ConditionGroup = {
+  [K in Conjunction as `$${K}`]?: Condition[];
+};
+
+export type NestedConditionGroup = {
   [K in Conjunction as `$${K}`]?: ConditionOrConjunctionGroup[];
 };
 

--- a/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
@@ -7,8 +7,10 @@ export enum Conjunction {
 }
 
 export type ConditionGroup = {
-  [K in Conjunction as `$${K}`]?: Condition[]
+  [K in Conjunction as `$${K}`]?: ConditionOrConjunctionGroup[];
 };
+
+export type ConditionOrConjunctionGroup = Condition | ConditionGroup;
 
 export enum Operator {
   after = 'after',


### PR DESCRIPTION
## **Description**

Enabling search criteria to be nested. This is a small novo elements change with bigger Novo ramifications for handling nested searches.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**