### PR TITLE
feat(Query Builder): Replace Radius with Inside Radius and add new Outside Radius operator for address field

### DIFF
--- a/projects/novo-elements/src/elements/field/input.ts
+++ b/projects/novo-elements/src/elements/field/input.ts
@@ -14,7 +14,6 @@ import {
   Directive,
   DoCheck,
   ElementRef,
-  EventEmitter,
   HostBinding,
   HostListener,
   Inject,
@@ -24,7 +23,6 @@ import {
   OnChanges,
   OnDestroy,
   Optional,
-  Output,
   Self,
 } from '@angular/core';
 import { FormGroupDirective, NgControl, NgForm } from '@angular/forms';
@@ -428,5 +426,4 @@ export class NovoInput extends NovoInputBase implements NovoFieldControl<any>, O
   // Accept `any` to avoid conflicts with other directives on `<input>` that may
   // accept different types.
   static ngAcceptInputType_value: any;
-  @Output() onSelect = new EventEmitter<unknown>();
 }

--- a/projects/novo-elements/src/elements/field/input.ts
+++ b/projects/novo-elements/src/elements/field/input.ts
@@ -14,6 +14,7 @@ import {
   Directive,
   DoCheck,
   ElementRef,
+  EventEmitter,
   HostBinding,
   HostListener,
   Inject,
@@ -23,6 +24,7 @@ import {
   OnChanges,
   OnDestroy,
   Optional,
+  Output,
   Self,
 } from '@angular/core';
 import { FormGroupDirective, NgControl, NgForm } from '@angular/forms';
@@ -426,4 +428,5 @@ export class NovoInput extends NovoInputBase implements NovoFieldControl<any>, O
   // Accept `any` to avoid conflicts with other directives on `<input>` that may
   // accept different types.
   static ngAcceptInputType_value: any;
+  @Output() onSelect = new EventEmitter<unknown>();
 }

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/abstract-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/abstract-condition.definition.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Directive, Input, OnDestroy, OnInit, QueryList, ViewChild, ViewChildren } from '@angular/core';
-import { FormControlDirective, FormControlName, UntypedFormGroup } from '@angular/forms';
+import { FormControlName, UntypedFormGroup } from '@angular/forms';
 import { NovoLabelService } from 'novo-elements/services';
-import { NovoConditionFieldDef, NovoConditionOperatorsDef } from '../query-builder.directives';
+import { NovoConditionFieldDef } from '../query-builder.directives';
 import { Operator } from '../query-builder.types';
 
 @Directive()

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.spec.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.spec.ts
@@ -1,0 +1,74 @@
+import { signal } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { NovoDefaultAddressConditionDef } from './address-condition.definition';
+
+describe('NovoDefaultAddressConditionDef', () => {
+    beforeEach(() => {
+        NovoDefaultAddressConditionDef.prototype.radiusUnits = signal('km');
+    })
+
+    describe('Function: isRadiusOperatorSelected', () => {
+        it('should return false if operator is not insideRadius or outsideRadius', () => {
+            const formGroup = new FormGroup({
+                value: new FormControl(null),
+                operator: new FormControl('includeAny'),
+            });
+            const actual = (NovoDefaultAddressConditionDef.prototype as any).isRadiusOperatorSelected(formGroup);
+            expect(actual).toBeFalsy();
+        });
+        it('should return true if operator is insideRadius', () => {
+            const formGroup = new FormGroup({
+                value: new FormControl(null),
+                operator: new FormControl('insideRadius'),
+            });
+            const actual = (NovoDefaultAddressConditionDef.prototype as any).isRadiusOperatorSelected(formGroup);
+            expect(actual).toBeTruthy();
+        });
+        it('should return true if operator is outsideRadius', () => {
+            const formGroup = new FormGroup({
+                value: new FormControl(null),
+                operator: new FormControl('outsideRadius'),
+            });
+            const actual = (NovoDefaultAddressConditionDef.prototype as any).isRadiusOperatorSelected(formGroup);
+            expect(actual).toBeTruthy();
+        });
+    });
+    describe('Function: updateRadiusInValues', () => {
+        it('should return values updated with the radius based on form values if radius operator is selected', () => {
+            const expected = [{
+                id: 1,
+                radius: {
+                    operator: 'insideRadius',
+                    units: 'km',
+                    value: 3,
+                },
+            }];
+            const values = [
+                { id: 1 },
+            ];
+            const formGroup = new FormGroup({
+                value: new FormControl(null),
+                operator: new FormControl('insideRadius'),
+                supportingValue: new FormControl(3),
+            });
+            const actual = (NovoDefaultAddressConditionDef.prototype as any).updateRadiusInValues(formGroup, values);
+            expect(actual).toEqual(expected);
+        });
+        it('should not set raidus if radius operator is not selected', () => {
+            const expected = [{
+                id: 1,
+                radius: undefined,
+            }];
+            const values = [
+                { id: 1 },
+            ];
+            const formGroup = new FormGroup({
+                value: new FormControl(null),
+                operator: new FormControl('includeAny'),
+                supportingValue: new FormControl(null),
+            });
+            const actual = (NovoDefaultAddressConditionDef.prototype as any).updateRadiusInValues(formGroup, values);
+            expect(actual).toEqual(expected);
+        });
+    });
+});

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
@@ -55,12 +55,12 @@ import { NovoSelectElement } from 'novo-elements/elements/select';
               type="number"
               min="1"
               step="1"
