### PR TITLE
fix(Button): Set the native disabled attribute

### DIFF
--- a/projects/novo-elements/src/elements/button/Button.spec.ts
+++ b/projects/novo-elements/src/elements/button/Button.spec.ts
@@ -1,10 +1,12 @@
 // NG2
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 // APP
 import { NovoButtonElement } from './Button';
+import { Component, Input } from '@angular/core';
 
 describe('Elements: NovoButtonElement', () => {
-  let fixture;
+  let fixture: ComponentFixture<NovoButtonElement>;
   let component;
 
   beforeAll(() => {
@@ -20,5 +22,47 @@ describe('Elements: NovoButtonElement', () => {
 
   it('should be compiled', () => {
     expect(component).toBeDefined();
+  });
+
+  it('should not assign disabled attribute to self when registered as <novo-button>', () => {
+    fixture.componentRef.setInput('disabled', true);
+    fixture.detectChanges();
+    expect(fixture.debugElement.nativeElement.getAttribute('disabled')).toBe(null);
+  });
+});
+
+@Component({
+  template: '<button theme="dialogue" [disabled]="disableButton"></button>',
+  selector: 'test-button-component',
+})
+class TestButtonContainer {
+  @Input() disableButton = false;
+}
+
+describe('<button> with NovoButtonElement directive', () => {
+  let fixture: ComponentFixture<TestButtonContainer>;
+  let component;
+
+  beforeAll(() => {
+    TestBed.configureTestingModule({
+      declarations: [NovoButtonElement, TestButtonContainer],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestButtonContainer);
+    component = fixture.componentInstance;
+  });
+
+  it('should be compiled', () => {
+    fixture.detectChanges();
+    expect(component).toBeDefined();
+    expect(fixture.debugElement.query(By.directive(NovoButtonElement))).toBeTruthy();
+  });
+
+  it('should disable the element when the disabled property is specified', () => {
+    fixture.componentRef.setInput('disableButton', true);
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('button')).nativeElement.disabled).toBe(true);
   });
 });

--- a/projects/novo-elements/src/elements/button/Button.ts
+++ b/projects/novo-elements/src/elements/button/Button.ts
@@ -1,5 +1,5 @@
 // NG2
-import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, HostListener, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, HostListener, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { BooleanInput, Helpers, Key } from 'novo-elements/utils';
 
 @Component({
@@ -63,7 +63,7 @@ import { BooleanInput, Helpers, Key } from 'novo-elements/utils';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class NovoButtonElement {
+export class NovoButtonElement implements OnChanges {
   /**
    * The text color of the button. Should be used for Icon buttons. see theme.
    */
@@ -107,9 +107,18 @@ export class NovoButtonElement {
   @HostBinding('class.novo-button-disabled')
   disabled: boolean = false;
 
+  @HostBinding('attr.disabled')
+  disabledAttr: undefined | '' = undefined;
+
   private _icon: string;
 
   constructor(public element: ElementRef) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.disabled && this.element.nativeElement.tagName === 'BUTTON') {
+      this.disabledAttr = changes.disabled.currentValue ? '' : undefined;
+    }
+  }
 
   @HostListener('keydown', ['$event'])
   handleKeydown(event: KeyboardEvent) {


### PR DESCRIPTION
… events

## **Description**

When we set up a <button> element as a Button.ts component, we want to ensure the native disabled attribute is still set - as this is the best way of blocking keyboard tabbing access to the button.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**