### PR TITLE
feat(Tooltip): tooltipOnOverflow, proper reactive resizing enablement

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,8 @@
 import 'jest-preset-angular/setup-jest';
+// polyfill
+globalThis.ResizeObserver = globalThis.ResizeObserver ||
+    jest.fn().mockImplementation(() => ({
+        disconnect: jest.fn(),
+        observe: jest.fn(),
+        unobserve: jest.fn(),
+    }));

--- a/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
@@ -4,6 +4,7 @@ import { ComponentPortal } from '@angular/cdk/portal';
 import { AfterViewInit, Directive, ElementRef, HostListener, Input, OnDestroy, OnInit, ViewContainerRef } from '@angular/core';
 // APP
 import { NovoTooltip } from './Tooltip.component';
+import { BooleanInput } from 'novo-elements/utils';
 
 @Directive({
   selector: '[tooltip]',
@@ -40,8 +41,9 @@ export class TooltipDirective implements OnDestroy, OnInit, AfterViewInit {
   isHTML: boolean;
   @Input('tooltipCloseOnClick')
   closeOnClick: boolean = false;
+  @BooleanInput()
   @Input('tooltipOnOverflow')
-  overflow: boolean = false;
+  onOverflow: boolean = false;
 
   private tooltipInstance: NovoTooltip | null;
   private portal: ComponentPortal<NovoTooltip>;
@@ -91,7 +93,7 @@ export class TooltipDirective implements OnDestroy, OnInit, AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    if (this.overflow && this.elementRef?.nativeElement) {
+    if (this.onOverflow && this.elementRef?.nativeElement) {
       this._resizeObserver = new ResizeObserver(() => {
         const isOverflowing = this.elementRef.nativeElement.scrollWidth > this.elementRef.nativeElement.clientWidth;
         this.active = isOverflowing;

--- a/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
@@ -72,7 +72,7 @@ export class TooltipDirective implements OnDestroy, OnInit, AfterViewInit {
 
   @HostListener('mouseenter')
   onMouseEnter(): void {
-    if (this.tooltip && this.active && !this.always) {
+    if (this.tooltip && this._active() && !this.always) {
       this.show();
     }
   }

--- a/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
@@ -105,7 +105,7 @@ export class TooltipDirective implements OnDestroy, OnInit, AfterViewInit {
         const isOverflowing = this.elementRef.nativeElement.scrollWidth > this.elementRef.nativeElement.clientWidth;
         this._active.set(isOverflowing);
       });
-      this._resizeObserver.observe(this.elementRef.nativeElement);
+      this._resizeObserver?.observe(this.elementRef.nativeElement);
     }
   }
 

--- a/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
@@ -1,7 +1,7 @@
 // NG
 import { ConnectedPosition, FlexibleConnectedPositionStrategy, Overlay, OverlayConfig, OverlayRef } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
-import { AfterViewInit, Directive, ElementRef, HostListener, Input, OnDestroy, OnInit, ViewContainerRef } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, HostListener, Input, OnDestroy, OnInit, ViewContainerRef, signal } from '@angular/core';
 // APP
 import { NovoTooltip } from './Tooltip.component';
 import { BooleanInput } from 'novo-elements/utils';
@@ -29,8 +29,6 @@ export class TooltipDirective implements OnDestroy, OnInit, AfterViewInit {
   rounded: boolean;
   @Input('tooltipAlways')
   always: boolean;
-  @Input('tooltipActive')
-  active: boolean = true;
   @Input('tooltipPreline')
   preline: boolean;
   @Input('removeTooltipArrow')
@@ -44,6 +42,15 @@ export class TooltipDirective implements OnDestroy, OnInit, AfterViewInit {
   @BooleanInput()
   @Input('tooltipOnOverflow')
   onOverflow: boolean = false;
+
+  private _active = signal<boolean>(true);
+  @Input('tooltipActive')
+  set active(value: boolean) {
+    this._active.set(value);
+  }
+  get active(): boolean {
+    return this._active();
+  }
 
   private tooltipInstance: NovoTooltip | null;
   private portal: ComponentPortal<NovoTooltip>;
@@ -96,7 +103,7 @@ export class TooltipDirective implements OnDestroy, OnInit, AfterViewInit {
     if (this.onOverflow && this.elementRef?.nativeElement) {
       this._resizeObserver = new ResizeObserver(() => {
         const isOverflowing = this.elementRef.nativeElement.scrollWidth > this.elementRef.nativeElement.clientWidth;
-        this.active = isOverflowing;
+        this._active.set(isOverflowing);
       });
       this._resizeObserver.observe(this.elementRef.nativeElement);
     }

--- a/projects/novo-examples/src/components/tooltip/tooltip-examples.md
+++ b/projects/novo-examples/src/components/tooltip/tooltip-examples.md
@@ -28,3 +28,7 @@ order: 4
 ## Toggle Trigger
 
 <code-example example="tooltip-toggle"></code-example>
+
+## Overflow
+
+<code-example example="tooltip-overflow"></code-example>

--- a/projects/novo-examples/src/components/tooltip/tooltip-overflow/index.ts
+++ b/projects/novo-examples/src/components/tooltip/tooltip-overflow/index.ts
@@ -1,0 +1,1 @@
+export * from './tooltip-overflow-example';

--- a/projects/novo-examples/src/components/tooltip/tooltip-overflow/tooltip-overflow-example.css
+++ b/projects/novo-examples/src/components/tooltip/tooltip-overflow/tooltip-overflow-example.css
@@ -1,0 +1,55 @@
+/** CSS for this example */
+:host {
+  margin: auto;
+  padding: 20px 30px;
+  position: relative;
+  display: flex;
+}
+
+:host > span {
+  cursor: pointer;
+  margin: auto;
+}
+
+.resizable-box {
+  width: 200px;
+  height: 150px;
+  border: 1px solid black;
+  position: relative;
+  overflow: hidden;
+}
+
+.resize-handle {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  background-color: red;
+}
+
+.resize-handle.top {
+  top: -5px;
+  left: 50%;
+  cursor: n-resize;
+  transform: translateX(-50%);
+}
+
+.resize-handle.right {
+  top: 50%;
+  right: -5px;
+  cursor: e-resize;
+  transform: translateY(-50%);
+}
+
+.resize-handle.bottom {
+  bottom: -5px;
+  left: 50%;
+  cursor: s-resize;
+  transform: translateX(-50%);
+}
+
+.resize-handle.left {
+  top: 50%;
+  left: -5px;
+  cursor: w-resize;
+  transform: translateY(-50%);
+}

--- a/projects/novo-examples/src/components/tooltip/tooltip-overflow/tooltip-overflow-example.css
+++ b/projects/novo-examples/src/components/tooltip/tooltip-overflow/tooltip-overflow-example.css
@@ -4,52 +4,6 @@
   padding: 20px 30px;
   position: relative;
   display: flex;
-}
-
-:host > span {
-  cursor: pointer;
-  margin: auto;
-}
-
-.resizable-box {
-  width: 200px;
-  height: 150px;
-  border: 1px solid black;
-  position: relative;
-  overflow: hidden;
-}
-
-.resize-handle {
-  position: absolute;
-  width: 10px;
-  height: 10px;
-  background-color: red;
-}
-
-.resize-handle.top {
-  top: -5px;
-  left: 50%;
-  cursor: n-resize;
-  transform: translateX(-50%);
-}
-
-.resize-handle.right {
-  top: 50%;
-  right: -5px;
-  cursor: e-resize;
-  transform: translateY(-50%);
-}
-
-.resize-handle.bottom {
-  bottom: -5px;
-  left: 50%;
-  cursor: s-resize;
-  transform: translateX(-50%);
-}
-
-.resize-handle.left {
-  top: 50%;
-  left: -5px;
-  cursor: w-resize;
-  transform: translateY(-50%);
+  flex-direction: column;
+  width: 50%;
 }

--- a/projects/novo-examples/src/components/tooltip/tooltip-overflow/tooltip-overflow-example.html
+++ b/projects/novo-examples/src/components/tooltip/tooltip-overflow/tooltip-overflow-example.html
@@ -1,0 +1,5 @@
+<div cdkResizable cdkResizableHandle class="resizable-box">
+  <span [tooltip]="longText" tooltipOnOverflow>
+    {{longText}}
+  </span>
+</div>

--- a/projects/novo-examples/src/components/tooltip/tooltip-overflow/tooltip-overflow-example.html
+++ b/projects/novo-examples/src/components/tooltip/tooltip-overflow/tooltip-overflow-example.html
@@ -1,5 +1,6 @@
-<div cdkResizable cdkResizableHandle class="resizable-box">
-  <span [tooltip]="longText" tooltipOnOverflow>
-    {{longText}}
-  </span>
-</div>
+<novo-card padding="lg">
+  <novo-text ellipsis [tooltip]="longText" tooltipOnOverflow>{{ longText }}</novo-text>
+</novo-card>
+<novo-card padding="lg">
+  <novo-text ellipsis [tooltip]="shortText" tooltipOnOverflow>{{ shortText }}</novo-text>
+</novo-card>

--- a/projects/novo-examples/src/components/tooltip/tooltip-overflow/tooltip-overflow-example.ts
+++ b/projects/novo-examples/src/components/tooltip/tooltip-overflow/tooltip-overflow-example.ts
@@ -11,6 +11,7 @@ import { Component } from '@angular/core';
 export class TooltipOverflowExample {
   public tooltipActive: boolean = true;
   longText = 'Lorem Ipsum pariatur laborum tempor voluptate non adipisicing reprehenderit.';
+  shortText = 'Lorem Ipsum!';
 
   public toggleTooltip() {
     this.tooltipActive = !this.tooltipActive;

--- a/projects/novo-examples/src/components/tooltip/tooltip-overflow/tooltip-overflow-example.ts
+++ b/projects/novo-examples/src/components/tooltip/tooltip-overflow/tooltip-overflow-example.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+
+/**
+ * @title Tooltip Overflow Example
+ */
+@Component({
+  selector: 'tooltip-overflow-example',
+  templateUrl: 'tooltip-overflow-example.html',
+  styleUrls: ['tooltip-overflow-example.css'],
+})
+export class TooltipOverflowExample {
+  public tooltipActive: boolean = true;
+  longText = 'Lorem Ipsum pariatur laborum tempor voluptate non adipisicing reprehenderit.';
+
+  public toggleTooltip() {
+    this.tooltipActive = !this.tooltipActive;
+  }
+}

--- a/projects/novo-examples/src/examples.routes.ts
+++ b/projects/novo-examples/src/examples.routes.ts
@@ -3420,6 +3420,8 @@ export class TooltipDevelopPage {
 <p><code-example example="tooltip-options"></code-example></p>
 <h2>Toggle Trigger</h2>
 <p><code-example example="tooltip-toggle"></code-example></p>
+<h2>Overflow</h2>
+<p><code-example example="tooltip-overflow"></code-example></p>
 `,
   host: { class: 'markdown-page' }
 })


### PR DESCRIPTION
## **Description**

Implemented properly reactive tooltip enablement upon width overflow

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**