### PR TITLE
test(TabbedGroupPicker): Change the automation-ids on options to expr…

### DIFF
--- a/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.html
+++ b/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.html
@@ -48,7 +48,7 @@
           #tabbedGroupPickerVirtualScrollViewport>
           <novo-option
             *cdkVirtualFor="let item of displayTab.data"
-            [attr.data-automation-id]="item[displayTab.labelField]"
+            [attr.data-automation-id]="item[displayTab.valueField]"
             [allowSelection]="selectionEnabled"
             [selected]="item.selected"
             (click)="activateItem(item)"


### PR DESCRIPTION
…ess value rather than label

## **Description**

No changes to functionality. This replaces the data-automation-id on TabbedGroupPicker options so it presents the field's "name" rather than "label". eg:

label: "Favorite Color"
name: "customText5"

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**