### PR TITLE
fix(Picker): Add null check when clearing custom text value

### DIFF
--- a/projects/novo-elements/src/elements/picker/Picker.spec.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.spec.ts
@@ -316,6 +316,62 @@ describe('Elements: NovoPickerElement', () => {
     }));
   });
 
+  describe('clearValue', () => {
+    beforeEach(() => {
+      component._value = 'initialValue';
+      component.term = 'initialTerm';
+      component.popup = {
+        instance: {
+          customTextValue: 'popupValue',
+        },
+      };
+      component.select = {
+        emit: jest.fn()
+      } as unknown;
+      component.changed = {
+        emit: jest.fn()
+      } as unknown;
+      spyOn(component, 'onModelChange');
+      spyOn(component, 'hideResults');
+    });
+
+    it('should clear the value, emit the new value, and optionally clear the term', () => {
+      component.clearValue(true);
+
+      expect(component._value).toBeNull();
+      expect(component.select.emit).toHaveBeenCalledWith(null);
+      expect(component.changed.emit).toHaveBeenCalledWith({ value: null, rawValue: { label: '', value: null } });
+      expect(component.onModelChange).toHaveBeenCalledWith(null);
+      expect(component.term).toBe('');
+      expect(component.popup.instance.customTextValue).toBeNull();
+      expect(component.hideResults).toHaveBeenCalled();
+    });
+    it('should clear the value and emit the new value without clearing the term', () => {
+      component.clearValue(false);
+
+      expect(component._value).toBeNull();
+      expect(component.select.emit).toHaveBeenCalledWith(null);
+      expect(component.changed.emit).toHaveBeenCalledWith({ value: null, rawValue: { label: '', value: null } });
+      expect(component.onModelChange).toHaveBeenCalledWith(null);
+      expect(component.term).toBe('initialTerm');
+      expect(component.popup.instance.customTextValue).toBe('popupValue');
+      expect(component.hideResults).not.toHaveBeenCalled();
+    });
+    it('should not try to clear out customTextValue if popup and popup.instance are undefined', () => {
+      component.popup = undefined;
+      component.clearValue(true);
+
+      expect(component.popup).toBeUndefined();
+
+      component.popup = {
+        instance: undefined,
+      };
+      component.clearValue(true);
+
+      expect(component.popup.instance).toBeUndefined();
+    });
+  });
+
   describe('Method: registerOnChange()', () => {
     it('should be defined.', () => {
       expect(component.registerOnChange).toBeDefined();

--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -265,7 +265,9 @@ export class NovoPickerElement implements OnInit {
 
     if (wipeTerm) {
       this.term = '';
-      this.popup.instance.customTextValue = null;
+      if (this.popup?.instance) {
+        this.popup.instance.customTextValue = null;
+      }
       this.hideResults();
     }
     this.ref.markForCheck();


### PR DESCRIPTION
## **Description**

Added a safety check when clearing the customTextValue on popup instance, which doesn't get created until Picker results are shown. This was causing console logs when a user would try clear a picker on a form before ever expanding the results.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**