### PR TITLE
feat(Data Table): Allow skipping explicit table.state update

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table-clear-button.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table-clear-button.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Output } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output } from '@angular/core';
 import { NovoLabelService } from 'novo-elements/services';
 import { DataTableState } from './state/data-table-state.service';
 
@@ -44,6 +44,8 @@ export class NovoDataTableClearButton<T> {
   queryClear: EventEmitter<boolean> = new EventEmitter();
   @Output()
   allClear: EventEmitter<boolean> = new EventEmitter();
+  @Input()
+  skipUpdate: boolean;
 
   constructor(public state: DataTableState<T>, private ref: ChangeDetectorRef, public labels: NovoLabelService) {}
 
@@ -58,8 +60,13 @@ export class NovoDataTableClearButton<T> {
   }
 
   clearSearch(): void {
-    this.state.clearQuery();
-    this.queryClear.emit(true);
+    if (this.skipUpdate) {
+      this.queryClear.emit(true);
+      this.state.clearQuery(false);
+    } else {
+      this.state.clearQuery();
+      this.queryClear.emit(true);
+    }
   }
 
   clearSelected(): void {

--- a/projects/novo-elements/src/elements/modal/modal.component.ts
+++ b/projects/novo-elements/src/elements/modal/modal.component.ts
@@ -29,7 +29,7 @@ export class NovoModalElement {
       <ng-content select="h2"></ng-content>
       <ng-content select="p"></ng-content>
     </section>
-    <footer class="novo-notification-footer"><ng-content select="button,novo-button"></ng-content></footer>
+    <footer class="novo-notification-footer"><ng-content select="button,novo-button,novo-dropdown"></ng-content></footer>
   `,
   styleUrls: ['./notification.component.scss'],
   host: {


### PR DESCRIPTION
## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**