### PR TITLE
test(TabbedGroupPicker): Add data-automation-value attribute

### DIFF
--- a/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.html
+++ b/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.html
@@ -49,6 +49,7 @@
           <novo-option
             *cdkVirtualFor="let item of displayTab.data"
             [attr.data-automation-id]="item[displayTab.labelField]"
+            [attr.data-automation-value]="item[displayTab.valueField]"
             [allowSelection]="selectionEnabled"
             [selected]="item.selected"
             (click)="activateItem(item)"

--- a/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.spec.ts
+++ b/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.spec.ts
@@ -80,17 +80,19 @@ describe('Elements: NovoTabbedGroupPickerElement', () => {
         .map((e, i) => String(Math.pow(1000 + i, 5))); // make a bunch of ~16 character strings
       const tabNames = names.slice(0, 100);
       const labelFieldNames = names.splice(0, 100);
-      const tabs = tabNames.map((typeName, i) => ({
+      const tabs: any[] = tabNames.map((typeName, i) => ({
         typeName,
         labelField: labelFieldNames[i], // search/filter only looks at labelField
+        valueField: 'value',
         data: null,
       }));
       tabs.forEach((tab) => {
-        const { labelField } = tab;
+        const { labelField, valueField } = tab;
         tab.data = Array(1000)
           .fill(0)
           .map((n, i) => ({
             [labelField]: turnNumbersIntoLetters(`${labelField}${i}`),
+            [valueField]: i,
           }));
       });
       return tabs;

--- a/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.ts
+++ b/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.ts
@@ -416,7 +416,8 @@ export class NovoTabbedGroupPickerElement implements OnDestroy, OnInit {
     this.displayTabs.forEach(
       (displayTab, i) =>
         (displayTab.data = this.tabs[i].data.filter((item) =>
-          item[displayTab.labelField].toLowerCase().includes(searchTerm.toLowerCase()),
+          item[displayTab.labelField].toLowerCase().includes(searchTerm.toLowerCase()) ||
+          item[displayTab.valueField]?.toString().toLowerCase().includes(searchTerm.toLowerCase()),
         )),
     );
     this.ref.markForCheck();


### PR DESCRIPTION
## **Description**

New automation-value attribute is based on the tab's valueField / name.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**