### PR TITLE
feat(): next

### DIFF
--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-header-cell.component.ts
@@ -11,6 +11,7 @@ import {
   OnDestroy,
   OnInit,
   Optional,
+  Output,
   Renderer2,
   TemplateRef,
   ViewChild,
@@ -60,7 +61,7 @@ import { DataTableState } from '../state/data-table-state.service';
           [tooltip]="labels.filters"
           tooltipPosition="right"
           [attr.data-feature-id]="'novo-data-table-filter-' + this.id"
-          (click)="focusInput()">filter</novo-icon>
+          (click)="clickedFilter($event)">filter</novo-icon>
         <ng-container [ngSwitch]="config.filterConfig.type">
           <ng-container *ngSwitchCase="'date'" (keydown.escape)="handleEscapeKeydown($event)">
             <novo-data-table-cell-filter-header [filter]="filter" (clearFilter)="clearFilter()"></novo-data-table-cell-filter-header>
@@ -216,6 +217,9 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
   resized: EventEmitter<IDataTableColumn<T>>;
   @Input()
   filterTemplate: TemplateRef<any>;
+
+  @Output()
+  toggledFilter = new EventEmitter<string>();
   @HostBinding('class.resizable')
   public resizable: boolean;
 
@@ -540,7 +544,12 @@ export class NovoDataTableCellHeader<T> implements IDataTableSortFilter, OnInit,
     this.dropdown.openPanel(); // Ensures that the panel correctly updates to the dynamic size of the dropdown
   }
 
-  public focusInput(): void {
+  public clickedFilter(clickEvt: MouseEvent): void {
+    if ((typeof this.config.filterConfig === 'object') && this.config.filterConfig.type === 'custom' && !this.filterTemplate) {
+      this.toggledFilter.next(this.id);
+      clickEvt.stopImmediatePropagation();
+      return;
+    }
     if (this.filterInput && this.filterInput.nativeElement) {
       setTimeout(() => this.filterInput.nativeElement.focus(), 0);
     }

--- a/projects/novo-elements/src/elements/data-table/data-table.component.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.ts
@@ -124,6 +124,7 @@ import { DataTableState } from './state/data-table-state.service';
               *cdkHeaderCellDef
               [column]="column"
               [filterTemplate]="templates['column-filter-' + (column.filterable?.customTemplate || column.id)]"
+              (toggledFilter)="toggledFilter.next($event)"
               [novo-data-table-cell-config]="column"
               [resized]="resized"
               [defaultSort]="defaultSort"
@@ -464,6 +465,7 @@ export class NovoDataTable<T> implements AfterContentInit, OnDestroy {
     allSelected: boolean;
     selectedCount: number;
   }>();
+  @Output() toggledFilter = new EventEmitter<string>();
 
   public dataSource: DataTableSource<T>;
   public loading: boolean = true;

--- a/projects/novo-elements/src/elements/field/formats/base-format.ts
+++ b/projects/novo-elements/src/elements/field/formats/base-format.ts
@@ -12,4 +12,5 @@ export enum DATE_FORMATS {
   DATE = 'date',
   ISO8601 = 'iso8601',
   STRING = 'string',
+  YEAR_MONTH_DAY = 'yyyy-mm-dd',
 }

--- a/projects/novo-elements/src/elements/field/formats/date-format.spec.ts
+++ b/projects/novo-elements/src/elements/field/formats/date-format.spec.ts
@@ -93,4 +93,24 @@ describe('NovoDateFormatDirective', () => {
         fixture.detectChanges();
         expect(fixture.debugElement.query(By.css('input')).nativeElement.value).toBe('04/01/2022');
     });
+
+    describe('Function: formatYearMonthDay', () => {
+        it('should format date in yyyy-mm-dd format', () => {
+            const expected = '2025-10-22';
+            const date = new Date('10/22/2025');
+            const actual = directive.formatYearMonthDay(date);
+            expect(actual).toEqual(expected);
+        });
+        it('should return null if called with an invalid date', () => {
+            const date: any = 'not a date';
+            let actual = directive.formatYearMonthDay(date);
+            expect(actual).toBeNull();
+
+            actual = directive.formatYearMonthDay(undefined as any);
+            expect(actual).toBeNull();
+
+            actual = directive.formatYearMonthDay(null as any);
+            expect(actual).toBeNull();
+        });
+    });
 });

