### PR TITLE
fix(Select): Changes to better support screen readers in <novo-select>

### DIFF
--- a/projects/novo-elements/src/elements/common/typography/label/label.component.ts
+++ b/projects/novo-elements/src/elements/common/typography/label/label.component.ts
@@ -1,5 +1,5 @@
 // NG2
-import { Component } from '@angular/core';
+import { Component, HostBinding, input } from '@angular/core';
 import { NovoBaseTextElement } from '../base/base-text.component';
 
 /**
@@ -13,6 +13,8 @@ import { NovoBaseTextElement } from '../base/base-text.component';
  * <novo-label color="grapefruit">Label</novo-label>
  */
 
+let nextId = 0;
+
 @Component({
   selector: 'novo-label,[novo-label]',
   template: ` <ng-content></ng-content> `,
@@ -21,4 +23,13 @@ import { NovoBaseTextElement } from '../base/base-text.component';
     class: 'novo-label',
   },
 })
-export class NovoLabel extends NovoBaseTextElement {}
+export class NovoLabel extends NovoBaseTextElement {
+  @HostBinding('attr.id')
+  public id: string;
+
+  inputId = input(null, { alias: 'id' });
+
+  ngOnInit() {
+    this.id = this.inputId() || `novo-label-${++nextId}`;
+  }
+}

--- a/projects/novo-elements/src/elements/common/typography/label/label.component.ts
+++ b/projects/novo-elements/src/elements/common/typography/label/label.component.ts
@@ -1,5 +1,5 @@
 // NG2
