### PR TITLE
fix(types): Update keyword types

### DIFF
--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -13,8 +13,8 @@ export interface IDataTablePreferences {
   savedSearchName?: string;
   savedSearchOwner?: DataTableSavedSearchOwner;
   appliedSearchType?: AppliedSearchType;
-  autoBuildEntityId?: number;
-  autoBuildEntityData?: any;
+  autobuildEntityId?: number;
+  autobuildEntityData?: any;
   hasUnsavedChanges?: boolean;
   unsavedChanges?: any;
 }

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -9,6 +9,7 @@ export interface IDataTablePreferences {
   pageSize?: number;
   displayedColumns?: string[];
   columnWidths?: { id: string; width: number }[];
+  autoBuildEntityId?: number;
   savedSearchId?: number;
   savedSearchName?: string;
   savedSearchOwner?: DataTableSavedSearchOwner;

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -282,11 +282,12 @@ export interface IKeyword {
 export interface IKeywordGroup {
   id: number;
   name: string;
+  uniqueName?: string;
   keywords: IKeyword[];
 }
 
 export interface IKeywordBlock {
-  exclude: boolean;
+  exclude?: boolean;
   keywordGroups: IKeywordGroup[];
 }
 

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -9,11 +9,12 @@ export interface IDataTablePreferences {
   pageSize?: number;
   displayedColumns?: string[];
   columnWidths?: { id: string; width: number }[];
-  autoBuildEntityId?: number;
   savedSearchId?: number;
   savedSearchName?: string;
   savedSearchOwner?: DataTableSavedSearchOwner;
   appliedSearchType?: AppliedSearchType;
+  autoBuildEntityId?: number;
+  autoBuildEntityData?: any;
   hasUnsavedChanges?: boolean;
   unsavedChanges?: any;
 }


### PR DESCRIPTION
## **Description**

Updating the types to include the new optional "uniqueName" and making the exclude optional, which is backwards compatible and safe because testing exclude using a falsy check will work for "false" or "undefined" or "null". The exclude is not guaranteed to be there if the data is coming in from an outside call. Likewise, uniqueName is not guaranteed from the outside call yet, but should be there going forward, so optional for now.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**