### PR TITLE
fix(CKEditor): disabling version check to avoid licensing notification

### DIFF
--- a/projects/novo-elements/src/addons/ckeditor/CKEditor.spec.ts
+++ b/projects/novo-elements/src/addons/ckeditor/CKEditor.spec.ts
@@ -98,6 +98,7 @@ describe('Elements: NovoCKEditorElement', () => {
     it('should return extended config object #1', () => {
       component.minimal = false;
       expect(component.getBaseConfig()).toEqual({
+        versionCheck: false,
         enterMode: window.CKEDITOR.ENTER_BR,
         entities: false,
         shiftEnterMode: window.CKEDITOR.ENTER_P,
@@ -149,6 +150,7 @@ describe('Elements: NovoCKEditorElement', () => {
       component.minimal = false;
       component.fileBrowserImageUploadUrl = '/foo/bar/baz.cfm';
       expect(component.getBaseConfig()).toEqual({
+        versionCheck: false,
         enterMode: window.CKEDITOR.ENTER_BR,
         entities: false,
         shiftEnterMode: window.CKEDITOR.ENTER_P,
@@ -199,6 +201,7 @@ describe('Elements: NovoCKEditorElement', () => {
     it('should return minimal config object', () => {
       component.minimal = true;
       expect(component.getBaseConfig()).toEqual({
+        versionCheck: false,
         enterMode: window.CKEDITOR.ENTER_BR,
         entities: false,
         shiftEnterMode: window.CKEDITOR.ENTER_P,

--- a/projects/novo-elements/src/addons/ckeditor/CKEditor.ts
+++ b/projects/novo-elements/src/addons/ckeditor/CKEditor.ts
@@ -169,6 +169,7 @@ export class NovoCKEditorElement implements OnDestroy, AfterViewInit, ControlVal
 
   getBaseConfig(): { [key: string]: any } {
     const baseConfig = {
+      versionCheck: false,
       enterMode: CKEDITOR.ENTER_BR,
       entities: false,
       shiftEnterMode: CKEDITOR.ENTER_P,


### PR DESCRIPTION
## **Description**
ck editor is going to be displaying a notification/warning on all instances using version 22 and earlier telling users to update to the new licensed version, so this config update is to disable that warning.

https://ckeditor.com/blog/important-update-for-ckeditor-4-users/?utm_campaign=cke4_security_patch_lts&utm_source=pardot&utm_medium=email&utm_term=june-preannouncement&utm_content=esm

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**