-import { Component, computed, input } from '@angular/core';
+import { Component, HostBinding, input, OnInit } from '@angular/core';
 import { NovoBaseTextElement } from '../base/base-text.component';
 
 /**
@@ -17,16 +17,20 @@ let nextId = 0;
 
 @Component({
   selector: 'novo-label,[novo-label]',
-  template: `<ng-content></ng-content>`,
+  template: ` <ng-content></ng-content> `,
   styleUrls: ['./label.scss'],
   host: {
     class: 'novo-label',
-    '[attr.id]': 'computedId()',
   },
 })
-export class NovoLabel extends NovoBaseTextElement {
+export class NovoLabel extends NovoBaseTextElement implements OnInit{
+  @HostBinding('attr.id')
+  public id: string;
+
   inputId = input(null, { alias: 'id' });
 
-  computedId = computed(() => this.inputId() || `novo-label-${++nextId}`);
+  ngOnInit() {
+    this.id = this.inputId() || `novo-label-${++nextId}`;
+  }
 }
 

--- a/projects/novo-elements/src/elements/common/typography/label/label.component.ts
+++ b/projects/novo-elements/src/elements/common/typography/label/label.component.ts
@@ -1,5 +1,5 @@
 // NG2
-import { Component, computed, HostBinding, input } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { NovoBaseTextElement } from '../base/base-text.component';
 
 /**
@@ -21,15 +21,12 @@ let nextId = 0;
   styleUrls: ['./label.scss'],
   host: {
     class: 'novo-label',
+    '[attr.id]': 'computedId()',
   },
 })
 export class NovoLabel extends NovoBaseTextElement {
-  inputId = input<string | null>(null, { alias: 'id' });
+  inputId = input(null, { alias: 'id' });
 
-  computedId = computed(() => this.inputId() ?? `novo-label-${++nextId}`);
-
-  @HostBinding('attr.id')
-  get id(): string {
-    return this.computedId();
-  }
+  computedId = computed(() => this.inputId() || `novo-label-${++nextId}`);
 }
+

--- a/projects/novo-elements/src/elements/common/typography/label/label.component.ts
+++ b/projects/novo-elements/src/elements/common/typography/label/label.component.ts
@@ -1,5 +1,5 @@
 // NG2
-import { Component, computed, input } from '@angular/core';
+import { Component, computed, HostBinding, input } from '@angular/core';
 import { NovoBaseTextElement } from '../base/base-text.component';
 
 /**
@@ -17,15 +17,19 @@ let nextId = 0;
 
 @Component({
   selector: 'novo-label,[novo-label]',
-  template: ` <ng-content></ng-content> `,
+  template: `<ng-content></ng-content>`,
   styleUrls: ['./label.scss'],
   host: {
     class: 'novo-label',
-    '[attr.id]': 'id()',
   },
 })
 export class NovoLabel extends NovoBaseTextElement {
-  inputId = input(null, { alias: 'id' });
+  inputId = input<string | null>(null, { alias: 'id' });
 
-  id = computed(() => this.inputId() || `novo-label-${++nextId}`);
+  computedId = computed(() => this.inputId() ?? `novo-label-${++nextId}`);
+
+  @HostBinding('attr.id')
+  get id(): string {
+    return this.computedId();
+  }
 }

--- a/projects/novo-elements/src/elements/common/typography/label/label.component.ts
+++ b/projects/novo-elements/src/elements/common/typography/label/label.component.ts
@@ -1,5 +1,6 @@
 // NG2
-import { Component, HostBinding, input } from '@angular/core';
+import { Component, HostBinding, input, OnInit } from '@angular/core';
+
 import { NovoBaseTextElement } from '../base/base-text.component';
 
 /**
@@ -23,7 +24,7 @@ let nextId = 0;
     class: 'novo-label',
   },
 })
-export class NovoLabel extends NovoBaseTextElement {
+export class NovoLabel extends NovoBaseTextElement implements OnInit {
   @HostBinding('attr.id')
   public id: string;
 

--- a/projects/novo-elements/src/elements/common/typography/label/label.component.ts
+++ b/projects/novo-elements/src/elements/common/typography/label/label.component.ts
@@ -1,6 +1,5 @@
 // NG2
-import { Component, HostBinding, input, OnInit } from '@angular/core';
-
+import { Component, computed, input } from '@angular/core';
 import { NovoBaseTextElement } from '../base/base-text.component';
 
 /**
@@ -22,15 +21,11 @@ let nextId = 0;
   styleUrls: ['./label.scss'],
   host: {
     class: 'novo-label',
+    '[attr.id]': 'id()',
   },
 })
-export class NovoLabel extends NovoBaseTextElement implements OnInit {
-  @HostBinding('attr.id')
-  public id: string;
-
+export class NovoLabel extends NovoBaseTextElement {
   inputId = input(null, { alias: 'id' });
 
-  ngOnInit() {
-    this.id = this.inputId() || `novo-label-${++nextId}`;
-  }
+  id = computed(() => this.inputId() || `novo-label-${++nextId}`);
 }

--- a/projects/novo-elements/src/elements/select/Select.scss
+++ b/projects/novo-elements/src/elements/select/Select.scss
@@ -9,6 +9,18 @@
   min-width: 180px;
   cursor: pointer;
 
+  &:focus .novo-select-trigger {
+    border-bottom: 1px solid $positive;
+    i {
+      color: rgba(0, 0, 0, 0.73);
+    }
+  }
+  /* cdk-mouse-focused will only apply this state when the user focuses with the mouse.
+  &.cdk-mouse-focused {*/
+  &:focus {
+    outline: none;
+  }
+
   .novo-select-trigger {
     @include novo-body-text();
     display: flex;
@@ -32,18 +44,8 @@
     &.empty {
       color: #a9a9a9;
     }
-    &:focus,
-    &:hover {
-      outline: none;
-    }
     &:hover {
       border-bottom: 1px solid lighten($dark, 15%);
-    }
-    &:focus {
-      border-bottom: 1px solid $positive;
-      i {
-        color: rgba(0, 0, 0, 0.73);
-      }
     }
 
     .novo-select-placeholder {

--- a/projects/novo-elements/src/elements/select/Select.scss
+++ b/projects/novo-elements/src/elements/select/Select.scss
@@ -15,8 +15,7 @@
       color: rgba(0, 0, 0, 0.73);
     }
   }
-  /* cdk-mouse-focused will only apply this state when the user focuses with the mouse.
-  &.cdk-mouse-focused {*/
+
   &:focus {
     outline: none;
   }


### PR DESCRIPTION
## **Description**

Sample changes to provide better screenreader accessibility on the <novo-select> component.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**