### PR TITLE
fix(ChipList): Fixed a bug clearing ChipLists when clicked

### DIFF
--- a/projects/novo-elements/src/elements/chips/ChipList.ts
+++ b/projects/novo-elements/src/elements/chips/ChipList.ts
@@ -683,9 +683,7 @@ export class NovoChipList
     } else {
       valueToEmit = this.selected ? this.selected.value : fallbackValue;
     }
-    this._value = valueToEmit;
     this.change.emit(new NovoChipListChange(this, valueToEmit));
-    this.valueChange.emit(valueToEmit);
     this._onChange(valueToEmit);
     this._changeDetectorRef.markForCheck();
   }


### PR DESCRIPTION
## **Description**

The click / change event now does not change the chipList's value - when set to undefined it was clearing the chiplist.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**