### PR TITLE
feat(DataTable): updating some data table types

### DIFF
--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -29,6 +29,7 @@ export interface DataTableWhere {
   query: string;
   criteria?: AdaptiveCriteria;
   keywords?: SearchKeywords;
+  booleanKeywords?: string;
   scoreByEntityId?: number;
   form: any;
 }

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -16,6 +16,7 @@ export interface IDataTablePreferences {
   autobuildEntity?: AutobuildEntityData;
   hasUnsavedChanges?: boolean;
   unsavedChanges?: any;
+  useBooleanKeywords?: boolean;
 }
 
 export interface AutobuildEntityData {
@@ -295,6 +296,7 @@ export interface IKeywordGroup {
 }
 
 export interface IKeywordBlock {
+  operator?: 'and' | 'or';
   exclude?: boolean;
   keywordGroups: IKeywordGroup[];
 }


### PR DESCRIPTION
## **Description**

updating some types to support top level ORs and nested ANDs in our keyword search objects.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**