### PR TITLE
feat(): Add matchMetaData to DataTableWhere

### DIFF
--- a/projects/novo-elements/src/elements/data-table/interfaces.ts
+++ b/projects/novo-elements/src/elements/data-table/interfaces.ts
@@ -31,6 +31,7 @@ export interface DataTableWhere {
   keywords?: SearchKeywords;
   booleanKeywords?: string;
   scoreByEntityId?: number;
+  matchMetaData?: any;
   form: any;
 }
 


### PR DESCRIPTION
## **Description**

Added matchMetaData to DataTableWhere in interfaces.ts

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**