### PR TITLE
feat(QueryBuilder): adding flag to show/hide first row's operator

### DIFF
--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.html
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.html
@@ -9,7 +9,7 @@
         overlayHeight="20rem"
         [displayWith]="fieldDisplayWith"
         [style.minWidth.px]="160"
-        [style.maxWidth.px]="(isFirst() || isConditionHost) ? 200 : 160"
+        [style.maxWidth.px]="(hideOperator() || isConditionHost) ? 200 : 160"
         [displayIcon]="displayIcon">
         <novo-optgroup class="filter-search-results">
           <novo-option>

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
@@ -69,10 +69,10 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
   @ViewChild(ConditionInputOutlet, { static: true }) _inputOutlet: ConditionInputOutlet;
 
   @Input() label: any;
-  isFirst = input(false);
   @Input() andIndex: number;
   @Input() groupIndex: number;
   @Input() addressConfig: AddressCriteriaConfig;
+  hideOperator = input(true);
 
   // This component can either be directly hosted as a host to a condition, or it can be part of a condition group within a criteria builder.
   // In the former case, config will come from inputs, and we will instantiate our own QueryBuilderService. In the latter, it comes from
@@ -109,7 +109,7 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
     if (this.staticFieldSelection()) {
       return '13rem 1fr';
     } else {
-      const firstColumnWidth = this.isFirst() ? '20rem' : '16rem';
+      const firstColumnWidth = this.hideOperator() ? '20rem' : '16rem';
       return `${firstColumnWidth} 13rem 1fr`;
     }
   });

--- a/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.html
+++ b/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.html
@@ -3,8 +3,8 @@
     <ng-container
       *ngFor="let andGroup of root.controls; let andIndex = index; let isFirst = first;let isLast = last;">
       <ng-container [formGroupName]="andIndex">
-        <novo-flex class="condition-row" align="end" gap="sm">
-          <novo-dropdown *ngIf="!isFirst && qbs.allowedGroupings.length > 1; else labeledGroup">
+        <novo-flex class="condition-row" align="end" gap="sm" #flex>
+          <novo-dropdown *ngIf="(!isFirst || !hideFirstOperator) && qbs.allowedGroupings.length > 1; else labeledGroup">
             <button theme="dialogue" icon="collapse" size="sm">{{qbs.getConjunctionLabel(controlName)}}</button>
             <novo-optgroup>
               <novo-option *ngFor="let c of qbs.allowedGroupings" (click)="updateControlName(c)">
@@ -12,10 +12,10 @@
             </novo-optgroup>
           </novo-dropdown>
           <ng-template #labeledGroup>
-            <novo-label *ngIf="!isFirst" color="ash" size="xs" uppercase padding="sm">
+            <novo-label *ngIf="!isFirst || !hideFirstOperator" color="ash" size="xs" uppercase padding="sm">
               {{qbs.getConjunctionLabel(controlName)}}</novo-label>
           </ng-template>
-          <novo-condition-builder [groupIndex]="groupIndex" [andIndex]="andIndex" [isFirst]="isFirst"></novo-condition-builder>
+          <novo-condition-builder [groupIndex]="groupIndex" [andIndex]="andIndex" [hideOperator]="isFirst && hideFirstOperator"></novo-condition-builder>
           <novo-button theme="icon" icon="delete-o" color="negative" (click)="removeCondition(andIndex)"
             [disabled]="cantRemoveRow()">
           </novo-button>

