### PR TITLE
feat(Tooltip): Added the tooltipIfShrink attribute

### DIFF
--- a/projects/novo-elements/src/elements/chips/ChipList.scss
+++ b/projects/novo-elements/src/elements/chips/ChipList.scss
@@ -5,6 +5,11 @@ $novo-chip-list-margin: 4px;
 $novo-chip-input-width: 100px;
 $novo-chip-input-margin: 4px;
 
+.novo-chip-list {
+  overflow: hidden;
+  flex-grow: 1;
+}
+
 .novo-chip-list-wrapper {
   display: flex;
   flex-direction: row;

--- a/projects/novo-elements/src/elements/chips/Chips.scss
+++ b/projects/novo-elements/src/elements/chips/Chips.scss
@@ -39,6 +39,7 @@
     flex-flow: row wrap;
     gap: 0.4rem;
     align-items: center;
+    max-width: 100%;
   }
   .chip-input-container {
     flex: 1 15rem;

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.scss
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.scss
@@ -50,9 +50,9 @@
         overflow: hidden;
       }
       novo-chip-list {
-        width: 36rem;
+        flex-grow: 1;
         novo-chip {
-          max-width: 33rem;
+          max-width: min(33rem, 100% - 9px);
         }
       }
       novo-chips {

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
@@ -53,7 +53,7 @@ import { NovoSelectElement } from 'novo-elements/elements/select';
           <novo-field #novoField class="address-location">
             <novo-chip-list [(ngModel)]="chipListModel" [ngModelOptions]="{ standalone: true }" (click)="openPlacesList(viewIndex)">
               <novo-chip *ngFor="let item of formGroup.get('value').value" (removed)="remove(item, formGroup, viewIndex)">
-                <novo-text ellipsis>{{ item.formatted_address }}</novo-text>
+                <novo-text ellipsis [tooltip]="item.formatted_address" tooltipIfShrunk>{{ item.formatted_address }}</novo-text>
                 <novo-icon novoChipRemove>close</novo-icon>
               </novo-chip>
               <input

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
@@ -27,7 +27,7 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
         <novo-field *novoSwitchCases="['includeAny', 'includeAll', 'excludeAny']">
           <novo-chip-list #chipList aria-label="filter value" formControlName="value">
             <novo-chip *ngFor="let chip of formGroup.value?.value || []" [value]="chip" (removed)="remove(chip, formGroup)">
-              <novo-text ellipsis>{{ chip }}</novo-text>
+              <novo-text ellipsis [tooltip]="chip" tooltipIfShrunk>{{ chip }}</novo-text>
               <novo-icon novoChipRemove>close</novo-icon>
             </novo-chip>
             <input

--- a/projects/novo-elements/src/elements/query-builder/query-builder.module.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.module.ts
@@ -38,6 +38,7 @@ import { ConditionGroupComponent } from './condition-group/condition-group.compo
 import { CriteriaBuilderComponent } from './criteria-builder/criteria-builder.component';
 import { NovoConditionFieldDef, NovoConditionInputDef, NovoConditionOperatorsDef } from './query-builder.directives';
 import { NovoConditionTemplatesComponent } from './condition-templates/condition-templates.component';
+import { NovoTooltipModule } from 'novo-elements/elements/tooltip';
 
 @NgModule({
   imports: [
@@ -70,7 +71,8 @@ import { NovoConditionTemplatesComponent } from './condition-templates/condition
     NovoChipsModule,
     NovoSelectSearchModule,
     NovoDropdownModule,
-    NovoFormExtrasModule
+    NovoFormExtrasModule,
+    NovoTooltipModule
   ],
   declarations: [
     CriteriaBuilderComponent,

--- a/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
@@ -4,6 +4,7 @@ import { ComponentPortal } from '@angular/cdk/portal';
 import { Directive, ElementRef, HostListener, Input, OnDestroy, OnInit, ViewContainerRef } from '@angular/core';
 // APP
 import { NovoTooltip } from './Tooltip.component';
+import { BooleanInput } from 'novo-elements/utils';
 
 @Directive({
   selector: '[tooltip]',
@@ -40,6 +41,13 @@ export class TooltipDirective implements OnDestroy, OnInit {
   isHTML: boolean;
   @Input('tooltipCloseOnClick')
   closeOnClick: boolean = false;
+  /**
+   * Only activate the tooltip directive if this text is shrunken from its full height
+   * (eg, it is a <novo-text ellipsis> and the "..." is showing)
+   */
+  @BooleanInput()
+  @Input('tooltipIfShrunk')
+  onlyOnShrunk: boolean = false;
 
   private tooltipInstance: NovoTooltip | null;
   private portal: ComponentPortal<NovoTooltip>;
@@ -58,9 +66,15 @@ export class TooltipDirective implements OnDestroy, OnInit {
     return size.toLowerCase() === (this.size || '').toLowerCase();
   }
 
+  isActive(): boolean {
+    const isShrunken = this.elementRef.nativeElement.offsetWidth < this.elementRef.nativeElement.scrollWidth;
+    const isShrunkenActive = isShrunken || !this.onlyOnShrunk;
+    return this.active && isShrunkenActive;
+  }
+
   @HostListener('mouseenter')
   onMouseEnter(): void {
-    if (this.tooltip && this.active && !this.always) {
+    if (this.tooltip && this.isActive() && !this.always) {
       this.show();
     }
   }

--- a/projects/novo-examples/src/components/tooltip/index.ts
+++ b/projects/novo-examples/src/components/tooltip/index.ts
@@ -1,4 +1,5 @@
 export * from './tooltip-align';
+export * from './tooltip-ellipses';
 export * from './tooltip-options';
 export * from './tooltip-placement';
 export * from './tooltip-sizes';

--- a/projects/novo-examples/src/components/tooltip/tooltip-ellipses/index.ts
+++ b/projects/novo-examples/src/components/tooltip/tooltip-ellipses/index.ts
@@ -1,0 +1,1 @@
+export * from './tooltip-ellipses-example';

--- a/projects/novo-examples/src/components/tooltip/tooltip-ellipses/tooltip-ellipses-example.css
+++ b/projects/novo-examples/src/components/tooltip/tooltip-ellipses/tooltip-ellipses-example.css
@@ -1,0 +1,4 @@
+.tooltip-ellipses-small-container {
+    width: 175px;
+    display: flex;
+}

--- a/projects/novo-examples/src/components/tooltip/tooltip-ellipses/tooltip-ellipses-example.html
+++ b/projects/novo-examples/src/components/tooltip/tooltip-ellipses/tooltip-ellipses-example.html
@@ -1,0 +1,6 @@
+<novo-card padding="lg" class="tooltip-ellipses-small-container">
+    <novo-text ellipsis [tooltip]="murdererTip" tooltipIfShrunk class="shrunk-text">{{ murdererTip }}</novo-text>
+</novo-card>
+<novo-card padding="lg" >
+    <novo-text ellipsis [tooltip]="nonTooltip" tooltipIfShrunk class="nonshrunk-text">{{ nonTooltip }}</novo-text>
+</novo-card>

--- a/projects/novo-examples/src/components/tooltip/tooltip-ellipses/tooltip-ellipses-example.ts
+++ b/projects/novo-examples/src/components/tooltip/tooltip-ellipses/tooltip-ellipses-example.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+
+/**
+ * @title Tooltip Ellipses Example
+ */
+@Component({
+  selector: 'tooltip-ellipses-example',
+  templateUrl: 'tooltip-ellipses-example.html',
+  styleUrls: ['tooltip-ellipses-example.css'],
+})
+export class TooltipEllipsesExample {
+  public murdererTip: string = `The murderer! It was the butler, Jenkins!`;
+
+  public nonTooltip: string = 'I knew who it was all along. I don\'t need a tip.';
+}

--- a/projects/novo-examples/src/components/tooltip/tooltip-examples.md
+++ b/projects/novo-examples/src/components/tooltip/tooltip-examples.md
@@ -28,3 +28,7 @@ order: 4
 ## Toggle Trigger
 
 <code-example example="tooltip-toggle"></code-example>
+
+## Tooltip w/ Ellipses
+
+<code-example example="tooltip-ellipses"></code-example>

--- a/projects/novo-examples/src/examples.routes.ts
+++ b/projects/novo-examples/src/examples.routes.ts
@@ -3420,6 +3420,8 @@ export class TooltipDevelopPage {
 <p><code-example example="tooltip-options"></code-example></p>
 <h2>Toggle Trigger</h2>
 <p><code-example example="tooltip-toggle"></code-example></p>
+<h2>Tooltip w/ Ellipses</h2>
+<p><code-example example="tooltip-ellipses"></code-example></p>
 `,
   host: { class: 'markdown-page' }
 })

--- a/projects/novo-examples/src/examples.routes.ts
+++ b/projects/novo-examples/src/examples.routes.ts
@@ -202,7 +202,7 @@ export class AsideDesignPage {
 <p>Asides (a.k.a. Slideout) should be invoked via <code>NovoAsideService</code> and therefore all properties should be private or internal. Any values that need to be passed to the your <code>aside</code> instance should be passed by the service and will be available in your slideout via <code>NovoAsideRef.params</code>.</p>
 <pre><code class="language-typescript"><span class="hljs-meta">&#64;Component</span>(&#123;...&#125;)
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">RandomComponent</span> &#123;
-  <span class="hljs-title function_">constructor</span>(<span class="hljs-params"><span class="hljs-keyword">private</span> aside:NovoAsideService</span>) &#123;&#125;
+  <span class="hljs-title function_">constructor</span>(<span class="hljs-params"><span class="hljs-keyword">private</span> <span class="hljs-attr">aside</span>:<span class="hljs-title class_">NovoAsideService</span></span>) &#123;&#125;
   <span class="hljs-title function_">handleAction</span>(<span class="hljs-params"></span>) &#123;
     <span class="hljs-keyword">const</span> ref = <span class="hljs-variable language_">this</span>.<span class="hljs-property">aside</span>.<span class="hljs-title function_">open</span>(<span class="hljs-title class_">AddFormSlideout</span>, &#123; <span class="hljs-attr">record</span>: <span class="hljs-number">123</span> &#125;);
     <span class="hljs-comment">/* you can listen to the close event */</span>
@@ -246,7 +246,7 @@ export class AsideDesignPage {
 &#125;
 <span class="hljs-meta">&#64;Component</span>(&#123;&#125;)
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">AddFormSlideout</span> &#123;
-  <span class="hljs-title function_">constructor</span>(<span class="hljs-params">ref:NovoAsideRef&lt;AddFormParams&gt;</span>) &#123;
+  <span class="hljs-title function_">constructor</span>(<span class="hljs-params"><span class="hljs-attr">ref</span>:<span class="hljs-title class_">NovoAsideRef</span>&lt;<span class="hljs-title class_">AddFormParams</span>&gt;</span>) &#123;
     <span class="hljs-comment">/**
      * All passed values are available
      * via ref.params
@@ -2031,7 +2031,7 @@ export class ModalDesignPage {
   <span class="hljs-attr">isDefault</span>: <span class="hljs-built_in">boolean</span>;
 &#125;
 ...
-<span class="hljs-title function_">constructor</span>(<span class="hljs-params">ref:NovoModalRef&lt;MyParams&gt;</span>) &#123;
+<span class="hljs-title function_">constructor</span>(<span class="hljs-params"><span class="hljs-attr">ref</span>:<span class="hljs-title class_">NovoModalRef</span>&lt;<span class="hljs-title class_">MyParams</span>&gt;</span>) &#123;
   <span class="hljs-keyword">if</span>(ref.<span class="hljs-property">params</span>.<span class="hljs-property">isDefault</span>) &#123;
     <span class="hljs-comment">/* ^ Will not need to by type cast */</span>
   &#125;
@@ -2046,7 +2046,7 @@ export class ModalDesignPage {
 <p>Modals should be invoked via <code>NovoModalService</code> and therefore all properties should be private or internal. Any values that need to be passed to the your <code>Modal</code> instance should be passed by the service and available in your modal.</p>
 <pre><code class="language-typescript"><span class="hljs-meta">&#64;Component</span>(&#123;...&#125;)
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">RandomComponent</span> &#123;
-  <span class="hljs-title function_">constructor</span>(<span class="hljs-params"><span class="hljs-keyword">private</span> modal:NovoModalService</span>) &#123;&#125;
+  <span class="hljs-title function_">constructor</span>(<span class="hljs-params"><span class="hljs-keyword">private</span> <span class="hljs-attr">modal</span>:<span class="hljs-title class_">NovoModalService</span></span>) &#123;&#125;
   <span class="hljs-title function_">handleAction</span>(<span class="hljs-params"></span>) &#123;
     <span class="hljs-keyword">const</span> ref = <span class="hljs-variable language_">this</span>.<span class="hljs-property">modal</span>.<span class="hljs-title function_">open</span>(<span class="hljs-title class_">ConfirmDeleteModal</span>, &#123; <span class="hljs-attr">record</span>: <span class="hljs-number">123</span> &#125;);
     <span class="hljs-comment">/* you can listen to the close event */</span>
@@ -2090,7 +2090,7 @@ export class ModalDesignPage {
 &#125;
 <span class="hljs-meta">&#64;Component</span>(&#123;&#125;)
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">ConfirmDeleteModal</span> &#123;
-  <span class="hljs-title function_">constructor</span>(<span class="hljs-params">ref:NovoModalRef&lt;DeleteModalParams&gt;</span>) &#123;
+  <span class="hljs-title function_">constructor</span>(<span class="hljs-params"><span class="hljs-attr">ref</span>:<span class="hljs-title class_">NovoModalRef</span>&lt;<span class="hljs-title class_">DeleteModalParams</span>&gt;</span>) &#123;
     <span class="hljs-comment">/**
      * All passed values are available
      * via ref.params


### PR DESCRIPTION
## **Description**

Added an option to the Tooltip directive that only turns it on when the content underneath it is has been "shrunk" - to be used specifically when certain content is using the ellipses class to cap the maximum width.

Also adds a number of styling changes to the Chip List so that chips collapse correctly with ellipses (using the new attribute) and do not push their "X" button past the edge of the content.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**
![new-tooltip-example](https://github.com/user-attachments/assets/f50e947a-47a1-49ad-becd-2dc2ca22dadc)
![query-builder-chip-tooltip](https://github.com/user-attachments/assets/d6705e68-8ff2-4aae-9ca9-94061b0491c8)
