### PR TITLE
feat(): next

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   build:
     name: Build & Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:
       fail-fast: false
@@ -32,7 +32,7 @@ jobs:
           path: dist
 
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build
     steps:
       - uses: actions/checkout@master

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -297,6 +297,7 @@ import { DataTableState } from './state/data-table-state.service';
         [loading]="paginationOptions.loading"
         [errorLoading]="paginationOptions.errorLoading"
         [paginationRefreshSubject]="paginationRefreshSubject"
+        [showPaginationTotalRecordCount]="true"
       >
       </novo-data-table-pagination>
     </footer>

--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -16,6 +16,7 @@ export interface IDataTablePreferences {
   autobuildEntity?: AutobuildEntityData;
   hasUnsavedChanges?: boolean;
   unsavedChanges?: any;
+  useBooleanKeywords?: boolean;
 }
 
 export interface AutobuildEntityData {
@@ -28,6 +29,7 @@ export interface DataTableWhere {
   query: string;
   criteria?: AdaptiveCriteria;
   keywords?: SearchKeywords;
+  booleanKeywords?: string;
   scoreByEntityId?: number;
   form: any;
 }
@@ -295,6 +297,7 @@ export interface IKeywordGroup {
 }
 
 export interface IKeywordBlock {
+  operator?: 'and' | 'or';
   exclude?: boolean;
   keywordGroups: IKeywordGroup[];
 }

--- a/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.scss
+++ b/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.scss
@@ -120,5 +120,9 @@ $breakpoint: 1000px;
         opacity: 1;
       }
     }
+    .novo-data-table-of-total-amount {
+      color: $slate;
+      font-size: 12px;
+    }
   }
 }

--- a/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
+++ b/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.ts
@@ -76,6 +76,9 @@ const MAX_PAGES_DISPLAYED = 5;
         [attr.data-feature-id]="dataFeatureId"
       >
       </novo-select>
+      <div *ngIf="showPaginationTotalRecordCount && !loading && !errorLoading" class="novo-data-table-of-total-amount" data-automation-id="novo-data-table-of-total-amount">
+        {{ labels.ofXAmount(length) }}
+      </div>
       <span class="spacer"></span>
       <ul *ngIf="!loading && !errorLoading" class="pager" data-automation-id="pager">
         <li class="page" (click)="selectPage(page - 1)" [ngClass]="{ disabled: page === 0 }">
@@ -150,6 +153,8 @@ export class NovoDataTablePagination<T> implements OnInit, OnDestroy {
   public errorLoading: boolean = false;
   @Input()
   public paginationRefreshSubject = new Subject<void>();
+  @Input()
+  public showPaginationTotalRecordCount: boolean = false;
 
   @Input()
   get length(): number {

--- a/projects/novo-elements/src/elements/picker/extras/grouped-multi-picker-results/GroupedMultiPickerResults.scss
+++ b/projects/novo-elements/src/elements/picker/extras/grouped-multi-picker-results/GroupedMultiPickerResults.scss
@@ -11,6 +11,7 @@
   transition: all 0.15s cubic-bezier(0.35, 0, 0.25, 1);
   display: flex;
   flex-direction: row;
+  width: fit-content;
   novo-list-item {
     cursor: pointer;
     flex-shrink: 0;

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
@@ -10,10 +10,10 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
   selector: 'novo-picker-condition-def',
   template: `
     <ng-container novoConditionFieldDef>
-      <novo-field *novoConditionOperatorsDef="let formGroup" [formGroup]="formGroup">
+      <novo-field *novoConditionOperatorsDef="let formGroup; fieldMeta as meta" [formGroup]="formGroup">
         <novo-select [placeholder]="labels.operator" formControlName="operator" (onSelect)="onOperatorSelect(formGroup)">
           <novo-option value="includeAny">{{ labels.includeAny }}</novo-option>
-          <novo-option value="includeAll">{{ labels.includeAll }}</novo-option>
+          <novo-option value="includeAll" *ngIf="!meta?.removeIncludeAll">{{ labels.includeAll }}</novo-option>
           <novo-option value="excludeAny">{{ labels.exclude }}</novo-option>
           <novo-option value="isNull">{{ labels.isEmpty }}</novo-option>
         </novo-select>

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
@@ -15,10 +15,10 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
   template: `
     <!-- fieldTypes should be UPPERCASE -->
     <ng-container novoConditionFieldDef="STRING">
-      <novo-field *novoConditionOperatorsDef="let formGroup" [formGroup]="formGroup">
+      <novo-field *novoConditionOperatorsDef="let formGroup; fieldMeta as meta" [formGroup]="formGroup">
         <novo-select [placeholder]="labels.operator" formControlName="operator" (onSelect)="onOperatorSelect(formGroup)">
           <novo-option value="includeAny">{{ labels.includeAny }}</novo-option>
-          <novo-option value="includeAll">{{ labels.includeAll }}</novo-option>
+          <novo-option value="includeAll" *ngIf="!meta?.removeIncludeAll">{{ labels.includeAll }}</novo-option>
           <novo-option value="excludeAny">{{ labels.exclude }}</novo-option>
           <novo-option value="isEmpty">{{ labels.isEmpty }}</novo-option>
         </novo-select>

--- a/projects/novo-elements/src/services/novo-label-service.ts
+++ b/projects/novo-elements/src/services/novo-label-service.ts
@@ -182,6 +182,10 @@ export class NovoLabelService {
     return `Showing ${shown} of ${total} Results.`;
   }
 
+  ofXAmount(amount: number) {
+    return `of ${amount}`;
+  }
+
   totalRecords(total: number, select = false) {
     return select ? `Select all ${total} records.` : `De-select remaining ${total} records.`;
   }

--- a/projects/novo-examples/src/examples.routes.ts
+++ b/projects/novo-examples/src/examples.routes.ts
@@ -877,6 +877,9 @@ export class ButtonDevelopPage {
 <h2>Loading</h2>
 <p>Buttons can display a loading state when given the &quot;loading&quot; parameter. When loading is true the button will be disabled and get a loading spinner.</p>
 <p><code-example example="button-loading"></code-example></p>
+<h2>Two Icons</h2>
+<p>A second icon can be specified, and it will take the opposite side of the primary icon.</p>
+<p><code-example example="button-two-icon"></code-example></p>
 `,
   host: { class: 'markdown-page' }
 })


### PR DESCRIPTION
## **Description**

feat(NovoDataTablePagination): Add option to show the total number of records in a table next to pagination #1648
feat(DataTable): updating some data table types #1647
fix(Build): updating build runner due to github decommissioning ubuntu 20.04 support in april #1653
feat(QueryBuilder): Add option to not show Include All option dependi… #1654
fix(GroupedMultiPickerResults): Ensure Background Visibility #1655

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**