### PR TITLE
style(ConditionBuilder): Move the icon for address to row bottom

### DIFF
--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.scss
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.scss
@@ -45,6 +45,11 @@
           }
         }
       }
+      novo-field.address-location {
+        .novo-field-suffix {
+          align-self: flex-end;
+        }
+      }
       .novo-field-infix {
         white-space: nowrap;
         overflow: hidden;

--- a/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.html
+++ b/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.html
@@ -16,7 +16,7 @@
               {{qbs.getConjunctionLabel(controlName)}}</novo-label>
           </ng-template>
           <novo-condition-builder [groupIndex]="groupIndex" [andIndex]="andIndex" [hideOperator]="isFirst && hideFirstOperator" [scope]="scope" [conditionType]="controlName"></novo-condition-builder>
-          <novo-button theme="icon" icon="delete-o" color="negative" (click)="removeCondition(andIndex)">
+          <novo-button class="delete-btn" theme="icon" icon="delete-o" color="negative" (click)="removeCondition(andIndex)">
           </novo-button>
         </novo-flex>
       </ng-container>

--- a/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.scss
+++ b/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.scss
@@ -9,4 +9,7 @@
   .condition-row {
     width: 100%;
   }
+  .delete-btn {
+    margin-bottom: 1px;
+  }
 }


### PR DESCRIPTION
## **Description**

Moved address pin / delete icon to stay at the bottom of the entry region
Moved the Chips search magnifier down to align with other icons

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**
<img width="1001" height="325" alt="novo-elements-query-builder" src="https://github.com/user-attachments/assets/e6135e22-deb9-4ea1-b568-9377e8f6ff9b" />
