### PR TITLE
fix(QueryBuilder): Prevent a logic error normalizing dates

### DIFF
--- a/projects/novo-elements/src/elements/field/formats/date-range-format.ts
+++ b/projects/novo-elements/src/elements/field/formats/date-range-format.ts
@@ -95,7 +95,7 @@ export class NovoDateRangeFormatDirective extends IMaskDirective<any> {
 
   normalize(value: string | Date) {
     const pattern = this.labels.dateFormat.toUpperCase();
-    return DateUtil.format(DateUtil.parse(value), pattern);
+    return DateUtil.format(value ? DateUtil.parse(value) : null, pattern);
   }
 
   formatAsIso(value: DateRange): string {
@@ -125,6 +125,13 @@ export class NovoDateRangeFormatDirective extends IMaskDirective<any> {
   }
 
   writeValue(value: any) {
+    if (this['_initialValue'] && value === this['_initialValue']) {
+      // if this call is coming from the super class, skip through.
+      // If we ever wanted to reduce the need for this hack/workaround, we could refactor
+      // IMaskDirective to exist as a child portion of DateRangeFormatDirective.
+      super.writeValue(value);
+      return;
+    }
     const formattedValue = this.formatValue(value);
     if (formattedValue !== this.maskValue) {
       super.writeValue(this.formatValue(value));

--- a/projects/novo-elements/src/elements/field/formats/date-time-format.spec.ts
+++ b/projects/novo-elements/src/elements/field/formats/date-time-format.spec.ts
@@ -1,0 +1,67 @@
+import { Component, DebugElement, ElementRef, inject, Renderer2 } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { NovoDateTimeFormatDirective } from './date-time-format';
+import { NovoLabelService } from 'novo-elements/services';
+import { DateLike } from 'novo-elements/utils';
+import { ControlValueAccessor, FormControl, FormsModule } from '@angular/forms';
+import { ReactiveFormsModule } from '@angular/forms';
+
+jest.mock('angular-imask', () => {
+    return {
+        IMaskDirective: class implements ControlValueAccessor {
+            renderer = inject(Renderer2);
+            element = inject(ElementRef);
+            writeValue(val) {
+                this.renderer.setProperty(this.element.nativeElement, 'value', val || '');
+            }
+            registerOnChange(fn: any): void {}
+            registerOnTouched(fn: any): void {}
+        }
+    };
+});
+
+@Component({
+    selector: 'test-datetime-format',
+    template: `<input [formControl]="testControl" dateTimeFormat="iso8601">`,
+})
+class DateFormatTestComponent {
+    testControl = new FormControl<DateLike>(new Date());
+}
+
+describe('NovoDateTimeFormatDirective', () => {
+    let fixture: ComponentFixture<DateFormatTestComponent>;
+    let dbgDirective: DebugElement;
+    let directive: NovoDateTimeFormatDirective;
+    let input: HTMLInputElement;
+
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            declarations: [NovoDateTimeFormatDirective, DateFormatTestComponent],
+            imports: [ FormsModule, ReactiveFormsModule ],
+            providers: [ NovoLabelService ]
+        }).compileComponents();
+        fixture = TestBed.createComponent(DateFormatTestComponent);
+        
+    }));
+
+    beforeEach(() => {
+        fixture.detectChanges();
+        dbgDirective = fixture.debugElement.query(By.directive(NovoDateTimeFormatDirective));
+        directive = dbgDirective.injector.get(NovoDateTimeFormatDirective);
+        input = fixture.debugElement.query(By.css('input')).nativeElement;
+    });
+
+    it('should format date/time', () => {
+        fixture.componentInstance.testControl.setValue('January 4, 2022 11:30:00');
+        fixture.detectChanges();
+        expect(input.value).toEqual('01/04/2022, 11:30 AM');
+    });
+
+    it('should safely handle receiving a blank value', () => {
+        fixture.componentInstance.testControl.setValue('');
+        fixture.detectChanges();
+        expect(input.value).toEqual('');
+    });
+});

--- a/projects/novo-elements/src/elements/field/formats/date-time-format.ts
+++ b/projects/novo-elements/src/elements/field/formats/date-time-format.ts
@@ -177,7 +177,7 @@ export class NovoDateTimeFormatDirective extends IMaskDirective<any> implements 
 
   normalize(value: string) {
     const pattern = this.labels.dateFormat.toUpperCase();
-    return DateUtil.format(DateUtil.parse(value), pattern);
+    return DateUtil.format(value ? DateUtil.parse(value) : null, pattern);
   }
 
   formatAsIso(date: Date): string {


### PR DESCRIPTION
## **Description**

This format code is called when clearing values from inputs, which leads to an error when formatting "" that prevents some other logic.
Unit tests pending...

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**