### PR TITLE
fix(DatePickerInput): Add hideFooter input to pass to DatePicker

### DIFF
--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -20,7 +20,7 @@ import { isValid } from 'date-fns';
 // App
 import { NovoOverlayTemplateComponent } from 'novo-elements/elements/common';
 import { DateFormatService, NovoLabelService } from 'novo-elements/services';
-import { DateUtil, Helpers, Key } from 'novo-elements/utils';
+import { BooleanInput, DateUtil, Helpers, Key } from 'novo-elements/utils';
 
 // Value accessor for the component (supports ngModel)
 const DATE_VALUE_ACCESSOR = {
@@ -60,6 +60,7 @@ const DATE_VALUE_ACCESSOR = {
         [disabledDateMessage]="disabledDateMessage"
         [ngModel]="value"
         [weekStart]="weekStart"
+        [hideFooter]="hideFooter"
       ></novo-date-picker>
     </novo-overlay-template>
   `,
@@ -125,6 +126,12 @@ export class NovoDatePickerInputElement implements OnInit, OnChanges, AfterViewI
    */
   @Input()
   overlayOnElement: ElementRef;
+  /**
+   * Whether the footer in the date picker which contains `today` button should be hidden.
+   **/
+  @Input()
+  @BooleanInput()
+  public hideFooter: boolean = false;
   /**
    * Sets the field as to appear disabled, users will not be able to interact with the text field.
    **/


### PR DESCRIPTION
## **Description**

Added hideFooter input to flow down to the DatePicker.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**