### PR TITLE
feat(input): remove checkbox input type limitation

### DIFF
--- a/projects/novo-elements/src/elements/field/input.ts
+++ b/projects/novo-elements/src/elements/field/input.ts
@@ -38,7 +38,7 @@ import { NovoFieldControl } from './field-control';
 export const NOVO_INPUT_VALUE_ACCESSOR = new InjectionToken<{ value: any }>('NOVO_INPUT_VALUE_ACCESSOR');
 
 // Invalid input type. Using one of these will throw an NovoInputUnsupportedTypeError.
-const NOVO_INPUT_INVALID_TYPES = ['button', 'checkbox', 'file', 'hidden', 'image', 'radio', 'reset', 'submit'];
+const NOVO_INPUT_INVALID_TYPES = ['button', 'file', 'hidden', 'image', 'radio', 'reset', 'submit'];
 
 let nextUniqueId = 0;
 


### PR DESCRIPTION
## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**