### PR TITLE
feat(ConditionBuilder): Add an "Equals" operator for Date field

### DIFF
--- a/projects/novo-elements/src/elements/field/formats/base-format.ts
+++ b/projects/novo-elements/src/elements/field/formats/base-format.ts
@@ -12,4 +12,5 @@ export enum DATE_FORMATS {
   DATE = 'date',
   ISO8601 = 'iso8601',
   STRING = 'string',
+  YEAR_MONTH_DAY = 'yyyy-mm-dd',
 }

--- a/projects/novo-elements/src/elements/field/formats/date-format.spec.ts
+++ b/projects/novo-elements/src/elements/field/formats/date-format.spec.ts
@@ -93,4 +93,24 @@ describe('NovoDateFormatDirective', () => {
         fixture.detectChanges();
         expect(fixture.debugElement.query(By.css('input')).nativeElement.value).toBe('04/01/2022');
     });
+
+    describe('Function: formatYearMonthDay', () => {
+        it('should format date in yyyy-mm-dd format', () => {
+            const expected = '2025-10-22';
+            const date = new Date('10/22/2025');
+            const actual = directive.formatYearMonthDay(date);
+            expect(actual).toEqual(expected);
+        });
+        it('should return null if called with an invalid date', () => {
+            const date: any = 'not a date';
+            let actual = directive.formatYearMonthDay(date);
+            expect(actual).toBeNull();
+
+            actual = directive.formatYearMonthDay(undefined as any);
+            expect(actual).toBeNull();
+
+            actual = directive.formatYearMonthDay(null as any);
+            expect(actual).toBeNull();
+        });
+    });
 });

--- a/projects/novo-elements/src/elements/field/formats/date-format.ts
+++ b/projects/novo-elements/src/elements/field/formats/date-format.ts
@@ -79,6 +79,13 @@ export class NovoDateFormatDirective extends IMaskDirective<any> {
     return null;
   }
 
+  formatYearMonthDay(date: Date): string {
+    if (date && isValid(date)) {
+       return DateUtil.format(date, 'YYYY-MM-DD');
+    }
+    return null;
+  }
+
   formatValue(value: any, options?: DateParseOptions): string {
     if (value == null) return '';
     const dateFormat = this.labels.dateFormatString().toUpperCase();
@@ -108,6 +115,9 @@ export class NovoDateFormatDirective extends IMaskDirective<any> {
           break;
         case DATE_FORMATS.STRING:
           formatted = this.formatValue(date);
+          break;
+        case DATE_FORMATS.YEAR_MONTH_DAY:
+          formatted = this.formatYearMonthDay(date);
           break;
         default:
           formatted = date;

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
@@ -24,7 +24,7 @@ import { NovoLabelService } from 'novo-elements/services';
       </novo-field>
       <ng-container *novoConditionInputDef="let formGroup; viewIndex as viewIndex" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">
         <novo-field *novoSwitchCases="['before', 'after', 'equalTo']">
-          <input novoInput dateFormat="iso8601" [picker]="datepicker" formControlName="value"/>
+          <input novoInput dateFormat="yyyy-mm-dd" [picker]="datepicker" formControlName="value"/>
           <novo-picker-toggle triggerOnFocus [overlayId]="viewIndex" novoSuffix icon="calendar">
             <novo-date-picker (onSelect)="closePanel($event, viewIndex)" #datepicker></novo-date-picker>
           </novo-picker-toggle>

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
@@ -16,13 +16,14 @@ import { NovoLabelService } from 'novo-elements/services';
         <novo-select [placeholder]="labels.operator" formControlName="operator" (onSelect)="onOperatorSelect(formGroup)">
           <novo-option value="before">{{ labels.before }}</novo-option>
           <novo-option value="after">{{ labels.after }}</novo-option>
+          <novo-option value="equalTo">{{ labels.equals }}</novo-option>
           <novo-option value="within">{{ labels.within }}</novo-option>
           <novo-option value="between">{{ labels.between }}</novo-option>
           <novo-option value="isNull" *ngIf="!meta?.removeIsEmpty">{{ labels.isEmpty }}</novo-option>
         </novo-select>
       </novo-field>
       <ng-container *novoConditionInputDef="let formGroup; viewIndex as viewIndex" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">
-        <novo-field *novoSwitchCases="['before', 'after']">
+        <novo-field *novoSwitchCases="['before', 'after', 'equalTo']">
           <input novoInput dateFormat="iso8601" [picker]="datepicker" formControlName="value"/>
           <novo-picker-toggle triggerOnFocus [overlayId]="viewIndex" novoSuffix icon="calendar">
             <novo-date-picker (onSelect)="closePanel($event, viewIndex)" #datepicker></novo-date-picker>
@@ -62,7 +63,7 @@ export class NovoDefaultDateConditionDef extends AbstractConditionFieldDef {
 
   constructor(labelService: NovoLabelService) {
     super(labelService);
-    this.defineOperatorEditGroup(Operator.before, Operator.after);
+    this.defineOperatorEditGroup(Operator.before, Operator.after, Operator.equalTo);
   }
 
   closePanel(event, viewIndex): void {

--- a/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.ts
+++ b/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.ts
@@ -120,6 +120,9 @@ export class JustCriteriaExample implements OnInit {
 
   editTypeFn = (field: any) => {
     if (field.optionsType === 'Brewery') return 'custom';
+    if (field.dataSpecialization === 'DATE') {
+      return field.dataSpecialization;
+    }
     return (field.inputType || field.dataType || field.type).toLowerCase();
   };
 


### PR DESCRIPTION
Updated just-criteria-example to better cover display of both Date and Datetime fields

## **Description**

- This adds an "Equals" operator option for the date comparator (not date-time).
- Also adds a new date format for Date Conditions to create a string date (YYYY-MM-DD) without any timezone conversion.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**