-              placeholder="{{ labels.miles }}"
+              placeholder="{{ unitsLabel() }}"
               [value]="radius()"
               #distanceInput
               (input)="onRadiusSelect(formGroup, $event)"
             />
-            <span *ngIf="!!this.radius()" style="margin-left: 8px;">{{ labels.miles }}</span>
+            <span *ngIf="!!this.radius()" style="margin-left: 8px;">{{ unitsLabel() }}</span>
           </novo-field>
           <novo-field #novoField class="address-location">
             <novo-chip-list [(ngModel)]="chipListModel" [ngModelOptions]="{ standalone: true }" (click)="openPlacesList(viewIndex)">
@@ -113,6 +113,9 @@ export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef im
   );
   radiusEnabled: Signal<boolean> = computed(() =>
     this.config()?.radiusEnabled || this.defaults.radiusEnabled
+  );
+  unitsLabel: Signal<string> = computed(() =>
+    this.radiusUnits() === RadiusUnits.miles ? this.labels.miles : this.labels.km
   );
 
   radius: WritableSignal<number> = signal(null);

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
@@ -55,11 +55,12 @@ import { NovoSelectElement } from 'novo-elements/elements/select';
               type="number"
               min="1"
               step="1"
-              placeholder="Miles"
+              placeholder="{{ labels.miles }}"
+              [value]="radius()"
               #distanceInput
               (input)="onRadiusSelect(formGroup, $event)"
             />
-            <span *ngIf="!!this.radius()" style="margin-left: 8px;">Miles</span>
+            <span *ngIf="!!this.radius()" style="margin-left: 8px;">{{ labels.miles }}</span>
           </novo-field>
           <novo-field #novoField class="address-location">
             <novo-chip-list [(ngModel)]="chipListModel" [ngModelOptions]="{ standalone: true }" (click)="openPlacesList(viewIndex)">

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
@@ -52,12 +52,13 @@ import { NovoSelectElement } from 'novo-elements/elements/select';
               novoInput
               type="number"
               min="1"
+              max="9999"
               step="1"
               formControlName="supportingValue"
               #distanceInput
               (input)="onRadiusSelect(formGroup, $event)"
             />
