### PR TITLE
fix(Overlay): Drag events close overlays

### DIFF
--- a/projects/novo-elements/src/elements/common/overlay/Overlay.ts
+++ b/projects/novo-elements/src/elements/common/overlay/Overlay.ts
@@ -183,6 +183,7 @@ export class NovoOverlayTemplateComponent implements OnDestroy {
         const clickedOutside: boolean =
           this.panelOpen &&
           clickTarget !== this.getConnectedElement().nativeElement &&
+          this.isInDocument(clickTarget) &&
           !this.getConnectedElement().nativeElement.contains(clickTarget) &&
           (!!this.overlayRef && !this.overlayRef.overlayElement.contains(clickTarget)) &&
           !this.elementIsInNestedOverlay(clickTarget);
@@ -192,6 +193,10 @@ export class NovoOverlayTemplateComponent implements OnDestroy {
         return clickedOutside;
       }),
     );
+  }
+
+  private isInDocument(node: Node): boolean {
+    return node.getRootNode().nodeType === Node.DOCUMENT_NODE;
   }
 
   /**


### PR DESCRIPTION
## **Description**

When the overlay received a mouse event from a drag that had just completed, it pointed to the ghost version of the element that existed for the drag, and was just removed. All the elements we inspect for being "outside the overlay" should be in the DOM, so this adds that check.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**