### PR TITLE
fix(addressComponent): Update valid and invalid arrays when the config required property updates externally

### DIFF
--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -1,10 +1,9 @@
 // NG2
-import { Component, EventEmitter, forwardRef, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
+import { Component, DoCheck, EventEmitter, forwardRef, Input, OnInit, Output } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 // APP
 import { NovoLabelService } from 'novo-elements/services';
-import { COUNTRIES, findByCountryId, getStates } from 'novo-elements/utils';
-import { Helpers } from 'novo-elements/utils';
+import { COUNTRIES, findByCountryId, getStates, Helpers } from 'novo-elements/utils';
 
 // Value accessor for the component (supports ngModel)
 const ADDRESS_VALUE_ACCESSOR = {
@@ -187,7 +186,7 @@ export interface NovoAddressConfig {
   `,
   styleUrls: ['./Address.scss'],
 })
-export class NovoAddressElement implements ControlValueAccessor, OnInit, OnChanges {
+export class NovoAddressElement implements ControlValueAccessor, OnInit, DoCheck {
   @Input()
   config: NovoAddressConfig;
   private _readOnly = false;

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -204,6 +204,7 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit, OnChang
   get readOnly(): boolean {
     return this._readOnly;
   }
+  private previousRequiredState: Record<string, boolean> = {};
   states: Array<any> = [];
   fieldList: Array<string> = ['address1', 'address2', 'city', 'state', 'zip', 'countryID'];
   model: any;
@@ -279,20 +280,24 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit, OnChang
         this.config[field].pickerConfig.defaultOptions = this.stateOptions;
       }
     });
+
+    this.fieldList.forEach((field: string) => {
+      this.previousRequiredState[field] = this.config?.[field]?.required;
+    });
+
+    this.initComplete = true;
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes.config && !changes.config.firstChange) {
-      const previousConfig = changes.config.previousValue;
-      const currentConfig = changes.config.currentValue;
-
+  ngDoCheck(): void {
+    if (this.initComplete && this.config) {
       this.fieldList.forEach((field: string) => {
-        const prevRequired = previousConfig?.[field]?.required;
-        const currRequired = currentConfig?.[field]?.required;
+        const prevRequired = this.previousRequiredState[field];
+        const currRequired = this.config?.[field]?.required;
 
         if (prevRequired !== currRequired) {
           this.isValid(field);
           this.isInvalid(field);
+          this.previousRequiredState[field] = currRequired;
         }
       });
     }

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -1,5 +1,5 @@
 // NG2
-import { Component, EventEmitter, forwardRef, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, forwardRef, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 // APP
 import { NovoLabelService } from 'novo-elements/services';
@@ -187,7 +187,7 @@ export interface NovoAddressConfig {
   `,
   styleUrls: ['./Address.scss'],
 })
-export class NovoAddressElement implements ControlValueAccessor, OnInit {
+export class NovoAddressElement implements ControlValueAccessor, OnInit, OnChanges {
   @Input()
   config: NovoAddressConfig;
   private _readOnly = false;
@@ -279,6 +279,23 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit {
         this.config[field].pickerConfig.defaultOptions = this.stateOptions;
       }
     });
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.config && !changes.config.firstChange) {
+      const previousConfig = changes.config.previousValue;
+      const currentConfig = changes.config.currentValue;
+
+      this.fieldList.forEach((field: string) => {
+        const prevRequired = previousConfig?.[field]?.required;
+        const currRequired = currentConfig?.[field]?.required;
+
+        if (prevRequired !== currRequired) {
+          this.isValid(field);
+          this.isInvalid(field);
+        }
+      });
+    }
   }
 
   isValid(field: string): void {


### PR DESCRIPTION
## **Description**

Check for validity changes with the Address configuration since field interactions can alter this after initialization

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**