### PR TITLE
fix(types): Update autobuild types

### DIFF
--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -13,10 +13,15 @@ export interface IDataTablePreferences {
   savedSearchName?: string;
   savedSearchOwner?: DataTableSavedSearchOwner;
   appliedSearchType?: AppliedSearchType;
-  autobuildEntityId?: number;
-  autobuildEntityData?: any;
+  autobuildEntity?: AutobuildEntityData;
   hasUnsavedChanges?: boolean;
   unsavedChanges?: any;
+}
+
+export interface AutobuildEntityData {
+  id: number;
+  searchEntity: string;
+  [key: string]: any;
 }
 
 export interface DataTableWhere {


### PR DESCRIPTION
## **Description**

Clean up and simplify the types that were added for autobuild saved searches, before we release the feature to production.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**