### PR TITLE
feat(): next

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5972,9 +5972,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
@@ -5985,7 +5985,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -8005,8 +8005,9 @@
     },
     "node_modules/depd": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -8026,8 +8027,9 @@
     },
     "node_modules/destroy": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
@@ -8256,8 +8258,9 @@
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.670",
@@ -8289,9 +8292,10 @@
       }
     },
     "node_modules/encodeurl": {
-      "version": "1.0.2",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -8582,8 +8586,9 @@
     },
     "node_modules/etag": {
       "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -8651,37 +8656,37 @@
       "license": "Apache-2.0"
     },
     "node_modules/express": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
+      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
+        "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
+        "finalhandler": "1.3.1",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
+        "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "0.1.10",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "type-is": "~1.6.18",
@@ -8859,12 +8864,13 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.2.0",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
@@ -8877,16 +8883,18 @@
     },
     "node_modules/finalhandler/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/finalhandler/node_modules/ms": {
       "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
     },
     "node_modules/find-cache-dir": {
       "version": "4.0.0",
@@ -9045,8 +9053,9 @@
     },
     "node_modules/fresh": {
       "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -9890,8 +9899,9 @@
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
         "inherits": "2.0.4",
@@ -13218,9 +13228,13 @@
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.1",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
       "dev": true,
-      "license": "MIT"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -16810,10 +16824,13 @@
       "license": "MIT"
     },
     "node_modules/object-inspect": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
       "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -16825,8 +16842,9 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -17304,9 +17322,10 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "dev": true,
-      "license": "MIT"
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "dev": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -17995,12 +18014,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dev": true,
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -19012,9 +19031,10 @@
       "license": "ISC"
     },
     "node_modules/send": {
-      "version": "0.18.0",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -19036,21 +19056,33 @@
     },
     "node_modules/send/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/send/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true,
-      "license": "MIT"
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
@@ -19131,14 +19163,15 @@
       }
     },
     "node_modules/serve-static": {
-      "version": "1.15.0",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "0.19.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -19162,8 +19195,9 @@
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true
     },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
@@ -19760,8 +19794,9 @@
     },
     "node_modules/statuses": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -20747,8 +20782,9 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.6"
       }
@@ -21278,8 +21314,9 @@
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@angular/cli": "^17.2.0",
         "@angular/compiler-cli": "^17.2.0",
         "@angular/language-service": "^17.2.0",
-        "@bullhorn/bullhorn-icons": "^2.25.0",
+        "@bullhorn/bullhorn-icons": "^2.33.0",
         "@codemirror/lang-javascript": "^6.1.9",
         "@github-docs/frontmatter": "^1.3.1",
         "@schematics/angular": "^15.2.10",
