### PR TITLE
style(Chips/QueryBuilder): Fixes to chip-list width max/ellipsis appearance

### DIFF
--- a/projects/novo-elements/src/elements/chips/Chip.scss
+++ b/projects/novo-elements/src/elements/chips/Chip.scss
@@ -122,6 +122,7 @@ $chip-spacing: (
     // Makes `<img>` tags behave like `background-size: cover`. Not supported
     // in IE, but we're using it as a progressive enhancement.
     object-fit: cover;
+    flex-shrink: 0;
   }
 
   .novo-chip-remove,

--- a/projects/novo-elements/src/elements/chips/ChipList.scss
+++ b/projects/novo-elements/src/elements/chips/ChipList.scss
@@ -5,6 +5,11 @@ $novo-chip-list-margin: 4px;
 $novo-chip-input-width: 100px;
 $novo-chip-input-margin: 4px;
 
+.novo-chip-list {
+  overflow: hidden;
+  flex-grow: 1;
+}
+
 .novo-chip-list-wrapper {
   display: flex;
   flex-direction: row;

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.scss
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.scss
@@ -50,9 +50,9 @@
         overflow: hidden;
       }
       novo-chip-list {
-        width: 36rem;
+        flex-grow: 1;
         novo-chip {
-          max-width: 33rem;
+          max-width: min(33rem, 100% - 9px);
         }
       }
       novo-chips {

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
@@ -53,7 +53,7 @@ import { NovoSelectElement } from 'novo-elements/elements/select';
           <novo-field #novoField class="address-location">
             <novo-chip-list [(ngModel)]="chipListModel" [ngModelOptions]="{ standalone: true }" (click)="openPlacesList(viewIndex)">
               <novo-chip *ngFor="let item of formGroup.get('value').value" (removed)="remove(item, formGroup, viewIndex)">
-                <novo-text ellipsis>{{ item.formatted_address }}</novo-text>
+                <novo-text ellipsis [tooltip]="item.formatted_address" tooltipOnOverflow>{{ item.formatted_address }}</novo-text>
                 <novo-icon novoChipRemove>close</novo-icon>
               </novo-chip>
               <input

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
@@ -27,7 +27,7 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
         <novo-field *novoSwitchCases="['includeAny', 'includeAll', 'excludeAny']">
           <novo-chip-list #chipList aria-label="filter value" formControlName="value">
             <novo-chip *ngFor="let chip of formGroup.value?.value || []" [value]="chip" (removed)="remove(chip, formGroup)">
-              <novo-text ellipsis>{{ chip }}</novo-text>
+              <novo-text ellipsis [tooltip]="chip" tooltipOnOverflow>{{ chip }}</novo-text>
               <novo-icon novoChipRemove>close</novo-icon>
             </novo-chip>
             <input

--- a/projects/novo-elements/src/elements/query-builder/query-builder.module.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.module.ts
@@ -38,6 +38,7 @@ import { ConditionGroupComponent } from './condition-group/condition-group.compo
 import { CriteriaBuilderComponent } from './criteria-builder/criteria-builder.component';
 import { NovoConditionFieldDef, NovoConditionInputDef, NovoConditionOperatorsDef } from './query-builder.directives';
 import { NovoConditionTemplatesComponent } from './condition-templates/condition-templates.component';
+import { NovoTooltipModule } from 'novo-elements/elements/tooltip';
 
 @NgModule({
   imports: [
@@ -70,7 +71,8 @@ import { NovoConditionTemplatesComponent } from './condition-templates/condition
     NovoChipsModule,
     NovoSelectSearchModule,
     NovoDropdownModule,
-    NovoFormExtrasModule
+    NovoFormExtrasModule,
+    NovoTooltipModule,
   ],
   declarations: [
     CriteriaBuilderComponent,

--- a/projects/novo-examples/src/examples.routes.ts
+++ b/projects/novo-examples/src/examples.routes.ts
@@ -202,7 +202,7 @@ export class AsideDesignPage {
 <p>Asides (a.k.a. Slideout) should be invoked via <code>NovoAsideService</code> and therefore all properties should be private or internal. Any values that need to be passed to the your <code>aside</code> instance should be passed by the service and will be available in your slideout via <code>NovoAsideRef.params</code>.</p>
 <pre><code class="language-typescript"><span class="hljs-meta">&#64;Component</span>(&#123;...&#125;)
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">RandomComponent</span> &#123;
-  <span class="hljs-title function_">constructor</span>(<span class="hljs-params"><span class="hljs-keyword">private</span> aside:NovoAsideService</span>) &#123;&#125;
+  <span class="hljs-title function_">constructor</span>(<span class="hljs-params"><span class="hljs-keyword">private</span> <span class="hljs-attr">aside</span>:<span class="hljs-title class_">NovoAsideService</span></span>) &#123;&#125;
   <span class="hljs-title function_">handleAction</span>(<span class="hljs-params"></span>) &#123;
     <span class="hljs-keyword">const</span> ref = <span class="hljs-variable language_">this</span>.<span class="hljs-property">aside</span>.<span class="hljs-title function_">open</span>(<span class="hljs-title class_">AddFormSlideout</span>, &#123; <span class="hljs-attr">record</span>: <span class="hljs-number">123</span> &#125;);
     <span class="hljs-comment">/* you can listen to the close event */</span>
@@ -246,7 +246,7 @@ export class AsideDesignPage {
 &#125;
 <span class="hljs-meta">&#64;Component</span>(&#123;&#125;)
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">AddFormSlideout</span> &#123;
-  <span class="hljs-title function_">constructor</span>(<span class="hljs-params">ref:NovoAsideRef&lt;AddFormParams&gt;</span>) &#123;
+  <span class="hljs-title function_">constructor</span>(<span class="hljs-params"><span class="hljs-attr">ref</span>:<span class="hljs-title class_">NovoAsideRef</span>&lt;<span class="hljs-title class_">AddFormParams</span>&gt;</span>) &#123;
     <span class="hljs-comment">/**
      * All passed values are available
      * via ref.params
@@ -2031,7 +2031,7 @@ export class ModalDesignPage {
   <span class="hljs-attr">isDefault</span>: <span class="hljs-built_in">boolean</span>;
 &#125;
 ...
-<span class="hljs-title function_">constructor</span>(<span class="hljs-params">ref:NovoModalRef&lt;MyParams&gt;</span>) &#123;
+<span class="hljs-title function_">constructor</span>(<span class="hljs-params"><span class="hljs-attr">ref</span>:<span class="hljs-title class_">NovoModalRef</span>&lt;<span class="hljs-title class_">MyParams</span>&gt;</span>) &#123;
   <span class="hljs-keyword">if</span>(ref.<span class="hljs-property">params</span>.<span class="hljs-property">isDefault</span>) &#123;
     <span class="hljs-comment">/* ^ Will not need to by type cast */</span>
   &#125;
@@ -2046,7 +2046,7 @@ export class ModalDesignPage {
 <p>Modals should be invoked via <code>NovoModalService</code> and therefore all properties should be private or internal. Any values that need to be passed to the your <code>Modal</code> instance should be passed by the service and available in your modal.</p>
 <pre><code class="language-typescript"><span class="hljs-meta">&#64;Component</span>(&#123;...&#125;)
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">RandomComponent</span> &#123;
-  <span class="hljs-title function_">constructor</span>(<span class="hljs-params"><span class="hljs-keyword">private</span> modal:NovoModalService</span>) &#123;&#125;
+  <span class="hljs-title function_">constructor</span>(<span class="hljs-params"><span class="hljs-keyword">private</span> <span class="hljs-attr">modal</span>:<span class="hljs-title class_">NovoModalService</span></span>) &#123;&#125;
   <span class="hljs-title function_">handleAction</span>(<span class="hljs-params"></span>) &#123;
     <span class="hljs-keyword">const</span> ref = <span class="hljs-variable language_">this</span>.<span class="hljs-property">modal</span>.<span class="hljs-title function_">open</span>(<span class="hljs-title class_">ConfirmDeleteModal</span>, &#123; <span class="hljs-attr">record</span>: <span class="hljs-number">123</span> &#125;);
     <span class="hljs-comment">/* you can listen to the close event */</span>
@@ -2090,7 +2090,7 @@ export class ModalDesignPage {
 &#125;
 <span class="hljs-meta">&#64;Component</span>(&#123;&#125;)
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">ConfirmDeleteModal</span> &#123;
-  <span class="hljs-title function_">constructor</span>(<span class="hljs-params">ref:NovoModalRef&lt;DeleteModalParams&gt;</span>) &#123;
+  <span class="hljs-title function_">constructor</span>(<span class="hljs-params"><span class="hljs-attr">ref</span>:<span class="hljs-title class_">NovoModalRef</span>&lt;<span class="hljs-title class_">DeleteModalParams</span>&gt;</span>) &#123;
     <span class="hljs-comment">/**
      * All passed values are available
      * via ref.params


### PR DESCRIPTION
## **Description**

Adds a number of styling changes to the Chip List. This makes use of the new tooltipOnOverflow option so that chips collapse correctly with ellipses (using the new attribute) and do not push their "X" button past the edge of the content.

This MR is based on f/tooltip-on-overflow and will be retargeted once that's merged.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**