### PR TITLE
fix(NovoDataTablePagination): updating displayed pages when setting page

### DIFF
--- a/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.spec.ts
+++ b/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.spec.ts
@@ -24,6 +24,26 @@ describe('Elements: NovoDataTablePagination', () => {
     component = fixture.debugElement.componentInstance;
   }));
 
+  fdescribe('Setter: set page()', () => {
+    beforeEach(() => {
+      component.pageSize = 25;
+      component.length = 500;
+      component.ngOnInit();
+      spyOn(component, 'updateDisplayedPageSizeOptions').and.callThrough();
+    });
+    it('should set displayed pages via updateDisplayedPageSizeOptions function', () => {
+      component.selectPage(10);
+      expect(component.page).toEqual(10);
+      const actualDisplayedPageNumbers1 = component.pages.map((page) => page.number);
+      expect(actualDisplayedPageNumbers1).toEqual([8, 9, 10, 11, 12]);
+      component.page = 1;
+      expect(component.page).toEqual(1);
+      const actualDisplayedPageNumbers2 = component.pages.map((page) => page.number);
+      expect(component.updateDisplayedPageSizeOptions).toHaveBeenCalled();
+      expect(actualDisplayedPageNumbers2).toEqual([1, 2, 3, 4, 5]);
+    });
+  });
+
   describe('Method: selectPage()', () => {
     beforeEach(() => {
       spyOn(component.state, 'checkRetainment');

--- a/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.spec.ts
+++ b/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.spec.ts
@@ -24,7 +24,7 @@ describe('Elements: NovoDataTablePagination', () => {
     component = fixture.debugElement.componentInstance;
   }));
 
-  fdescribe('Setter: set page()', () => {
+  describe('Setter: set page()', () => {
     beforeEach(() => {
       component.pageSize = 25;
       component.length = 500;

--- a/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
+++ b/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
@@ -114,6 +114,7 @@ export class NovoDataTablePagination<T> implements OnInit, OnDestroy {
     this.longRangeLabel = this.labels.getRangeText(this.page, this.pageSize, this.length, false);
     this.shortRangeLabel = this.labels.getRangeText(this.page, this.pageSize, this.length, true);
     this.state.page = this._page;
+    this.updateDisplayedPageSizeOptions();
   }
   _page: number = 0;
 


### PR DESCRIPTION
## **Description**

when setting the page, we could be setting a page that is not in the currently displayed list of pages. ie when we apply a sort, we will set the page to the first page, but we may have done this while on the 10th page, making the displayed pages [8, 9, 10, 11, 12] which was causing an inconsistency with the 'displayed pages' and the currently displayed page. calling `updateDisplayedPageSizeOptions()` any time we set a page should solve this issue.

fixes #1297 

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**