### PR TITLE
fix(Select): Hide legacy options select if text-filtered

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "jest": "~29.7.0",
         "jest-environment-jsdom": "~29.7.0",
         "jest-jasmine2": "~29.7.0",
-        "jest-preset-angular": "~13.1.6",
+        "jest-preset-angular": "~14.5.5",
         "markdown-it": "^12.0.6",
         "markdown-it-attrs": "^4.0.0",
         "markdown-it-container": "^3.0.0",
@@ -14674,32 +14674,36 @@
       }
     },
     "node_modules/jest-preset-angular": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/jest-preset-angular/-/jest-preset-angular-13.1.6.tgz",
-      "integrity": "sha512-0pXSm6168Qn+qKp7DpzYoaIp0uyMHdQaWYVp8jlw7Mh+NEBtrBjKqts3kLeBHgAhGMQArp07S2IxZ6eCr8fc7Q==",
+      "version": "14.5.5",
+      "resolved": "https://registry.npmjs.org/jest-preset-angular/-/jest-preset-angular-14.5.5.tgz",
+      "integrity": "sha512-PUykbixXEYSltKQE4450YuBiO8SMo2SwdGRHAdArRuV06Igq8gaLRVt9j8suj/4qtm2xRqoKnh5j52R0PfQxFw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
-        "esbuild-wasm": ">=0.13.8",
-        "jest-environment-jsdom": "^29.0.0",
-        "jest-util": "^29.0.0",
-        "pretty-format": "^29.0.0",
-        "ts-jest": "^29.0.0"
+        "esbuild-wasm": ">=0.15.13",
+        "jest-environment-jsdom": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0",
+        "ts-jest": "^29.3.0"
       },
       "engines": {
         "node": "^14.15.0 || >=16.10.0"
       },
       "optionalDependencies": {
-        "esbuild": ">=0.13.8"
+        "esbuild": ">=0.15.13"
       },
       "peerDependencies": {
-        "@angular-devkit/build-angular": ">=13.0.0 <18.0.0",
-        "@angular/compiler-cli": ">=13.0.0 <18.0.0",
-        "@angular/core": ">=13.0.0 <18.0.0",
-        "@angular/platform-browser-dynamic": ">=13.0.0 <18.0.0",
+        "@angular/compiler-cli": ">=15.0.0 <20.0.0",
+        "@angular/core": ">=15.0.0 <20.0.0",
+        "@angular/platform-browser-dynamic": ">=15.0.0 <20.0.0",
         "jest": "^29.0.0",
-        "typescript": ">=4.4"
+        "jsdom": ">=20.0.0",
+        "typescript": ">=4.8"
+      },
+      "peerDependenciesMeta": {
+        "jsdom": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-regex-util": {
@@ -25565,11 +25569,10 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.2.5",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.5.tgz",
-      "integrity": "sha512-KD8zB2aAZrcKIdGk4OwpJggeLcH1FgrICqDSROWqlnJXGCXK4Mn6FcdK2B6670Xr73lHMG1kHw8R87A0ecZ+vA==",
+      "version": "29.3.2",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.2.tgz",
+      "integrity": "sha512-bJJkrWc6PjFVz5g2DGCNUo8z7oFEYaz1xP1NpeDU7KNLMWPpEyV8Chbpkn8xjzgRDpQhnGMyvyldoL7h8JXyug==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "ejs": "^3.1.10",
@@ -25578,7 +25581,8 @@
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.6.3",
+        "semver": "^7.7.1",
+        "type-fest": "^4.39.1",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
@@ -25614,16 +25618,27 @@
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ts-jest/node_modules/yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "jest": "~29.7.0",
     "jest-environment-jsdom": "~29.7.0",
     "jest-jasmine2": "~29.7.0",
-    "jest-preset-angular": "~13.1.6",
+    "jest-preset-angular": "~14.5.5",
     "markdown-it": "^12.0.6",
     "markdown-it-attrs": "^4.0.0",
     "markdown-it-container": "^3.0.0",

--- a/projects/novo-elements/src/elements/select-search/select-search.component.ts
+++ b/projects/novo-elements/src/elements/select-search/select-search.component.ts
@@ -258,7 +258,9 @@ export class NovoSelectSearchComponent implements OnInit, OnDestroy, ControlValu
     @Optional() @Inject(NovoOption) public novoOption: NovoOption = null,
     private liveAnnouncer: LiveAnnouncer,
     @Optional() @Inject(NovoFieldElement) public matFormField: NovoFieldElement = null,
-  ) {}
+  ) {
+    this.novoSelect.hideLegacyOptionsForSearch.set(true);
+  }
 
   ngOnInit() {
     // set custom panel class

--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -272,7 +272,7 @@ export class NovoSelectElement
   onModelTouched: Function = () => {};
   filterTerm: string = '';
   filterTermTimeout;
-  filteredOptions: any[];
+  filteredOptions: any;
   disabled: boolean = false;
 
   /** Element for the panel containing the autocomplete options. */
@@ -286,6 +286,7 @@ export class NovoSelectElement
   @ViewChildren(NovoOption)
   viewOptions: QueryList<NovoOption>;
 
+  // This signal may be set programmatically by a SelectSearchComponent.
   hideLegacyOptionsForSearch = signal(false);
 
   hideLegacyOptions = input(false, { transform: booleanAttribute });
@@ -842,7 +843,7 @@ export class NovoSelectElement
         .map((item) => {
           return {
             ...item,
-            disabled: item.readOnly || item.disabled,
+            disabled: Boolean(item.readOnly || item.disabled),
           };
         })
         .map((item) => {

--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -5,13 +5,16 @@ import { SelectionModel } from '@angular/cdk/collections';
 import { hasModifierKey } from '@angular/cdk/keycodes';
 import {
   AfterViewInit,
+  booleanAttribute,
   ChangeDetectorRef,
   Component,
+  computed,
   ContentChildren,
   ElementRef,
   EventEmitter,
   HostListener,
   Inject,
+  input,
   Input,
   NgZone,
   OnChanges,
@@ -21,6 +24,7 @@ import {
   Output,
   QueryList,
   Self,
+  signal,
   SimpleChanges,
   ViewChild,
   ViewChildren,
@@ -206,6 +210,12 @@ export class NovoSelectElement
   _userTabIndex: number | null = null;
   /** The FocusKeyManager which handles focus. */
   _keyManager: ActiveDescendantKeyManager<NovoOption>;
+  /** 
+   * The display string for the current value, kept from when the associated <novo-option> has stopped rendering
+   * due to filtration
+   */
+  private _lingeringDisplayValue: string = null;
+  private _legacyOption: any;
 
   @Input()
   id: string = this._uniqueId;
@@ -262,7 +272,7 @@ export class NovoSelectElement
   onModelTouched: Function = () => {};
   filterTerm: string = '';
   filterTermTimeout;
-  filteredOptions: any;
+  filteredOptions: any[];
   disabled: boolean = false;
 
   /** Element for the panel containing the autocomplete options. */
@@ -275,6 +285,14 @@ export class NovoSelectElement
   contentOptions: QueryList<NovoOption>;
   @ViewChildren(NovoOption)
   viewOptions: QueryList<NovoOption>;
+
+  hideLegacyOptionsForSearch = signal(false);
+
+  hideLegacyOptions = input(false, { transform: booleanAttribute });
+
+  private displayLegacyOptions = computed(() => {
+    return !(this.hideLegacyOptionsForSearch() || this.hideLegacyOptions());
+  })
 
   @ViewChild('panel')
   panel: ElementRef;
@@ -294,6 +312,7 @@ export class NovoSelectElement
         this._setSelectionByValue(newValue);
       }
       this._value = newValue;
+      this._lingeringDisplayValue = null;
     }
   }
   private _value: any = null;
@@ -504,17 +523,20 @@ export class NovoSelectElement
     });
     if (correspondingOption) {
       this._selectionModel.select(correspondingOption);
-    } else if (value && !correspondingOption) {
+    } else if (value && !correspondingOption && this.displayLegacyOptions()) {
+      // If searchComponent is present, we are using a text input filter; so if there is an
+      // option not in the list, it is just filtered out
       // Double Check option not already added.
       const legacyOption = this.filteredOptions.find((it) => it.value === value);
       if (!legacyOption) {
         // Add a disabled option to the list and select it
-        this.filteredOptions.push({
+        this._legacyOption = {
           disabled: true,
           tooltip: 'Value is not provided in list of valid options.',
           label: value?.label || value,
           value,
-        });
+        }
+        this.filteredOptions.push(this._legacyOption);
         this.ref.detectChanges();
       }
     }
