### PR TITLE
fix(TabbedGroupPicker): Fix scroll behavior, add to examples

### DIFF
--- a/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.ts
+++ b/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.ts
@@ -248,6 +248,8 @@ export class NovoTabbedGroupPickerElement implements OnDestroy, OnInit {
     if (event) {
       this.scrollViewportHeight = this.getPixelHeight(this.scrollableInstance.getElementRef().nativeElement);
       this.virtualScrollItemSize = this.getPixelHeight(this.scrollableInstance.getElementRef().nativeElement.querySelector('novo-option'));
+      // Emit a fake scroll event so the rendered items update
+      this.scrollableInstance.getElementRef().nativeElement.dispatchEvent(new Event('scroll'));
     }
   }
 


### PR DESCRIPTION
## **Description**

Ensure that when the TabbedGroupPicker opens, its virtual scrolling updates to show the first elements in the list

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**