### PR TITLE
fix(Tooltip): Add closeOnClick input to pass to Tooltip

### DIFF
--- a/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
@@ -38,6 +38,8 @@ export class TooltipDirective implements OnDestroy, OnInit {
   autoPosition: boolean = true;
   @Input('tooltipIsHTML')
   isHTML: boolean;
+  @Input('tooltipCloseOnClick')
+  closeOnClick: boolean;
 
   private tooltipInstance: NovoTooltip | null;
   private portal: ComponentPortal<NovoTooltip>;
@@ -66,6 +68,14 @@ export class TooltipDirective implements OnDestroy, OnInit {
   @HostListener('mouseleave')
   onMouseLeave(): void {
     if (this.overlayRef && !this.always) {
+      this.hide();
+      this.overlayRef.dispose();
+    }
+  }
+
+  @HostListener('click')
+  onclick(): void {
+    if (this.overlayRef && !this.always && this.closeOnClick) {
       this.hide();
       this.overlayRef.dispose();
     }

--- a/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
@@ -39,7 +39,7 @@ export class TooltipDirective implements OnDestroy, OnInit {
   @Input('tooltipIsHTML')
   isHTML: boolean;
   @Input('tooltipCloseOnClick')
-  closeOnClick: boolean;
+  closeOnClick: boolean = false;
 
   private tooltipInstance: NovoTooltip | null;
   private portal: ComponentPortal<NovoTooltip>;

--- a/projects/novo-elements/src/elements/tooltip/Tooltip.spec.ts
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.spec.ts
@@ -4,16 +4,19 @@ import { Component } from '@angular/core';
 import { async, TestBed } from '@angular/core/testing';
 // App
 import { TooltipDirective } from './Tooltip.directive';
+import { By } from '@angular/platform-browser';
 
 @Component({
   selector: 'test-component',
-  template: `<div tooltip="test" tooltipPosition="right"></div>`,
+  template: `<div tooltip="test" tooltipPosition="right"></div>
+             <div tooltip="test" [tooltipCloseOnClick]="true" tooltipPosition="right"></div>`,
 })
 class TestComponent {}
 
 describe('Elements: TooltipDirective', () => {
   let fixture;
   let component;
+  let tooltipHost;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -22,9 +25,31 @@ describe('Elements: TooltipDirective', () => {
     }).compileComponents();
     fixture = TestBed.createComponent(TestComponent);
     component = fixture.debugElement.componentInstance;
+    tooltipHost = fixture.debugElement.queryAll(By.directive(TooltipDirective))
   }));
 
   it('should initialize with defaults', () => {
     expect(component).toBeDefined();
   });
+
+  describe('function: onclick', () => {
+    it('should not close tooltip on click', async() => {
+      tooltipHost[0].triggerEventHandler('mouseenter');
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('novo-tooltip'))).toBeTruthy();
+      tooltipHost[0].triggerEventHandler('click');
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('novo-tooltip'))).toBeTruthy();
+    });
+
+    it('should close tooltip on click', async() => {
+      tooltipHost[1].triggerEventHandler('mouseenter');
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('novo-tooltip'))).toBeTruthy();
+      tooltipHost[1].triggerEventHandler('click')
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('novo-tooltip'))).toBeFalsy();
+    });
+  });
+
 });


### PR DESCRIPTION
## **Description**

added a new input closeOnClick and a close event which is executed if closeOnClick is true

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**