### PR TITLE
feat(DatePicker): Add optional dateForInitialView input

### DIFF
--- a/projects/novo-elements/src/elements/date-picker/DatePicker.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePicker.ts
@@ -260,7 +260,9 @@ export class NovoDatePickerElement implements ControlValueAccessor, OnInit {
     if (this.model) {
       this.modelToSelection(this.model);
     }
-    if (this.selection && this.selection.length) {
+    if (1) {
+      this.updateView(DateUtil.addDays(new Date(), -45));
+    } else if (this.selection && this.selection.length) {
       this.updateView(this.selection[0]);
     }
   }

--- a/projects/novo-elements/src/elements/date-picker/DatePicker.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePicker.ts
@@ -159,6 +159,9 @@ export class NovoDatePickerElement implements ControlValueAccessor, OnInit {
   @Input()
   disabledDateMessage: string;
 
+  @Input()
+  dateForInitialView?: Date;
+
   // Select callback for output
   @Output()
   onSelect: EventEmitter<any> = new EventEmitter(false);
@@ -260,8 +263,8 @@ export class NovoDatePickerElement implements ControlValueAccessor, OnInit {
     if (this.model) {
       this.modelToSelection(this.model);
     }
-    if (1) {
-      this.updateView(DateUtil.addDays(new Date(), -45));
+    if (this.dateForInitialView) {
+      this.updateView(this.dateForInitialView);
     } else if (this.selection && this.selection.length) {
       this.updateView(this.selection[0]);
     }

--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -144,6 +144,11 @@ export class NovoDatePickerInputElement implements OnInit, OnChanges, AfterViewI
   @Input()
   disabledDateMessage: string;
   /**
+   * An optional date/month to show in the DatePicker initially besides the current date/month
+   */
+  @Input()
+  dateForInitialView?: Date;
+  /**
    * Day of the week the calendar should display first, Sunday=0...Saturday=6
    **/
   @Input()

--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -61,6 +61,7 @@ const DATE_VALUE_ACCESSOR = {
         [ngModel]="value"
         [weekStart]="weekStart"
         [hideFooter]="hideFooter"
+        [dateForInitialView]="dateForInitialView"
       ></novo-date-picker>
     </novo-overlay-template>
   `,


### PR DESCRIPTION
## **Description**

Added an optional input for DatePickerInput flowing to DatePicker called `dateForInitialView ` to make sure a certain month shows initially in the date picker when opened that is not the current month/date.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**