### PR TITLE
feat(Picker): Add Optional Keyboard Nav Logic

### DIFF
--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -252,8 +252,8 @@ export class NovoPickerElement implements OnInit {
     }
 
     if (this.allowTabNavigation && event.key === Key.Tab) {
+      this.closePanel();
       this.tab.emit();
-      return;
     }
   }
 

--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -118,6 +118,8 @@ export class NovoPickerElement implements OnInit {
   width: string;
   @Input()
   minWidth: string;
+  @Input()
+  allowTabNavigation: boolean = false;
 
   // Disable from typing into the picker (result template does everything)
   @Input()
@@ -142,6 +144,8 @@ export class NovoPickerElement implements OnInit {
   blur: EventEmitter<any> = new EventEmitter();
   @Output()
   typing: EventEmitter<any> = new EventEmitter();
+  @Output()
+  tab: EventEmitter<any> = new EventEmitter();
 
   @ViewChild(NovoOverlayTemplateComponent, { static: true })
   public container: NovoOverlayTemplateComponent;
@@ -212,8 +216,13 @@ export class NovoPickerElement implements OnInit {
       return;
     }
     if (this.panelOpen && !this.disablePickerInput) {
-      if (event.key === Key.Escape || event.key === Key.Tab) {
+      if (event.key === Key.Escape || (event.key === Key.Tab && !this.allowTabNavigation)) {
         this.hideResults();
+        return;
+      }
+
+      if (this.allowTabNavigation && event.key === Key.Tab) {
+        this.tab.emit();
         return;
       }
 

--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -221,11 +221,6 @@ export class NovoPickerElement implements OnInit {
         return;
       }
 
-      if (this.allowTabNavigation && event.key === Key.Tab) {
-        this.tab.emit();
-        return;
-      }
-
       if (event.key === Key.ArrowUp) {
         this.popup.instance.prevActiveMatch();
         this.ref.markForCheck();
@@ -254,6 +249,11 @@ export class NovoPickerElement implements OnInit {
       if (event.key === Key.Delete && Helpers.isBlank(this._value)) {
         this.clearValue(true);
       }
+    }
+
+    if (this.allowTabNavigation && event.key === Key.Tab) {
+      this.tab.emit();
+      return;
     }
   }
 


### PR DESCRIPTION
## **Description**

Added logic for tab output for the Picker component, it will be used for keyboard navigation in adjustments, it is turned off by default.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**