### PR TITLE
feat(NovoDefaultStringConditionDef): set multiple as true for novo-ch…

### DIFF
--- a/projects/novo-elements/src/elements/chips/Chip.ts
+++ b/projects/novo-elements/src/elements/chips/Chip.ts
@@ -155,6 +155,9 @@ export class NovoChipElement extends NovoChipMixinBase implements FocusableOptio
   /** Whether the chip list is selectable */
   _chipListSelectable: boolean = true;
 
+  /** Whether the chip list allows toggling */
+  _chipListToggleable: boolean = true;
+
   /** Whether the chip list is in multi-selection mode. */
   _chipListMultiple: boolean = false;
 
@@ -334,7 +337,9 @@ export class NovoChipElement extends NovoChipMixinBase implements FocusableOptio
     } else {
       event.stopPropagation();
     }
-    this.toggleSelected(true);
+    if (this._chipListToggleable) {
+      this.toggleSelected(true);
+    }
   }
 
   /** Handle custom key presses. */

--- a/projects/novo-elements/src/elements/chips/ChipList.ts
+++ b/projects/novo-elements/src/elements/chips/ChipList.ts
@@ -11,8 +11,8 @@ import {
   ContentChildren,
   DoCheck,
   ElementRef,
-  EventEmitter, input,
-  Input, InputSignal,
+  EventEmitter,
+  Input,
   OnDestroy,
   OnInit,
   Optional,
@@ -164,8 +164,6 @@ export class NovoChipList
   get role(): string | null {
     return this.empty ? null : 'listbox';
   }
-
-  ignoreValueUpdates: InputSignal<boolean> = input(false);
 
   /** An object used to control when error messages are shown. */
   @Input() errorStateMatcher: ErrorStateMatcher;

--- a/projects/novo-elements/src/elements/chips/ChipList.ts
+++ b/projects/novo-elements/src/elements/chips/ChipList.ts
@@ -403,12 +403,6 @@ export class NovoChipList
       this._allowFocusEscape();
     });
 
