### PR TITLE
feat(NovoOverlay): contextual custom overlay containers

### DIFF
--- a/projects/novo-elements/src/elements/common/overlay/Overlay.ts
+++ b/projects/novo-elements/src/elements/common/overlay/Overlay.ts
@@ -5,6 +5,7 @@ import {
   HorizontalConnectionPos,
   Overlay,
   OverlayConfig,
+  OverlayContainer,
   OverlayRef,
   ScrollStrategy,
   VerticalConnectionPos,
@@ -17,6 +18,7 @@ import {
   Component,
   ElementRef,
   EventEmitter,
+  inject,
   Inject,
   Input,
   NgZone,
@@ -89,6 +91,8 @@ export class NovoOverlayTemplateComponent implements OnDestroy {
   // The subscription for closing actions (some are bound to document)
   protected closingActionsSubscription: Subscription;
   private _parent: ElementRef;
+  private overlayContainer: OverlayContainer = inject(OverlayContainer);
+  private overlayContext: string;
 
   constructor(
     protected overlay: Overlay,
@@ -131,6 +135,9 @@ export class NovoOverlayTemplateComponent implements OnDestroy {
     this.changeDetectorRef.markForCheck();
     setTimeout(() => {
       if (this.overlayRef) {
+        if (this.overlayContainer.getContainerElement()?.attributes.getNamedItem('novoContext')) {
+            this.overlayContext = this.overlayContainer.getContainerElement().attributes.getNamedItem('novoContext').value;
+        }
         this.overlayRef.updatePosition();
         this.opening.emit(true);
         setTimeout(() => {
@@ -186,6 +193,7 @@ export class NovoOverlayTemplateComponent implements OnDestroy {
           this.isInDocument(clickTarget) &&
           !this.getConnectedElement().nativeElement.contains(clickTarget) &&
           (!!this.overlayRef && !this.overlayRef.overlayElement.contains(clickTarget)) &&
+          this.elementIsInContext(clickTarget) &&
           !this.elementIsInNestedOverlay(clickTarget);
         if (this.panelOpen && !!this.overlayRef && this.overlayRef.overlayElement.contains(clickTarget) && this.closeOnSelect) {
           this.select.emit(event);
@@ -340,6 +348,20 @@ export class NovoOverlayTemplateComponent implements OnDestroy {
 
   protected getConnectedElement(): ElementRef {
     return this.parent;
+  }
+
+  private elementIsInContext(el) {
+    // this is to support multiple overlay contexts
+    if (this.overlayContext) {
+      while (el.parentNode) {
+        if (el.localName === this.overlayContext) {
+          return true;
+        }
+        el = el.parentNode;
+      }
+      return false;
+    }
+    return true;
   }
 
   protected elementIsInNestedOverlay(el): boolean {

--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
@@ -48,7 +48,7 @@ import { DataTableState } from '../state/data-table-state.service';
         [value]="sortValue"></novo-sort-button>
       <novo-dropdown
         *ngIf="config.filterable"
-        side="right"
+        side="left"
         parentScrollSelector=".novo-data-table-container"
         containerClass="data-table-dropdown"
         data-automation-id="novo-data-table-filter"

--- a/projects/novo-elements/src/elements/modal/modal.service.ts
+++ b/projects/novo-elements/src/elements/modal/modal.service.ts
@@ -21,6 +21,7 @@ const DEFAULT_CONFIG: ModalConfig = {
 @Injectable({ providedIn: 'root' })
 export class NovoModalService {
   _parentViewContainer: ViewContainerRef;
+  overlayRef: OverlayRef;
 
   set parentViewContainer(view: ViewContainerRef) {
     console.warn('parentViewContainer is deprecated');
@@ -35,6 +36,7 @@ export class NovoModalService {
 
     // Returns an OverlayRef which is a PortalHost
     const overlayRef = this.createOverlay(modalConfig);
+    this.overlayRef = overlayRef;
 
     // Instantiate remote control
     const modalRef = new NovoModalRef<typeof params>(component, params, overlayRef);


### PR DESCRIPTION
## **Description**

- adding accessible overlay ref on modal service
- adding support for contextual custom overlay containers to allow for multiple overlay contexts
- updating the side of the filter icon the data table filter overlay attaches to, to avoid the overlays popping up under left-side menus and bowling alleys

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**