### PR TITLE
feat(Types): Migrate novo specific types to novo

### DIFF
--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -9,20 +9,8 @@ export interface IDataTablePreferences {
   pageSize?: number;
   displayedColumns?: string[];
   columnWidths?: { id: string; width: number }[];
-  savedSearchId?: number;
   savedSearchName?: string;
-  savedSearchOwner?: DataTableSavedSearchOwner;
   appliedSearchType?: AppliedSearchType;
-  autobuildEntity?: AutobuildEntityData;
-  hasUnsavedChanges?: boolean;
-  unsavedChanges?: any;
-  useBooleanKeywords?: boolean;
-}
-
-export interface AutobuildEntityData {
-  id: number;
-  searchEntity: string;
-  [key: string]: any;
 }
 
 export interface DataTableWhere {
@@ -32,12 +20,6 @@ export interface DataTableWhere {
   booleanKeywords?: string;
   scoreByEntityId?: number;
   form: any;
-}
-
-export interface DataTableSavedSearchOwner {
-  id: number;
-  firstName: string;
-  lastName: string;
 }
 
 export enum AppliedSearchType {


### PR DESCRIPTION
## **Description**

Several items got added to the IDataTablePreferences that are not required to be in Novo Elements, and causes us to make a lot of typing additions that are Novo specific. Migrating these types to Novo by extending the IDataTablePreferences in Novo for the Novo-specific types. This avoids adding a bunch more Novo-specific types in this ticket. 

If the cleanup is not possible because of backwards-compat issues, I can instead kill this MR, start the extension of the types in Novo now, and not do this backwards-incompatible cleanup. 

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**