### PR TITLE
fix(Release): added a note to the release process readme

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -2,7 +2,8 @@
 
 ## Automatic
 
-    # On the Github Actions Tab, run the Workflow for "Release Novo Elements" 
+    # On the Github Actions Tab, run the Workflow for "Release Novo Elements"
+    # The release version number will be decided based on commits tagged with "feat()", "fix()", "chore()", "breaking()", "refactor()" messages. Others may not trigger a release.
 
 
 ### Manual (if automatic fails)


### PR DESCRIPTION
## **Description**

Two-pronged MR. Adds a note to help people avoid the mistake of a missing release, and triggers a release for styling fixes.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**