### PR TITLE
feat(QueryBuilder): Ensure supporting value is included when updating…

### DIFF
--- a/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.html
+++ b/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.html
@@ -5,7 +5,7 @@
       <ng-container [formGroupName]="andIndex">
         <novo-flex class="condition-row" [ngClass]="{ isFirst: andIndex === 0 }" [class]="scope" align="end" gap="sm" #flex>
           <novo-dropdown *ngIf="(!isFirst || !hideFirstOperator) && qbs.allowedGroupings.length > 1; else labeledGroup">
-            <button theme="dialogue" icon="collapse" size="sm">{{qbs.getConjunctionLabel(controlName)}}</button>
+            <button theme="dialogue" icon="collapse" size="sm" [attr.data-automation-id]="controlName">{{qbs.getConjunctionLabel(controlName)}}</button>
             <novo-optgroup>
               <novo-option *ngFor="let c of qbs.allowedGroupings" (click)="updateControlName(c)">
                 {{qbs.getConjunctionLabel(c)}}</novo-option>

--- a/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-group/condition-group.component.ts
@@ -76,7 +76,7 @@ export class ConditionGroupComponent implements OnInit, OnDestroy {
       delete this.parentForm.controls[this.controlName];
       this.controlName = name;
       // scrub properties not on control
-      const currentStrict = current.map((item) => (({ conditionType, field, operator, scope, value, ...rest }) => ({ conditionType, field, operator, scope, value }))(item));
+      const currentStrict = current.map((item) => (({ conditionType, field, operator, scope, value, supportingValue, ...rest }) => ({ conditionType, field, operator, scope, value, supportingValue }))(item));
       this.parentForm.get(this.controlName)?.setValue(currentStrict);
       this.cdr.markForCheck();
     }


### PR DESCRIPTION
… control name

## **Description**

- There is an issue with the allowed groupings dropdown (AND/NOT/OR) that gets triggered when the user changes the selection. It was caused by supportingValue being stripped in updateNameControl.

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**