### PR TITLE
feat(Types): Keywords are no longer required in the autobuild response

### DIFF
--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -293,7 +293,7 @@ export interface IKeywordGroup {
   id: number;
   name: string;
   uniqueName?: string;
-  keywords: IKeyword[];
+  keywords?: IKeyword[];
 }
 
 export interface IKeywordBlock {


### PR DESCRIPTION
## **Description**

Making the keywords array no longer required, since the autobuild endpoint doesn't always contain it.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**