### PR TITLE
fix(ChipList): Minor styling appearance fix

### DIFF
--- a/projects/novo-elements/src/elements/chips/ChipList.scss
+++ b/projects/novo-elements/src/elements/chips/ChipList.scss
@@ -1,7 +1,7 @@
 @import "../../styles/variables.scss";
 @import "../common/typography/text.mixins";
 
-$novo-chip-list-margin: 4px;
+$novo-chip-list-margin: 8px;
 $novo-chip-input-width: 100px;
 $novo-chip-input-margin: 4px;
 

--- a/projects/novo-elements/src/elements/chips/ChipList.scss
+++ b/projects/novo-elements/src/elements/chips/ChipList.scss
@@ -45,6 +45,6 @@ novo-field.novo-focused {
 
 input.novo-chip-input {
   width: 20px;
-  margin: $novo-chip-input-margin;
+  margin: 0 $novo-chip-input-margin;
   flex: 1 0 20px;
 }

--- a/projects/novo-elements/src/elements/chips/ChipList.scss
+++ b/projects/novo-elements/src/elements/chips/ChipList.scss
@@ -47,4 +47,5 @@ input.novo-chip-input {
   width: 20px;
   margin: 0 $novo-chip-input-margin;
   flex: 1 0 20px;
+  line-height: 1.5;
 }

--- a/projects/novo-elements/src/elements/chips/ChipList.scss
+++ b/projects/novo-elements/src/elements/chips/ChipList.scss
@@ -15,12 +15,7 @@ $novo-chip-input-margin: 4px;
   flex-direction: row;
   flex-wrap: wrap;
   align-items: center;
-  margin: -$novo-chip-list-margin;
-
-  input.novo-input-element,
-  .novo-chip {
-    margin: $novo-chip-list-margin;
-  }
+  gap: $novo-chip-list-margin;
 }
 
 .novo-chip-list-stacked {

--- a/projects/novo-elements/src/elements/chips/ChipList.scss
+++ b/projects/novo-elements/src/elements/chips/ChipList.scss
@@ -7,7 +7,6 @@ $novo-chip-input-margin: 4px;
 
 .novo-chip-list {
   overflow: hidden;
-  flex-grow: 1;
 }
 
 .novo-chip-list-wrapper {

--- a/projects/novo-examples/src/examples.routes.ts
+++ b/projects/novo-examples/src/examples.routes.ts
@@ -241,7 +241,7 @@ export class AsideDesignPage {
 <p><em>Note:</em> All modal components should be declared as <code>entryComponents</code> in the module.</p>
 <h2>NovoAsideRef&lt;T&gt;</h2>
 <p><code>NovoAsideRef</code> should be injected into your modal component and all pass params can be accessed in the <code>params</code> property.</p>
-<pre><code class="language-typescript"><span class="hljs-keyword">interface</span> AddFormParams &#123;
+<pre><code class="language-typescript"><span class="hljs-keyword">interface</span> <span class="hljs-title class_">AddFormParams</span> &#123;
   <span class="hljs-attr">record</span>: <span class="hljs-built_in">number</span>;
 &#125;
 <span class="hljs-meta">&#64;Component</span>(&#123;&#125;)
@@ -2027,7 +2027,7 @@ export class ModalDesignPage {
 <ul>
 <li>
 <p><code>NovoModalParams</code> should no longer be used, instead use <code>NovoModalRef.params</code>. This is because <code>NovoModalRef</code> accepts a generic for the params property.</p>
-<pre><code class="language-typescript"><span class="hljs-keyword">interface</span> MyParams &#123;
+<pre><code class="language-typescript"><span class="hljs-keyword">interface</span> <span class="hljs-title class_">MyParams</span> &#123;
   <span class="hljs-attr">isDefault</span>: <span class="hljs-built_in">boolean</span>;
 &#125;
 ...
@@ -2085,7 +2085,7 @@ export class ModalDesignPage {
 <p><em>Note:</em> All modal components should be declared as <code>entryComponents</code> in the module.</p>
 <h2>NovoModalRef&lt;T&gt;</h2>
 <p><code>NovoModalRef</code> should be injected into your modal component and all pass params can be accessed in the <code>params</code> property.</p>
-<pre><code class="language-typescript"><span class="hljs-keyword">interface</span> DeleteModalParams &#123;
+<pre><code class="language-typescript"><span class="hljs-keyword">interface</span> <span class="hljs-title class_">DeleteModalParams</span> &#123;
   <span class="hljs-attr">record</span>: <span class="hljs-built_in">number</span>;
 &#125;
 <span class="hljs-meta">&#64;Component</span>(&#123;&#125;)
@@ -5603,8 +5603,8 @@ export class PatternsNativeFormsPage {
 <input readonly name="id" id="id" value="04D6H89Z" /></p>
 <p><label for="disabled">Random disabled input</label>
 <input disabled name="disabled" id="disabled" placeholder="Because why not?" /></p>
-<p><label for="about">About me</label>
-<textarea name="about" id="about" placeholder="I am a textarea..."></textarea></p>
+<p><label for="about">About me</label></p>
+<textarea name="about" id="about" placeholder="I am a textarea..."></textarea>
 <p><label>Choose a Doe:</label></p>
   <div>
     <input type="radio" id="john" name="drone" value="john" checked />


### PR DESCRIPTION
## **Description**

Changed a negative margin hack into `gap` to prevent bugs where the edge was cut off.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**