@@ -556,6 +578,10 @@ export class NovoSelectElement
         }
       }
     }
+    const legacyOptionIndex = this.filteredOptions.lastIndexOf(this._legacyOption);
+    if (legacyOptionIndex !== -1) {
+      this.filteredOptions.splice(legacyOptionIndex, 1);
+    }
 
     if (wasSelected !== this._selectionModel.isSelected(option)) {
       this._propagateChanges();
@@ -566,7 +592,7 @@ export class NovoSelectElement
 
   private _getDisplayValue(option: NovoOption & { value?: any; label?: string }): string {
     if (!option) {
-      return '';
+      return this._lingeringDisplayValue ?? '';
     }
     let toDisplay = option.viewValue;
     if (this.displayWith) {
@@ -574,7 +600,12 @@ export class NovoSelectElement
     }
     // Simply falling back to an empty string if the display value is falsy does not work properly.
     // The display value can also be the number zero and shouldn't fall back to an empty string.
-    const displayValue = toDisplay != null ? toDisplay : '';
+    let displayValue = toDisplay != null ? toDisplay : '';
+    if (displayValue != '') {
+      this._lingeringDisplayValue = displayValue;
+    } else if (this._lingeringDisplayValue) {
+      displayValue = this._lingeringDisplayValue;
+    }
     return displayValue;
   }
 

--- a/projects/novo-examples/src/examples.routes.ts
+++ b/projects/novo-examples/src/examples.routes.ts
@@ -4552,6 +4552,9 @@ export class RadioButtonsPage {
 <h5>Multiple Selections With Search</h5>
 <p>The <code>novo-select-search</code> is compatible with the <code>multiple</code> option as well.</p>
 <p><code-example example="multiple-select-with-search"></code-example></p>
+<h5>Legacy Options</h5>
+<p>When a value is set manually on a <code>novo-select</code> that is not reflected in its options, it will be displayed as a disabled option. The value can be removed, but will not appear subsequently. This behavior can be disabled with the <code>hideLegacyOptions</code> input.</p>
+<p><code-example example="legacy-select-option"></code-example></p>
 `,
   host: { class: 'markdown-page' }
 })

--- a/projects/novo-examples/src/form-controls/select/index.ts
+++ b/projects/novo-examples/src/form-controls/select/index.ts
@@ -1,5 +1,6 @@
 export * from './basic-select';
 export * from './basic-select-with-search';
+export * from './legacy-select-option';
 export * from './long-select';
 export * from './multiple-select';
 export * from './multiple-select-with-search';

--- a/projects/novo-examples/src/form-controls/select/legacy-select-option/index.ts
+++ b/projects/novo-examples/src/form-controls/select/legacy-select-option/index.ts
@@ -1,0 +1,1 @@
+export * from './legacy-select-option-example';

--- a/projects/novo-examples/src/form-controls/select/legacy-select-option/legacy-select-option-example.css
+++ b/projects/novo-examples/src/form-controls/select/legacy-select-option/legacy-select-option-example.css
@@ -1,0 +1,1 @@
+/** No CSS for this example */

--- a/projects/novo-examples/src/form-controls/select/legacy-select-option/legacy-select-option-example.html
+++ b/projects/novo-examples/src/form-controls/select/legacy-select-option/legacy-select-option-example.html
@@ -1,0 +1,10 @@
+<novo-field>
+  <novo-label>
+    <span class="caption">Selected Value:</span> {{value}}
+  </novo-label>
+  <novo-select [placeholder]="placeholder" [(ngModel)]="value">
+    <novo-option *ngFor="let option of options" [value]="option">
+      {{option}}
+    </novo-option>
+  </novo-select>
+</novo-field>

--- a/projects/novo-examples/src/form-controls/select/legacy-select-option/legacy-select-option-example.ts
+++ b/projects/novo-examples/src/form-controls/select/legacy-select-option/legacy-select-option-example.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+
+/**
+ * @title Legacy Select Option Example
+ */
+@Component({
+  selector: 'legacy-select-option-example',
+  templateUrl: './legacy-select-option-example.html',
+  styleUrls: ['./legacy-select-option-example.css'],
+})
+export class LegacySelectOptionExample {
+  public placeholder: string = 'Select...';
+  public options: Array<string> = ['Alpha', 'Bravo', 'Charlie'];
+  public value: string = 'Delta';
+}

--- a/projects/novo-examples/src/form-controls/select/select.md
+++ b/projects/novo-examples/src/form-controls/select/select.md
@@ -31,3 +31,9 @@ When many option can be selected, use the `multiple` attribute which allows for 
 The `novo-select-search` is compatible with the `multiple` option as well.
 
 <code-example example="multiple-select-with-search"></code-example>
+
+##### Legacy Options
+
+When a value is set manually on a `novo-select` that is not reflected in its options, it will be displayed as a disabled option. The value can be removed, but will not appear subsequently. This behavior can be disabled with the `hideLegacyOptions` input.
+
+<code-example example="legacy-select-option"></code-example>

--- a/tools/examples-module.ts
+++ b/tools/examples-module.ts
@@ -261,6 +261,8 @@ const task = () => {
       }
 
       results.push(example);
+    } else {
+      console.warn(`No primary component located for example file "${sourcePath}". It may be missing a title comment.`)
     }
   }
 


### PR DESCRIPTION

## **Description**

When we apply text filtration of <novo-select> options, it can cause the UI to mistakenly show the current value as a "legacy option" - a disabled entry that shows it can no longer be selected. Since these are less useful when the set of options is large, we can just hide it. We've better clarified the code that causes these to display, and provided an example for users. There's also an added option allowing legacy options to be hidden completely in any case.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**