@@ -2529,7 +2529,9 @@
       "license": "MIT"
     },
     "node_modules/@bullhorn/bullhorn-icons": {
-      "version": "2.29.0",
+      "version": "2.33.0",
+      "resolved": "https://registry.npmjs.org/@bullhorn/bullhorn-icons/-/bullhorn-icons-2.33.0.tgz",
+      "integrity": "sha512-he/YTqUDP7+OdI4jJcLvW7dvyQU5MPYG6Le0Xx9JV6aVxuRj2Z42Pv+Xx9CmoYL9XN6TJbtGqGHiqHJxKTfSgg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@angular/cli": "^17.2.0",
     "@angular/compiler-cli": "^17.2.0",
     "@angular/language-service": "^17.2.0",
-    "@bullhorn/bullhorn-icons": "^2.25.0",
+    "@bullhorn/bullhorn-icons": "^2.33.0",
     "@codemirror/lang-javascript": "^6.1.9",
     "@github-docs/frontmatter": "^1.3.1",
     "@schematics/angular": "^15.2.10",

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -20,7 +20,7 @@ export interface IDataTablePreferences {
 export interface DataTableWhere {
   query: string;
   criteria?: AdaptiveCriteria;
-  keywords?: string[];
+  keywords?: SearchKeywords;
   form: any;
 }
 
@@ -262,3 +262,34 @@ export enum AdaptiveOperator {
   EndsWith = 'endsWith',
   Radius = 'radius',
 }
+
+export interface IKeywordSearchResponse {
+  items: IKeywordGroup[];
+  meta: {
+    currentPage: number;
+    itemCount: number;
+    itemsPerPage: number;
+    totalItems: number;
+    totalPages: number;
+  };
+}
+
+export interface IKeyword {
+  id: number;
+  name: string;
+}
+
+export interface IKeywordGroup {
+  id: number;
+  name: string;
+  keywords: IKeyword[];
+}
+
+export interface IKeywordBlock {
+  exclude: boolean;
+  keywordGroups: IKeywordGroup[];
+}
+
+export type NestedKeywordGroups = IKeywordBlock[];
+
+export type SearchKeywords = string[] | NestedKeywordGroups;

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -13,10 +13,15 @@ export interface IDataTablePreferences {
   savedSearchName?: string;
   savedSearchOwner?: DataTableSavedSearchOwner;
   appliedSearchType?: AppliedSearchType;
-  autobuildEntityId?: number;
-  autobuildEntityData?: any;
+  autobuildEntity?: AutobuildEntityData;
   hasUnsavedChanges?: boolean;
   unsavedChanges?: any;
+}
+
+export interface AutobuildEntityData {
+  id: number;
+  searchEntity: string;
+  [key: string]: any;
 }
 
 export interface DataTableWhere {

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -28,6 +28,7 @@ export interface DataTableWhere {
   query: string;
   criteria?: AdaptiveCriteria;
   keywords?: SearchKeywords;
+  scoreByEntityId?: number;
   form: any;
 }
 

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -13,6 +13,8 @@ export interface IDataTablePreferences {
   savedSearchName?: string;
   savedSearchOwner?: DataTableSavedSearchOwner;
   appliedSearchType?: AppliedSearchType;
+  autobuildEntityId?: number;
+  autobuildEntityData?: any;
   hasUnsavedChanges?: boolean;
   unsavedChanges?: any;
 }
@@ -282,11 +284,12 @@ export interface IKeyword {
 export interface IKeywordGroup {
   id: number;
   name: string;
+  uniqueName?: string;
   keywords: IKeyword[];
 }
 
 export interface IKeywordBlock {
-  exclude: boolean;
+  exclude?: boolean;
   keywordGroups: IKeywordGroup[];
 }
 

--- a/projects/novo-elements/src/elements/field/formats/date-format.ts
+++ b/projects/novo-elements/src/elements/field/formats/date-format.ts
@@ -67,6 +67,9 @@ export class NovoDateFormatDirective extends IMaskDirective<any> {
 
   normalize(value: string) {
     const pattern = this.labels.dateFormat.toUpperCase();
+    if (!value) {
+      return "";
+    }
     return DateUtil.format(DateUtil.parse(value), pattern);
   }
 

--- a/projects/novo-elements/src/elements/form/ControlTemplates.ts
+++ b/projects/novo-elements/src/elements/form/ControlTemplates.ts
@@ -645,6 +645,7 @@ import { NovoTemplateService } from 'novo-elements/services';
           [popoverDisabled]="control.popoverDisabled"
           [popoverAnimation]="control.popoverAnimation"
           [popoverDismissTimeout]="control.popoverDismissTimeout"
+          (onChange)="methods.modelChange($event)"
         ></novo-switch>
       </div>
     </ng-template>

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.html
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.html
@@ -9,7 +9,7 @@
         overlayHeight="20rem"
         [displayWith]="fieldDisplayWith"
         [style.minWidth.px]="160"
-        [style.maxWidth.px]="(isFirst() || isConditionHost) ? 200 : 160"
+        [style.maxWidth.px]="(hideOperator() || isConditionHost) ? 200 : 160"
         [displayIcon]="displayIcon">
         <novo-optgroup class="filter-search-results">
           <novo-option>
@@ -39,15 +39,6 @@
 </form>
 
 <novo-condition-templates *ngIf="isConditionHost" [addressConfig]="addressConfig"/>
-
-<!-- EMPTY STATE TEMPLATE -->
-<!-- <ng-template #empty>
-  <novo-non-ideal-state>
-    <novo-icon size="xl" color="grapefruit">search</novo-icon>
-    <novo-title>No results found.</novo-title>
-    <novo-text>Your search didn't find anything. Try searching for something else.</novo-text>
-  </novo-non-ideal-state>
-</ng-template> -->
 
 <!-- LOADING TEMPLATE -->
 <ng-template #loading>

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/abstract-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/abstract-condition.definition.ts
@@ -1,11 +1,11 @@
-import { Directive, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { UntypedFormGroup } from '@angular/forms';
+import { AfterViewInit, Directive, Input, OnDestroy, OnInit, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import { FormControlDirective, FormControlName, UntypedFormGroup } from '@angular/forms';
 import { NovoLabelService } from 'novo-elements/services';
-import { NovoConditionFieldDef } from '../query-builder.directives';
+import { NovoConditionFieldDef, NovoConditionOperatorsDef } from '../query-builder.directives';
 import { Operator } from '../query-builder.types';
 
 @Directive()
-export abstract class AbstractConditionFieldDef implements OnDestroy, OnInit {
+export abstract class AbstractConditionFieldDef implements OnDestroy, OnInit, AfterViewInit {
   /** Column name that should be used to reference this column. */
   @Input()
   get name(): string {
@@ -20,24 +20,63 @@ export abstract class AbstractConditionFieldDef implements OnDestroy, OnInit {
   _name: string;
 
   defaultOperator: Operator | string;
+  protected _previousOperatorValue: Operator;
+
+  protected operatorEditGroups: Set<Operator>[] = [];
 
   @ViewChild(NovoConditionFieldDef, { static: true }) fieldDef: NovoConditionFieldDef;
+  @ViewChildren(FormControlName) formControlsByName: QueryList<FormControlName>;
 
   constructor(public labels: NovoLabelService) {}
 
   ngOnInit() {
     this._syncFieldDefName();
     this._syncFieldDefOperatorValue();
+    this._previousOperatorValue = this.defaultOperator as Operator;
     // Need to add self to FilterBuilder because "ContentChildren won't find it"
     this.fieldDef?.register();
+  }
+
+  ngAfterViewInit() {
+    setTimeout(() => {
+      this.frameAfterViewInit();
+    });
+  }
+
+  frameAfterViewInit() {
+    const operatorField = this.formControlsByName.find(formControlDirective => formControlDirective.name === 'operator')?.control;
+    if (operatorField) {
+      this._previousOperatorValue = operatorField.value;
+    }
   }
 
   ngOnDestroy() {
     this.fieldDef?.unregister();
   }
 
+  /**
+   * Define an edit group of operators. Once defined, if the user switches from one of these operators to another,
+   * then the condition value will not be cleared. This makes sense if both operators use the same UI controls for editing.
+   * @param operators The set of Operator values intended to share UI controls.
+   */
+  protected defineOperatorEditGroup(...operators: Operator[]): void {
+    this.operatorEditGroups.push(new Set(operators));
+  }
+
   onOperatorSelect(formGroup: UntypedFormGroup): void {
-    formGroup.get('value').setValue(null);
+    let clearVal = true;
+    if (this._previousOperatorValue && this.operatorEditGroups?.length) {
+      const previousOperatorGroupIndex = this.operatorEditGroups.findIndex(grp => grp.has(this._previousOperatorValue));
+      const newOperatorValue = formGroup.get('operator').getRawValue();
+      const newOperatorGroupIndex = this.operatorEditGroups.findIndex(grp => grp.has(newOperatorValue));
+      if (previousOperatorGroupIndex !== -1 && newOperatorGroupIndex !== -1 && previousOperatorGroupIndex === newOperatorGroupIndex) {
+        clearVal = false;
+      }
+    }
+    this._previousOperatorValue = formGroup.get('operator').value;
+    if (clearVal) {
+      formGroup.get('value').setValue(null);
+    }
   }
 
   /** Synchronizes the column definition name with the text column name. */

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
@@ -4,6 +4,7 @@ import {
   Component,
   computed,
   ElementRef,
+  inject,
   input,
   InputSignal,
   OnDestroy,
@@ -15,7 +16,7 @@ import {
   ViewEncapsulation,
   WritableSignal
 } from '@angular/core';
-import { AbstractControl } from '@angular/forms';
+import { AbstractControl, UntypedFormGroup } from '@angular/forms';
 import { NovoPickerToggleElement } from 'novo-elements/elements/field';
 import { PlacesListComponent } from 'novo-elements/elements/places';
 import { NovoLabelService } from 'novo-elements/services';
@@ -23,6 +24,7 @@ import { Helpers, Key } from 'novo-elements/utils';
 import { Subscription } from 'rxjs';
 import { AddressCriteriaConfig, AddressData, AddressRadius, AddressRadiusUnitsName, Operator, RadiusUnits } from '../query-builder.types';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
+import { NovoSelectElement } from 'novo-elements/elements/select';
 
 /**
  * Handle selection of field values when a list of options is provided.
@@ -78,10 +80,11 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.Default,
 })
-export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef implements AfterViewInit, OnDestroy {
+export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef implements OnDestroy {
   @ViewChildren(NovoPickerToggleElement) overlayChildren: QueryList<NovoPickerToggleElement>;
   @ViewChildren('addressInput') inputChildren: QueryList<ElementRef>;
   @ViewChild('placesPicker') placesPicker: PlacesListComponent;
+  @ViewChildren(NovoSelectElement) addressSideTest: any;
 
   // Static defaults
   radiusValues: number[] = [5, 10, 20, 30, 40, 50, 100];
@@ -115,19 +118,21 @@ export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef im
 
   private _addressChangesSubscription: Subscription = Subscription.EMPTY;
 
-  constructor(public element: ElementRef, public labels: NovoLabelService) {
-    super(labels);
+  public element = inject(ElementRef);
+
+  constructor(labelService: NovoLabelService) {
+    super(labelService);
+    this.defineOperatorEditGroup(Operator.includeAny, Operator.excludeAny, Operator.radius);
   }
 
-  ngAfterViewInit() {
-    setTimeout(() => {
-      // Initialize the radius value from existing data
-      this.assignRadiusFromValue();
+  frameAfterViewInit(): void {
+    super.frameAfterViewInit();
+    // Initialize the radius value from existing data
+    this.assignRadiusFromValue();
 
-      // Update the radius on address value changes
-      this._addressChangesSubscription = this.inputChildren.changes.subscribe(() => {
-        this.assignRadiusFromValue();
-      })
+    // Update the radius on address value changes
+    this._addressChangesSubscription = this.inputChildren.changes.subscribe(() => {
+      this.assignRadiusFromValue();
     });
   }
 
@@ -201,6 +206,17 @@ export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef im
       formGroup.get('value').setValue(oldValue);
     }
     this.closePlacesList(viewIndex);
+  }
+
+  // Override abstract behavior - allow moving location from includeAny to radius, but when moving the opposite direction,
+  // trim out radius information from the value
+  onOperatorSelect(formGroup: UntypedFormGroup): void {
+    const previousOperator = this._previousOperatorValue;
+    super.onOperatorSelect(formGroup);
+    if ([previousOperator, formGroup.get('operator').getRawValue()].indexOf(Operator.radius) !== -1 &&
+        formGroup.get('value').getRawValue() != null) {
+      formGroup.get('value').setValue(this.updateRadiusInValues(formGroup, this.getValue(formGroup)));
+    }
   }
 
   onRadiusSelect(formGroup: AbstractControl, radius: number): void {

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
@@ -184,7 +184,9 @@ export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef im
       address_components: event.address_components,
       formatted_address: event.formatted_address,
       geometry: event.geometry,
+      name: event.name,
       place_id: event.place_id,
+      types: event.types,
     };
     const current: AddressData | AddressData[] = this.getValue(formGroup);
     const updated: AddressData[] = Array.isArray(current) ? [...current, valueToAdd] : [valueToAdd];

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/boolean-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/boolean-condition.definition.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
 import { Operator } from '../query-builder.types';
+import { NovoLabelService } from 'novo-elements/services';
 
 /**
  * When constructing a query using a field that is a boolean with only true/false as possible values.
@@ -29,4 +30,9 @@ import { Operator } from '../query-builder.types';
 })
 export class NovoDefaultBooleanConditionDef extends AbstractConditionFieldDef {
   defaultOperator = Operator.include;
+
+  constructor(labelService: NovoLabelService) {
+    super(labelService);
+    this.defineOperatorEditGroup(Operator.include, Operator.exclude, Operator.isNull);
+  }
 }

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, QueryList, ViewChildren, ViewEncaps
 import { NovoPickerToggleElement } from 'novo-elements/elements/field';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
 import { Operator } from '../query-builder.types';
+import { NovoLabelService } from 'novo-elements/services';
 
 /**
  * Most complicated of the default conditions defs, a date needs to provide a different
@@ -58,6 +59,11 @@ export class NovoDefaultDateConditionDef extends AbstractConditionFieldDef {
   overlayChildren: QueryList<NovoPickerToggleElement>;
 
   defaultOperator = Operator.within;
+
+  constructor(labelService: NovoLabelService) {
+    super(labelService);
+    this.defineOperatorEditGroup(Operator.before, Operator.after);
+  }
 
   closePanel(event, viewIndex): void {
     const overlay = this.overlayChildren.find(item => item.overlayId === viewIndex);

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/date-time-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/date-time-condition.definition.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, QueryList, ViewChildren, ViewEncaps
 import { NovoPickerToggleElement } from 'novo-elements/elements/field';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
 import { Operator } from '../query-builder.types';
+import { NovoLabelService } from 'novo-elements/services';
 
 /**
  * Most complicated of the default conditions defs, a date needs to provide a different
@@ -57,6 +58,11 @@ export class NovoDefaultDateTimeConditionDef extends AbstractConditionFieldDef {
   overlayChildren: QueryList<NovoPickerToggleElement>;
 
   defaultOperator = Operator.within;
+
+  constructor(labelService: NovoLabelService) {
+    super(labelService);
+    this.defineOperatorEditGroup(Operator.before, Operator.after);
+  }
 
   closePanel(event, viewIndex): void {
     const overlay = this.overlayChildren.find(item => item.overlayId === viewIndex);

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/number-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/number-condition.definition.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
 import { Operator } from '../query-builder.types';
+import { NovoLabelService } from 'novo-elements/services';
 
 /**
  * When constructing a query using a field that is an Int, Double, Number ...etc.
@@ -36,4 +37,9 @@ import { Operator } from '../query-builder.types';
 })
 export class NovoDefaultNumberConditionDef extends AbstractConditionFieldDef {
   defaultOperator = Operator.equalTo;
+
+  constructor(labelService: NovoLabelService) {
+    super(labelService);
+    this.defineOperatorEditGroup(Operator.greaterThan, Operator.lessThan, Operator.equalTo);
+  }
 }

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
@@ -1,7 +1,7 @@
-import { ChangeDetectionStrategy, Component, ViewChild, ViewEncapsulation } from '@angular/core';
-import { AbstractConditionFieldDef } from './abstract-condition.definition';
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { NovoLabelService } from 'novo-elements/services';
 import { Operator } from '../query-builder.types';
-import { NovoSelectElement } from 'novo-elements/elements/select';
+import { AbstractConditionFieldDef } from './abstract-condition.definition';
 
 /**
  * Handle selection of field values when a list of options is provided.
@@ -41,4 +41,9 @@ import { NovoSelectElement } from 'novo-elements/elements/select';
 })
 export class NovoDefaultPickerConditionDef extends AbstractConditionFieldDef {
   defaultOperator = Operator.includeAny;
+
+  constructor(labelService: NovoLabelService) {
+    super(labelService);
+    this.defineOperatorEditGroup(Operator.includeAny, Operator.includeAll, Operator.excludeAny);
+  }
 }

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.spec.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.spec.ts
@@ -1,0 +1,55 @@
+import { FormControl, FormGroup } from '@angular/forms';
+import { NovoDefaultStringConditionDef } from './string-condition.definition';
+
+describe('StringConditionDefinition', () => {
+    let formGroup: FormGroup;
+
+    beforeEach(() => {
+        formGroup = new FormGroup({
+            value: new FormControl(null),
+            operator: new FormControl('includeAny'),
+        });
+    })
+
+    it('should combine arrays in the form control', () => {
+        const mockEvent = {
+            input: {
+                value: 'string1'
+            },
+            value: 'string1'
+        };
+        NovoDefaultStringConditionDef.prototype.add(mockEvent, formGroup);
+        expect(formGroup.controls.value.value).toEqual(['string1']);
+        const arrayOne = formGroup.controls.value.value;
+        mockEvent.value = 'string2';
+        NovoDefaultStringConditionDef.prototype.add(mockEvent, formGroup);
+        expect(formGroup.controls.value.value).toEqual(['string1', 'string2']);
+        // verify this is a different array object for change detection
+        expect(formGroup.controls.value.value).not.toBe(arrayOne);
+    });
+
+    it('should remove values accordingly', () => {
+        const arrayOne = ['string1', 'string3', 'string5'];
+        formGroup.controls.value.setValue(arrayOne);
+        NovoDefaultStringConditionDef.prototype.remove('string3', formGroup);
+        expect(formGroup.controls.value.value).toEqual(['string1', 'string5']);
+        expect(formGroup.controls.value.value).not.toBe(arrayOne);
+    });
+
+    describe('AbstractConditionFieldDef', () => {
+        it('should only reset value if the operator edit group has changed', () => {
+            const mockObj = {
+                _previousOperatorValue: 'includeAny',
+                operatorEditGroups: [new Set(['includeAny', 'includeAll'])],
+            };
+            formGroup.controls.value.setValue('test');
+            formGroup.controls.operator.setValue('includeAll');
+            NovoDefaultStringConditionDef.prototype.onOperatorSelect.call(mockObj, formGroup);
+            expect(formGroup.controls.value.value).toBe('test');
+
+            formGroup.controls.operator.setValue('notEditGroup');
+            NovoDefaultStringConditionDef.prototype.onOperatorSelect.call(mockObj, formGroup);
+            expect(formGroup.controls.value.value).toBe(null);
+        });
+    });
+});

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
@@ -1,7 +1,8 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 import { AbstractControl } from '@angular/forms';
-import { AbstractConditionFieldDef } from './abstract-condition.definition';
+import { NovoLabelService } from 'novo-elements/services';
 import { Operator } from '../query-builder.types';
+import { AbstractConditionFieldDef } from './abstract-condition.definition';
 
 /**
  * Constructing filters against String fields can be complex. Each "chip" added to the
@@ -58,6 +59,11 @@ import { Operator } from '../query-builder.types';
 })
 export class NovoDefaultStringConditionDef extends AbstractConditionFieldDef {
   defaultOperator = Operator.includeAny;
+
+  constructor(labelService: NovoLabelService) {
+    super(labelService);
+    this.defineOperatorEditGroup(Operator.includeAny, Operator.includeAll, Operator.excludeAny);
+  }
 
   getValue(formGroup: AbstractControl): any[] {
     return formGroup.value?.value || [];

--- a/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.html
+++ b/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.html
@@ -3,8 +3,8 @@
     <ng-container
       *ngFor="let andGroup of root.controls; let andIndex = index; let isFirst = first;let isLast = last;">
       <ng-container [formGroupName]="andIndex">
-        <novo-flex class="condition-row" align="end" gap="sm">
-          <novo-dropdown *ngIf="!isFirst && qbs.allowedGroupings.length > 1; else labeledGroup">
+        <novo-flex class="condition-row" [ngClass]="{ isFirst: andIndex === 0 }" [class]="scope" align="end" gap="sm" #flex>
+          <novo-dropdown *ngIf="(!isFirst || !hideFirstOperator) && qbs.allowedGroupings.length > 1; else labeledGroup">
             <button theme="dialogue" icon="collapse" size="sm">{{qbs.getConjunctionLabel(controlName)}}</button>
             <novo-optgroup>
               <novo-option *ngFor="let c of qbs.allowedGroupings" (click)="updateControlName(c)">
@@ -12,24 +12,24 @@
             </novo-optgroup>
           </novo-dropdown>
           <ng-template #labeledGroup>
-            <novo-label *ngIf="!isFirst" color="ash" size="xs" uppercase padding="sm">
+            <novo-label *ngIf="!isFirst || !hideFirstOperator" color="ash" size="xs" uppercase padding="sm">
               {{qbs.getConjunctionLabel(controlName)}}</novo-label>
           </ng-template>
-          <novo-condition-builder [groupIndex]="groupIndex" [andIndex]="andIndex" [isFirst]="isFirst"></novo-condition-builder>
-          <novo-button theme="icon" icon="delete-o" color="negative" (click)="removeCondition(andIndex)"
-            [disabled]="cantRemoveRow()">
+          <novo-condition-builder [groupIndex]="groupIndex" [andIndex]="andIndex" [hideOperator]="isFirst && hideFirstOperator" [scope]="scope" [conditionType]="controlName"></novo-condition-builder>
+          <novo-button theme="icon" icon="delete-o" color="negative" (click)="removeCondition(andIndex)">
           </novo-button>
         </novo-flex>
       </ng-container>
     </ng-container>
     <button
+      *ngIf="!qbs.hasMultipleScopes()"
       theme="dialogue"
       data-automation-id="add-advanced-search-condition"
       icon="add-thin"
       side="left"
       size="sm"
-      uppercase (click)="addCondition()">
+      uppercase
+      (click)="addCondition()">
       {{ labels.addCondition }}</button>
   </novo-stack>
-  <!-- <button class="and-or-button" theme="secondary" size="sm" (click)="addRootCondition()">{{ addCriteriaLabel }}</button> -->
 </div>

--- a/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.ts
@@ -7,8 +7,10 @@ import { Condition, Conjunction } from '../query-builder.types';
 import { NovoLabelService } from 'novo-elements/services';
 
 const EMPTY_CONDITION: Condition = {
+  conditionType: '$and',
   field: null,
   operator: null,
+  scope: null,
   value: null,
 };
 @Component({
@@ -24,7 +26,11 @@ const EMPTY_CONDITION: Condition = {
 export class ConditionGroupComponent implements OnInit, OnDestroy {
   @Input() controlName: string = '$' + Conjunction.AND;
   @Input() groupIndex: number;
+  @Input() hideFirstOperator: boolean = true;
+  @Input() canBeEmpty: boolean = false;
+  @Input() formGroupName: any;
 
+  public scope: string;
   public parentForm: UntypedFormGroup;
   /** Subject that emits when the component has been destroyed. */
   private readonly _onDestroy = new Subject<void>();
@@ -40,14 +46,25 @@ export class ConditionGroupComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.parentForm = this.controlContainer.control as UntypedFormGroup;
     this.controlName = Object.keys(this.parentForm.controls)[0];
+    this.updateGroupScope();
     merge(this.parentForm.parent.valueChanges, this.qbs.stateChanges)
       .pipe(takeUntil(this._onDestroy))
       .subscribe(() => this.cdr.markForCheck());
   }
 
+  ngOnChanges() {
+    this.updateGroupScope();
+  }
+
   ngOnDestroy() {
     this._onDestroy.next();
     this._onDestroy.complete();
+  }
+
+  updateGroupScope() {
+    if (this.parentForm && this.controlName) {
+      this.scope = this.parentForm.value[this.controlName][0]?.scope || this.qbs.scopes()[0];
+    }
   }
 
   updateControlName(value: string) {
@@ -57,7 +74,9 @@ export class ConditionGroupComponent implements OnInit, OnDestroy {
       this.parentForm.controls[name] = this.parentForm.controls[this.controlName];
       delete this.parentForm.controls[this.controlName];
       this.controlName = name;
-      this.parentForm.get(this.controlName).setValue(current);
+      // scrub properties not on control
+      const currentStrict = current.map((item) => (({ conditionType, field, operator, scope, value, ...rest }) => ({ conditionType, field, operator, scope, value }))(item));
+      this.parentForm.get(this.controlName)?.setValue(currentStrict);
       this.cdr.markForCheck();
     }
   }
@@ -68,19 +87,29 @@ export class ConditionGroupComponent implements OnInit, OnDestroy {
 
   addCondition(data?: any) {
     const condition = this.newCondition(data);
+    const onlyConditionIsEmpty = JSON.stringify(this.root.value) === JSON.stringify([EMPTY_CONDITION]);
     this.root.push(condition);
+    this.qbs.hasMultipleScopes() && onlyConditionIsEmpty && this.removeCondition(0);
     this.cdr.markForCheck();
   }
 
   removeCondition(index: number) {
+    const isPrimaryScope = this.scope === this.qbs.scopes()[0];
+    const lastRowInGroup = this.root.length === 1;
+    const lastRowInQueryBuilder = this.cantRemoveRow();
     this.root.removeAt(index);
+    if ((lastRowInQueryBuilder || (lastRowInGroup && isPrimaryScope)) && !this.canBeEmpty) {
+      this.addCondition();
+    }
     this.cdr.markForCheck();
   }
 
-  newCondition({ field, operator, value }: Condition = EMPTY_CONDITION): UntypedFormGroup {
+  newCondition({ field, operator, scope, value }: Condition = EMPTY_CONDITION): UntypedFormGroup {
     return this.formBuilder.group({
+      conditionType: '$and',
       field: [field, Validators.required],
       operator: [operator, Validators.required],
+      scope: [scope],
       value: [value],
     });
   }

--- a/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.html
+++ b/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.html
@@ -2,11 +2,17 @@
   <novo-stack [formArrayName]="controlName" class="criteria-builder-inner">
     <ng-container
       *ngFor="let andGroup of root.controls; let andIndex = index; let isFirst = first;let isLastAnd = last;">
-      <novo-label *ngIf="!isFirst" color="ash" size="xs" uppercase padding="sm">{{ qbs.getConjunctionLabel('and') }}
-      </novo-label>
-      <novo-condition-group [groupIndex]="andIndex" [formGroupName]="andIndex"></novo-condition-group>
+      <novo-label *ngIf="!isFirst" color="ash" size="xs" uppercase padding="sm">{{ qbs.hasMultipleScopes() ? conditionGroup.scope + ' ' + labels.filterss : qbs.getConjunctionLabel('and') }}</novo-label>
+      <novo-condition-group [hideFirstOperator]="hideFirstOperator" [canBeEmpty]="canBeEmpty" [groupIndex]="andIndex" [formGroupName]="andIndex" #conditionGroup></novo-condition-group>
     </ng-container>
   </novo-stack>
+  <novo-tabbed-group-picker
+    *ngIf="qbs.hasMultipleScopes()"
+    [tabs]="tabbedGroupPickerTabs()"
+    [selectionEnabled]="false"
+    [buttonConfig]="addButtonConfig"
+    (activation)="onFieldSelect($event)">
+  </novo-tabbed-group-picker>
 </form>
 <novo-condition-templates [addressConfig]="addressConfig"/>
 

--- a/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.ts
@@ -4,24 +4,33 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  computed,
   ContentChildren,
   forwardRef,
   Input,
   OnDestroy,
   OnInit,
   QueryList,
+  viewChild,
+  viewChildren,
 } from '@angular/core';
 import { ControlContainer, FormArray, FormBuilder, NG_VALUE_ACCESSOR, UntypedFormGroup, Validators } from '@angular/forms';
 import { interval, Subject } from 'rxjs';
 import { debounce, filter, startWith, takeUntil } from 'rxjs/operators';
+import { NovoTabbedGroupPickerElement, TabbedGroupPickerButtonConfig, TabbedGroupPickerTab } from 'novo-elements/elements/tabbed-group-picker';
+import { NovoLabelService } from 'novo-elements/services';
+import { Helpers } from 'novo-elements/utils';
+import { ConditionGroupComponent } from '../condition-group/condition-group.component';
 import { NovoConditionFieldDef } from '../query-builder.directives';
 import { QueryBuilderService } from '../query-builder.service';
 import { NOVO_CRITERIA_BUILDER } from '../query-builder.tokens';
 import { BaseFieldDef, Condition, ConditionGroup, Conjunction, AddressCriteriaConfig } from '../query-builder.types';
 
 const EMPTY_CONDITION: Condition = {
+  conditionType: '$and',
   field: null,
   operator: null,
+  scope: null,
   value: null,
 };
 @Component({
@@ -44,11 +53,45 @@ export class CriteriaBuilderComponent implements OnInit, OnDestroy, AfterContent
   @Input() allowedGroupings = [Conjunction.AND, Conjunction.OR, Conjunction.NOT];
   @Input() editTypeFn: (field: BaseFieldDef) => string;
   @Input() addressConfig: AddressCriteriaConfig;
+  @Input() canBeEmpty: boolean = false;
+
+  @Input('hideFirstOperator')
+  set HideFirstOperator(hide: boolean) {
+      if (!Helpers.isEmpty(hide)) {
+        this._hideFirstOperator = hide;
+      }
+  }
+  get hideFirstOperator() {
+    return this._hideFirstOperator;
+  }
+  private _hideFirstOperator: boolean = true;
 
   @ContentChildren(NovoConditionFieldDef, { descendants: true }) _contentFieldDefs: QueryList<NovoConditionFieldDef>;
+  scopedFieldPicker = viewChild(NovoTabbedGroupPickerElement);
+  conditionGroups = viewChildren(ConditionGroupComponent);
 
   public parentForm: UntypedFormGroup;
   public innerForm: UntypedFormGroup;
+  public tabbedGroupPickerTabs = computed<TabbedGroupPickerTab[]>(() => {
+    const tabs = [];
+    this.qbs.scopes()?.forEach((scope) => {
+      tabs.push({
+        typeName: scope,
+        typeLabel: scope,
+        valueField: 'name',
+        labelField: 'label',
+        data: this.qbs.config.fields.find((field) => field.value === scope)?.options || [],
+      });
+    });
+    return tabs;
+  });
+  public addButtonConfig: TabbedGroupPickerButtonConfig = {
+    theme: 'dialogue',
+    side: 'left',
+    size: 'sm',
+    icon: 'add-thin',
+    label: this.labels.addCondition,
+  };
   /** Subject that emits when the component has been destroyed. */
   private readonly _onDestroy = new Subject<void>();
 
@@ -57,6 +100,7 @@ export class CriteriaBuilderComponent implements OnInit, OnDestroy, AfterContent
     private formBuilder: FormBuilder,
     private cdr: ChangeDetectorRef,
     public qbs: QueryBuilderService,
+    public labels: NovoLabelService,
   ) {
     if (!qbs.componentHost) {
       qbs.componentHost = this;
@@ -114,13 +158,30 @@ export class CriteriaBuilderComponent implements OnInit, OnDestroy, AfterContent
     this._onDestroy.complete();
   }
 
-  private isConditionGroup(group: unknown) {
+  private isConditionGroup(group: unknown): group is ConditionGroup {
     return Object.keys(group).every((key) => ['$and', '$or', '$not'].includes(key));
   }
 
   private setInitialValue(value: ConditionGroup[] | Condition[]) {
-    if (value.length && this.isConditionGroup(value[0])) {
-      value.forEach((it) => this.addConditionGroup(it));
+    if (value.length) {
+      if (this.isConditionGroup(value[0])) {
+        value.forEach((it) => this.addConditionGroup(it));
+      } else {
+        const conditions: Condition[] = [...value] as Condition[];
+        if (this.qbs.hasMultipleScopes()) {
+          // divide up by scope into separate groups
+          const scopedConditions: { [key: string]: Condition[] } = {};
+          conditions.forEach((condition) => {
+            scopedConditions[condition.scope] = scopedConditions[condition.scope] || [];
+            scopedConditions[condition.scope].push(condition);
+          })
+          for (const scope in scopedConditions) {
+            this.addConditionGroup({ $and: scopedConditions[scope] });
+          }
+        } else {
+          this.addConditionGroup({ $and: conditions });
+        }
+      }
     } else {
       this.addConditionGroup({ $and: value });
     }
@@ -145,10 +206,12 @@ export class CriteriaBuilderComponent implements OnInit, OnDestroy, AfterContent
     return this.formBuilder.group(controls);
   }
 
-  newCondition({ field, operator, value }: Condition = EMPTY_CONDITION): UntypedFormGroup {
+  newCondition({ field, operator, scope, value }: Condition = EMPTY_CONDITION): UntypedFormGroup {
     return this.formBuilder.group({
+      conditionType: '$and',
       field: [field, Validators.required],
       operator: [operator, Validators.required],
+      scope: [scope],
       value: [value],
     });
   }
@@ -163,7 +226,19 @@ export class CriteriaBuilderComponent implements OnInit, OnDestroy, AfterContent
     }
   }
 
+  onFieldSelect(field) {
+    this.scopedFieldPicker().dropdown.closePanel();
+    const condition = { field: field.name, operator: null, scope: field.scope, value: null };
+    const group = this.conditionGroups().find((group) => group.scope === field.scope);
+    if (group) {
+      group.addCondition(condition);
+    } else {
+      this.addConditionGroup({ $and: [condition] })
+    }
+  }
+
   private _configureQueryBuilderService() {
+    this.qbs.scopes.set(this.config?.fields.map((f) => f.value));
     this.qbs.config = this.config;
     this.qbs.editTypeFn = this.editTypeFn;
     this.qbs.allowedGroupings = this.allowedGroupings as Conjunction[];

--- a/projects/novo-elements/src/elements/query-builder/query-builder.module.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.module.ts
@@ -23,6 +23,7 @@ import { NovoSearchBoxModule } from 'novo-elements/elements/search';
 import { NovoSelectModule } from 'novo-elements/elements/select';
 import { NovoSelectSearchModule } from 'novo-elements/elements/select-search';
 import { NovoSwitchModule } from 'novo-elements/elements/switch';
+import { NovoTabbedGroupPickerModule } from 'novo-elements/elements/tabbed-group-picker';
 import { NovoTabModule } from 'novo-elements/elements/tabs';
 import { ConditionBuilderComponent, ConditionInputOutlet, ConditionOperatorOutlet } from './condition-builder/condition-builder.component';
 import { NovoDefaultAddressConditionDef } from './condition-definitions/address-condition.definition';
@@ -56,6 +57,7 @@ import { NovoConditionTemplatesComponent } from './condition-templates/condition
     NovoOptionModule,
     NovoFlexModule,
     NovoTabModule,
+    NovoTabbedGroupPickerModule,
     NovoLoadingModule,
     NovoCardModule,
     NovoDatePickerModule,

--- a/projects/novo-elements/src/elements/query-builder/query-builder.service.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { computed, Injectable, signal } from '@angular/core';
 import { Subject } from 'rxjs';
 import { NovoLabelService } from 'novo-elements/services';
 import { BaseConditionFieldDef } from './query-builder.directives';
@@ -17,6 +17,8 @@ export interface QueryBuilderConfig {
 export class QueryBuilderService {
   private _customFieldDefs = new Set<BaseConditionFieldDef>();
   private _fieldDefsByName = new Map<string, BaseConditionFieldDef>();
+  public scopes = signal([]);
+  public hasMultipleScopes = computed(() => this.scopes()?.length > 1);
   /**
    * Will dispatch when properties changes, subscribe to this if component should
    * re-render when props are updated

--- a/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
@@ -81,8 +81,10 @@ export interface AddressData {
   address_components: AddressComponent[];
   formatted_address: string;
   geometry: AddressGeometry;
+  name?: string;
   place_id: string;
   radius?: AddressRadius;
+  types?: string[];
 }
 
 export interface AddressRadius {

--- a/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
@@ -6,6 +6,8 @@ export enum Conjunction {
   NOT = 'not',
 }
 
+export type ConditionType = '$and' | '$or' | '$not';
+
 export type ConditionGroup = {
   [K in Conjunction as `$${K}`]?: Condition[];
 };
@@ -37,8 +39,10 @@ export enum Operator {
 export type OperatorName = keyof typeof Operator;
 
 export interface Condition {
+  conditionType?: ConditionType;
   field: string;
   operator: OperatorName | string;
+  scope?: string;
   value: any;
 }
 

--- a/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.html
+++ b/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.html
@@ -3,6 +3,7 @@
     class="tabbed-group-picker-button"
     [theme]="buttonConfig.theme"
     [side]="buttonConfig.side"
+    [size]="buttonConfig.size"
     [icon]="buttonConfig.icon"
     [loading]="loading">
     <ng-content></ng-content>
@@ -52,8 +53,8 @@
             [attr.data-automation-value]="item[displayTab.valueField]"
             [allowSelection]="selectionEnabled"
             [selected]="item.selected"
-            (click)="activateItem(item)"
-            (keydown.space)="activateItem(item)"
+            (click)="activateItem(item, displayTab)"
+            (keydown.space)="activateItem(item, displayTab)"
             novoInert>
             {{item[displayTab.labelField]}}
           </novo-option>

--- a/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.spec.ts
+++ b/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.spec.ts
@@ -481,7 +481,7 @@ describe('Elements: NovoTabbedGroupPickerElement', () => {
 
       component.activateItem(chicken);
       expect(selection).toBeUndefined();
-      expect(activation).toBe(chicken);
+      expect(activation).toEqual({ ...chicken, scope: 'quickselect' });
     });
   })
 });

--- a/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.ts
+++ b/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.ts
@@ -63,6 +63,7 @@ export type TabbedGroupPickerButtonConfig = {
   side: string;
   icon: string;
   label: string;
+  size?: string;
 };
 
 @Component({
@@ -253,12 +254,12 @@ export class NovoTabbedGroupPickerElement implements OnDestroy, OnInit {
     }
   }
 
-  activateItem(item: any): void {
+  activateItem(item: any, tab?: TabbedGroupPickerTab): void {
     if (this.selectionEnabled) {
       item.selected = !item.selected;
       this.onItemToggled(item);
     }
-    this.activation.emit(item);
+    this.activation.emit({ ...item, scope: tab?.typeName || 'quickselect' });
   }
 
   onItemToggled(item: Option) {

--- a/projects/novo-elements/src/elements/tiles/Tiles.module.ts
+++ b/projects/novo-elements/src/elements/tiles/Tiles.module.ts
@@ -2,11 +2,11 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-// APP
+import { NovoButtonModule } from 'novo-elements/elements/button';
 import { NovoTilesElement } from './Tiles';
 
 @NgModule({
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, NovoButtonModule, ReactiveFormsModule],
   declarations: [NovoTilesElement],
   exports: [NovoTilesElement],
 })

--- a/projects/novo-elements/src/elements/tiles/Tiles.scss
+++ b/projects/novo-elements/src/elements/tiles/Tiles.scss
@@ -1,15 +1,7 @@
 @import "../../styles/variables.scss";
 
 :host {
-  $border-width: 0.2em;
-  $border-radius: 3px;
-  $positive-lighter: lighten($positive, 20%);
-  $disabled-color: lighten($grey, 20%);
   display: inline-block;
-  position: relative;
-  color: $positive;
-  $border-properties: solid $border-width $positive-lighter;
-
   input {
     appearance: none !important;
     height: 0 !important;
@@ -17,66 +9,38 @@
     position: absolute;
   }
   & > .tile-container {
+    background: $white;
     display: flex;
-    text-align: center;
-    background-color: var(--background-bright);
-    border: solid thin $ocean;
-    border-radius: $border-radius;
-    position: relative;
-    align-items: center;
+    border: solid thin $slate;
+    border-radius: 3px;
     .tile {
-      padding: 0 $spacing-md;
-      line-height: 3.2rem;
-      height: 100%;
-      z-index: 1;
-      position: relative;
-      cursor: pointer;
-      letter-spacing: 0.02em;
+      margin: 2px;
+      gap: .5rem;
       &:not(:last-child) {
-        border-right: solid thin $ocean;
+        margin-right: 3px;
       }
-      &:not(.disabled) {
-        &.active {
-          box-shadow: inset 3px 2px 4px 0px rgba(0, 0, 0, 0.3);
-          color: $white;
-          background: $ocean;
-        }
-        &:hover {
-          box-shadow: 0 3px 7px rgba(0, 0, 0, 0.15), 0 1px 2px rgba(0, 0, 0, 0.15);
-        }
-      }
-      &.active {
-        font-weight: 600;
+      &.defaultColor.active {
+          background: darken($ocean, 20%);
       }
       &.disabled {
         cursor: not-allowed;
         opacity: 0.4;
       }
-      label {
-        z-index: 1;
-        position: relative;
-        cursor: inherit;
+      ::ng-deep span {
+        text-transform: none;
+        label {
+          cursor: inherit;
+        }
       }
     }
-    &.active {
-      color: $positive;
-      border-color: $positive;
-      box-shadow: 0px 0px 15px 3px rgba(74, 137, 220, 0.25);
-    }
     &.disabled {
-      border-color: $disabled-color;
+      border-color: lighten($grey, 20%);
       opacity: 0.4;
       pointer-events: auto;
       cursor: not-allowed;
       .tile {
         pointer-events: none;
         opacity: 1;
-        &:hover {
-          box-shadow: none;
-        }
-        &.active {
-          box-shadow: inset 3px 2px 4px 0px rgba(0, 0, 0, 0.3);
-        }
       }
     }
   }

--- a/projects/novo-elements/src/elements/tiles/Tiles.ts
+++ b/projects/novo-elements/src/elements/tiles/Tiles.ts
@@ -28,13 +28,15 @@ const TILES_VALUE_ACCESSOR = {
   providers: [TILES_VALUE_ACCESSOR],
   template: `
     <div class="tile-container" [class.active]="focused" [class.disabled]="disabled">
-      <div
-        class="tile"
+      <button class="tile"
         *ngFor="let option of _options; let i = index"
-        [ngClass]="{ active: option.checked, disabled: option.disabled }"
+        [ngClass]="{ defaultColor: !option.color, active: option.checked, disabled: option.disabled }"
+        [theme]="option.checked ? 'primary' : 'dialogue'"
+        [color]="option.checked ? option.color || 'darken($ocean, 20%)' : 'dark'"
+        [icon]="option.icon"
+        [side]="option.iconSide || 'left'"
         (click)="select($event, option)"
-        [attr.data-automation-id]="option.label || option"
-      >
+        [attr.data-automation-id]="option.label || option">
         <input
           class="tiles-input"
           [name]="name"
@@ -49,7 +51,7 @@ const TILES_VALUE_ACCESSOR = {
         <label [attr.for]="name + i" [attr.data-automation-id]="option.label || option">
           {{ option.label || option }}
         </label>
-      </div>
+      </button>
     </div>
   `,
   styleUrls: ['./Tiles.scss'],

--- a/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
@@ -38,6 +38,8 @@ export class TooltipDirective implements OnDestroy, OnInit {
   autoPosition: boolean = true;
   @Input('tooltipIsHTML')
   isHTML: boolean;
+  @Input('tooltipCloseOnClick')
+  closeOnClick: boolean = false;
 
   private tooltipInstance: NovoTooltip | null;
   private portal: ComponentPortal<NovoTooltip>;
@@ -66,6 +68,14 @@ export class TooltipDirective implements OnDestroy, OnInit {
   @HostListener('mouseleave')
   onMouseLeave(): void {
     if (this.overlayRef && !this.always) {
+      this.hide();
+      this.overlayRef.dispose();
+    }
+  }
+
+  @HostListener('click')
+  onclick(): void {
+    if (this.overlayRef && !this.always && this.closeOnClick) {
       this.hide();
       this.overlayRef.dispose();
     }

--- a/projects/novo-elements/src/elements/tooltip/Tooltip.spec.ts
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.spec.ts
@@ -4,16 +4,19 @@ import { Component } from '@angular/core';
 import { async, TestBed } from '@angular/core/testing';
 // App
 import { TooltipDirective } from './Tooltip.directive';
+import { By } from '@angular/platform-browser';
 
 @Component({
   selector: 'test-component',
-  template: `<div tooltip="test" tooltipPosition="right"></div>`,
+  template: `<div tooltip="test" tooltipPosition="right"></div>
+             <div tooltip="test" [tooltipCloseOnClick]="true" tooltipPosition="right"></div>`,
 })
 class TestComponent {}
 
 describe('Elements: TooltipDirective', () => {
   let fixture;
   let component;
+  let tooltipHost;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -22,9 +25,31 @@ describe('Elements: TooltipDirective', () => {
     }).compileComponents();
     fixture = TestBed.createComponent(TestComponent);
     component = fixture.debugElement.componentInstance;
+    tooltipHost = fixture.debugElement.queryAll(By.directive(TooltipDirective))
   }));
 
   it('should initialize with defaults', () => {
     expect(component).toBeDefined();
   });
+
+  describe('function: onclick', () => {
+    it('should not close tooltip on click', async() => {
+      tooltipHost[0].triggerEventHandler('mouseenter');
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('novo-tooltip'))).toBeTruthy();
+      tooltipHost[0].triggerEventHandler('click');
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('novo-tooltip'))).toBeTruthy();
+    });
+
+    it('should close tooltip on click', async() => {
+      tooltipHost[1].triggerEventHandler('mouseenter');
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('novo-tooltip'))).toBeTruthy();
+      tooltipHost[1].triggerEventHandler('click')
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('novo-tooltip'))).toBeFalsy();
+    });
+  });
+
 });

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -17,6 +17,7 @@ export class NovoLabelService {
   and = 'and';
   not = 'not';
   filters = 'Filter';
+  filterss = 'Filters';
   clear = 'Clear';
   sort = 'Sort';
   distributionListOwner = 'Owner';

--- a/projects/novo-examples/src/components/query-builder/just-criteria/MockMeta.ts
+++ b/projects/novo-examples/src/components/query-builder/just-criteria/MockMeta.ts
@@ -1,4 +1,4 @@
-export const MockMeta = {
+export const MockCandidateMeta = {
   entity: 'Candidate',
   entityMetaUrl: '/meta/Candidate?fields=*',
   label: 'Candidate',
@@ -8,6 +8,7 @@ export const MockMeta = {
       name: 'id',
       type: 'ID',
       dataType: 'id',
+      label: 'ID',
       optional: false,
     },
     {
@@ -9265,5 +9266,154 @@ export const MockMeta = {
         label: 'Brewery',
       },
     },
+  ],
+};
+
+export const MockNoteMeta = {
+  entity: 'Note',
+  entityMetaUrl: '/meta/Note?fields=*',
+  label: 'Note',
+  dateLastModified: '1651869983247',
+  fields: [
+    {
+      name: 'notes.action',
+      type: 'SCALAR',
+      dataType: 'String',
+      maxLength: 30,
+      confidential: false,
+      optional: true,
+      label: 'Action',
+      required: true,
+      readOnly: false,
+      multiValue: false,
+      inputType: 'SELECT',
+      options: [
+        {
+          value: 'Outbound Call',
+          label: 'Outbound Call'
+        },
+        {
+          value: 'Inbound Call',
+          label: 'Inbound Call'
+        },
+        {
+          value: 'Left Message',
+          label: 'Left Message'
+        },
+        {
+          value: 'Email',
+          label: 'Email'
+        },
+        {
+          value: 'Appointment',
+          label: 'Appointment'
+        },
+        {
+          value: 'Recruiter Interview',
+          label: 'Recruiter Interview'
+        },
+        {
+          value: 'Technical Interview',
+          label: 'Technical Interview'
+        },
+        {
+          value: 'Manager Interview',
+          label: 'Manager Interview'
+        },
+        {
+          value: 'Reference Check',
+          label: 'Reference Check'
+        },
+      ],
+      defaultValue: 'Outbound Call',
+      hideFromSearch: false,
+      sortOrder: 40,
+      hint: 0,
+      description: 0,
+      systemRequired: false,
+      shouldAddCustomEntityLabel: false
+    },
+    {
+      name: 'notes.commentingPerson',
+      type: 'TO_ONE',
+      confidential: false,
+      optional: false,
+      label: 'Author',
+      required: false,
+      readOnly: false,
+      multiValue: false,
+      inputType: 'SELECT',
+      optionsType: 'CorporateUser',
+      optionsUrl: 'options/CorporateUser',
+      hideFromSearch: false,
+      sortOrder: 20,
+      hint: 0,
+      description: 0,
+      systemRequired: false,
+      shouldAddCustomEntityLabel: false,
+      associatedEntity: {
+        entity: 'Person',
+        entityMetaUrl: 'meta/Person?fields=*',
+        label: 'Person',
+        dateLastModified: 1724848513984,
+        fields: [
+          {
+            name: 'id',
+            type: 'ID',
+            dataType: 'Integer',
+            optional: false,
+            label: 'ID'
+          },
+          {
+            name: 'firstName',
+            type: 'SCALAR',
+            dataType: 'String',
+            maxLength: 50,
+            confidential: false,
+            optional: true,
+            label: 'First Name',
+            required: false,
+            readOnly: false,
+            multiValue: false,
+            hideFromSearch: false,
+            systemRequired: false,
+            shouldAddCustomEntityLabel: false
+          },
+          {
+            name: 'lastName',
+            type: 'SCALAR',
+            dataType: 'String',
+            maxLength: 50,
+            confidential: false,
+            optional: true,
+            label: 'Last Name',
+            required: false,
+            readOnly: false,
+            multiValue: false,
+            hideFromSearch: false,
+            systemRequired: false,
+            shouldAddCustomEntityLabel: false
+          }
+        ]
+      }
+    },
+    {
+      name: 'notes.dateAdded',
+      type: 'SCALAR',
+      dataType: 'Timestamp',
+      dataSpecialization: 'DATETIME',
+      confidential: false,
+      optional: false,
+      label: 'Date Added',
+      required: false,
+      readOnly: false,
+      multiValue: false,
+      hideFromSearch: false,
+      sortOrder: 10,
+      hint: 0,
+      description: 0,
+      systemRequired: false,
+      shouldAddCustomEntityLabel: false
+    }
   ],
 };

--- a/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.html
+++ b/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.html
@@ -5,24 +5,57 @@
     [allowedGroupings]="mode.value"
     [config]="config"
     [editTypeFn]="editTypeFn"
+    [hideFirstOperator]="hideFirstOperator"
+    [canBeEmpty]="canBeEmpty"
     [addressConfig]="addressConfig">
     <custom-picker-condition-def name="CUSTOM"></custom-picker-condition-def>
   </novo-criteria-builder>
 
   <novo-row gap="md" justify="end">
-    <button theme="primary" size="sm" (click)="builder.addConditionGroup()">Add a group</button>
-    <button theme="secondary" size="sm" (click)="builder.clearAllConditions()">Clear All</button>
+    <button theme="primary" size="sm" *ngIf="!useNoteMeta" (click)="builder.addConditionGroup()">Add a group</button>
+    <button theme="secondary" size="sm" (click)="resetGroups()">Reset</button>
+    <button theme="secondary" size="sm" (click)="resetQueryForm(useNoteMeta)">Repopulate</button>
   </novo-row>
 </form>
 
 <novo-row align="start" gap="xl" margin="xl">
   <section>
     <novo-label>Join Operators</novo-label>
-    <novo-radio-group #mode [value]="and">
+    <novo-radio-group #mode [value]="andOrNot">
       <novo-radio name="mode" [value]="and">Only And</novo-radio>
       <novo-radio name="mode" [value]="andOr">And, Or</novo-radio>
       <novo-radio name="mode" [value]="andOrNot">And, Or, Not</novo-radio>
     </novo-radio-group>
+  </section>
+</novo-row>
+
+<novo-row align="start" gap="xl" margin="xl">
+  <section>
+    <novo-label marginRight="md">Add Additional Scope
+      <span tooltip="Adding an additional entity scope to the searchable fields will change the behavior when adding a new condition">
+        <novo-icon>info</novo-icon>
+      </span></novo-label>
+    <novo-tiles [options]="useNoteMetaOptions" [(ngModel)]="useNoteMeta" (onChange)="setFieldConfig($event)"/>
+  </section>
+</novo-row>
+
+<novo-row align="start" gap="xl" margin="xl">
+  <section>
+    <novo-label marginRight="md">Hide First Operator
+      <span tooltip="Disabling will display the AND/OR/NOT operator in the first row. Enabling (default) will hide it">
+        <novo-icon>info</novo-icon>
+      </span></novo-label>
+    <novo-tiles [options]="hideFirstOperatorOptions" [(ngModel)]="hideFirstOperator"/>
+  </section>
+</novo-row>
+
+<novo-row align="start" gap="xl" margin="xl">
+  <section>
+    <novo-label marginRight="md">Can Be Empty
+      <span tooltip="Enabling will allow you to delete a row if it is the only row in the criteria builder. Disabling (default) will keep the final row, and will instead clear it out">
+        <novo-icon>info</novo-icon>
+      </span></novo-label>
+    <novo-tiles [options]="canBeEmptyOptions" [(ngModel)]="canBeEmpty"/>
   </section>
 </novo-row>
 

--- a/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.ts
+++ b/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
 import { AbstractControl, UntypedFormBuilder, UntypedFormControl } from '@angular/forms';
 import {
   AbstractConditionFieldDef,
@@ -49,9 +49,7 @@ export class CustomPickerConditionDef extends AbstractConditionFieldDef implemen
   /** Subject that emits when the component has been destroyed. */
   protected _onDestroy = new Subject<void>();
 
-  constructor(public http: HttpClient, labels: NovoLabelService) {
-    super(labels);
-  }
+  http = inject(HttpClient);
 
   ngOnInit() {
     super.ngOnInit();
@@ -92,7 +90,10 @@ export class JustCriteriaExample implements OnInit {
   andOr = [Conjunction.AND, Conjunction.OR];
   andOrNot = [Conjunction.AND, Conjunction.OR, Conjunction.NOT];
 
-  addressConfig: AddressCriteriaConfig = {};
+  addressConfig: AddressCriteriaConfig = {
+    radiusEnabled: true,
+    radiusUnits: 'miles'
+  };
   addressRadiusEnabled: boolean = false;
   addressRadiusEnabledOptions: { label: string, value: boolean }[] = [
     { label: 'Yes', value: true },

--- a/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.ts
+++ b/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit, viewChild, ViewEncapsulation } from '@angular/core';
 import { AbstractControl, UntypedFormBuilder, UntypedFormControl } from '@angular/forms';
 import {
   AbstractConditionFieldDef,
@@ -13,7 +13,7 @@ import {
 } from 'novo-elements';
 import { ReplaySubject, Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
-import { MockMeta } from './MockMeta';
+import { MockCandidateMeta, MockNoteMeta } from './MockMeta';
 
 @Component({
   selector: 'custom-picker-condition-def',
@@ -81,7 +81,7 @@ export class CustomPickerConditionDef extends AbstractConditionFieldDef implemen
   styleUrls: ['just-criteria-example.css'],
 })
 export class JustCriteriaExample implements OnInit {
-  @ViewChild('criteriaBuilder', { static: true }) criteriaBuilder: CriteriaBuilderComponent;
+  criteriaBuilder = viewChild(CriteriaBuilderComponent);
 
   queryForm: AbstractControl;
   config: any = null;
@@ -100,6 +100,24 @@ export class JustCriteriaExample implements OnInit {
     { label: 'No', value: false },
   ];
 
+  useNoteMeta: boolean = false;
+  useNoteMetaOptions = [
+    { label: 'True', value: true },
+    { label: 'False', value: false }
+  ];
+
+  hideFirstOperator: boolean = true;
+  hideFirstOperatorOptions = [
+    { label: 'True', value: true },
+    { label: 'False', value: false }
+  ];
+
+  canBeEmpty: boolean = false;
+  canBeEmptyOptions = [
+    { label: 'True', value: true },
+    { label: 'False', value: false }
+  ];
+
   editTypeFn = (field: any) => {
     if (field.optionsType === 'Brewery') return 'custom';
     return (field.inputType || field.dataType || field.type).toLowerCase();
@@ -109,16 +127,16 @@ export class JustCriteriaExample implements OnInit {
 
   ngOnInit() {
     this.queryForm = this.formBuilder.group({ criteria: [] });
-    this.getFieldConfig().then((fields) => {
+    this.getFieldConfig(this.useNoteMeta).then((fields) => {
       this.prepopulateForm();
       this.config = { fields };
       this.cdr.detectChanges();
     });
-    // this.setQueryForm([]);
   }
 
-  getFieldConfig() {
-    return Promise.all([MockMeta]).then((metas) => {
+  getFieldConfig(useNoteMeta: boolean) {
+    const allMetas = useNoteMeta ? [MockCandidateMeta, MockNoteMeta] : [MockCandidateMeta];
+    return Promise.all(allMetas).then((metas) => {
       return metas.map((it) => ({
         value: it.entity,
         label: it.label,
@@ -131,29 +149,66 @@ export class JustCriteriaExample implements OnInit {
     });
   }
 
-  prepopulateForm() {
-    const prepopulatedData: Condition[] = [{
-      field: 'id',
-      operator: 'equalTo',
-      value: 123,
-    }, {
-      field: 'availability',
-      operator: 'includeAny',
-      value: ['test'],
-    }, {
-      field: 'customDate1',
-      operator: 'within',
-      value: '-30',
-    }, {
-      field: 'address',
-      operator: 'includeAny',
-      value: null,
-    }];
+  setFieldConfig(useNoteMeta: boolean) {
+    this.resetQueryForm();
+    this.getFieldConfig(useNoteMeta).then((fields) => {
+      this.config = { fields };
+      this.cdr.detectChanges();
+    });
+  }
+
+  prepopulateForm(addAdditionalScope = false) {
+    const prepopulatedData: any = [
+      {
+        $and: [
+          {
+            field: 'id',
+            operator: 'equalTo',
+            scope: 'Candidate',
+            value: 123,
+          }, {
+            field: 'availability',
+            operator: 'includeAny',
+            scope: 'Candidate',
+            value: ['test'],
+          }, {
+            field: 'customDate1',
+            operator: 'within',
+            scope: 'Candidate',
+            value: '-30',
+          }, {
+            field: 'address',
+            operator: 'includeAny',
+            scope: 'Candidate',
+            value: null,
+          },
+        ],
+      },
+    ];
+    const prepopulatedNoteConditions: any = {
+      $not: [
+        {
+          field: 'notes.action',
+          operator: 'includeAny',
+          scope: 'Note',
+          value: ['Left Message'],
+        }, {
+          field: 'notes.dateAdded',
+          operator: 'within',
+          scope: 'Note',
+          value: '-7',
+        },
+      ],
+    };
+    if (addAdditionalScope) {
+      prepopulatedData.push(prepopulatedNoteConditions);
+    }
     this.setQueryForm(prepopulatedData);
   }
 
-  resetQueryForm() {
-    this.setQueryForm({ criteria: [] });
+  resetQueryForm(addAdditionalScope = false) {
+    this.criteriaBuilder().clearAllConditions();
+    this.prepopulateForm(addAdditionalScope);
   }
 
   setQueryForm(criteria?) {
@@ -162,6 +217,11 @@ export class JustCriteriaExample implements OnInit {
 
   onSubmit() {
     console.log('Your form data : ', this.queryForm.value);
+  }
+
+  resetGroups() {
+    this.criteriaBuilder().clearAllConditions();
+    this.criteriaBuilder().addConditionGroup();
   }
 
   addressRadiusEnabledChanged(enabled: boolean) {

--- a/projects/novo-examples/src/components/query-builder/single-field-criteria-example/single-field-criteria-example.ts
+++ b/projects/novo-examples/src/components/query-builder/single-field-criteria-example/single-field-criteria-example.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectorRef, Component, OnInit, ViewChild, computed } from '@angular/core';
 import { AbstractControl, UntypedFormBuilder } from '@angular/forms';
 import { BaseFieldDef, CriteriaBuilderComponent, FieldConfig, QueryBuilderConfig } from 'novo-elements';
-import { MockMeta } from '../just-criteria/MockMeta';
+import { MockCandidateMeta as MockMeta } from '../just-criteria/MockMeta';
 
 /**
  * @title Single Field Criteria Example

--- a/projects/novo-examples/src/design/colors/analytics-colors/analytics-colors-example.ts
+++ b/projects/novo-examples/src/design/colors/analytics-colors/analytics-colors-example.ts
@@ -2,6 +2,8 @@
 import { Component } from '@angular/core';
 // Vendor
 import { NovoToastService } from 'novo-elements';
+// App
+import { analyticsColors as colors } from '../colors';
 
 /**
  * @title Analytics Colors
@@ -12,59 +14,7 @@ import { NovoToastService } from 'novo-elements';
   styleUrls: ['./analytics-colors-example.scss'],
 })
 export class AnalyticsColorsExample {
-  public analyticsColors: Array<any> = [
-    {
-      name: 'grapefruit',
-      variables: ['grapefruit'],
-      hex: 'DA4453',
-    },
-    {
-      name: 'bittersweet',
-      variables: ['bittersweet'],
-      hex: 'EB6845',
-    },
-    {
-      name: 'sunflower',
-      variables: ['sunflower'],
-      hex: 'F6B042',
-    },
-    {
-      name: 'grass',
-      variables: ['grass'],
-      hex: '8CC152',
-    },
-    {
-      name: 'mint',
-      variables: ['mint'],
-      hex: '37BC9B',
-    },
-    {
-      name: 'aqua',
-      variables: ['aqua'],
-      hex: '3BAFDA',
-    },
-    {
-      name: 'ocean',
-      variables: ['ocean'],
-      hex: '4A89DC',
-    },
-    {
-      name: 'carnation',
-      variables: ['carnation'],
-      hex: 'D770AD',
-    },
-    {
-      name: 'lavender',
-      variables: ['lavender'],
-      hex: '967ADC',
-    },
-    {
-      name: 'mountain',
-      variables: ['mountain'],
-      hex: '9678B6',
-    },
-  ];
-
+  analyticsColors = colors;
   options: any;
 
   constructor(private toaster: NovoToastService) {}

--- a/projects/novo-examples/src/design/colors/colors.ts
+++ b/projects/novo-examples/src/design/colors/colors.ts
@@ -1,0 +1,220 @@
+export const primaryColors: Array<any> = [
+  {
+    name: 'navigation',
+    variables: ['navigation'],
+    hex: '202945',
+  },
+  {
+    name: 'positive',
+    variables: ['positive'],
+    hex: '4A89DC',
+  },
+  {
+    name: 'dark',
+    variables: ['dark'],
+    hex: '3D464D',
+  },
+  {
+    name: 'background',
+    variables: ['background'],
+    hex: 'F4F4F4',
+  },
+  {
+    name: 'background dark',
+    variables: ['background-dark'],
+    hex: 'E2E2E2',
+  },
+  {
+    name: 'neutral',
+    variables: ['neutral'],
+    hex: '4F5361',
+  },
+  {
+    name: 'success',
+    variables: ['success'],
+    hex: '8CC152',
+  },
+  {
+    name: 'negative',
+    variables: ['negative'],
+    hex: 'DA4453',
+  },
+  {
+    name: 'warning',
+    variables: ['warning'],
+    hex: 'F6B042',
+  },
+  {
+    name: 'empty',
+    variables: ['empty'],
+    hex: 'CCCDCC',
+  },
+  {
+    name: 'sand',
+    variables: ['sand'],
+    hex: 'F4F4F4',
+  },
+  {
+    name: 'silver',
+    variables: ['silver'],
+    hex: 'E2E2E2',
+  },
+  {
+    name: 'stone',
+    variables: ['stone'],
+    hex: 'BEBEBE',
+  },
+  {
+    name: 'ash',
+    variables: ['ash'],
+    hex: 'A0A0A0',
+  },
+  {
+    name: 'slate',
+    variables: ['slate'],
+    hex: '707070',
+  },
+  {
+    name: 'charcoal',
+    variables: ['charcoal'],
+    hex: '282828',
+  },
+];
+
+export const entityColors: Array<any> = [
+  {
+    name: 'lead',
+    variables: ['lead'],
+    hex: 'AA6699',
+  },
+  {
+    name: 'contact',
+    variables: ['contact'],
+    hex: 'FFAA44',
+  },
+  {
+    name: 'company',
+    variables: ['company'],
+    hex: '3399DD',
+  },
+  {
+    name: 'candidate',
+    variables: ['candidate'],
+    hex: '44BB77',
+  },
+  {
+    name: 'opportunity',
+    variables: ['opportunity'],
+    hex: '662255',
+  },
+  {
+    name: 'job',
+    variables: ['job'],
+    hex: 'BB5566',
+  },
+  {
+    name: 'job code',
+    variables: ['jobCode'],
+    hex: '696D79',
+  },
+  {
+    name: 'earn code',
+    variables: ['earnCode'],
+    hex: '696D79',
+  },
+  {
+    name: 'submission',
+    variables: ['submission'],
+    hex: 'A9ADBB',
+  },
+  {
+    name: 'placement',
+    variables: ['placement'],
+    hex: '0B344F',
+  },
+  {
+    name: 'sendout',
+    variables: ['sendout'],
+    hex: '747884',
+  },
+  {
+    name: 'note',
+    variables: ['note'],
+    hex: '747884',
+  },
+  {
+    name: 'contract',
+    variables: ['contract'],
+    hex: '454EA0',
+  },
+  {
+    name: 'invoice statement',
+    variables: ['invoiceStatement'],
+    hex: '696D79',
+  },
+  {
+    name: 'billable charge',
+    variables: ['billableCharge'],
+    hex: '696D79',
+  },
+  {
+    name: 'payable charge',
+    variables: ['payableCharge'],
+    hex: '696D79',
+  },
+];
+
+export const analyticsColors: Array<any> = [
+  {
+    name: 'grapefruit',
+    variables: ['grapefruit'],
+    hex: 'DA4453',
+  },
+  {
+    name: 'bittersweet',
+    variables: ['bittersweet'],
+    hex: 'EB6845',
+  },
+  {
+    name: 'sunflower',
+    variables: ['sunflower'],
+    hex: 'F6B042',
+  },
+  {
+    name: 'grass',
+    variables: ['grass'],
+    hex: '8CC152',
+  },
+  {
+    name: 'mint',
+    variables: ['mint'],
+    hex: '37BC9B',
+  },
+  {
+    name: 'aqua',
+    variables: ['aqua'],
+    hex: '3BAFDA',
+  },
+  {
+    name: 'ocean',
+    variables: ['ocean'],
+    hex: '4A89DC',
+  },
+  {
+    name: 'carnation',
+    variables: ['carnation'],
+    hex: 'D770AD',
+  },
+  {
+    name: 'lavender',
+    variables: ['lavender'],
+    hex: '967ADC',
+  },
+  {
+    name: 'mountain',
+    variables: ['mountain'],
+    hex: '9678B6',
+  },
+];
+
+export const allColors: Array<any> = [...primaryColors, ...entityColors, ...analyticsColors];

--- a/projects/novo-examples/src/design/colors/entity-colors/entity-colors-example.ts
+++ b/projects/novo-examples/src/design/colors/entity-colors/entity-colors-example.ts
@@ -2,6 +2,8 @@
 import { Component } from '@angular/core';
 // Vendor
 import { NovoToastService } from 'novo-elements';
+// App
+import { entityColors as colors } from '../colors';
 
 /**
  * @title Entity Colors
@@ -12,89 +14,7 @@ import { NovoToastService } from 'novo-elements';
   styleUrls: ['./entity-colors-example.scss'],
 })
 export class EntityColorsExample {
-  entityColors: Array<any> = [
-    {
-      name: 'lead',
-      variables: ['lead'],
-      hex: 'AA6699',
-    },
-    {
-      name: 'contact',
-      variables: ['contact'],
-      hex: 'FFAA44',
-    },
-    {
-      name: 'company',
-      variables: ['company'],
-      hex: '3399DD',
-    },
-    {
-      name: 'candidate',
-      variables: ['candidate'],
-      hex: '44BB77',
-    },
-    {
-      name: 'opportunity',
-      variables: ['opportunity'],
-      hex: '662255',
-    },
-    {
-      name: 'job',
-      variables: ['job'],
-      hex: 'BB5566',
-    },
-    {
-      name: 'job code',
-      variables: ['jobCode'],
-      hex: '696D79',
-    },
-    {
-      name: 'earn code',
-      variables: ['earnCode'],
-      hex: '696D79',
-    },
-    {
-      name: 'submission',
-      variables: ['submission'],
-      hex: 'A9ADBB',
-    },
-    {
-      name: 'placement',
-      variables: ['placement'],
-      hex: '0B344F',
-    },
-    {
-      name: 'sendout',
-      variables: ['sendout'],
-      hex: '747884',
-    },
-    {
-      name: 'note',
-      variables: ['note'],
-      hex: '747884',
-    },
-    {
-      name: 'contract',
-      variables: ['contract'],
-      hex: '454EA0',
-    },
-    {
-      name: 'invoice statement',
-      variables: ['invoiceStatement'],
-      hex: '696D79',
-    },
-    {
-      name: 'billable charge',
-      variables: ['billableCharge'],
-      hex: '696D79',
-    },
-    {
-      name: 'payable charge',
-      variables: ['payableCharge'],
-      hex: '696D79',
-    },
-  ];
-
+  entityColors = colors;
   options: any;
 
   constructor(private toaster: NovoToastService) {}

--- a/projects/novo-examples/src/design/colors/index.ts
+++ b/projects/novo-examples/src/design/colors/index.ts
@@ -1,3 +1,4 @@
 export * from './analytics-colors';
 export * from './entity-colors';
 export * from './primary-colors';
+export * from './colors';

--- a/projects/novo-examples/src/design/colors/primary-colors/primary-colors-example.ts
+++ b/projects/novo-examples/src/design/colors/primary-colors/primary-colors-example.ts
@@ -2,6 +2,8 @@
 import { Component } from '@angular/core';
 // Vendor
 import { NovoToastService } from 'novo-elements';
+// App
+import { primaryColors as colors } from '../colors';
 
 /**
  * @title Primary Colors
@@ -12,88 +14,7 @@ import { NovoToastService } from 'novo-elements';
   styleUrls: ['./primary-colors-example.scss'],
 })
 export class PrimaryColorsExample {
-  primaryColors: Array<any> = [
-    {
-      name: 'navigation',
-      variables: ['navigation'],
-      hex: '202945',
-    },
-    {
-      name: 'positive',
-      variables: ['positive'],
-      hex: '4A89DC',
-    },
-    {
-      name: 'dark',
-      variables: ['dark'],
-      hex: '3D464D',
-    },
-    {
-      name: 'background',
-      variables: ['background'],
-      hex: 'F4F4F4',
-    },
-    {
-      name: 'background dark',
-      variables: ['background-dark'],
-      hex: 'E2E2E2',
-    },
-    {
-      name: 'neutral',
-      variables: ['neutral'],
-      hex: '4F5361',
-    },
-    {
-      name: 'success',
-      variables: ['success'],
-      hex: '8CC152',
-    },
-    {
-      name: 'negative',
-      variables: ['negative'],
-      hex: 'DA4453',
-    },
-    {
-      name: 'warning',
-      variables: ['warning'],
-      hex: 'F6B042',
-    },
-    {
-      name: 'empty',
-      variables: ['empty'],
-      hex: 'CCCDCC',
-    },
-    {
-      name: 'sand',
-      variables: ['sand'],
-      hex: 'F4F4F4',
-    },
-    {
-      name: 'silver',
-      variables: ['silver'],
-      hex: 'E2E2E2',
-    },
-    {
-      name: 'stone',
-      variables: ['stone'],
-      hex: 'BEBEBE',
-    },
-    {
-      name: 'ash',
-      variables: ['ash'],
-      hex: 'A0A0A0',
-    },
-    {
-      name: 'slate',
-      variables: ['slate'],
-      hex: '707070',
-    },
-    {
-      name: 'charcoal',
-      variables: ['charcoal'],
-      hex: '282828',
-    },
-  ];
+  primaryColors = colors;
   options: any;
 
   constructor(private toaster: NovoToastService) {}

--- a/projects/novo-examples/src/form-controls/tiles/tiles-usage/tiles-usage-example.html
+++ b/projects/novo-examples/src/form-controls/tiles/tiles-usage/tiles-usage-example.html
@@ -1,12 +1,31 @@
-<novo-tiles [options]="demoTiles" (onChange)="colorSelect($event)" [(ngModel)]="value"
-  (onDisabledOptionClick)="disabledClicked($event)"
-  (onSelectedOptionClick)="selectedClicked($event)"></novo-tiles>
+Default:
+<br />
+<novo-tiles
+  [options]="demoTilesDefault"
+  (onChange)="select('Default', $event)"
+  [(ngModel)]="valueDefault" />
 <hr />
-<button theme="primary" type="button" name="button" (click)="toggleShown()">Show Tiles</button>
-<button theme="primary" type="button" name="button" (click)="addTile()">Add Tile</button>
+Icons:
 <br />
+<novo-tiles
+  [options]="demoTilesIcons"
+  (onChange)="select('Icons', $event)"
+  [(ngModel)]="valueIcons" />
+<hr />
+Disabled:
 <br />
-<novo-tiles *ngIf="shown" [options]="demoTiles" (onChange)="colorSelect($event)" [(ngModel)]="value"></novo-tiles>
-
-You have picked (output): <strong>{{ currentColor || 'No selection' }}</strong>
-You have picked (ngModel): <strong>{{ value || 'No selection' }}</strong>
+<novo-tiles disabled
+  [options]="demoTilesDisabled"
+  (onChange)="select('Disabled', $event)"
+  [(ngModel)]="valueDisabled" />
+<hr />
+Custom Colors:
+<br />
+<novo-tiles
+  [options]="demoTilesColor"
+  (onChange)="select('Color', $event)"
+  [(ngModel)]="valueColor" />
+<novo-row gap="md" justify="end">
+    <button theme="primary" type="button" name="addButton" (click)="addTile()">Add Tile</button>
+    <button theme="secondary" type="button" name="resetButton" (click)="resetTiles()">Reset</button>
+</novo-row>

--- a/projects/novo-examples/src/form-controls/tiles/tiles-usage/tiles-usage-example.ts
+++ b/projects/novo-examples/src/form-controls/tiles/tiles-usage/tiles-usage-example.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { allColors } from '../../../design';
 
 /**
  * @title Tiles Usage Example
@@ -9,46 +10,73 @@ import { Component } from '@angular/core';
   styleUrls: ['tiles-usage-example.css'],
 })
 export class TilesUsageExample {
-  public shown: boolean = false;
-  public demoTiles: Array<any> = [
+  public demoTilesDefault: Array<any> = [
     {
-      label: 'Red',
-      value: 'red',
+      label: 'Yes',
+      value: 'yes',
     },
     {
-      label: 'Green',
-      value: 'green',
+      label: 'No',
+      value: 'no',
     },
     {
-      label: 'Disabled',
-      value: 'disabled',
+      label: 'Maybe',
+      value: 'maybe',
       disabled: true,
     },
   ];
-  public currentColor: string;
-  public value: string = 'red';
+  public valueDefault: string = 'yes';
 
-  colorSelect(newColorValue) {
-    this.currentColor = newColorValue;
-  }
+  public demoTilesIcons: Array<any> = [
+    {
+      label: 'Include',
+      value: 'include',
+      icon: 'check',
+    },
+    {
+      label: 'Exclude',
+      value: 'exclude',
+      icon: 'exclude',
+    },
+  ];
+  public valueIcons: string = 'exclude';
 
-  disabledClicked(tile) {
-    console.log('Disabled tile clicked: ', tile); // tslint:disable-line
-  }
+  public demoTilesDisabled: Array<any> = [...this.demoTilesDefault];
+  public valueDisabled: string = 'yes';
 
-  selectedClicked(tile) {
-    console.log('Selected tile clicked: ', tile); // tslint:disable-line
-  }
+  public demoTilesColor: Array<any> = [
+    {
+      label: 'Good',
+      value: 'good',
+      color: 'success',
+    },
+    {
+      label: 'Bad',
+      value: 'bad',
+      color: 'negative',
+    },
+  ];
+  public valueColor: string = 'good';
 
-  toggleShown() {
-    this.shown = !this.shown;
+  addedTiles = 0;
+
+  select(demo: string, newValue) {
+    this[`current${demo}`] = newValue;
   }
 
   addTile() {
-    this.demoTiles.push({
-      label: 'Blue',
-      value: 'blue',
+    const randomColor = allColors[allColors.length * Math.random() | 0];
+    this.demoTilesColor.push({
+      label: randomColor.name.charAt(0).toUpperCase() + randomColor.name.slice(1),
+      value: randomColor.variables[0] + this.addedTiles,
+      color: randomColor.variables[0],
     });
-    this.demoTiles = [...this.demoTiles];
+    this.addedTiles++;
+    this.demoTilesColor = [...this.demoTilesColor];
+  }
+
+  resetTiles() {
+    this.demoTilesColor.length = 2;
+    this.demoTilesColor = [...this.demoTilesColor];
   }
 }


### PR DESCRIPTION
## **Description**

feat(Tiles): restyling the novo-tiles component to be more legible #1590
fix(ConditionBuilder): When swapping between similar operators, preserve value #1589
fix(types): Update keyword types #1591
feat(QueryBuilder): adding new 'multiple scope' concept to criteria builder #1592
feat(SwitchControl): add change propogation to Switch Control Template #1593
feat(AddressDef): adding some additional properties to the address obj we set in the query builder #1596
fix(Tooltip): Add closeOnClick input to pass to Tooltip #1598
fix(types): Update autobuild types #1600
chore(deps): bump serve-static and express #1602
chore(deps): bump send and express #1603
fix(Types): Add scoreByEntityId to the DataTableWhere type #1607

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**