### PR TITLE
fix(CriteriaBuilder): Rollback fix for criteria builder string condition chiplist bug 

### DIFF
--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
@@ -26,7 +26,7 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
       </novo-field>
       <ng-container *novoConditionInputDef="let formGroup" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">
         <novo-field *novoSwitchCases="['includeAny', 'includeAll', 'excludeAny', 'beginsWith']">
-          <novo-chip-list #chipList aria-label="filter value" multiple="true">
+          <novo-chip-list #chipList aria-label="filter value" formControlName="value">
             <novo-chip *ngFor="let chip of formGroup.value?.value || []" [value]="chip" (removed)="remove(chip, formGroup)">
               <novo-text ellipsis [tooltip]="chip" tooltipOnOverflow>{{ chip }}</novo-text>
               <novo-icon novoChipRemove>close</novo-icon>


### PR DESCRIPTION
## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**