### PR TITLE
fix(Select): When Select's value is modified externally, checkboxes update accordingly

### DIFF
--- a/projects/novo-elements/src/elements/common/option/option.component.ts
+++ b/projects/novo-elements/src/elements/common/option/option.component.ts
@@ -138,7 +138,7 @@ export class NovoOptionBase implements FocusableOption, AfterViewChecked, OnDest
     if (!this._selected) {
       this._selected = true;
       this._changeDetectorRef.markForCheck();
-      // this._emitSelectionChangeEvent();
+      this._emitSelectionChangeEvent();
     }
   }
 
@@ -147,7 +147,18 @@ export class NovoOptionBase implements FocusableOption, AfterViewChecked, OnDest
     if (this._selected) {
       this._selected = false;
       this._changeDetectorRef.markForCheck();
-      // this._emitSelectionChangeEvent();
+      this._emitSelectionChangeEvent();
+    }
+  }
+
+  toggleSelection(val?: boolean): void {
+    if (typeof val === 'undefined') {
+      val = !this._selected;
+    }
+    if (val && !this._selected) {
+      this.select();
+    } else if (!val && this._selected) {
+      this.deselect();
     }
   }
 

--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -647,6 +647,19 @@ export class NovoSelectElement
 
   writeValue(value: any): void {
     this.value = value;
+    if (value) {
+      if (!(Array.isArray(value))) {
+        value = [value];
+      }
+    } else {
+      value = [];
+    }
+    const options = this._getOptions();
+    if (options) {
+      options.forEach(option => {
+        option.toggleSelection(value.indexOf(option.value) !== -1);
+      });
+    }
   }
 
   registerOnChange(fn: Function): void {


### PR DESCRIPTION
## **Description**

Until this fix, if ngModel/control updates changed the selected values of a <novo-select>, the display would show the updated value information, but the dropdown's checkboxes would still be checked.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**