### PR TITLE
fix(ChipList): Prevent Chips from stretching

### DIFF
--- a/projects/novo-elements/src/elements/chips/ChipList.scss
+++ b/projects/novo-elements/src/elements/chips/ChipList.scss
@@ -7,7 +7,6 @@ $novo-chip-input-margin: 4px;
 
 .novo-chip-list {
   overflow: hidden;
-  flex-grow: 1;
 }
 
 .novo-chip-list-wrapper {


### PR DESCRIPTION
## **Description**

Targeted fix to prevent chip-list being longer than necessary in some cases.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**