### PR TITLE
fix(Chips): Draft - Resolve an issue where Chips were boxing {value, label}

### DIFF
--- a/projects/novo-elements/src/elements/chips/Chips.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.ts
@@ -198,10 +198,14 @@ export class NovoChipsElement implements OnInit, ControlValueAccessor {
         this.source.getLabels(noLabels).then((result) => {
           for (const value of result) {
             if (value.hasOwnProperty('label')) {
-              this.items.push({
-                value,
-                label: value.label,
-              });
+              if (value.hasOwnProperty('value')) {
+                this.items.push(value);
+              } else {
+                this.items.push({
+                  value,
+                  label: value.label,
+                });
+              }
             } else if (this.source.options && Array.isArray(this.source.options)) {
               this.items.push(this.getLabelFromOptions(value));
             } else {


### PR DESCRIPTION
## **Description**

An experimental fix for a problem seen in certain chips where, upon reopening/binding values, they represent themselves with values such as:
`[ { value: { value: 1, label: 'Frank' }, label: 'Frank }]`
Deploying PR branch for further testing

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**