### PR TITLE
test(ConditionBuilder): Added automation attributes to boolean condition selector

### DIFF
--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/boolean-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/boolean-condition.definition.ts
@@ -19,8 +19,8 @@ import { NovoLabelService } from 'novo-elements/services';
       </novo-field>
       <novo-field *novoConditionInputDef="let formGroup" [style.width.px]="125" [formGroup]="formGroup">
         <novo-radio-group formControlName="value">
-          <novo-radio [value]="true">{{ formGroup.value.operator === 'isNull' ? labels.yes : labels.true }}</novo-radio>
-          <novo-radio [value]="false">{{ formGroup.value.operator === 'isNull' ? labels.no : labels.false }}</novo-radio>
+          <novo-radio data-automation-value="true" [value]="true">{{ formGroup.value.operator === 'isNull' ? labels.yes : labels.true }}</novo-radio>
+          <novo-radio data-automation-value="false" [value]="false">{{ formGroup.value.operator === 'isNull' ? labels.no : labels.false }}</novo-radio>
         </novo-radio-group>
       </novo-field>
     </ng-container>

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
@@ -44,8 +44,8 @@ import { NovoLabelService } from 'novo-elements/services';
         </novo-field>
         <novo-field *novoSwitchCases="['isNull']">
           <novo-radio-group formControlName="value">
-            <novo-radio [value]="true">{{ labels.yes }}</novo-radio>
-            <novo-radio [value]="false">{{ labels.no }}</novo-radio>
+            <novo-radio data-automation-value="true" [value]="true">{{ labels.yes }}</novo-radio>
+            <novo-radio data-automation-value="false" [value]="false">{{ labels.no }}</novo-radio>
           </novo-radio-group>
         </novo-field>
       </ng-container>

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/date-time-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/date-time-condition.definition.ts
@@ -43,8 +43,8 @@ import { NovoLabelService } from 'novo-elements/services';
         </novo-field>
         <novo-field *novoSwitchCases="['isNull']">
           <novo-radio-group formControlName="value">
-            <novo-radio [value]="true">{{ labels.yes }}</novo-radio>
-            <novo-radio [value]="false">{{ labels.no }}</novo-radio>
+            <novo-radio data-automation-value="true" [value]="true">{{ labels.yes }}</novo-radio>
+            <novo-radio data-automation-value="false" [value]="false">{{ labels.no }}</novo-radio>
           </novo-radio-group>
         </novo-field>
       </ng-container>

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/number-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/number-condition.definition.ts
@@ -25,8 +25,8 @@ import { NovoLabelService } from 'novo-elements/services';
         </novo-field>
         <novo-field *novoSwitchCases="['isNull']">
           <novo-radio-group formControlName="value">
-            <novo-radio [value]="true">{{ labels.yes }}</novo-radio>
-            <novo-radio [value]="false">{{ labels.no }}</novo-radio>
+            <novo-radio data-automation-value="true" [value]="true">{{ labels.yes }}</novo-radio>
+            <novo-radio data-automation-value="false" [value]="false">{{ labels.no }}</novo-radio>
           </novo-radio-group>
         </novo-field>
       </ng-container>

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
@@ -29,8 +29,8 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
         </novo-field>
         <novo-field *novoSwitchCases="['isNull']">
           <novo-radio-group formControlName="value">
-            <novo-radio [value]="true">{{ labels.yes }}</novo-radio>
-            <novo-radio [value]="false">{{ labels.no }}</novo-radio>
+            <novo-radio data-automation-value="true" [value]="true">{{ labels.yes }}</novo-radio>
+            <novo-radio data-automation-value="false" [value]="false">{{ labels.no }}</novo-radio>
           </novo-radio-group>
         </novo-field>
       </ng-container>

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
@@ -41,8 +41,8 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
         </novo-field>
         <novo-field *novoSwitchCases="['isEmpty']">
           <novo-radio-group formControlName="value">
-            <novo-radio [value]="true">{{ labels.yes }}</novo-radio>
-            <novo-radio [value]="false">{{ labels.no }}</novo-radio>
+            <novo-radio data-automation-value="true" [value]="true">{{ labels.yes }}</novo-radio>
+            <novo-radio data-automation-value="false" [value]="false">{{ labels.no }}</novo-radio>
           </novo-radio-group>
         </novo-field>
       </ng-container>


### PR DESCRIPTION
## **Description**

It was difficult to reliably grab Yes/No/True/False values from the boolean condition selector when writing automation tests; in the DOM, the only indicator was the user label.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**