### PR TITLE
feat(Novo Notification): added novo-dropdown to ng-content

### DIFF
--- a/projects/novo-elements/src/elements/common/overlay/Overlay.ts
+++ b/projects/novo-elements/src/elements/common/overlay/Overlay.ts
@@ -80,6 +80,8 @@ export class NovoOverlayTemplateComponent implements OnDestroy {
   public opening: EventEmitter<any> = new EventEmitter();
   @Output()
   public closing: EventEmitter<any> = new EventEmitter();
+  @Output()
+  public backDropClicked: EventEmitter<any> = new EventEmitter();
 
   public overlayRef: OverlayRef | null;
   public portal: TemplatePortal<any>;
@@ -219,7 +221,10 @@ export class NovoOverlayTemplateComponent implements OnDestroy {
   protected createOverlay(template: TemplateRef<any>): void {
     this.portal = new TemplatePortal(template, this.viewContainerRef);
     this.overlayRef = this.overlay.create(this.getOverlayConfig());
-    this.overlayRef.backdropClick().subscribe(() => this.closePanel());
+    this.overlayRef.backdropClick().subscribe(() => {
+      this.backDropClicked.emit(true);
+      this.closePanel();
+    });
   }
 
   protected destroyOverlay(): void {

--- a/projects/novo-elements/src/elements/data-table/data-table-clear-button.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table-clear-button.component.ts
@@ -1,6 +1,7 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Output } from '@angular/core';
 import { NovoLabelService } from 'novo-elements/services';
 import { DataTableState } from './state/data-table-state.service';
+import { BooleanInput } from 'novo-elements/utils';
 
 @Component({
   selector: 'novo-data-table-clear-button',
@@ -44,7 +45,7 @@ export class NovoDataTableClearButton<T> {
   queryClear: EventEmitter<boolean> = new EventEmitter();
   @Output()
   allClear: EventEmitter<boolean> = new EventEmitter();
-  @Input()
+  @BooleanInput()
   emitOnly: boolean = false;
 
   constructor(public state: DataTableState<T>, private ref: ChangeDetectorRef, public labels: NovoLabelService) { }

--- a/projects/novo-elements/src/elements/data-table/data-table-clear-button.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table-clear-button.component.ts
@@ -45,36 +45,42 @@ export class NovoDataTableClearButton<T> {
   @Output()
   allClear: EventEmitter<boolean> = new EventEmitter();
   @Input()
-  skipUpdate: boolean;
+  emitOnly: boolean = false;
 
-  constructor(public state: DataTableState<T>, private ref: ChangeDetectorRef, public labels: NovoLabelService) {}
+  constructor(public state: DataTableState<T>, private ref: ChangeDetectorRef, public labels: NovoLabelService) { }
 
   clearSort(): void {
-    this.state.clearSort();
+    if (!this.emitOnly) {
+      this.state.clearSort();
+    }
     this.sortClear.emit(true);
   }
 
   clearFilter(): void {
-    this.state.clearFilter();
+    if (!this.emitOnly) {
+      this.state.clearFilter();
+    }
     this.filterClear.emit(true);
   }
 
   clearSearch(): void {
-    if (this.skipUpdate) {
-      this.queryClear.emit(true);
-    } else {
+    if (!this.emitOnly) {
       this.state.clearQuery();
-      this.queryClear.emit(true);
     }
+    this.queryClear.emit(true);
   }
 
   clearSelected(): void {
-    this.state.clearSelected();
+    if (!this.emitOnly) {
+      this.state.clearSelected();
+    }
     this.selectedClear.emit(true);
   }
 
   clearAll(): void {
-    this.state.reset();
+    if (!this.emitOnly) {
+      this.state.reset();
+    }
     this.allClear.emit(true);
     this.selectedClear.emit(true);
     this.sortClear.emit(true);

--- a/projects/novo-elements/src/elements/data-table/data-table-clear-button.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table-clear-button.component.ts
@@ -62,7 +62,6 @@ export class NovoDataTableClearButton<T> {
   clearSearch(): void {
     if (this.skipUpdate) {
       this.queryClear.emit(true);
-      this.state.clearQuery(false);
     } else {
       this.state.clearQuery();
       this.queryClear.emit(true);

--- a/projects/novo-elements/src/elements/data-table/data-table-clear-button.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table-clear-button.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Output } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output } from '@angular/core';
 import { NovoLabelService } from 'novo-elements/services';
 import { DataTableState } from './state/data-table-state.service';
 
@@ -44,6 +44,8 @@ export class NovoDataTableClearButton<T> {
   queryClear: EventEmitter<boolean> = new EventEmitter();
   @Output()
   allClear: EventEmitter<boolean> = new EventEmitter();
+  @Input()
+  skipUpdate: boolean;
 
   constructor(public state: DataTableState<T>, private ref: ChangeDetectorRef, public labels: NovoLabelService) {}
 
@@ -58,8 +60,13 @@ export class NovoDataTableClearButton<T> {
   }
 
   clearSearch(): void {
-    this.state.clearQuery();
-    this.queryClear.emit(true);
+    if (this.skipUpdate) {
+      this.queryClear.emit(true);
+      this.state.clearQuery(false);
+    } else {
+      this.state.clearQuery();
+      this.queryClear.emit(true);
+    }
   }
 
   clearSelected(): void {

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -12,6 +12,8 @@ export interface IDataTablePreferences {
   savedSearchId?: number;
   savedSearchName?: string;
   appliedSearchType?: AppliedSearchType;
+  hasUnsavedChanges?: boolean;
+  unsavedChanges?: any;
 }
 
 export interface DataTableWhere {

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -11,6 +11,7 @@ export interface IDataTablePreferences {
   columnWidths?: { id: string; width: number }[];
   savedSearchId?: number;
   savedSearchName?: string;
+  savedSearchOwner?: DataTableSavedSearchOwner;
   appliedSearchType?: AppliedSearchType;
   hasUnsavedChanges?: boolean;
   unsavedChanges?: any;
@@ -21,6 +22,12 @@ export interface DataTableWhere {
   criteria?: AdaptiveCriteria;
   keywords?: string[];
   form: any;
+}
+
+export interface DataTableSavedSearchOwner {
+  id: number;
+  firstName: string;
+  lastName: string;
 }
 
 export enum AppliedSearchType {

--- a/projects/novo-elements/src/elements/modal/modal.component.ts
+++ b/projects/novo-elements/src/elements/modal/modal.component.ts
@@ -29,7 +29,7 @@ export class NovoModalElement {
       <ng-content select="h2"></ng-content>
       <ng-content select="p"></ng-content>
     </section>
-    <footer class="novo-notification-footer"><ng-content select="button,novo-button"></ng-content></footer>
+    <footer class="novo-notification-footer"><ng-content select="button,novo-button,novo-dropdown"></ng-content></footer>
   `,
   styleUrls: ['./notification.component.scss'],
   host: {

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
@@ -68,12 +68,9 @@ export class NovoDefaultStringConditionDef extends AbstractConditionFieldDef {
     input.value = '';
     const valueToAdd = event.value;
     if (valueToAdd !== '') {
-      const current = this.getValue(formGroup);
-      if (!Array.isArray(current)) {
-        formGroup.get('value').setValue([valueToAdd]);
-      } else {
-        formGroup.get('value').setValue([...current, valueToAdd]);
-      }
+      const current: any[] = this.getValue(formGroup);
+      const newValue: any[] = Array.isArray(current) ? [...current, valueToAdd] : [valueToAdd];
+      this.setFormValue(formGroup, newValue);
     }
   }
 
@@ -81,9 +78,14 @@ export class NovoDefaultStringConditionDef extends AbstractConditionFieldDef {
     const current = this.getValue(formGroup);
     const index = current.indexOf(valueToRemove);
     if (index >= 0) {
-      const oldValue = [...current]
-      oldValue.splice(index, 1);
-      formGroup.get('value').setValue(oldValue);
+      const value = [...current]
+      value.splice(index, 1);
+      this.setFormValue(formGroup, value);
     }
+  }
+
+  private setFormValue(formGroup: AbstractControl, newValue: any[]) {
+    formGroup.get('value').setValue([newValue]);
+    formGroup.markAsDirty();
   }
 }

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
@@ -85,7 +85,7 @@ export class NovoDefaultStringConditionDef extends AbstractConditionFieldDef {
   }
 
   private setFormValue(formGroup: AbstractControl, newValue: any[]) {
-    formGroup.get('value').setValue([newValue]);
+    formGroup.get('value').setValue(newValue);
     formGroup.markAsDirty();
   }
 }

--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -248,7 +248,7 @@ export class NovoSelectElement
   @Input() displayWith: ((value: any) => string) | null = null;
   /** * Function to compare the option values with the selected values. */
   @Input() compareWith: (o1: any, o2: any) => boolean = (o1: any, o2: any) =>
-    o1 === o2 || o1 === o2.id || (!Helpers.isEmpty(o1.id) && !Helpers.isEmpty(o2.id) && o1.id === o2.id);
+    o1 === o2 || o1 === o2?.id || (!Helpers.isEmpty(o1?.id) && !Helpers.isEmpty(o2?.id) && o1.id === o2.id);
 
   header: any = {
     open: false,

--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -248,7 +248,7 @@ export class NovoSelectElement
   @Input() displayWith: ((value: any) => string) | null = null;
   /** * Function to compare the option values with the selected values. */
   @Input() compareWith: (o1: any, o2: any) => boolean = (o1: any, o2: any) =>
-    o1 === o2 || o1 === o2?.id || (!Helpers.isEmpty(o1?.id) && !Helpers.isEmpty(o2?.id) && o1.id === o2.id);
+    o1 === o2 || o1 === o2.id || (!Helpers.isEmpty(o1.id) && !Helpers.isEmpty(o2.id) && o1.id === o2.id);
 
   header: any = {
     open: false,


### PR DESCRIPTION
## **Description**

- added `novo-dropdown` to novo-notifcation's allowable ng-content
- added `emitOnly` optional input in data-table-clear-button, preventing state-modifying method calls, only emitting a button event.
- added `backDropClicked` eventEmitter to the novo Overlay component
- fixed `string-condition.definition` -- manually setting form to dirty when value is programmatically changed

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**