### PR TITLE
fix(GroupedMultiPickerResults): Ensure Background Visibility

### DIFF
--- a/projects/novo-elements/src/elements/picker/extras/grouped-multi-picker-results/GroupedMultiPickerResults.scss
+++ b/projects/novo-elements/src/elements/picker/extras/grouped-multi-picker-results/GroupedMultiPickerResults.scss
@@ -11,6 +11,7 @@
   transition: all 0.15s cubic-bezier(0.35, 0, 0.25, 1);
   display: flex;
   flex-direction: row;
+  width: fit-content;
   novo-list-item {
     cursor: pointer;
     flex-shrink: 0;


### PR DESCRIPTION
## **Description**

The background visibility of the Grouped Multi Picker Results was not extending the entire length if the Grouped Multi Picker was inside of a modal. This change is to ensure the background fits the length of the results.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**