--- a/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.ts
@@ -24,6 +24,7 @@ const EMPTY_CONDITION: Condition = {
 export class ConditionGroupComponent implements OnInit, OnDestroy {
   @Input() controlName: string = '$' + Conjunction.AND;
   @Input() groupIndex: number;
+  @Input() hideFirstOperator: boolean = true;
 
   public parentForm: UntypedFormGroup;
   /** Subject that emits when the component has been destroyed. */

--- a/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.html
+++ b/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.html
@@ -4,7 +4,7 @@
       *ngFor="let andGroup of root.controls; let andIndex = index; let isFirst = first;let isLastAnd = last;">
       <novo-label *ngIf="!isFirst" color="ash" size="xs" uppercase padding="sm">{{ qbs.getConjunctionLabel('and') }}
       </novo-label>
-      <novo-condition-group [groupIndex]="andIndex" [formGroupName]="andIndex"></novo-condition-group>
+      <novo-condition-group [hideFirstOperator]="hideFirstOperator" [groupIndex]="andIndex" [formGroupName]="andIndex"></novo-condition-group>
     </ng-container>
   </novo-stack>
 </form>

--- a/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.ts
@@ -14,6 +14,7 @@ import {
 import { ControlContainer, FormArray, FormBuilder, NG_VALUE_ACCESSOR, UntypedFormGroup, Validators } from '@angular/forms';
 import { interval, Subject } from 'rxjs';
 import { debounce, filter, startWith, takeUntil } from 'rxjs/operators';
+import { Helpers } from 'novo-elements/utils';
 import { NovoConditionFieldDef } from '../query-builder.directives';
 import { QueryBuilderService } from '../query-builder.service';
 import { NOVO_CRITERIA_BUILDER } from '../query-builder.tokens';
@@ -45,10 +46,21 @@ export class CriteriaBuilderComponent implements OnInit, OnDestroy, AfterContent
   @Input() editTypeFn: (field: BaseFieldDef) => string;
   @Input() addressConfig: AddressCriteriaConfig;
 
+  @Input('hideFirstOperator')
+  set HideFirstOperator(hide: boolean) {
+      if (!Helpers.isEmpty(hide)) {
+        this._hideFirstOperator = hide;
+      }
+  }
+  get hideFirstOperator() {
+    return this._hideFirstOperator;
+  }
+
   @ContentChildren(NovoConditionFieldDef, { descendants: true }) _contentFieldDefs: QueryList<NovoConditionFieldDef>;
 
   public parentForm: UntypedFormGroup;
   public innerForm: UntypedFormGroup;
+  private _hideFirstOperator: boolean = true;
   /** Subject that emits when the component has been destroyed. */
   private readonly _onDestroy = new Subject<void>();
 

--- a/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.html
+++ b/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.html
@@ -5,6 +5,7 @@
     [allowedGroupings]="mode.value"
     [config]="config"
     [editTypeFn]="editTypeFn"
+    [hideFirstOperator]="hideFirstOperator"
     [addressConfig]="addressConfig">
     <custom-picker-condition-def name="CUSTOM"></custom-picker-condition-def>
   </novo-criteria-builder>
@@ -23,6 +24,13 @@
       <novo-radio name="mode" [value]="andOr">And, Or</novo-radio>
       <novo-radio name="mode" [value]="andOrNot">And, Or, Not</novo-radio>
     </novo-radio-group>
+  </section>
+</novo-row>
+
+<novo-row align="start" gap="xl" margin="xl">
+  <section>
+    <novo-label marginRight="md">Hide First Operator</novo-label>
+    <novo-tiles [options]="hideFirstOperatorOptions" [(ngModel)]="hideFirstOperator"/>
   </section>
 </novo-row>
 

--- a/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.ts
+++ b/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.ts
@@ -99,6 +99,12 @@ export class JustCriteriaExample implements OnInit {
     { label: 'No', value: false },
   ];
 
+  hideFirstOperator: boolean = undefined;
+  hideFirstOperatorOptions = [
+    { label: 'True', value: true },
+    { label: 'False', value: false }
+  ];
+
   editTypeFn = (field: any) => {
     if (field.optionsType === 'Brewery') return 'custom';
     return (field.inputType || field.dataType || field.type).toLowerCase();


### PR DESCRIPTION
## **Description**

we ran across a situation where we would like to show the QueryBuilder's operator for the first row, so we decided to put this behind a flag so it can be user configurable. it's defaulted to the original behavior so it will only change if explicitly updated.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**