### PR TITLE
feat(): next

### DIFF
--- a/projects/novo-elements/src/elements/button/Button.ts
+++ b/projects/novo-elements/src/elements/button/Button.ts
@@ -1,5 +1,15 @@
 // NG2
-import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, HostListener, Input, OnChanges, SimpleChanges } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component, computed,
+  ElementRef,
+  HostBinding,
+  HostListener, input,
+  Input,
+  InputSignal,
+  OnChanges, signal, Signal,
+  SimpleChanges, WritableSignal,
+} from '@angular/core';
 import { BooleanInput, Helpers, Key } from 'novo-elements/utils';
 
 @Component({
@@ -27,11 +37,11 @@ import { BooleanInput, Helpers, Key } from 'novo-elements/utils';
 
   template: `
     <!--Left Icon-->
-    <i *ngIf="icon && side === 'left' && !loading" [ngClass]="icon" class="novo-button-icon novo-button-icon-left"></i>
+    <i *ngIf="((icon && side === 'left') || (secondIcon && secondSide() === 'left')) && !loading" [ngClass]="leftSideIconClass()" class="novo-button-icon novo-button-icon-left"></i>
     <!--Transcluded Content-->
     <span #textContent class="button-contents"><ng-content></ng-content></span>
     <!--Right Icon-->
-    <i *ngIf="icon && side === 'right' && !loading" [ngClass]="icon" class="novo-button-icon novo-button-icon-right"></i>
+    <i *ngIf="((icon && side === 'right') || (secondIcon && secondSide() === 'right')) && !loading" [ngClass]="rightSideIconClass()" class="novo-button-icon novo-button-icon-right"></i>
     <!--Loading-->
     <i *ngIf="loading" class="loading novo-button-loading">
       <svg
@@ -70,9 +80,12 @@ export class NovoButtonElement implements OnChanges {
   @Input() color: string;
   /**
    * The side of the button to display the icon.
-   * @deprecated
    */
   @Input() side: string = 'right';
+  /**
+   * If a second icon is specified it will default to the opposite side as the primary icon.
+   */
+  secondSide: Signal<string> = computed(() => this.side === 'right' ? 'left' : 'right')
   /**
    * 	Sets the size of the button. One of: sm, lg
    */
@@ -87,17 +100,33 @@ export class NovoButtonElement implements OnChanges {
   @Input() loading: boolean;
   /**
    * Optionally display `bullhorn-icon` with the button along with the text.
-   * @deprecated
    */
   @Input()
   set icon(icon: string) {
     if (icon) {
-      this._icon = `bhi-${icon}`;
+      this._icon.set(`bhi-${icon}`);
     }
   }
   get icon(): string {
-    return this._icon;
+    return this._icon();
   }
+
+  /**
+   * A second icon can be specified, and it will take the opposite side of the primary icon.
+   */
+  @Input()
+  set secondIcon(icon: string) {
+    if (icon) {
+      this._secondIcon.set(`bhi-${icon}`);
+    }
+  }
+  get secondIcon(): string {
+    return this._secondIcon();
+  }
+
+  leftSideIconClass: Signal<string> = computed(() => this.side === 'left' ? this._icon() : this._secondIcon());
+
+  rightSideIconClass: Signal<string> = computed(() => this.side === 'right' ? this._icon() : this._secondIcon());
 
   /**
    * Make the button non-interactive.
@@ -110,7 +139,9 @@ export class NovoButtonElement implements OnChanges {
   @HostBinding('attr.disabled')
   disabledAttr: undefined | '' = undefined;
 
-  private _icon: string;
+  private _icon: WritableSignal<string> = signal(undefined);
+
+  private _secondIcon: WritableSignal<string> = signal(undefined);
 
   constructor(public element: ElementRef) {}
 

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -173,7 +173,7 @@ export interface IDataTableSort {
 
 export interface IDataTableFilter {
   id: string;
-  value: string | string[];
+  value: any;
   transform?: Function;
   type?: string;
   selectedOption?: Object;

--- a/projects/novo-elements/src/elements/field/field-fill.scss
+++ b/projects/novo-elements/src/elements/field/field-fill.scss
@@ -43,6 +43,22 @@
           border-bottom: 1px solid $negative !important;
         }
       }
+      &.novo-field-disabled {
+        .novo-field-input {
+          color: $grey !important;
+          border-bottom: 1px dashed $grey !important;
+        }
+        &:not(.novo-focused):hover {
+          .novo-field-input {
+            color: $grey !important;
+            border-bottom: 1px dashed $grey !important;
+          }
+        }
+      }
+      .novo-field-input:disabled {
+        color: $grey !important;
+        border-bottom: 1px dashed $grey !important;
+      }
     }
   }
 }

--- a/projects/novo-elements/src/elements/field/field-standard.scss
+++ b/projects/novo-elements/src/elements/field/field-standard.scss
@@ -22,6 +22,22 @@
           border-bottom: 1px solid $negative !important;
         }
       }
+      &.novo-field-disabled {
+        .novo-field-input {
+          color: $grey !important;
+          border-bottom: 1px dashed $grey !important;
+        }
+        &:not(.novo-focused):hover {
+          .novo-field-input {
+            color: $grey !important;
+            border-bottom: 1px dashed $grey !important;
+          }
+        }
+      }
+      .novo-field-input:disabled {
+        color: $grey !important;
+        border-bottom: 1px dashed $grey !important;
+      }
     }
   }
 }

--- a/projects/novo-elements/src/elements/select/Select.scss
+++ b/projects/novo-elements/src/elements/select/Select.scss
@@ -57,10 +57,23 @@
       right: 0px;
     }
   }
-  &[disabled] {
+  &[disabled],
+  &.novo-select-disabled {
     pointer-events: none;
     div[type="button"] {
       color: $grey;
+    }
+    i {
+      color: $grey !important;
+    }
+    .novo-select-trigger {
+      color: $grey !important;
+      border-bottom: 1px dashed $grey !important;
+
+      &:hover {
+        color: $grey !important;
+        border-bottom: 1px dashed $grey !important;
+      }
     }
   }
 }

--- a/projects/novo-examples/src/components/buttons/button-examples.md
+++ b/projects/novo-examples/src/components/buttons/button-examples.md
@@ -68,3 +68,9 @@ Button parameters can be dynamically set and change at runtime. The styles shoul
 Buttons can display a loading state when given the "loading" parameter. When loading is true the button will be disabled and get a loading spinner.
 
 <code-example example="button-loading"></code-example>
+
+## Two Icons
+
+A second icon can be specified, and it will take the opposite side of the primary icon.
+
+<code-example example="button-two-icon"></code-example>

--- a/projects/novo-examples/src/components/buttons/button-two-icon/button-two-icon-example.css
+++ b/projects/novo-examples/src/components/buttons/button-two-icon/button-two-icon-example.css
@@ -1,0 +1,5 @@
+/** No CSS for this example */
+
+button {
+  margin: 1rem;
+}

--- a/projects/novo-examples/src/components/buttons/button-two-icon/button-two-icon-example.html
+++ b/projects/novo-examples/src/components/buttons/button-two-icon/button-two-icon-example.html
@@ -1,0 +1,2 @@
+<button theme="primary" icon="edit" secondIcon="arrow-right">Two Icons</button>
+<button theme="primary" icon="bolt" secondIcon="configure-o" side="right">Two Icons</button>

--- a/projects/novo-examples/src/components/buttons/button-two-icon/button-two-icon-example.ts
+++ b/projects/novo-examples/src/components/buttons/button-two-icon/button-two-icon-example.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+/**
+ * @title Icon buttons
+ */
+@Component({
+  selector: 'button-two-icon-example',
+  templateUrl: 'button-two-icon-example.html',
+  styleUrls: ['button-two-icon-example.css'],
+})
+export class ButtonTwoIconExample {}

--- a/projects/novo-examples/src/components/buttons/button-two-icon/index.ts
+++ b/projects/novo-examples/src/components/buttons/button-two-icon/index.ts
@@ -1,0 +1,1 @@
+export * from './button-two-icon-example';

--- a/projects/novo-examples/src/components/buttons/index.ts
+++ b/projects/novo-examples/src/components/buttons/index.ts
@@ -8,3 +8,4 @@ export * from './button-overview';
 export * from './button-primary';
 export * from './button-secondary';
 export * from './button-standard';
+export * from './button-two-icon';


### PR DESCRIPTION
## **Description**

feat(Types): Fixing data table filter value type #1640
feat(novo-field): added disabled state styling to novo-field #1644
feat(Button): Add support for two icon buttons #1643

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**