### PR TITLE
fix(Select): restoring ngOnInit > initLegacyOptions

### DIFF
--- a/projects/novo-elements/src/elements/select/Select.ts
+++ b/projects/novo-elements/src/elements/select/Select.ts
@@ -210,7 +210,7 @@ export class NovoSelectElement
   _userTabIndex: number | null = null;
   /** The FocusKeyManager which handles focus. */
   _keyManager: ActiveDescendantKeyManager<NovoOption>;
-  /** 
+  /**
    * The display string for the current value, kept from when the associated <novo-option> has stopped rendering
    * due to filtration
    */
@@ -389,6 +389,7 @@ export class NovoSelectElement
 
   ngOnInit() {
     this.stateChanges.next();
+    this._initLegacyOptions();
     this.focusMonitor.monitor(this.elementRef.nativeElement).subscribe((origin) =>
       this.ngZone.run(() => {
         this._focused = !!origin;


### PR DESCRIPTION
## **Description**

Reverting the initLegacyOptions call removal from within ngOnInit, for the cases where options are not passed in via @Input (e.g., options via ng-content)

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**