### PR TITLE
feat(ConditionBuilder): Allow ability to not recreate templates when …

### DIFF
--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.spec.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.spec.ts
@@ -115,4 +115,30 @@ describe('ConditionBuilderComponent', () => {
     tick();
     expect(createFieldOperators).toHaveBeenCalledWith(queryBuilderService.getFieldDefsByName().get('BOOLEAN'));
   }));
+
+  it('should skip createFieldTemplates when resetInputAndOperator is called with recreateTemplates=false', fakeAsync(() => {
+    fixture.componentRef.setInput('config', fieldConfig);
+    fixture.detectChanges();
+    tick();
+
+    const createFieldTemplatesSpy = spyOn<any>(component, 'createFieldTemplates');
+    createFieldOperators.calls.reset();
+
+    component.resetInputAndOperator(false);
+
+    expect(createFieldTemplatesSpy).not.toHaveBeenCalled();
+  }));
+
+  it('should call createFieldTemplates when resetInputAndOperator is called with recreateTemplates=true (default)', fakeAsync(() => {
+    fixture.componentRef.setInput('config', fieldConfig);
+    fixture.detectChanges();
+    tick();
+
+    const createFieldTemplatesSpy = spyOn<any>(component, 'createFieldTemplates');
+    createFieldOperators.calls.reset();
+
+    component.resetInputAndOperator(true);
+
+    expect(createFieldTemplatesSpy).toHaveBeenCalled();
+  }));
 });

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.spec.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.spec.ts
@@ -141,4 +141,100 @@ describe('ConditionBuilderComponent', () => {
 
     expect(createFieldTemplatesSpy).toHaveBeenCalled();
   }));
+
+  describe('updateFieldSelection with allowEmptyField', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('config', fieldConfig);
+      parentForm.controls.supportingValue = formBuilder.control(null);
+      fixture.detectChanges();
+    });
+
+    it('should not set default field when allowEmptyField is true and no field is selected', fakeAsync(() => {
+      component.allowEmptyField = true;
+      parentForm.get('field').setValue(null);
+      const getDefaultFieldSpy = spyOn(component, 'getDefaultField');
+
+      tick();
+
+      component.updateFieldSelection();
+      tick();
+
+      // When allowEmptyField is true, getDefaultField should not be called
+      expect(getDefaultFieldSpy).not.toHaveBeenCalled();
+    }));
+
+    it('should set default field when allowEmptyField is false and no field is selected', fakeAsync(() => {
+      component.allowEmptyField = false;
+      parentForm.get('field').setValue(null);
+      const setValueSpy = spyOn(parentForm.get('field'), 'setValue');
+
+      tick();
+
+      component.updateFieldSelection();
+      tick();
+
+      // When allowEmptyField is false, should try to set default field
+      expect(setValueSpy).toHaveBeenCalledWith(jasmine.anything());
+    }));
+  });
+
+  describe('clearCondition', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('config', fieldConfig);
+      parentForm.controls.supportingValue = formBuilder.control(null);
+      fixture.detectChanges();
+    });
+
+    it('should clear all form values', fakeAsync(() => {
+      // Set up form with values
+      parentForm?.get('field')?.setValue('testradio');
+      parentForm?.get('operator')?.setValue('equals');
+      parentForm?.get('value')?.setValue('someValue');
+      parentForm?.get('supportingValue')?.setValue('supportingValue');
+
+      tick();
+
+      // Spy on setValue to verify it's called with null
+      const fieldSetValueSpy = spyOn(parentForm.get('field'), 'setValue');
+      const operatorSetValueSpy = spyOn(parentForm.get('operator'), 'setValue');
+      const valueSetValueSpy = spyOn(parentForm.get('value'), 'setValue');
+      const supportingValueSetValueSpy = spyOn(parentForm.get('supportingValue'), 'setValue');
+
+      // Call clearCondition
+      component.clearCondition();
+
+      // Verify setValue was called on each control with null
+      expect(fieldSetValueSpy).toHaveBeenCalledWith(null);
+      expect(operatorSetValueSpy).toHaveBeenCalledWith(null);
+      expect(valueSetValueSpy).toHaveBeenCalledWith(null);
+      expect(supportingValueSetValueSpy).toHaveBeenCalledWith(null);
+    }));
+
+    it('should reset the search term', fakeAsync(() => {
+      component.searchTerm.setValue('test search');
+
+      tick();
+
+      const searchTermSetValueSpy = spyOn(component.searchTerm, 'setValue');
+
+      component.clearCondition();
+
+      expect(searchTermSetValueSpy).toHaveBeenCalledWith('');
+    }));
+
+    it('should reset internal state (_lastContext)', () => {
+      // Mock to avoid side effects
+      spyOn(component, 'resetInputAndOperator');
+      spyOn(component, 'updateFieldSelection');
+
+      // Manually set _lastContext to simulate previous state
+      (component as any)._lastContext = { field: 'testradio', operator: 'equals' };
+
+      component.clearCondition();
+
+      // Verify _lastContext is reset to empty object
+      expect((component as any)._lastContext).toEqual({});
+    });
+
+  });
 });

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
@@ -197,18 +197,21 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
   }
 
   /**
-   * Resets the input and operator view containers, regenerates the field templates,
-   * and marks the component for change detection.
+   * Resets the input and operator view containers and marks the component for change detection.
    *
    * Use this method after updating form controls to reinitialize the input and
    * operator fields so that the view reflects the latest form control changes.
    *
+   * @param recreateTemplates - If true (default), regenerates the field templates.
+   *                           If false, only clears the outlets without recreating templates.
    * @returns void
    */
