### PR TITLE
fix(Select): novo-select, call _initLegacyOptions sooner to address race condition

### DIFF
--- a/projects/novo-elements/src/elements/common/option/option.component.ts
+++ b/projects/novo-elements/src/elements/common/option/option.component.ts
@@ -198,6 +198,7 @@ export class NovoOptionBase implements FocusableOption, AfterViewChecked, OnDest
       event.stopImmediatePropagation();
     }
   }
+
   _handlePassiveClick(event: MouseEvent) {
     if (!this.novoInert) {
       this._selectViaInteraction();

--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -506,7 +506,7 @@ export class NovoSelectElement
       this._selectionModel.select(correspondingOption);
     } else if (value && !correspondingOption) {
       // Double Check option not already added.
-      const legacyOption = this.filteredOptions?.find((it) => it.value === value);
+      const legacyOption = this.filteredOptions.find((it) => it.value === value);
       if (!legacyOption) {
         // Add a disabled option to the list and select it
         this.filteredOptions.push({

--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -212,8 +212,6 @@ export class NovoSelectElement
   @Input()
   name: string = this._uniqueId;
   @Input()
-  options: Array<any>;
-  @Input()
   placeholder: string = 'Select...';
   @Input()
   readonly: boolean;
@@ -311,6 +309,17 @@ export class NovoSelectElement
   }
   private _multiple: boolean = false;
 
+  /** Array of options to display in the select dropdown */
+  @Input()
+  set options(options: Array<any>) {
+    this._options = options;
+    this._initLegacyOptions();
+  }
+  get options(): Array<any> {
+    return this._options;
+  }
+  private _options: Array<any>;
+
   /** Whether the select is focused. */
   get focused(): boolean {
     return this._focused || this.panelOpen;
@@ -360,7 +369,6 @@ export class NovoSelectElement
 
   ngOnInit() {
     this.stateChanges.next();
-    this._initLegacyOptions();
     this.focusMonitor.monitor(this.elementRef.nativeElement).subscribe((origin) =>
       this.ngZone.run(() => {
         this._focused = !!origin;

--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -445,8 +445,6 @@ export class NovoSelectElement
     return false;
   }
 
-
-
   openPanel() {
     super.openPanel();
     this._highlightCorrectOption();

--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -437,7 +437,7 @@ export class NovoSelectElement
     return false;
   }
 
-  
+
 
   openPanel() {
     super.openPanel();
@@ -500,7 +500,7 @@ export class NovoSelectElement
       this._selectionModel.select(correspondingOption);
     } else if (value && !correspondingOption) {
       // Double Check option not already added.
-      const legacyOption = this.filteredOptions.find((it) => it.value === value);
+      const legacyOption = this.filteredOptions?.find((it) => it.value === value);
       if (!legacyOption) {
         // Add a disabled option to the list and select it
         this.filteredOptions.push({


### PR DESCRIPTION
## **Description**

- moved `_initLegacyOptions()` call in `ngOnInit` to the more relevent location: 
  - after **options** are set -- now via an **@Input** setter, which always beats `ngOnInit` in a race.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**