### PR TITLE
chore(cleanup): Add new whitespace lint rules and fix the errors

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -71,6 +71,9 @@ module.exports = [
       curly: 'error',
       'constructor-super': 'error',
       'comma-dangle': ['error', 'always-multiline'],
+      'keyword-spacing': ['error', { before: true, after: true }],
+      'space-infix-ops': 'error',
+      'comma-spacing': 'error',
     }
   },
   {

--- a/projects/novo-elements/src/addons/ckeditor/CKEditor.ts
+++ b/projects/novo-elements/src/addons/ckeditor/CKEditor.ts
@@ -18,7 +18,7 @@ declare global {
 // Prevents CKEDITOR from querying the page for all [contenteditable] elements (fixes a conflict against Codemirror Editor)
 try {
   CKEDITOR.disableAutoInline = true;
-} catch(err) {
+} catch (err) {
   // may be running in a context without CKEDITOR - ignore
 }
 

--- a/projects/novo-elements/src/elements/chips/Chips.spec.ts
+++ b/projects/novo-elements/src/elements/chips/Chips.spec.ts
@@ -92,7 +92,7 @@ describe('Elements: NovoChipsElement', () => {
 
   describe('Method: updateHiddenChips()', () => {
     it('should update hiddenChipsCount based on the items length and the hiddenChipsLimit property', () => {
-      component.items = ['A','B','C','D','E','F'];
+      component.items = ['A', 'B', 'C', 'D', 'E', 'F'];
       component.hiddenChipsLimit = 4;
       component._hiddenChipsLimit = component.hiddenChipsLimit;
       component.updateHiddenChips();
@@ -103,7 +103,7 @@ describe('Elements: NovoChipsElement', () => {
     });
 
     it('should reset the hiddenChipsLimit to the original limit if: currently showing all chips BUT there are no longer any extra chips to hide', () => {
-      component.items = ['A','B','C','D'];
+      component.items = ['A', 'B', 'C', 'D'];
       component._hiddenChipsLimit = 3;
       component.hiddenChipsLimit = component.CHIPS_SHOWN_MAX; // currently showing all chips
       component.items.pop(); // ['A', 'B', 'C']

--- a/projects/novo-elements/src/elements/form/Control.spec.ts
+++ b/projects/novo-elements/src/elements/form/Control.spec.ts
@@ -1242,7 +1242,7 @@ describe('Novo Control with Templates', () => {
       }).compileComponents();
       fixture = TestBed.createComponent(TestComponent2);
       testComponent = fixture.debugElement.componentInstance;
-    } catch(err) {
+    } catch (err) {
       console.error(err);
     }
   });
@@ -1260,7 +1260,7 @@ describe('Novo Control with Templates', () => {
       component.ngAfterContentInit();
       tick();
       fixture.detectChanges();
-    } catch(err) {
+    } catch (err) {
       console.error(err);
       fail('could not set up Control fixture');
     }

--- a/projects/novo-elements/src/services/date-format/DateFormat.ts
+++ b/projects/novo-elements/src/services/date-format/DateFormat.ts
@@ -113,7 +113,7 @@ export class DateFormatService {
       } else {
         isInvalidDate = false;
       }
-    } catch(err) {
+    } catch (err) {
       // ignore error - keep isInvalidDate true and date null
     }
     return [date, dateString, isInvalidDate];

--- a/projects/novo-elements/src/utils/app-bridge/AppBridge.spec.ts
+++ b/projects/novo-elements/src/utils/app-bridge/AppBridge.spec.ts
@@ -85,7 +85,7 @@ class MockPostrobot {
 function verifySimpleObject(obj) {
     try {
         JSON.stringify(obj);
-    } catch(err) {
+    } catch (err) {
         throw new Error('Object is not simple enough to use JSON.stringify');
     }
 }
@@ -114,7 +114,7 @@ describe('MockPostrobot', () => {
         try {
             await mockPostRobot2.send(mockPostRobot1.mockSource, 'httpPUT', complexObject);
             fail('should not have succeeded');
-        } catch(err) {
+        } catch (err) {
             expect(err.message).toBe('Object is not simple enough to use JSON.stringify');
         }
     });
@@ -123,7 +123,7 @@ describe('MockPostrobot', () => {
         try {
             await mockPostRobot2.send(mockPostRobot1.mockSource, 'httpPUT', { sendToWindow: mockPostRobot1.mockSource });
             fail('should not have succeeded');
-        } catch(err) {
+        } catch (err) {
             expect(err.message).toBe('Object is not simple enough to use JSON.stringify');
         }
     })
@@ -163,7 +163,7 @@ describe('AppBridge', () => {
             hostBridge.handle(handlerKey, (event, cb) => {
                 try {
                     return cb(handleFn(handlerKey, event));
-                } catch(err) {
+                } catch (err) {
                     cb(null, err);
                 }
             })
@@ -260,7 +260,7 @@ describe('AppBridge', () => {
                     try {
                         const response = await frame1Bridge[cmd].apply(frame1Bridge, cmdFunctionsWithArgs[cmd]);
                         fail(`Function passed unexpectedly when receiving ${failTerm}. Response: ${response}`);
-                    } catch(result) {
+                    } catch (result) {
                         expect(result).toBeFalsy();
                     }
                 });
@@ -303,7 +303,7 @@ describe('AppBridge', () => {
         try {
             await frame2Bridge.httpGET('snack');
             fail('expected promise rejection');
-        } catch(err) {
+        } catch (err) {
             expect(err).toBeNull();
         }
     });
@@ -398,7 +398,7 @@ describe('AppBridge', () => {
         try {
             await frame2Bridge.requestData({ type: 'all' });
             fail('Should not request data successfully');
-        } catch(err2) {
+        } catch (err2) {
             expect(err2).toBeFalsy();
         }
     });
@@ -427,7 +427,7 @@ describe('AppBridge', () => {
                 },
             });
             fail('Expected exception');
-        } catch(succeed) {
+        } catch (succeed) {
             expect(succeed).toBe(false);
         }
     });
@@ -443,7 +443,7 @@ describe('AppBridge', () => {
                 },
             });
             fail('Expected exception');
-        } catch(succeed) {
+        } catch (succeed) {
             expect(succeed).toBe(false);
         }
     });


### PR DESCRIPTION
## **Description**

- Added 3 new lint rules to check for whitespace errors, specifcally around spaces around keywords like if, else, try, catch, etc.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**