### PR TITLE
feat(QueryBuilder): Add option to not show Is Empty filter depending …

### DIFF
--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/boolean-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/boolean-condition.definition.ts
@@ -10,7 +10,7 @@ import { NovoLabelService } from 'novo-elements/services';
   selector: 'novo-boolean-condition-def',
   template: `
     <ng-container novoConditionFieldDef>
-      <novo-field *novoConditionOperatorsDef="let formGroup" [formGroup]="formGroup">
+      <novo-field *novoConditionOperatorsDef="let formGroup; fieldMeta as meta" [formGroup]="formGroup">
         <novo-select [placeholder]="labels.operator" formControlName="operator" (onSelect)="onOperatorSelect(formGroup)">
           <novo-option value="include">{{ labels.equals }}</novo-option>
           <novo-option value="exclude">{{ labels.doesNotEqual }}</novo-option>

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/boolean-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/boolean-condition.definition.ts
@@ -14,7 +14,7 @@ import { NovoLabelService } from 'novo-elements/services';
         <novo-select [placeholder]="labels.operator" formControlName="operator" (onSelect)="onOperatorSelect(formGroup)">
           <novo-option value="include">{{ labels.equals }}</novo-option>
           <novo-option value="exclude">{{ labels.doesNotEqual }}</novo-option>
-          <novo-option value="isNull">{{ labels.isEmpty }}</novo-option>
+          <novo-option value="isNull" *ngIf="!meta?.removeIsEmpty">{{ labels.isEmpty }}</novo-option>
         </novo-select>
       </novo-field>
       <novo-field *novoConditionInputDef="let formGroup" [style.width.px]="125" [formGroup]="formGroup">

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
@@ -18,7 +18,7 @@ import { NovoLabelService } from 'novo-elements/services';
           <novo-option value="after">{{ labels.after }}</novo-option>
           <novo-option value="within">{{ labels.within }}</novo-option>
           <novo-option value="between">{{ labels.between }}</novo-option>
-          <novo-option value="isNull">{{ labels.isEmpty }}</novo-option>
+          <novo-option value="isNull" *ngIf="!meta?.removeIsEmpty">{{ labels.isEmpty }}</novo-option>
         </novo-select>
       </novo-field>
       <ng-container *novoConditionInputDef="let formGroup; viewIndex as viewIndex" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
@@ -12,7 +12,7 @@ import { NovoLabelService } from 'novo-elements/services';
   selector: 'novo-date-condition-def',
   template: `
     <ng-container novoConditionFieldDef="DATE">
-      <novo-field *novoConditionOperatorsDef="let formGroup" [formGroup]="formGroup">
+      <novo-field *novoConditionOperatorsDef="let formGroup; fieldMeta as meta" [formGroup]="formGroup">
         <novo-select [placeholder]="labels.operator" formControlName="operator" (onSelect)="onOperatorSelect(formGroup)">
           <novo-option value="before">{{ labels.before }}</novo-option>
           <novo-option value="after">{{ labels.after }}</novo-option>

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/date-time-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/date-time-condition.definition.ts
@@ -18,7 +18,7 @@ import { NovoLabelService } from 'novo-elements/services';
           <novo-option value="after">{{ labels.after }}</novo-option>
           <novo-option value="within">{{ labels.within }}</novo-option>
           <novo-option value="between">{{ labels.between }}</novo-option>
-          <novo-option value="isNull">{{ labels.isEmpty }}</novo-option>
+          <novo-option value="isNull" *ngIf="!meta?.removeIsEmpty">{{ labels.isEmpty }}</novo-option>
         </novo-select>
       </novo-field>
       <ng-container *novoConditionInputDef="let formGroup; viewIndex as viewIndex" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/date-time-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/date-time-condition.definition.ts
@@ -12,7 +12,7 @@ import { NovoLabelService } from 'novo-elements/services';
   selector: 'novo-date-time-condition-def',
   template: `
     <ng-container novoConditionFieldDef="DATE">
-      <novo-field *novoConditionOperatorsDef="let formGroup" [formGroup]="formGroup">
+      <novo-field *novoConditionOperatorsDef="let formGroup; fieldMeta as meta" [formGroup]="formGroup">
         <novo-select [placeholder]="labels.operator" formControlName="operator" (onSelect)="onOperatorSelect(formGroup)">
           <novo-option value="before">{{ labels.before }}</novo-option>
           <novo-option value="after">{{ labels.after }}</novo-option>

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
@@ -15,7 +15,7 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
           <novo-option value="includeAny">{{ labels.includeAny }}</novo-option>
           <novo-option value="includeAll" *ngIf="!meta?.removeIncludeAll">{{ labels.includeAll }}</novo-option>
           <novo-option value="excludeAny">{{ labels.exclude }}</novo-option>
-          <novo-option value="isNull *ngIf="!meta?.removeIsEmpty">{{ labels.isEmpty }}</novo-option>
+          <novo-option value="isNull" *ngIf="!meta?.removeIsEmpty">{{ labels.isEmpty }}</novo-option>
         </novo-select>
       </novo-field>
       <ng-container *novoConditionInputDef="let formGroup; fieldMeta as meta" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
@@ -15,7 +15,7 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
           <novo-option value="includeAny">{{ labels.includeAny }}</novo-option>
           <novo-option value="includeAll" *ngIf="!meta?.removeIncludeAll">{{ labels.includeAll }}</novo-option>
           <novo-option value="excludeAny">{{ labels.exclude }}</novo-option>
-          <novo-option value="isNull">{{ labels.isEmpty }}</novo-option>
+          <novo-option value="isNull *ngIf="!meta?.removeIsEmpty">{{ labels.isEmpty }}</novo-option>
         </novo-select>
       </novo-field>
       <ng-container *novoConditionInputDef="let formGroup; fieldMeta as meta" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
@@ -20,7 +20,7 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
           <novo-option value="includeAny">{{ labels.includeAny }}</novo-option>
           <novo-option value="includeAll" *ngIf="!meta?.removeIncludeAll">{{ labels.includeAll }}</novo-option>
           <novo-option value="excludeAny">{{ labels.exclude }}</novo-option>
-          <novo-option value="isEmpty">{{ labels.isEmpty }}</novo-option>
+          <novo-option value="isEmpty" *ngIf="!meta?.removeIsEmpty">{{ labels.isEmpty }}</novo-option>
         </novo-select>
       </novo-field>
       <ng-container *novoConditionInputDef="let formGroup" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">


### PR DESCRIPTION
…on meta

## **Description**

Adds ability to not show the Is Empty filter in the condition dropdown if the field meta has the removeIsEmpty property set.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**