--- a/projects/novo-elements/src/elements/field/formats/date-format.ts
+++ b/projects/novo-elements/src/elements/field/formats/date-format.ts
@@ -79,6 +79,13 @@ export class NovoDateFormatDirective extends IMaskDirective<any> {
     return null;
   }
 
+  formatYearMonthDay(date: Date): string {
+    if (date && isValid(date)) {
+       return DateUtil.format(date, 'YYYY-MM-DD');
+    }
+    return null;
+  }
+
   formatValue(value: any, options?: DateParseOptions): string {
     if (value == null) return '';
     const dateFormat = this.labels.dateFormatString().toUpperCase();
@@ -108,6 +115,9 @@ export class NovoDateFormatDirective extends IMaskDirective<any> {
           break;
         case DATE_FORMATS.STRING:
           formatted = this.formatValue(date);
+          break;
+        case DATE_FORMATS.YEAR_MONTH_DAY:
+          formatted = this.formatYearMonthDay(date);
           break;
         default:
           formatted = date;

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.scss
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.scss
@@ -45,6 +45,11 @@
           }
         }
       }
+      novo-field.address-location {
+        .novo-field-suffix {
+          align-self: flex-end;
+        }
+      }
       .novo-field-infix {
         white-space: nowrap;
         overflow: hidden;

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/date-condition.definition.ts
@@ -16,14 +16,15 @@ import { NovoLabelService } from 'novo-elements/services';
         <novo-select [placeholder]="labels.operator" formControlName="operator" (onSelect)="onOperatorSelect(formGroup)">
           <novo-option value="before">{{ labels.before }}</novo-option>
           <novo-option value="after">{{ labels.after }}</novo-option>
+          <novo-option value="equalTo">{{ labels.equals }}</novo-option>
           <novo-option value="within">{{ labels.within }}</novo-option>
           <novo-option value="between">{{ labels.between }}</novo-option>
           <novo-option value="isNull" *ngIf="!meta?.removeIsEmpty">{{ labels.isEmpty }}</novo-option>
         </novo-select>
       </novo-field>
       <ng-container *novoConditionInputDef="let formGroup; viewIndex as viewIndex" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">
-        <novo-field *novoSwitchCases="['before', 'after']">
-          <input novoInput dateFormat="iso8601" [picker]="datepicker" formControlName="value"/>
+        <novo-field *novoSwitchCases="['before', 'after', 'equalTo']">
+          <input novoInput dateFormat="yyyy-mm-dd" [picker]="datepicker" formControlName="value"/>
           <novo-picker-toggle triggerOnFocus [overlayId]="viewIndex" novoSuffix icon="calendar">
             <novo-date-picker (onSelect)="closePanel($event, viewIndex)" #datepicker></novo-date-picker>
           </novo-picker-toggle>
@@ -62,7 +63,7 @@ export class NovoDefaultDateConditionDef extends AbstractConditionFieldDef {
 
   constructor(labelService: NovoLabelService) {
     super(labelService);
-    this.defineOperatorEditGroup(Operator.before, Operator.after);
+    this.defineOperatorEditGroup(Operator.before, Operator.after, Operator.equalTo);
   }
 
   closePanel(event, viewIndex): void {

--- a/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.html
+++ b/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.html
@@ -16,7 +16,7 @@
               {{qbs.getConjunctionLabel(controlName)}}</novo-label>
           </ng-template>
           <novo-condition-builder [groupIndex]="groupIndex" [andIndex]="andIndex" [hideOperator]="isFirst && hideFirstOperator" [scope]="scope" [conditionType]="controlName"></novo-condition-builder>
-          <novo-button theme="icon" icon="delete-o" color="negative" (click)="removeCondition(andIndex)">
+          <novo-button class="delete-btn" theme="icon" icon="delete-o" color="negative" (click)="removeCondition(andIndex)">
           </novo-button>
         </novo-flex>
       </ng-container>

--- a/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.scss
+++ b/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.scss
@@ -9,4 +9,7 @@
   .condition-row {
     width: 100%;
   }
+  .delete-btn {
+    margin-bottom: 1px;
+  }
 }

--- a/projects/novo-examples/src/components/data-table/data-table-rows/data-table-rows-example.html
+++ b/projects/novo-examples/src/components/data-table/data-table-rows/data-table-rows-example.html
@@ -31,6 +31,7 @@ Selection retention can be configured to keep records selected across pagination
     [refreshSubject]="refreshSubject"
     (preferencesChanged)="onPreferencesChanged($event)"
     (resized)="resized($event)"
+    (toggledFilter)="processCustomFilter($event)"
     [activeRowIdentifier]="selectedRecordId"
     [fixedHeader]="true"
     #basic>

--- a/projects/novo-examples/src/components/data-table/data-table-rows/data-table-rows-example.ts
+++ b/projects/novo-examples/src/components/data-table/data-table-rows/data-table-rows-example.ts
@@ -220,6 +220,15 @@ export class DataTableRowsExample implements AfterViewInit {
       resizable: true,
     },
     {
+      id: 'favoriteColor',
+      label: 'Favorite Color',
+      enabled: true,
+      type: 'text',
+      filterable: { type: 'custom' },
+      sortable: true,
+      resizable: true,
+    },
+    {
       id: 'priority',
       label: 'Priority',
       enabled: true,
@@ -271,6 +280,7 @@ export class DataTableRowsExample implements AfterViewInit {
     'email',
     'simpleEmbeddedObj',
     'status',
+    'favoriteColor',
     'priority',
     'percent',
     'bigdecimal',
@@ -328,6 +338,7 @@ export class DataTableRowsExample implements AfterViewInit {
         email: 'test@google.com',
         address: { city: 'City', state: null },
         bigdecimal: 3.25 * (i + 1) * (i % 5 === 1 ? -1 : 1),
+        favoriteColor: 'blue',
       });
       this.staticDataSet2.push({
         id: i + 1001,
@@ -346,6 +357,7 @@ export class DataTableRowsExample implements AfterViewInit {
         email: 'test@google.com',
         address: { city: 'City', state: 'State' },
         bigdecimal: -75,
+        favoriteColor: 'white',
       });
     }
     this.basicRows = [...this.staticDataSet1];
@@ -438,14 +450,21 @@ export class DataTableRowsExample implements AfterViewInit {
     this.table.expandRows(expand);
   }
 
-  public filterList(value: any): void {
-    this.table.state.filter = { id: 'status', type: 'text', value };
+  public filterList(value: any, field = 'status'): void {
+    this.table.state.filter = { id: field, type: 'text', value };
     this.table.state.updates.next({
       globalSearch: this.table.state.globalSearch,
       filter: this.table.state.filter,
       sort: this.table.state.sort,
     });
     this.ref.markForCheck();
+  }
+
+  public processCustomFilter(columnName: string) {
+    if (columnName === 'favoriteColor') {
+      const colorFilter = prompt('Favorite Color has been configured with a custom filter but no template. The table emitted a (toggledFilter) event which lets this function handle it as desired.\nEnter a favorite color:');
+      this.filterList(colorFilter, 'favoriteColor');
+    }
   }
 
   public toggle(event) {

--- a/projects/novo-examples/src/components/data-table/extras/mock-data.ts
+++ b/projects/novo-examples/src/components/data-table/extras/mock-data.ts
@@ -15,4 +15,5 @@ export interface MockData {
   email: string;
   address: { city?: string; state?: string };
   bigdecimal?: number;
+  favoriteColor?: string;
 }

--- a/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.ts
+++ b/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.ts
@@ -120,6 +120,9 @@ export class JustCriteriaExample implements OnInit {
 
   editTypeFn = (field: any) => {
     if (field.optionsType === 'Brewery') return 'custom';
+    if (field.dataSpecialization === 'DATE') {
+      return field.dataSpecialization;
+    }
     return (field.inputType || field.dataType || field.type).toLowerCase();
   };
 


### PR DESCRIPTION
## **Description**

feat(ConditionBuilder): Add an "Equals" operator for Date field #1683
style(ConditionBuilder): Move the icon for address to row bottom #1687
feat(DataTable): When column filter is type: 'custom' but has no template, emit an event to handle externally #1688
fix(NovoDataTableCellHeader): adding back removed public function #1689

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**