### PR TITLE
feat(Autocomplete): Introduce makeFirstItemActive option

### DIFF
--- a/projects/novo-elements/src/elements/autocomplete/autocomplete.component.ts
+++ b/projects/novo-elements/src/elements/autocomplete/autocomplete.component.ts
@@ -132,6 +132,10 @@ export class NovoAutocompleteElement
   }
   private _disabled: boolean;
 
+  @Input()
+  @BooleanInput()
+  makeFirstItemActive: boolean;
+
   /** Element for the panel containing the autocomplete options. */
   @ViewChild(NovoOverlayTemplateComponent)
   overlay: NovoOverlayTemplateComponent;
@@ -173,6 +177,9 @@ export class NovoAutocompleteElement
       this._watchSelectionEvents();
       Promise.resolve().then(() => {
         this.checkSelectedOptions();
+        if (this.makeFirstItemActive && this.options.length > 0) {
+          this._keyManager.setFirstItemActive();
+        }
       });
     });
   }

--- a/projects/novo-elements/src/elements/chips/ChipInput.ts
+++ b/projects/novo-elements/src/elements/chips/ChipInput.ts
@@ -2,7 +2,7 @@ import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import { hasModifierKey } from '@angular/cdk/keycodes';
 import { Directive, ElementRef, EventEmitter, forwardRef, Inject, Input, OnChanges, Output } from '@angular/core';
 import { NgControl } from '@angular/forms';
-import { Key } from 'novo-elements/utils';
+import { Key, KeyCodes } from 'novo-elements/utils';
 import { NovoChipsDefaultOptions, NOVO_CHIPS_DEFAULT_OPTIONS } from './ChipDefaults';
 import { NovoChipList } from './ChipList';
 import { NovoChipTextControl } from './ChipTextControl';

--- a/projects/novo-examples/src/components/autocomplete/autocomplete-with-chips/autocomplete-with-chips-example.html
+++ b/projects/novo-examples/src/components/autocomplete/autocomplete-with-chips/autocomplete-with-chips-example.html
@@ -17,7 +17,7 @@
       [novoChipInputSeparatorKeyCodes]="separatorKeysCodes"
       (novoChipInputTokenEnd)="add($event)" />
   </novo-chip-list>
-  <novo-autocomplete (optionSelected)="selected($event)" multiple>
+  <novo-autocomplete makeFirstItemActive (optionSelected)="selected($event)" multiple>
     <novo-option *ngFor="let fruit of filteredFruits | async" [value]="fruit">
       {{fruit}}
     </novo-option>


### PR DESCRIPTION
## **Description**

Add an attribute option to immediately activate the first result for autocomplete (rather than waiting for first down key)

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**