### PR TITLE
feat(DataTable): When column filter is type: 'custom' but has no template, emit an event to handle externally

### DIFF
--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
@@ -11,6 +11,7 @@ import {
   OnDestroy,
   OnInit,
   Optional,
+  Output,
   Renderer2,
   TemplateRef,
   ViewChild,
@@ -60,7 +61,7 @@ import { DataTableState } from '../state/data-table-state.service';
           [tooltip]="labels.filters"
           tooltipPosition="right"
           [attr.data-feature-id]="'novo-data-table-filter-' + this.id"
-          (click)="focusInput()">filter</novo-icon>
+          (click)="clickedFilter($event)">filter</novo-icon>
         <ng-container [ngSwitch]="config.filterConfig.type">
           <ng-container *ngSwitchCase="'date'" (keydown.escape)="handleEscapeKeydown($event)">
             <novo-data-table-cell-filter-header [filter]="filter" (clearFilter)="clearFilter()"></novo-data-table-cell-filter-header>
@@ -216,6 +217,9 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
   resized: EventEmitter<IDataTableColumn<T>>;
   @Input()
   filterTemplate: TemplateRef<any>;
+
+  @Output()
+  toggledFilter = new EventEmitter<string>();
   @HostBinding('class.resizable')
   public resizable: boolean;
 
@@ -540,7 +544,12 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
     this.dropdown.openPanel(); // Ensures that the panel correctly updates to the dynamic size of the dropdown
   }
 
-  public focusInput(): void {
+  public clickedFilter(clickEvt: MouseEvent): void {
+    if ((typeof this.config.filterConfig === 'object') && this.config.filterConfig.type === 'custom' && !this.filterTemplate) {
+      this.toggledFilter.next(this.id);
+      clickEvt.stopImmediatePropagation();
+      return;
+    }
     if (this.filterInput && this.filterInput.nativeElement) {
       setTimeout(() => this.filterInput.nativeElement.focus(), 0);
     }

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -124,6 +124,7 @@ import { DataTableState } from './state/data-table-state.service';
               *cdkHeaderCellDef
               [column]="column"
               [filterTemplate]="templates['column-filter-' + (column.filterable?.customTemplate || column.id)]"
+              (toggledFilter)="toggledFilter.next($event)"
               [novo-data-table-cell-config]="column"
               [resized]="resized"
               [defaultSort]="defaultSort"
@@ -464,6 +465,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
     allSelected: boolean;
     selectedCount: number;
   }>();
+  @Output() toggledFilter = new EventEmitter<string>();
 
   public dataSource: DataTableSource<T>;
   public loading: boolean = true;

--- a/projects/novo-examples/src/components/data-table/data-table-rows/data-table-rows-example.html
+++ b/projects/novo-examples/src/components/data-table/data-table-rows/data-table-rows-example.html
@@ -31,6 +31,7 @@ Selection retention can be configured to keep records selected across pagination
     [refreshSubject]="refreshSubject"
     (preferencesChanged)="onPreferencesChanged($event)"
     (resized)="resized($event)"
+    (toggledFilter)="processCustomFilter($event)"
     [activeRowIdentifier]="selectedRecordId"
     [fixedHeader]="true"
     #basic>

--- a/projects/novo-examples/src/components/data-table/data-table-rows/data-table-rows-example.ts
+++ b/projects/novo-examples/src/components/data-table/data-table-rows/data-table-rows-example.ts
@@ -220,6 +220,15 @@ export class DataTableRowsExample implements AfterViewInit {
       resizable: true,
     },
     {
+      id: 'favoriteColor',
+      label: 'Favorite Color',
+      enabled: true,
+      type: 'text',
+      filterable: { type: 'custom' },
+      sortable: true,
+      resizable: true,
+    },
+    {
       id: 'priority',
       label: 'Priority',
       enabled: true,
@@ -271,6 +280,7 @@ export class DataTableRowsExample implements AfterViewInit {
     'email',
     'simpleEmbeddedObj',
     'status',
+    'favoriteColor',
     'priority',
     'percent',
     'bigdecimal',
@@ -328,6 +338,7 @@ export class DataTableRowsExample implements AfterViewInit {
         email: 'test@google.com',
         address: { city: 'City', state: null },
         bigdecimal: 3.25 * (i + 1) * (i % 5 === 1 ? -1 : 1),
+        favoriteColor: 'blue',
       });
       this.staticDataSet2.push({
         id: i + 1001,
@@ -346,6 +357,7 @@ export class DataTableRowsExample implements AfterViewInit {
         email: 'test@google.com',
         address: { city: 'City', state: 'State' },
         bigdecimal: -75,
+        favoriteColor: 'white',
       });
     }
     this.basicRows = [...this.staticDataSet1];
@@ -438,14 +450,21 @@ export class DataTableRowsExample implements AfterViewInit {
     this.table.expandRows(expand);
   }
 
-  public filterList(value: any): void {
-    this.table.state.filter = { id: 'status', type: 'text', value };
+  public filterList(value: any, field = 'status'): void {
+    this.table.state.filter = { id: field, type: 'text', value };
     this.table.state.updates.next({
       globalSearch: this.table.state.globalSearch,
       filter: this.table.state.filter,
       sort: this.table.state.sort,
     });
     this.ref.markForCheck();
+  }
+
+  public processCustomFilter(columnName: string) {
+    if (columnName === 'favoriteColor') {
+      const colorFilter = prompt('Favorite Color has been configured with a custom filter but no template. The table emitted a (toggledFilter) event which lets this function handle it as desired.\nEnter a favorite color:');
+      this.filterList(colorFilter, 'favoriteColor');
+    }
   }
 
   public toggle(event) {

--- a/projects/novo-examples/src/components/data-table/extras/mock-data.ts
+++ b/projects/novo-examples/src/components/data-table/extras/mock-data.ts
@@ -15,4 +15,5 @@ export interface MockData {
   email: string;
   address: { city?: string; state?: string };
   bigdecimal?: number;
+  favoriteColor?: string;
 }


### PR DESCRIPTION
## **Description**

Enabling alternate behavior for setting up column filters on a table: If their configuration does not include a template for the input popup, then it will output an event with the column name for an outside component to handle.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**