-    this._selectionModel.changed.subscribe({
-      next: (value) => {
-        console.log(value);
-      },
-    });
-
     // When the list changes, re-subscribe
     this.chips.changes.pipe(startWith(null), takeUntil(this._destroyed)).subscribe(() => {
       Promise.resolve().then(() => {

--- a/projects/novo-elements/src/elements/chips/ChipList.ts
+++ b/projects/novo-elements/src/elements/chips/ChipList.ts
@@ -61,7 +61,7 @@ export class NovoChipListChange {
  */
 @Component({
   selector: 'novo-chip-list',
-  template: `<button (click)="debug()"></button><div class="novo-chip-list-wrapper"><ng-content></ng-content></div>`,
+  template: `<div class="novo-chip-list-wrapper"><ng-content></ng-content></div>`,
   styleUrls: ['./ChipList.scss'],
   exportAs: 'novoChipList',
   host: {

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
@@ -26,7 +26,7 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
       </novo-field>
       <ng-container *novoConditionInputDef="let formGroup" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">
         <novo-field *novoSwitchCases="['includeAny', 'includeAll', 'excludeAny', 'beginsWith']">
-          <novo-chip-list #chipList aria-label="filter value" multiple="true" formControlName="value">
+          <novo-chip-list #chipList aria-label="filter value" multiple="true" [chipsToggleable]="false" formControlName="value">
             <novo-chip *ngFor="let chip of formGroup.value?.value || []" [value]="chip" (removed)="remove(chip, formGroup)">
               <novo-text ellipsis [tooltip]="chip" tooltipOnOverflow>{{ chip }}</novo-text>
               <novo-icon novoChipRemove>close</novo-icon>

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/string-condition.definition.ts
@@ -26,7 +26,7 @@ import { AbstractConditionFieldDef } from './abstract-condition.definition';
       </novo-field>
       <ng-container *novoConditionInputDef="let formGroup" [ngSwitch]="formGroup.value.operator" [formGroup]="formGroup">
         <novo-field *novoSwitchCases="['includeAny', 'includeAll', 'excludeAny', 'beginsWith']">
-          <novo-chip-list #chipList aria-label="filter value" formControlName="value">
+          <novo-chip-list #chipList aria-label="filter value" multiple="true" formControlName="value">
             <novo-chip *ngFor="let chip of formGroup.value?.value || []" [value]="chip" (removed)="remove(chip, formGroup)">
               <novo-text ellipsis [tooltip]="chip" tooltipOnOverflow>{{ chip }}</novo-text>
               <novo-icon novoChipRemove>close</novo-icon>


### PR DESCRIPTION
## **Description**

When we pass a form control to the novo-chip-list component without making it multiple, we observe that the chip breaks into individual letters when we try to remove it (if we previously clicked on a chip and if there is one chip left), that's because:

when we click on a chip, we call this method:

```typescript
  toggleSelected(isUserInput: boolean = false): boolean {
    this._selected = !this.selected;
    this._dispatchSelectionChange(isUserInput);
    this._changeDetectorRef.markForCheck();
    return this.selected;
  }
```
and inside the ` _dispatchSelectionChange` method:

we emit the `selectionChange` event:

```typescript
 private _dispatchSelectionChange(isUserInput = false) {
    this.selectionChange.emit({
      source: this,
      isUserInput,
      selected: this._selected,
    });
  }
```

then in the `ChipsList` component we have this listener:

```typescript
private _listenToChipsSelection(): void {
    this._chipSelectionSubscription = this.chipSelectionChanges.subscribe((event) => {
      event.source.selected ? this._selectionModel.select(event.source) : this._selectionModel.deselect(event.source);

      // For single selection chip list, make sure the deselected value is unselected.
      if (!this.multiple) {
        this.chips.forEach((chip) => {
          if (!this._selectionModel.isSelected(chip) && chip.selected) {
            chip.deselect();
          }
        });
      }

      if (event.isUserInput) {
        this._propagateChanges();
      }
    });
  }
```

and inside ` _propagateChanges`, we have this logic

```typescript

...

  get selected(): NovoChipElement[] | NovoChipElement {
    return this.multiple ? this._selectionModel.selected : this._selectionModel.selected[0];
  }

...

private _propagateChanges(fallbackValue?: any): void {
    let valueToEmit: any = null;

   // selected is a getter and If multiple is FALSE, only the first item will be returned, so we will have just a string
    if (Array.isArray(this.selected)) {
      valueToEmit = this.selected.map((chip) => chip.value);
    } else {
      valueToEmit = this.selected ? this.selected.value : fallbackValue;
    }
    
    // so valueToEmit will be just a string and not an array, and below it will update the value of the form control to the string
     
    this.change.emit(new NovoChipListChange(this, valueToEmit));
    this._onChange(valueToEmit);
    this._changeDetectorRef.markForCheck();
  }
```

and finally in the NovoDefaultStringConditionDef component, we have this remove method

```typescript
remove(valueToRemove: string, formGroup: AbstractControl): void {
   // in our case the current value will be a string, for example 'test'
    const current = this.getValue(formGroup);
    // index will be 0
    const index = current.indexOf(valueToRemove);
    if (index >= 0) {
     // since current is a string and it is iterable, value will be an array ['t', 'e', 's', 't']
      const value = [...current]
      value.splice(index, 1);
      // and here it will set the split string to the form control
      this.setFormValue(formGroup, value);
    }
  }
```

and since in the template we render the chips directly from form control value, we will see three chips (e,s,t)

```html
   <novo-chip-list #chipList aria-label="filter value" formControlName="value">
            <novo-chip *ngFor="let chip of formGroup.value?.value || []" [value]="chip" (removed)="remove(chip, formGroup)">         
```

We can't remove `formControlName`, because it adds some properties that we use in our e2e tests. So, we need to set multiple to true, and I also added a new input property `chipsToggleable` to enable/disable the toggle feature. I don’t think we need to use it in the `NovoDefaultStringConditionDef` component.


#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**