### PR TITLE
fix(select): fixing first value population when tabbing through dropdown/select fields

### DIFF
--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -615,7 +615,7 @@ export class NovoSelectElement
   private _handleClosedKeydown(event: KeyboardEvent): void {
     const key = event.key;
     const isArrowKey = key === Key.ArrowDown || key === Key.ArrowUp || key === Key.ArrowLeft || key === Key.ArrowRight;
-    const isOpenKey = key === Key.Enter || key === Key.Space;
+    const isOpenKey = key === Key.Enter || key === Key.Space || key === Key.Tab;
     const manager = this._keyManager;
     // Open the select on ALT + arrow key to match the native <select>
     if ((!manager.isTyping() && isOpenKey && !hasModifierKey(event)) || ((this.multiple || event.altKey) && isArrowKey)) {

--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -447,7 +447,6 @@ export class NovoSelectElement
 
   openPanel() {
     super.openPanel();
-    this._highlightCorrectOption();
   }
 
   private _initializeSelection(): void {

--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -615,10 +615,12 @@ export class NovoSelectElement
   private _handleClosedKeydown(event: KeyboardEvent): void {
     const key = event.key;
     const isArrowKey = key === Key.ArrowDown || key === Key.ArrowUp || key === Key.ArrowLeft || key === Key.ArrowRight;
-    const isOpenKey = key === Key.Enter || key === Key.Space || key === Key.Tab;
+    const isOpenKey = key === Key.Enter || key === Key.Space;
     const manager = this._keyManager;
     // Open the select on ALT + arrow key to match the native <select>
-    if ((!manager.isTyping() && isOpenKey && !hasModifierKey(event)) || ((this.multiple || event.altKey) && isArrowKey)) {
+    if (key === Key.Tab) {
+      this.closePanel();
+    } else if ((!manager.isTyping() && isOpenKey && !hasModifierKey(event)) || ((this.multiple || event.altKey) && isArrowKey)) {
       event.preventDefault(); // prevents the page from scrolling down when pressing space
       this.openPanel();
     }
@@ -781,10 +783,14 @@ export class NovoSelectElement
    */
   private _highlightCorrectOption(): void {
     if (this._keyManager) {
+      if (this.empty) {
+        this._keyManager.setFirstItemActive();
+      } else {
         const options = this._getOptions();
         const index = options.findIndex(option => option.value === this._value)
         this._keyManager.setActiveItem(index);
       }
+    }
   }
 
   /** Calculates the height of the select's options. */

--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -654,7 +654,7 @@ export class NovoSelectElement
           hasDeselectedOptions ? option.select() : option.deselect();
         }
       });
-    } else if (Key.Escape === key) {
+    } else if (Key.Escape === key || Key.Tab === key) {
       this.closePanel();
     } else {
       const previouslyFocusedIndex = manager.activeItemIndex;

--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -781,14 +781,10 @@ export class NovoSelectElement
    */
   private _highlightCorrectOption(): void {
     if (this._keyManager) {
-      if (this.empty) {
-        this._keyManager.setFirstItemActive();
-      } else {
         const options = this._getOptions();
-        const index = options.findIndex(option => option.value == this._value)
+        const index = options.findIndex(option => option.value === this._value)
         this._keyManager.setActiveItem(index);
       }
-    }
   }
 
   /** Calculates the height of the select's options. */

--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -447,6 +447,7 @@ export class NovoSelectElement
 
   openPanel() {
     super.openPanel();
+    this._highlightCorrectOption();
   }
 
   private _initializeSelection(): void {


### PR DESCRIPTION
## **Description**

fixing first value population when tabbing through dropdown/select fields

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**