### PR TITLE
feat(QueryBuilder): Remove Is Empty option from numerical conditions

### DIFF
--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/number-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/number-condition.definition.ts
@@ -17,7 +17,6 @@ import { NovoLabelService } from 'novo-elements/services';
           <novo-option value="lessThan">{{ labels.lessThan }}</novo-option>
           <novo-option value="equalTo">{{ labels.equalTo }}</novo-option>
           <novo-option value="between">{{ labels.between }}</novo-option>
-          <novo-option value="isNull">{{ labels.isEmpty }}</novo-option>
         </novo-select>
       </novo-field>
       <ng-container *novoConditionInputDef="let formGroup" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">


### PR DESCRIPTION
…tions

## **Description**

There shouldn't usually be a situation where numerical values can be "null", so this option has not traditionally made sense.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**