-            <span style="margin-left: 8px;">{{ unitsLabel() }}</span>
+            <span style="margin-left: 8px; margin-right: 5px;">{{ unitsLabel() }}</span>
           </novo-field>
           <novo-field #novoField class="address-location">
             <novo-chip-list [(ngModel)]="chipListModel" [ngModelOptions]="{ standalone: true }" (click)="openPlacesList(viewIndex)">
@@ -95,10 +96,6 @@ export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef im
   @ViewChild('placesPicker') placesPicker: PlacesListComponent;
   @ViewChildren(NovoSelectElement) addressSideTest: any;
 
-  // Static defaults
-  radiusValues: number[] = [5, 10, 20, 30, 40, 50, 100];
-  defaultRadius: number = 30;
-
   // Overridable defaults
   defaults: AddressCriteriaConfig = {
     radiusEnabled: false,
@@ -114,14 +111,6 @@ export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef im
   unitsLabel: Signal<string> = computed(() =>
     this.radiusUnits() === RadiusUnits.miles ? this.labels.miles : this.labels.km
   );
-
-  radiusOptions: Signal<{ label: string; value: number; }[]> = computed(() => {
-    const unitsLabel = this.radiusUnits() === RadiusUnits.miles ? this.labels.miles : this.labels.km;
-    return this.radiusValues.map(value => ({
-      label: `${value.toString()} ${unitsLabel}`,
-      value,
-    }));
-  });
 
   defaultOperator = Operator.includeAny;
   chipListModel: any = '';

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
@@ -47,7 +47,7 @@ import { NovoSelectElement } from 'novo-elements/elements/select';
       </novo-field>
       <ng-container *novoConditionInputDef="let formGroup; viewIndex as viewIndex; fieldMeta as meta" [formGroup]="formGroup">
         <novo-flex justify="space-between" align="end">
-          <novo-field #input *ngIf="['insideRadius', 'outsideRadius'].includes(formGroup.value.operator)" class="address-radius">
+          <novo-field #input *ngIf="['radius', 'insideRadius', 'outsideRadius'].includes(formGroup.value.operator)" class="address-radius">
             <input
               novoInput
               type="number"

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
@@ -1,5 +1,4 @@
 import {
-  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
   computed,
@@ -14,7 +13,7 @@ import {
   ViewChild,
   ViewChildren,
   ViewEncapsulation,
-  WritableSignal
+  WritableSignal,
 } from '@angular/core';
 import { AbstractControl, UntypedFormGroup } from '@angular/forms';
 import { NovoPickerToggleElement } from 'novo-elements/elements/field';
@@ -22,7 +21,14 @@ import { PlacesListComponent } from 'novo-elements/elements/places';
 import { NovoLabelService } from 'novo-elements/services';
 import { Helpers, Key } from 'novo-elements/utils';
 import { Subscription } from 'rxjs';
-import { AddressCriteriaConfig, AddressData, AddressRadius, AddressRadiusUnitsName, Operator, RadiusUnits } from '../query-builder.types';
+import {
+  AddressCriteriaConfig,
+  AddressData,
+  AddressRadius,
+  AddressRadiusUnitsName,
+  Operator,
+  RadiusUnits,
+} from '../query-builder.types';
 import { AbstractConditionFieldDef } from './abstract-condition.definition';
 import { NovoSelectElement } from 'novo-elements/elements/select';
 
@@ -37,18 +43,23 @@ import { NovoSelectElement } from 'novo-elements/elements/select';
         <novo-select [placeholder]="labels.operator" formControlName="operator" (onSelect)="onOperatorSelect(formGroup)">
           <novo-option value="includeAny">{{ labels.includeAny }}</novo-option>
           <novo-option value="excludeAny">{{ labels.exclude }}</novo-option>
-          <novo-option value="radius" *ngIf="radiusEnabled()">{{ labels.radius }}</novo-option>
+          <novo-option value="insideRadius" *ngIf="radiusEnabled()">{{ labels.insideRadius }}</novo-option>
+          <novo-option value="outsideRadius" *ngIf="radiusEnabled()">{{ labels.outsideRadius }}</novo-option>
         </novo-select>
       </novo-field>
       <ng-container *novoConditionInputDef="let formGroup; viewIndex as viewIndex; fieldMeta as meta" [formGroup]="formGroup">
         <novo-flex justify="space-between" align="end">
-          <novo-field #novoRadiusField *ngIf="formGroup.value.operator === 'radius'" class="address-radius">
-            <novo-select
-              #radiusSelect [placeholder]="labels.radius"
-              (onSelect)="onRadiusSelect(formGroup, $event.selected)"
-              [value]="radius()"
-              [options]="radiusOptions()">
-            </novo-select>
+          <novo-field #input *ngIf="['insideRadius', 'outsideRadius'].includes(formGroup.value.operator)" class="address-radius">
+            <input
+              novoInput
+              type="number"
+              min="1"
+              step="1"
+              placeholder="Miles"
+              #distanceInput
+              (input)="onRadiusSelect(formGroup, $event)"
+            />
+            <span *ngIf="!!this.radius()" style="margin-left: 8px;">Miles</span>
           </novo-field>
           <novo-field #novoField class="address-location">
             <novo-chip-list [(ngModel)]="chipListModel" [ngModelOptions]="{ standalone: true }" (click)="openPlacesList(viewIndex)">
@@ -103,7 +114,7 @@ export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef im
     this.config()?.radiusEnabled || this.defaults.radiusEnabled
   );
 
-  radius: WritableSignal<number> = signal(this.defaultRadius);
+  radius: WritableSignal<number> = signal(null);
   radiusOptions: Signal<{ label: string; value: number; }[]> = computed(() => {
     const unitsLabel = this.radiusUnits() === RadiusUnits.miles ? this.labels.miles : this.labels.km;
     return this.radiusValues.map(value => ({
@@ -122,7 +133,7 @@ export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef im
 
   constructor(labelService: NovoLabelService) {
     super(labelService);
-    this.defineOperatorEditGroup(Operator.includeAny, Operator.excludeAny, Operator.radius);
+    this.defineOperatorEditGroup(Operator.includeAny, Operator.excludeAny, Operator.insideRadius, Operator.outsideRadius);
   }
 
   frameAfterViewInit(): void {
@@ -215,14 +226,14 @@ export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef im
   onOperatorSelect(formGroup: UntypedFormGroup): void {
     const previousOperator = this._previousOperatorValue;
     super.onOperatorSelect(formGroup);
-    if ([previousOperator, formGroup.get('operator').getRawValue()].indexOf(Operator.radius) !== -1 &&
+    if ([previousOperator, formGroup.get('operator').getRawValue()].indexOf(Operator.insideRadius) !== -1 && //
         formGroup.get('value').getRawValue() != null) {
       formGroup.get('value').setValue(this.updateRadiusInValues(formGroup, this.getValue(formGroup)));
     }
   }
 
-  onRadiusSelect(formGroup: AbstractControl, radius: number): void {
-    this.radius.set(radius);
+  onRadiusSelect(formGroup: AbstractControl, event): void {
+    this.radius.set(event.target.value);
     // We must dirty the form explicitly to show up as a user modification when it was done programmatically
     formGroup.get('value').setValue(this.updateRadiusInValues(formGroup, this.getValue(formGroup)));
     formGroup.markAsDirty();
@@ -247,8 +258,9 @@ export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef im
 
   private getRadiusData(formGroup: AbstractControl): AddressRadius {
     return {
-      value: this.getRadius(formGroup),
+      value: this.radius(),
       units: this.radiusUnits(),
+      operator: formGroup.value.operator,
     };
   }
 
@@ -257,6 +269,6 @@ export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef im
   }
 
   private isRadiusOperatorSelected(formGroup: AbstractControl): boolean {
-    return formGroup.get('operator').value === 'radius';
+    return ['insideRadius', 'outsideRadius'].includes(formGroup.get('operator')?.value) && this.radius !== null;
   }
 }

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
@@ -215,7 +215,7 @@ export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef im
   onOperatorSelect(formGroup: UntypedFormGroup): void {
     const previousOperator = this._previousOperatorValue;
     super.onOperatorSelect(formGroup);
-    if ([previousOperator, formGroup.get('operator').getRawValue()].indexOf(Operator.insideRadius) !== -1 && //
+    if ([previousOperator, formGroup.get('operator').getRawValue()].indexOf(Operator.insideRadius) !== -1 &&
         formGroup.get('value').getRawValue() != null) {
       formGroup.get('value').setValue(this.updateRadiusInValues(formGroup, this.getValue(formGroup)));
     }

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
@@ -50,6 +50,7 @@ import { NovoSelectElement } from 'novo-elements/elements/select';
           <novo-field #input *ngIf="['radius', 'insideRadius', 'outsideRadius'].includes(formGroup.value.operator)" class="address-radius">
             <input
               novoInput
+              paddingLeft="3px"
               type="number"
               min="1"
               max="9999"
@@ -58,7 +59,7 @@ import { NovoSelectElement } from 'novo-elements/elements/select';
               #distanceInput
               (input)="onRadiusSelect(formGroup, $event)"
             />
-            <span style="margin-left: 8px; margin-right: 5px;">{{ unitsLabel() }}</span>
+            <span marginLeft="2px" marginRight="4px" paddingTop="3px">{{ unitsLabel() }}</span>
           </novo-field>
           <novo-field #novoField class="address-location">
             <novo-chip-list [(ngModel)]="chipListModel" [ngModelOptions]="{ standalone: true }" (click)="openPlacesList(viewIndex)">
@@ -211,6 +212,9 @@ export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef im
   }
 
   onRadiusSelect(formGroup: AbstractControl, event): void {
+    const maxLengthRadius = event.target.value.slice(0, 4);
+    event.target.value = maxLengthRadius;
+    formGroup.get('supportingValue').setValue(maxLengthRadius);
     // We must dirty the form explicitly to show up as a user modification when it was done programmatically
     formGroup.get('value').setValue(this.updateRadiusInValues(formGroup, this.getValue(formGroup)));
     formGroup.markAsDirty();

--- a/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.ts
@@ -12,6 +12,7 @@ const EMPTY_CONDITION: Condition = {
   operator: null,
   scope: null,
   value: null,
+  supportingValue: null,
 };
 @Component({
   selector: 'novo-condition-group',
@@ -104,13 +105,14 @@ export class ConditionGroupComponent implements OnInit, OnDestroy {
     this.cdr.markForCheck();
   }
 
-  newCondition({ field, operator, scope, value }: Condition = EMPTY_CONDITION): UntypedFormGroup {
+  newCondition({ field, operator, scope, value, supportingValue }: Condition = EMPTY_CONDITION): UntypedFormGroup {
     return this.formBuilder.group({
       conditionType: '$and',
       field: [field, Validators.required],
       operator: [operator, Validators.required],
       scope: [scope],
       value: [value],
+      supportingValue: [supportingValue],
     });
   }
 

--- a/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/criteria-builder/criteria-builder.component.ts
@@ -32,6 +32,7 @@ const EMPTY_CONDITION: Condition = {
   operator: null,
   scope: null,
   value: null,
+  supportingValue: null,
 };
 @Component({
   selector: 'novo-criteria-builder',
@@ -206,13 +207,14 @@ export class CriteriaBuilderComponent implements OnInit, OnDestroy, AfterContent
     return this.formBuilder.group(controls);
   }
 
-  newCondition({ field, operator, scope, value }: Condition = EMPTY_CONDITION): UntypedFormGroup {
+  newCondition({ field, operator, scope, value, supportingValue }: Condition = EMPTY_CONDITION): UntypedFormGroup {
     return this.formBuilder.group({
       conditionType: '$and',
       field: [field, Validators.required],
       operator: [operator, Validators.required],
       scope: [scope],
       value: [value],
+      supportingValue: [supportingValue],
     });
   }
 

--- a/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
@@ -32,7 +32,8 @@ export enum Operator {
   isEmpty = 'isEmpty',
   isNull = 'isNull',
   lessThan = 'lessThan',
-  radius = 'radius',
+  insideRadius = 'insideRadius',
+  outsideRadius = 'outsideRadius',
   within = 'within',
 }
 
@@ -90,6 +91,7 @@ export interface AddressData {
 export interface AddressRadius {
   value: number;
   units: AddressRadiusUnitsName;
+  operator?: string;
 }
 
 export interface AddressComponent {

--- a/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
@@ -32,8 +32,7 @@ export enum Operator {
   isEmpty = 'isEmpty',
   isNull = 'isNull',
   lessThan = 'lessThan',
-  insideRadius = 'insideRadius',
-  outsideRadius = 'outsideRadius',
+  radius = 'radius',
   within = 'within',
 }
 
@@ -91,7 +90,6 @@ export interface AddressData {
 export interface AddressRadius {
   value: number;
   units: AddressRadiusUnitsName;
-  operator?: string;
 }
 
 export interface AddressComponent {

--- a/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
@@ -29,11 +29,12 @@ export enum Operator {
   include = 'include',
   includeAll = 'includeAll',
   includeAny = 'includeAny',
+  insideRadius = 'insideRadius',
   isEmpty = 'isEmpty',
   isNull = 'isNull',
   lessThan = 'lessThan',
-  insideRadius = 'insideRadius',
   outsideRadius = 'outsideRadius',
+  radius = 'radius',
   within = 'within',
 }
 

--- a/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
@@ -45,6 +45,7 @@ export interface Condition {
   operator: OperatorName | string;
   scope?: string;
   value: any;
+  supportingValue?: any;
 }
 
 export interface Criteria {

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -125,7 +125,8 @@ export class NovoLabelService {
   includeAll = 'Include All';
   exclude = 'Exclude';
   excludeAny = 'Exclude Any';
-  radius = 'Radius';
+  insideRadius = 'Radius (Inside)';
+  outsideRadius = 'Radius (Outside)';
   equals = 'Equals';
   equalTo = 'Equal To';
   greaterThan = 'Greater Than';

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -125,8 +125,7 @@ export class NovoLabelService {
   includeAll = 'Include All';
   exclude = 'Exclude';
   excludeAny = 'Exclude Any';
-  insideRadius = 'Radius (Inside)';
-  outsideRadius = 'Radius (Outside)';
+  radius = 'Radius';
   equals = 'Equals';
   equalTo = 'Equal To';
   greaterThan = 'Greater Than';

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -125,6 +125,7 @@ export class NovoLabelService {
   includeAll = 'Include All';
   exclude = 'Exclude';
   excludeAny = 'Exclude Any';
+  radius = 'Radius';
   insideRadius = 'Radius (Inside)';
   outsideRadius = 'Radius (Outside)';
   equals = 'Equals';

--- a/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.ts
+++ b/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.ts
@@ -181,6 +181,7 @@ export class JustCriteriaExample implements OnInit {
             operator: 'includeAny',
             scope: 'Candidate',
             value: null,
+            supportingValue: 5,
           },
         ],
       },


### PR DESCRIPTION
## **Description**

For address field in the Query Builder, replaced Radius with Inside Radius and added new Outside Radius operator. Also changed the value field from a dropdown to an integer field.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`


##### **Screenshots**
![Screenshot 2025-03-19 at 10 55 03 AM](https://github.com/user-attachments/assets/1e2853fd-818f-4940-ab3c-72609b3b3312)