### PR TITLE
chore(cleanup): Add eslint rule to catch focused tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,7 @@
 const tsParser = require('@typescript-eslint/parser');
 const tsPlugin = require('@typescript-eslint/eslint-plugin');
 const unusedImportsPlugin = require('eslint-plugin-unused-imports');
+const jestPlugin = require('eslint-plugin-jest');
 
 module.exports = [
   {
@@ -70,6 +71,15 @@ module.exports = [
       curly: 'error',
       'constructor-super': 'error',
       'comma-dangle': ['error', 'always-multiline'],
+    }
+  },
+  {
+    files: ['**/*.{test,spec}.{ts,tsx}'],
+    plugins: {
+      jest: jestPlugin,
+    },
+    rules: {
+      'jest/no-focused-tests': 'error',
     }
   }
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "conventional-changelog-cli": "~5.0.0",
         "eslint": "^9.39.1",
         "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-jest": "^29.13.0",
         "eslint-plugin-prettier": "^5.5.4",
         "eslint-plugin-unused-imports": "^4.3.0",
         "fs-extra": "^11.3.2",
@@ -15144,6 +15145,35 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jest": {
+      "version": "29.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.13.0.tgz",
+      "integrity": "sha512-VoONe0NsaQLb7ijvg4k35rzchqfyCaBsXammNMCkTyLvKLTpzQOVdXiPC54q7Vp/W7shMcqPBLwAc3yRSiGjSQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.0.0"
+      },
+      "engines": {
+        "node": "^20.12.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "jest": "*",
+        "typescript": ">=4.8.4 <6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-prettier": {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "conventional-changelog-cli": "~5.0.0",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-jest": "^29.13.0",
     "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-unused-imports": "^4.3.0",
     "fs-extra": "^11.3.2",


### PR DESCRIPTION
## **Description**

- Add eslint rule to catch focused unit tests

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**