### PR TITLE
fix(TabbedGroupPicker): adjusting indentation on groups

### DIFF
--- a/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.scss
+++ b/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.scss
@@ -127,7 +127,7 @@
           .quick-select-list {
             .quick-select-item {
               background: lighten($light, 10%);
-              padding: 0.5em 1.75em;
+              padding: 0.5em 0.8em;
               border-bottom: none;
             }
           }


### PR DESCRIPTION
## **Description**

the groups in the Tabbed Group Picker were indented farther than the nested items they contained, so the hierarchy looked a bit off. this PR gives the groups less indentation.

![Screenshot 2024-09-17 150326](https://github.com/user-attachments/assets/6d633189-960e-40aa-90e7-ad0dce6c2112)

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**