### PR TITLE
feat(AddressDef): adding some additional properties to the address obj we set in the query builder

### DIFF
--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
@@ -184,7 +184,9 @@ export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef im
       address_components: event.address_components,
       formatted_address: event.formatted_address,
       geometry: event.geometry,
+      name: event.name,
       place_id: event.place_id,
+      types: event.types,
     };
     const current: AddressData | AddressData[] = this.getValue(formGroup);
     const updated: AddressData[] = Array.isArray(current) ? [...current, valueToAdd] : [valueToAdd];

--- a/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
@@ -81,8 +81,10 @@ export interface AddressData {
   address_components: AddressComponent[];
   formatted_address: string;
   geometry: AddressGeometry;
+  name?: string;
   place_id: string;
   radius?: AddressRadius;
+  types?: string[];
 }
 
 export interface AddressRadius {


### PR DESCRIPTION
## **Description**

we needed a couple of additional properties (name, types) from the google places API response in our implementation of the query builder, so i added them here and made them optional to retain backwards compatibility.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**