### PR TITLE
fix(data-table-clear-button): convert emitOnly BooleanInput to Input

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table-clear-button.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table-clear-button.component.ts
@@ -1,7 +1,6 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Output } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Output, Input } from '@angular/core';
 import { NovoLabelService } from 'novo-elements/services';
 import { DataTableState } from './state/data-table-state.service';
-import { BooleanInput } from 'novo-elements/utils';
 
 @Component({
   selector: 'novo-data-table-clear-button',
@@ -45,7 +44,7 @@ export class NovoDataTableClearButton<T> {
   queryClear: EventEmitter<boolean> = new EventEmitter();
   @Output()
   allClear: EventEmitter<boolean> = new EventEmitter();
-  @BooleanInput()
+  @Input()
   emitOnly: boolean = false;
 
   constructor(public state: DataTableState<T>, private ref: ChangeDetectorRef, public labels: NovoLabelService) { }


### PR DESCRIPTION
## **Description**

`@BooleanInput` (a NovoElements utility) was not working as expected in the data-table-clear-button. Switched back to `@Input()`.


#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**