### PR TITLE
feat(Types): Fixing data table filter value type

### DIFF
--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -173,7 +173,7 @@ export interface IDataTableSort {
 
 export interface IDataTableFilter {
   id: string;
-  value: string | string[];
+  value: any;
   transform?: Function;
   type?: string;
   selectedOption?: Object;


### PR DESCRIPTION
## **Description**

The type has been incorrect for a while now, so fixing the filter value so that it matches up with the current code - the filter value can be any object, string, number, etc.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**