### PR TITLE
fix(NovoDataTableCellHeader): adding back removed public function

### DIFF
--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
@@ -550,6 +550,7 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
       clickEvt.stopImmediatePropagation();
       return;
     }
+    this.focusInput();
     if (this.multiSelect && this.dropdown) {
       this.dropdown._handleKeydown = (event: KeyboardEvent) => {
         this.multiSelectOptionFilterHandleKeydown(event);


### PR DESCRIPTION
## **Description**

a public function `focusInput` was removed in #1688 which could result in compilation errors for any consumers directly calling that function. this PR is adding it back to avoid those errors.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**