-  resetInputAndOperator(): void {
+  resetInputAndOperator(recreateTemplates: boolean = true): void {
     this._inputOutlet.viewContainer.clear();
     this._operatorOutlet.viewContainer.clear();
-    this.createFieldTemplates();
+    if (recreateTemplates) {
+      this.createFieldTemplates();
+    }
     this.cdr.markForCheck();
   }
 

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
@@ -113,6 +113,7 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
 
   public staticFieldSelection = computed(() => this.config().staticFieldSelection);
   private _lastContext: any = {};
+  public allowEmptyField: boolean = false;
   @HostBinding('class.condition-host')
   public isConditionHost = false;
 
@@ -234,7 +235,9 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
   updateFieldSelection() {
     const fieldConf = this.getField();
     if (!fieldConf) {
-      this.parentForm.get('field').setValue(this.getDefaultField());
+      if (!this.allowEmptyField) {
+        this.parentForm.get('field').setValue(this.getDefaultField());
+      }
       return;
     } else {
       this.fieldDisplayWith = () => fieldConf.label || fieldConf.name;

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
@@ -232,17 +232,14 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
    * @returns void
    */
   clearCondition(): void {
-    // Preserve the current allowEmptyField state to restore after clearing
-    const previousAllowEmptyField = this.allowEmptyField;
+    // Temporarily allow empty field so it won't auto-reset to default during clearing
+    this.allowEmptyField = true;
 
     // Clear all form values
     this.parentForm.get('field').setValue(null);
     this.parentForm.get('operator').setValue(null);
     this.parentForm.get('value').setValue(null);
     this.parentForm.get('supportingValue')?.setValue(null);
-
-    // Temporarily allow empty field so it won't auto-reset to default during clearing
-    this.allowEmptyField = true;
 
     // Reset the field search term
     this.searchTerm.setValue('');
@@ -254,8 +251,8 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
     this.updateFieldSelection();
     this.resetInputAndOperator(false);
 
-    // Restore the previous allowEmptyField state after clearing is complete
-    this.allowEmptyField = previousAllowEmptyField;
+    // Reset allowEmptyField back to false after clearing is complete
+    this.allowEmptyField = false;
   }
 
   getField() {

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
@@ -328,7 +328,7 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
   private createFieldTemplates() {
     const definition = this.findDefinitionForField(this.getField());
 
-    if (!this.parentForm.get('operator').value) {
+    if (!this.parentForm.get('operator').value && definition) {
       this.parentForm.get('operator').setValue(definition.defaultOperator);
     }
 

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
@@ -233,13 +233,13 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
    */
   clearCondition(): void {
     // Clear all form values
-    this.parentForm.get('field').setValue(null);
-    this.parentForm.get('operator').setValue(null);
-    this.parentForm.get('value').setValue(null);
-    this.parentForm.get('supportingValue')?.setValue(null);
+    this.parentForm?.get('field')?.setValue(null);
+    this.parentForm?.get('operator')?.setValue(null);
+    this.parentForm?.get('value')?.setValue(null);
+    this.parentForm?.get('supportingValue')?.setValue(null);
 
     // Reset the field search term
-    this.searchTerm.setValue('');
+    this.searchTerm?.setValue('');
 
     // Reset internal state so updateFieldSelection detects the change
     this._lastContext = {};

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
@@ -232,13 +232,16 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
    * @returns void
    */
   clearCondition(): void {
+    // Preserve the current allowEmptyField state to restore after clearing
+    const previousAllowEmptyField = this.allowEmptyField;
+
     // Clear all form values
     this.parentForm.get('field').setValue(null);
     this.parentForm.get('operator').setValue(null);
     this.parentForm.get('value').setValue(null);
     this.parentForm.get('supportingValue')?.setValue(null);
 
-    // Allow empty field so it won't auto-reset to default during clearing
+    // Temporarily allow empty field so it won't auto-reset to default during clearing
     this.allowEmptyField = true;
 
     // Reset the field search term
@@ -251,8 +254,8 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
     this.updateFieldSelection();
     this.resetInputAndOperator(false);
 
-    // Reset allowEmptyField back to false after clearing is complete
-    this.allowEmptyField = false;
+    // Restore the previous allowEmptyField state after clearing is complete
+    this.allowEmptyField = previousAllowEmptyField;
   }
 
   getField() {

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
@@ -1,6 +1,7 @@
 import {
   AfterContentInit,
   AfterViewInit,
+  BooleanInput,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -82,7 +83,7 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
   @Input() groupIndex: number;
   @Input() addressConfig: AddressCriteriaConfig;
   @Input() dateConfig: DateCriteriaConfig;
-  @Input() allowEmptyField: boolean = false;
+  @BooleanInput() @Input() allowEmptyField: boolean = false;
   hideOperator = input(true);
   conditionType = input();
 

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
@@ -216,6 +216,42 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
     this.cdr.markForCheck();
   }
 
+  /**
+   * Clears the entire condition (field, operator, value) and resets the condition builder UI.
+   *
+   * This method performs a complete reset of the condition builder:
+   * - Clears all form values (field, operator, value, supportingValue)
+   * - Allows empty field selection (prevents auto-restoration to default)
+   * - Resets the field search term
+   * - Clears internal state (_lastContext) to force re-detection of field changes
+   * - Updates field selection and clears UI outlets
+   *
+   * Use this method when you need to completely clear a condition and start fresh,
+   * such as when toggling a filter off or resetting a form group.
+   *
+   * @returns void
+   */
+  clearCondition(): void {
+    // Clear all form values
+    this.parentForm.get('field').setValue(null);
+    this.parentForm.get('operator').setValue(null);
+    this.parentForm.get('value').setValue(null);
+    this.parentForm.get('supportingValue')?.setValue(null);
+
+    // Allow empty field so it won't auto-reset to default
+    this.allowEmptyField = true;
+
+    // Reset the field search term
+    this.searchTerm.setValue('');
+
+    // Reset internal state so updateFieldSelection detects the change
+    this._lastContext = {};
+
+    // Update field selection and clear UI
+    this.updateFieldSelection();
+    this.resetInputAndOperator(false);
+  }
+
   getField() {
     const field = this.parentForm?.value?.field;
     if (!field) {

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
@@ -1,7 +1,6 @@
 import {
   AfterContentInit,
   AfterViewInit,
-  BooleanInput,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -28,7 +27,7 @@ import { BaseConditionFieldDef } from '../query-builder.directives';
 import { QueryBuilderConfig, QueryBuilderService } from '../query-builder.service';
 import { NOVO_CONDITION_BUILDER } from '../query-builder.tokens';
 import { AddressCriteriaConfig, BaseFieldDef, DateCriteriaConfig, FieldConfig, QueryFilterOutlet } from '../query-builder.types';
-import { Helpers } from 'novo-elements/utils';
+import { BooleanInput, Helpers } from 'novo-elements/utils';
 
 /**
  * Provides a handle for the table to grab the view container's ng-container to insert data rows.

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
@@ -232,9 +232,6 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
    * @returns void
    */
   clearCondition(): void {
-    // Temporarily allow empty field so it won't auto-reset to default during clearing
-    this.allowEmptyField = true;
-
     // Clear all form values
     this.parentForm.get('field').setValue(null);
     this.parentForm.get('operator').setValue(null);
@@ -250,9 +247,6 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
     // Update field selection and clear UI
     this.updateFieldSelection();
     this.resetInputAndOperator(false);
-
-    // Reset allowEmptyField back to false after clearing is complete
-    this.allowEmptyField = false;
   }
 
   getField() {

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
@@ -238,7 +238,7 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
     this.parentForm.get('value').setValue(null);
     this.parentForm.get('supportingValue')?.setValue(null);
 
-    // Allow empty field so it won't auto-reset to default
+    // Allow empty field so it won't auto-reset to default during clearing
     this.allowEmptyField = true;
 
     // Reset the field search term
@@ -250,6 +250,9 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
     // Update field selection and clear UI
     this.updateFieldSelection();
     this.resetInputAndOperator(false);
+
+    // Reset allowEmptyField back to false after clearing is complete
+    this.allowEmptyField = false;
   }
 
   getField() {

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.ts
@@ -82,6 +82,7 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
   @Input() groupIndex: number;
   @Input() addressConfig: AddressCriteriaConfig;
   @Input() dateConfig: DateCriteriaConfig;
+  @Input() allowEmptyField: boolean = false;
   hideOperator = input(true);
   conditionType = input();
 
@@ -113,7 +114,6 @@ export class ConditionBuilderComponent implements OnInit, OnChanges, AfterConten
 
   public staticFieldSelection = computed(() => this.config().staticFieldSelection);
   private _lastContext: any = {};
-  public allowEmptyField: boolean = false;
   @HostBinding('class.condition-host')
   public isConditionHost = false;
 

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/picker-condition.definition.ts
@@ -28,12 +28,12 @@ type FieldOption = BaseFieldDef['options'][number];
               <novo-select-search #filterInput allowDeselectDuringFilter></novo-select-search>
             </novo-option>
             <!-- What about optionUrl/optionType -->
-            @for (option of meta?.options; track optionTracker) {
+            @for (option of meta?.options; track optionTracker(option)) {
               <novo-option [hidden]="hideOption(option, filterInput?.value)" [value]="option.value" [attr.data-automation-value]="option.label">
                 {{ option.label}}
               </novo-option>
             }
-            @for (option of customOptions(meta?.options, select); track optionTracker) {
+            @for (option of customOptions(meta?.options, select); track optionTracker(option)) {
               <novo-option [hidden]="hideOption(option, filterInput?.value)" [value]="option.value" [attr.data-automation-value]="option.label">
                 {{ option.label}}
               </novo-option>


### PR DESCRIPTION
…calling reset on condition builder

## **Description**

- Add ability to allow for empty filters
- Add a clear condition function to fully clear out a function

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**