### PR TITLE
chore(): documentation cleanup

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,8 +4,6 @@ about: Report a bug to help us improve
 
 ---
 
-_**Note: for support questions, please use one of these channels:**_ [Chat: BullhornOSS Gitter](https://gitter.im/bullhorn/Open-Source)
-
 **Describe the bug**
 A short summary of what the bug is.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Novo Elements [![npm version](https://badge.fury.io/js/novo-elements.svg)](http://badge.fury.io/js/novo-elements) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/bullhorn/Open-Source?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+# Novo Elements [![npm version](https://badge.fury.io/js/novo-elements.svg)](http://badge.fury.io/js/novo-elements)
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
-# NOVO Elements [![npm version](https://badge.fury.io/js/novo-elements.svg)](http://badge.fury.io/js/novo-elements) [![Build Status](https://travis-ci.org/bullhorn/novo-elements.svg?branch=master)](https://travis-ci.org/bullhorn/novo-elements) [![Coverage Status](https://coveralls.io/repos/github/bullhorn/novo-elements/badge.svg?branch=master)](https://coveralls.io/github/bullhorn/novo-elements?branch=master)
-
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/bullhorn/Open-Source?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
-[![Dependency Status](https://david-dm.org/bullhorn/novo-elements.svg)](https://david-dm.org/bullhorn/novo-elements)
-[![devDependency Status](https://david-dm.org/bullhorn/novo-elements/dev-status.svg)](https://david-dm.org/bullhorn/novo-elements#info=devDependencies)
+# Novo Elements [![npm version](https://badge.fury.io/js/novo-elements.svg)](http://badge.fury.io/js/novo-elements) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/bullhorn/Open-Source?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 ## Dependencies
 

--- a/projects/novo-examples/src/examples.routes.ts
+++ b/projects/novo-examples/src/examples.routes.ts
@@ -1223,7 +1223,6 @@ export class LayoutsPage {
 <p><code-example example="tabs-vertical"></code-example></p>
 <h3>Button Tab Bars</h3>
 <p>Tabbed Button Bars get a similar style treatment to the <code>&quot;header&quot;</code> theme button.</p>
-<!-- <code-example example="tabs-condensed"></code-example> -->
 <h2>As Application Routing Mechanism</h2>
 <p>Follows the same color/white theme as above, but doesn't use the &quot;novo-tabs&quot; tag and you have to add the classes and html accordingly. The header will now control and route your application and put the content in the &quot;router-outlet&quot; and look/feel like our tabs component.</p>
 <p><code-example example="tabs-router"></code-example></p>
@@ -1860,9 +1859,6 @@ export class CardDescriptionPage {
 @Component({
   selector: 'home-page',
   template: `<h1>Novo Elements, Bullhorn's design system</h1>
-<blockquote>
-<div class="p">Version 6.0 is now available! Read about the new features and fixes <a href="#/updates/v6">here</a>.</div>
-</blockquote>
 <h2>Crafted amid Complexity</h2>
 <p>Enterprise software is highly complex and demands a high level of flexibility. Design offers clarity and enables us to make deep, powerful connections.</p>
 <img class="cover-img" src="assets/images/DesignSystem.png" width="100%"/>
@@ -3121,30 +3117,6 @@ export class TypographyPage {
     <pre><code>.box &#123;\n  &#64;include novo-padding-medium(); // use mixin \n  margin: $spacing-xs; // or use scss variables\n  padding: $spacing-xl;\n&#125; &#125;&#125;</code></pre>
   </typedef-snippet>
 </typedef-example>
-<!-- 
-<typedef-example>
-  <typedef-content>
-    <novo-flex gap="1rem">
-      <novo-box bg="ocean"><novo-box margin="xs" padding="xl" bg="white">xs</novo-box></novo-box>
-      <novo-box bg="ocean"><novo-box margin="sm" padding="lg" bg="white">sm</novo-box></novo-box>
-      <novo-box bg="ocean"><novo-box margin="md" padding="md" bg="white">md</novo-box></novo-box>
-      <novo-box bg="ocean"><novo-box margin="lg" padding="sm" bg="white">lg</novo-box></novo-box>
-      <novo-box bg="ocean"><novo-box margin="xl" padding="xs" bg="white">xl</novo-box></novo-box>
-    </novo-flex>
-  </typedef-content>
-  <typedef-specs>
-    <novo-label>Margin</novo-label>
-    <dl>
-      <dt>Font Size       </dt><dd>1.2rem</dd>
-      <dt>Line Height     </dt><dd>1.375 (28px)</dd>
-      <dt>Font Weight     </dt><dd>300</dd>
-      <dt>Max Line Length </dt><dd>550px</dd>
-    </dl>
-  </typedef-specs>
-  <typedef-snippet>
-    <code class="tc-positive">&lt;novo-box margin="sm"&gt;...&lt;/novo-box&gt;</code> or <code class="tc-negative">&#64;include novo-margin-medium()</code>
-  </typedef-snippet>
-</typedef-example> -->
 `,
   host: { class: 'markdown-page' },
   standalone: false,
@@ -4028,8 +4000,7 @@ export class SearchPage {
 <p><code-example example="single-field-criteria"></code-example></p>
 <h2>Full Query Builder</h2>
 <p>The difference between the Query and Criteria Builder is that it allow for the user to define multiple criteria and join them as either inclusion or exclusion criteria.  ie. Find <code>where fruit.seeds &gt;= 1 and not fruit.name='Avacodo'</code></p>
-<p>TBW</p>
-<!-- <code-example example="just-criteria"></code-example> -->`,
+`,
   host: { class: 'markdown-page' },
   standalone: false,
 })

--- a/projects/novo-examples/src/home/home.md
+++ b/projects/novo-examples/src/home/home.md
@@ -7,8 +7,6 @@ order: 1
 Novo Elements, Bullhorn's design system
 ============
 
-> Version 6.0 is now available! Read about the new features and fixes [here](#/updates/v6).
-
 Crafted amid Complexity
 -----------------------
 


### PR DESCRIPTION
## **Description**

Cleanup of out of date documentation

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**