### PR TITLE
feat(control): allow control type override for editor

### DIFF
--- a/projects/novo-elements/src/elements/form/utils/FormUtils.ts
+++ b/projects/novo-elements/src/elements/form/utils/FormUtils.ts
@@ -390,6 +390,7 @@ export class FormUtils {
         break;
       case 'editor':
         control = new EditorControl(controlConfig);
+        if (controlConfig.template) { control.controlType = controlConfig.template }
         break;
       case 'editor-minimal':
         control = new EditorControl(controlConfig);


### PR DESCRIPTION
## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**