### PR TITLE
feat(Search): adding ability to override parent element for custom overlay positioning

### DIFF
--- a/projects/novo-elements/src/elements/common/overlay/Overlay.ts
+++ b/projects/novo-elements/src/elements/common/overlay/Overlay.ts
@@ -159,7 +159,7 @@ export class NovoOverlayTemplateComponent implements OnDestroy {
   }
 
   /**
-   * A stream of actions that should close the autocomplete panel, including
+   * A stream of actions that should close the panel, including
    * when an option is selected, on blur, and when TAB is pressed.
    */
   public get panelClosingActions(): Observable<any> {
@@ -169,7 +169,7 @@ export class NovoOverlayTemplateComponent implements OnDestroy {
     );
   }
 
-  /** Stream of clicks outside of the autocomplete panel. */
+  /** Stream of clicks outside of the panel. */
   protected get outsideClickStream(): Observable<any> {
     if (!this.document) {
       return observableOf();

--- a/projects/novo-elements/src/elements/common/typography/base/base-text.component.ts
+++ b/projects/novo-elements/src/elements/common/typography/base/base-text.component.ts
@@ -115,7 +115,7 @@ export class NovoBaseTextElement {
   @BooleanInput()
   extrabold: boolean;
 
-  constructor(protected element: ElementRef) {}
+  constructor(public element: ElementRef) {}
 
   get nativeElement() {
     return this.element.nativeElement;

--- a/projects/novo-elements/src/elements/header/Header.ts
+++ b/projects/novo-elements/src/elements/header/Header.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, Input } from '@angular/core';
+import { Component, ElementRef, HostBinding, Input } from '@angular/core';
 import { BooleanInput } from 'novo-elements/utils';
 
 @Component({
@@ -116,4 +116,6 @@ export class NovoHeaderComponent {
   }
 
   private _theme: string;
+
+  constructor(public element: ElementRef) {}
 }

--- a/projects/novo-elements/src/elements/search/SearchBox.ts
+++ b/projects/novo-elements/src/elements/search/SearchBox.ts
@@ -10,6 +10,7 @@ import {
   HostBinding,
   Input,
   NgZone,
+  OnInit,
   Output,
   ViewChild,
 } from '@angular/core';
@@ -60,7 +61,7 @@ const SEARCH_VALUE_ACCESSOR = {
   `,
   styleUrls: ['./SearchBox.scss'],
 })
-export class NovoSearchBoxElement implements ControlValueAccessor {
+export class NovoSearchBoxElement implements ControlValueAccessor, OnInit {
   @Input()
   public name: string;
   @Input()
@@ -90,6 +91,8 @@ export class NovoSearchBoxElement implements ControlValueAccessor {
   public hasBackdrop: boolean = false;
   @Input()
   public allowPropagation: boolean = false;
+  @Input()
+  public overrideElement: ElementRef;
   @Output()
   public searchChanged: EventEmitter<string> = new EventEmitter<string>();
   @Output()
@@ -117,6 +120,12 @@ export class NovoSearchBoxElement implements ControlValueAccessor {
     private _changeDetectorRef: ChangeDetectorRef,
     private _zone: NgZone,
   ) {}
+
+  ngOnInit() {
+    if (this.overrideElement) {
+      this.element = this.overrideElement;
+    }
+  }
 
   /**
    * @name showFasterFind


### PR DESCRIPTION
## **Description**

this way we can attach the overlay to any element we want.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**