### PR TITLE
feat(ConditionBuilder): Added some automation values

### DIFF
--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
@@ -36,10 +36,10 @@ import { NovoLabelService } from 'novo-elements/services';
         </novo-field>
         <novo-field *novoSwitchCases="['within']">
           <novo-select [placeholder]="labels.selectDateRange" formControlName="value">
-            <novo-option value="7">{{ labels.next7Days }}</novo-option>
-            <novo-option value="-7">{{ labels.past7Days }}</novo-option>
-            <novo-option value="-30">{{ labels.past30Days }}</novo-option>
-            <novo-option value="-90">{{ labels.past90Days }}</novo-option>
+            <novo-option value="7" [attr.data-automation-value]="labels.next7Days">{{ labels.next7Days }}</novo-option>
+            <novo-option value="-7" [attr.data-automation-value]="labels.past7Days">{{ labels.past7Days }}</novo-option>
+            <novo-option value="-30" [attr.data-automation-value]="labels.past30Days">{{ labels.past30Days }}</novo-option>
+            <novo-option value="-90" [attr.data-automation-value]="labels.past90Days">{{ labels.past90Days }}</novo-option>
           </novo-select>
         </novo-field>
         <novo-field *novoSwitchCases="['isNull']">

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/date-time-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/date-time-condition.definition.ts
@@ -42,10 +42,10 @@ import { NovoLabelService } from 'novo-elements/services';
         </novo-field>
         <novo-field *novoSwitchCases="['within']">
           <novo-select [placeholder]="labels.selectDateRange" formControlName="value">
-            <novo-option value="7">{{ labels.next7Days }}</novo-option>
-            <novo-option value="-7">{{ labels.past7Days }}</novo-option>
-            <novo-option value="-30">{{ labels.past30Days }}</novo-option>
-            <novo-option value="-90">{{ labels.past90Days }}</novo-option>
+            <novo-option value="7" [attr.data-automation-value]="labels.next7Days">{{ labels.next7Days }}</novo-option>
+            <novo-option value="-7" [attr.data-automation-value]="labels.past7Days">{{ labels.past7Days }}</novo-option>
+            <novo-option value="-30" [attr.data-automation-value]="labels.past30Days">{{ labels.past30Days }}</novo-option>
+            <novo-option value="-90" [attr.data-automation-value]="labels.past90Days">{{ labels.past90Days }}</novo-option>
           </novo-select>
         </novo-field>
         <novo-field *novoSwitchCases="['isNull']">


### PR DESCRIPTION
## **Description**

Adds data-automation-value attributes to the 4 'Within' options that appear for datetime fields.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**