### PR TITLE
feat(novo-field): added disabled state styling to novo-field 

### DIFF
--- a/projects/novo-elements/src/elements/field/field-fill.scss
+++ b/projects/novo-elements/src/elements/field/field-fill.scss
@@ -48,6 +48,12 @@
           color: $grey !important;
           border-bottom: 1px dashed $grey !important;
         }
+        &:not(.novo-focused):hover {
+          .novo-field-input {
+            color: $grey !important;
+            border-bottom: 1px dashed $grey !important;
+          }
+        }
       }
       .novo-field-input:disabled {
         color: $grey !important;

--- a/projects/novo-elements/src/elements/field/field-fill.scss
+++ b/projects/novo-elements/src/elements/field/field-fill.scss
@@ -43,6 +43,16 @@
           border-bottom: 1px solid $negative !important;
         }
       }
+      &.novo-field-disabled {
+        .novo-field-input {
+          color: $grey !important;
+          border-bottom: 1px dashed $grey !important;
+        }
+      }
+      .novo-field-input:disabled {
+        color: $grey !important;
+        border-bottom: 1px dashed $grey !important;
+      }
     }
   }
 }

--- a/projects/novo-elements/src/elements/field/field-standard.scss
+++ b/projects/novo-elements/src/elements/field/field-standard.scss
@@ -27,6 +27,12 @@
           color: $grey !important;
           border-bottom: 1px dashed $grey !important;
         }
+        &:not(.novo-focused):hover {
+          .novo-field-input {
+            color: $grey !important;
+            border-bottom: 1px dashed $grey !important;
+          }
+        }
       }
       .novo-field-input:disabled {
         color: $grey !important;

--- a/projects/novo-elements/src/elements/field/field-standard.scss
+++ b/projects/novo-elements/src/elements/field/field-standard.scss
@@ -22,6 +22,16 @@
           border-bottom: 1px solid $negative !important;
         }
       }
+      &.novo-field-disabled {
+        .novo-field-input {
+          color: $grey !important;
+          border-bottom: 1px dashed $grey !important;
+        }
+      }
+      .novo-field-input:disabled {
+        color: $grey !important;
+        border-bottom: 1px dashed $grey !important;
+      }
     }
   }
 }

--- a/projects/novo-elements/src/elements/select/Select.scss
+++ b/projects/novo-elements/src/elements/select/Select.scss
@@ -57,7 +57,8 @@
       right: 0px;
     }
   }
-  &[disabled] {
+  &[disabled],
+  &.novo-select-disabled {
     pointer-events: none;
     div[type="button"] {
       color: $grey;

--- a/projects/novo-elements/src/elements/select/Select.scss
+++ b/projects/novo-elements/src/elements/select/Select.scss
@@ -69,6 +69,11 @@
     .novo-select-trigger {
       color: $grey !important;
       border-bottom: 1px dashed $grey !important;
+
+      &:hover {
+        color: $grey !important;
+        border-bottom: 1px dashed $grey !important;
+      }
     }
   }
 }

--- a/projects/novo-elements/src/elements/select/Select.scss
+++ b/projects/novo-elements/src/elements/select/Select.scss
@@ -62,6 +62,13 @@
     div[type="button"] {
       color: $grey;
     }
+    i {
+      color: $grey !important;
+    }
+    .novo-select-trigger {
+      color: $grey !important;
+      border-bottom: 1px dashed $grey !important;
+    }
   }
 }
 


### PR DESCRIPTION
added disabled state styling to novo-field underlined appearance

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**