### PR TITLE
feat(Condition Builder): Add reset method to condition builder

### DIFF
--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
@@ -187,15 +187,20 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
     this.results$ = Promise.resolve(this.fieldConfig.options);
   }
 
-  reset(values: Record<string, any>): void {
-    // Reset form controls based on the values provided.
-    Object.entries(values).forEach(([key, value]) => {
-      this.parentForm.get(key).setValue(value, { emitEvent: false, onlySelf: true });
-    });
-    // Reinitialize the field and operator template.
+  /**
+   * Resets the input and operator view containers, regenerates the field templates,
+   * and marks the component for change detection.
+   *
+   * Use this method after updating form controls to reinitialize the input and
+   * operator fields so that the view reflects the latest form control changes.
+   *
+   * @returns void
+   */
+  resetInputAndOperator(): void {
+    this._inputOutlet.viewContainer.clear();
+    this._operatorOutlet.viewContainer.clear();
     this.createFieldTemplates();
-    // Make the form untouched.
-    this.parentForm.markAsPristine();
+    this.cdr.markForCheck();
   }
 
   getField() {

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
@@ -187,6 +187,17 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
     this.results$ = Promise.resolve(this.fieldConfig.options);
   }
 
+  reset(values: Record<string, any>): void {
+    // Reset form controls based on the values provided.
+    Object.entries(values).forEach(([key, value]) => {
+      this.parentForm.get(key).setValue(value, { emitEvent: false, onlySelf: true });
+    });
+    // Reinitialize the field and operator template.
+    this.createFieldTemplates();
+    // Make the form untouched.
+    this.parentForm.markAsPristine();
+  }
+
   getField() {
     const field = this.parentForm?.value?.field;
     if (!field) return null;


### PR DESCRIPTION
## **Description**

I added a reset method that takes a values object where key is the key of the form control and value is the value that should be set for the form control.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**