### PR TITLE
feat(Criteria Builder): Add reset values method

### DIFF
--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -13,10 +13,15 @@ export interface IDataTablePreferences {
   savedSearchName?: string;
   savedSearchOwner?: DataTableSavedSearchOwner;
   appliedSearchType?: AppliedSearchType;
-  autobuildEntityId?: number;
-  autobuildEntityData?: any;
+  autobuildEntity?: AutobuildEntityData;
   hasUnsavedChanges?: boolean;
   unsavedChanges?: any;
+}
+
+export interface AutobuildEntityData {
+  id: number;
+  searchEntity: string;
+  [key: string]: any;
 }
 
 export interface DataTableWhere {

--- a/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.ts
@@ -24,7 +24,15 @@ import { ConditionGroupComponent } from '../condition-group/condition-group.comp
 import { NovoConditionFieldDef } from '../query-builder.directives';
 import { QueryBuilderService } from '../query-builder.service';
 import { NOVO_CRITERIA_BUILDER } from '../query-builder.tokens';
-import { BaseFieldDef, Condition, ConditionGroup, Conjunction, AddressCriteriaConfig } from '../query-builder.types';
+import {
+  BaseFieldDef,
+  Condition,
+  ConditionGroup,
+  Conjunction,
+  AddressCriteriaConfig,
+  ConditionOrConditionGroup,
+  NestedConditionGroup
+} from '../query-builder.types';
 
 const EMPTY_CONDITION: Condition = {
   conditionType: '$and',
@@ -234,6 +242,34 @@ export class CriteriaBuilderComponent implements OnInit, OnDestroy, AfterContent
       group.addCondition(condition);
     } else {
       this.addConditionGroup({ $and: [condition] })
+    }
+  }
+
+  resetValues() {
+    for (const conditionOrGroup of this.root?.value as ConditionOrConditionGroup[]) {
+      this.resetValuesRecursively(conditionOrGroup);
+    }
+  }
+
+  private resetValuesRecursively(conditionOrGroup: ConditionOrConditionGroup) {
+    if (this.isConditionGroup(conditionOrGroup)) {
+      if (conditionOrGroup.$and?.length) {
+        for (const condition of conditionOrGroup.$and) {
+          this.resetValuesRecursively(condition);
+        }
+      }
+      if (conditionOrGroup.$or?.length) {
+        for (const condition of conditionOrGroup.$or) {
+          this.resetValuesRecursively(condition);
+        }
+      }
+      if (conditionOrGroup.$not?.length) {
+        for (const condition of conditionOrGroup.$not) {
+          this.resetValuesRecursively(condition);
+        }
+      }
+    } else if (conditionOrGroup.hasOwnProperty('value')) {
+      (conditionOrGroup as Condition).value = null;
     }
   }
 

--- a/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.html
+++ b/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.html
@@ -15,6 +15,7 @@
     <button theme="primary" size="sm" *ngIf="!useNoteMeta" (click)="builder.addConditionGroup()">Add a group</button>
     <button theme="secondary" size="sm" (click)="resetGroups()">Reset</button>
     <button theme="secondary" size="sm" (click)="resetQueryForm(useNoteMeta)">Repopulate</button>
+    <button theme="dialog" size="sm" (click)="resetValues()">Reset Values</button>
   </novo-row>
 </form>
 

--- a/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.ts
+++ b/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.ts
@@ -211,6 +211,10 @@ export class JustCriteriaExample implements OnInit {
     this.prepopulateForm(addAdditionalScope);
   }
 
+  resetValues() {
+    this.criteriaBuilder().resetValues();
+  }
+
   setQueryForm(criteria?) {
     this.queryForm.setValue({ criteria });
   }


### PR DESCRIPTION
## **Description**

Added a new method to the criteria builder to reset all of the values without clearing the form.

![image](https://github.com/user-attachments/assets/373f6a89-6b67-4176-ad86-63faf1845f50)


#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**