### PR TITLE
feat(DateFormatService): Add a regex for use in datetime imask

### DIFF
--- a/projects/novo-elements/src/services/date-format/DateFormat.ts
+++ b/projects/novo-elements/src/services/date-format/DateFormat.ts
@@ -78,6 +78,12 @@ export class DateFormatService {
     return [this.getDateMask(), /\,?/, /\s/, this.getTimeMask(militaryTime)];
   }
 
+  // Return a universal date-and-time input mask that can be used for any locale,
+  // and allows partial values (so that imask does not reject while typing)
+  getPermissiveDateTimeMask(): RegExp {
+    return /^((\d)(\d|\/|\.|\-){0,7})?(\d){0,2}\,?(\s[\d\:]{0,5})?(\s([AaPp][Mm]?))?$/;
+  }
+
   getTimePlaceHolder(militaryTime: boolean): string {
     if (militaryTime) {
       return this.labels.timeFormatPlaceholder24Hour;


### PR DESCRIPTION
## **Description**

No functional changes to novo-elements; this only provides "housing" for a regex that may be used in a redesigned date-time input presenting dates in this general format:
"09/02/2025, 3:00 PM"
...as well as any variations using other regional formats, or 24-hour time.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**