### PR TITLE
fix(): Memory management fixes

### DIFF
--- a/projects/novo-elements/src/addons/code-editor/CodeEditor.ts
+++ b/projects/novo-elements/src/addons/code-editor/CodeEditor.ts
@@ -1,6 +1,7 @@
 // NG2
-import { AfterViewInit, Component, ElementRef, EventEmitter, HostBinding, HostListener, Input, OnDestroy, OnInit, Output, ViewChild, forwardRef } from '@angular/core';
+import { AfterViewInit, Component, DestroyRef, ElementRef, EventEmitter, HostBinding, HostListener, Input, OnDestroy, OnInit, Output, ViewChild, forwardRef } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 // Vendor
 import { defaultKeymap } from '@codemirror/commands';
 import { javascript } from '@codemirror/lang-javascript';
@@ -57,7 +58,7 @@ export class NovoCodeEditor implements ControlValueAccessor, OnInit, OnDestroy, 
   @HostBinding('class.editor-disabled')
   private disabled = false;
 
-  constructor(private elementRef: ElementRef) {}
+  constructor(private elementRef: ElementRef, private destroyRef: DestroyRef) {}
 
   ngOnInit(): void {
   }
@@ -124,11 +125,11 @@ export class NovoCodeEditor implements ControlValueAccessor, OnInit, OnDestroy, 
   }
 
   registerOnChange(fn: any) {
-    this.changed.subscribe(fn);
+    this.changed.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(fn);
   }
 
   registerOnTouched(fn: any) {
-    this.blur.subscribe(fn);
+    this.blur.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(fn);
   }
 
   setDisabledState(isDisabled: boolean): void {

--- a/projects/novo-elements/src/addons/code-editor/CodeEditor.ts
+++ b/projects/novo-elements/src/addons/code-editor/CodeEditor.ts
@@ -64,7 +64,10 @@ export class NovoCodeEditor implements ControlValueAccessor, OnInit, OnDestroy, 
   }
 
   ngOnDestroy(): void {
-
+    if (this.editorView) {
+      this.editorView.destroy();
+      this.editorView = null;
+    }
   }
 
   ngAfterViewInit(): void {

--- a/projects/novo-elements/src/elements/common/overlay/Overlay.ts
+++ b/projects/novo-elements/src/elements/common/overlay/Overlay.ts
@@ -16,6 +16,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  DestroyRef,
   ElementRef,
   EventEmitter,
   inject,
@@ -29,6 +30,7 @@ import {
   ViewChild,
   ViewContainerRef,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 // Vendor
 import { Helpers } from 'novo-elements/utils';
 import { fromEvent, merge, Observable, of as observableOf, Subscription } from 'rxjs';
@@ -94,6 +96,7 @@ export class NovoOverlayTemplateComponent implements OnDestroy {
   protected closingActionsSubscription: Subscription;
   private _parent: ElementRef;
   private overlayContainer: OverlayContainer = inject(OverlayContainer);
+  private destroyRef = inject(DestroyRef);
   private overlayContext: string;
 
   constructor(
@@ -234,7 +237,7 @@ export class NovoOverlayTemplateComponent implements OnDestroy {
   protected createOverlay(template: TemplateRef<any>): void {
     this.portal = new TemplatePortal(template, this.viewContainerRef);
     this.overlayRef = this.overlay.create(this.getOverlayConfig());
-    this.overlayRef.backdropClick().subscribe(() => {
+    this.overlayRef.backdropClick().pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.backDropClicked.emit(true);
       this.closePanel();
     });

--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -14,7 +14,6 @@ import {
   SimpleChanges,
   ViewChild,
   forwardRef,
-  inject,
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 // Vendor
@@ -201,13 +200,13 @@ export class NovoDatePickerInputElement implements OnInit, OnChanges, AfterViewI
   /** Element for the panel containing the autocomplete options. */
   @ViewChild(NovoOverlayTemplateComponent)
   overlay: NovoOverlayTemplateComponent;
-  destroyRef = inject(DestroyRef);
 
   constructor(
     public element: ElementRef,
     public labels: NovoLabelService,
     private _changeDetectorRef: ChangeDetectorRef,
     public dateFormatService: DateFormatService,
+    private destroyRef: DestroyRef,
   ) {
     this.placeholder = this.labels.localizedDatePlaceholder();
   }

--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.ts
@@ -3,6 +3,7 @@ import {
   AfterViewInit,
   ChangeDetectorRef,
   Component,
+  DestroyRef,
   ElementRef,
   EventEmitter,
   HostBinding,
@@ -13,6 +14,7 @@ import {
   SimpleChanges,
   ViewChild,
   forwardRef,
+  inject,
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 // Vendor
@@ -21,6 +23,7 @@ import { isValid } from 'date-fns';
 import { NovoOverlayTemplateComponent } from 'novo-elements/elements/common';
 import { DateFormatService, NovoLabelService } from 'novo-elements/services';
 import { BooleanInput, DateUtil, Helpers, Key } from 'novo-elements/utils';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 // Value accessor for the component (supports ngModel)
 const DATE_VALUE_ACCESSOR = {
@@ -198,6 +201,7 @@ export class NovoDatePickerInputElement implements OnInit, OnChanges, AfterViewI
   /** Element for the panel containing the autocomplete options. */
   @ViewChild(NovoOverlayTemplateComponent)
   overlay: NovoOverlayTemplateComponent;
+  destroyRef = inject(DestroyRef);
 
   constructor(
     public element: ElementRef,
@@ -218,7 +222,7 @@ export class NovoDatePickerInputElement implements OnInit, OnChanges, AfterViewI
   }
 
   ngAfterViewInit(): void {
-    this.overlay.panelClosingActions.subscribe(this._handleOverlayClickout.bind(this));
+    this.overlay.panelClosingActions.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(this._handleOverlayClickout.bind(this));
   }
 
   _initFormatOptions() {

--- a/projects/novo-elements/src/elements/layout/content/layout-content.component.ts
+++ b/projects/novo-elements/src/elements/layout/content/layout-content.component.ts
@@ -4,12 +4,14 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  DestroyRef,
   ElementRef,
   Inject,
   NgZone,
   ViewEncapsulation,
 } from '@angular/core';
 import { NOVO_LAYOUT_CONTAINER } from '../layout.constants';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
     selector: 'novo-layout-content',
@@ -29,12 +31,13 @@ export class NovoLayoutContent extends CdkScrollable implements AfterContentInit
     elementRef: ElementRef<HTMLElement>,
     scrollDispatcher: ScrollDispatcher,
     ngZone: NgZone,
+    private destroyRef: DestroyRef,
   ) {
     super(elementRef, scrollDispatcher, ngZone);
   }
 
   ngAfterContentInit() {
-    this._container._contentMarginChanges.subscribe(() => {
+    this._container._contentMarginChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this._changeDetectorRef.markForCheck();
     });
   }

--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -7,11 +7,9 @@ import {
   ElementRef,
   EventEmitter,
   forwardRef,
-  inject,
   Input,
   OnInit,
   Output,
-  Renderer2,
   ViewChild,
   ViewContainerRef,
   ViewEncapsulation,
@@ -163,11 +161,12 @@ export class NovoPickerElement implements OnInit {
   onModelChange: Function = () => {};
   onModelTouched: Function = () => {};
 
-  destroyRef = inject(DestroyRef);
-  renderer = inject(Renderer2);
 
-
-  constructor(public element: ElementRef, private componentUtils: ComponentUtils, private ref: ChangeDetectorRef) {}
+  constructor(
+    public element: ElementRef,
+    private componentUtils: ComponentUtils,
+    private ref: ChangeDetectorRef,
+    private destroyRef: DestroyRef) {}
 
   ngOnInit() {
     if (this.overrideElement) {
@@ -181,9 +180,15 @@ export class NovoPickerElement implements OnInit {
     this.resultsComponent = this.config.resultsTemplate || PickerResults;
 
     const pasteObserver = fromEvent(this.input.nativeElement, 'paste').pipe(takeUntilDestroyed(this.destroyRef), debounceTime(debounceTimeInMilliSeconds), distinctUntilChanged());
-    pasteObserver.subscribe((event: ClipboardEvent) => this.onDebouncedKeyup(event));
+    pasteObserver.subscribe({
+      next: (event: ClipboardEvent) => this.onDebouncedKeyup(event),
+      error: (err) => this.hideResults(err),
+    });
     const keyboardObserver = fromEvent(this.input.nativeElement, 'keyup').pipe(takeUntilDestroyed(this.destroyRef), debounceTime(debounceTimeInMilliSeconds), distinctUntilChanged());
-    keyboardObserver.subscribe((event: KeyboardEvent) => this.onDebouncedKeyup(event));
+    keyboardObserver.subscribe({
+      next: (event: KeyboardEvent) => this.onDebouncedKeyup(event),
+      error: (err) => this.hideResults(err),
+    });
   }
 
   private onDebouncedKeyup(event: KeyboardEvent | ClipboardEvent) {

--- a/projects/novo-elements/src/elements/picker/Picker.ts
+++ b/projects/novo-elements/src/elements/picker/Picker.ts
@@ -3,12 +3,15 @@ import {
   ChangeDetectorRef,
   Component,
   ComponentRef,
+  DestroyRef,
   ElementRef,
   EventEmitter,
   forwardRef,
+  inject,
   Input,
   OnInit,
   Output,
+  Renderer2,
   ViewChild,
   ViewContainerRef,
   ViewEncapsulation,
@@ -20,6 +23,7 @@ import { ComponentUtils } from 'novo-elements/services';
 import { Helpers, Key, notify } from 'novo-elements/utils';
 import { NovoOverlayTemplateComponent } from 'novo-elements/elements/common';
 import { PickerResults } from './extras/picker-results/PickerResults';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 // Value accessor for the component (supports ngModel)
 const PICKER_VALUE_ACCESSOR = {
@@ -159,6 +163,10 @@ export class NovoPickerElement implements OnInit {
   onModelChange: Function = () => {};
   onModelTouched: Function = () => {};
 
+  destroyRef = inject(DestroyRef);
+  renderer = inject(Renderer2);
+
+
   constructor(public element: ElementRef, private componentUtils: ComponentUtils, private ref: ChangeDetectorRef) {}
 
   ngOnInit() {
@@ -172,16 +180,10 @@ export class NovoPickerElement implements OnInit {
     // Custom results template
     this.resultsComponent = this.config.resultsTemplate || PickerResults;
 
-    const pasteObserver = fromEvent(this.input.nativeElement, 'paste').pipe(debounceTime(debounceTimeInMilliSeconds), distinctUntilChanged());
-    pasteObserver.subscribe(
-      (event: ClipboardEvent) => this.onDebouncedKeyup(event),
-      (err) => this.hideResults(err),
-    );
-    const keyboardObserver = fromEvent(this.input.nativeElement, 'keyup').pipe(debounceTime(debounceTimeInMilliSeconds), distinctUntilChanged());
-    keyboardObserver.subscribe(
-      (event: KeyboardEvent) => this.onDebouncedKeyup(event),
-      (err) => this.hideResults(err),
-    );
+    const pasteObserver = fromEvent(this.input.nativeElement, 'paste').pipe(takeUntilDestroyed(this.destroyRef), debounceTime(debounceTimeInMilliSeconds), distinctUntilChanged());
+    pasteObserver.subscribe((event: ClipboardEvent) => this.onDebouncedKeyup(event));
+    const keyboardObserver = fromEvent(this.input.nativeElement, 'keyup').pipe(takeUntilDestroyed(this.destroyRef), debounceTime(debounceTimeInMilliSeconds), distinctUntilChanged());
+    keyboardObserver.subscribe((event: KeyboardEvent) => this.onDebouncedKeyup(event));
   }
 
   private onDebouncedKeyup(event: KeyboardEvent | ClipboardEvent) {

--- a/projects/novo-elements/src/elements/popover/PopOver.ts
+++ b/projects/novo-elements/src/elements/popover/PopOver.ts
@@ -7,10 +7,12 @@ import {
   HostListener,
   Input,
   OnChanges,
+  OnDestroy,
   Output,
   SimpleChange,
   ViewContainerRef,
 } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { PopOverContent } from './PopOverContent';
 
 @Directive({
@@ -21,10 +23,11 @@ import { PopOverContent } from './PopOverContent';
     selector: '[popover], [novoPopover]',
     standalone: false,
 })
-export class PopOverDirective implements OnChanges {
+export class PopOverDirective implements OnChanges, OnDestroy {
   protected PopoverComponent = PopOverContent;
   protected popover: ComponentRef<PopOverContent>;
   protected visible: boolean;
+  private subscriptions = new Subscription();
 
   constructor(protected viewContainerRef: ViewContainerRef, protected resolver: ComponentFactoryResolver) {}
 
@@ -98,6 +101,10 @@ export class PopOverDirective implements OnChanges {
     }
   }
 
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
+
   toggle() {
     if (!this.visible) {
       this.show();
@@ -137,7 +144,7 @@ export class PopOverDirective implements OnChanges {
         popover.title = this.popoverTitle;
       }
 
-      popover.onCloseFromOutside.subscribe(() => this.hide());
+      this.subscriptions.add(popover.onCloseFromOutside.subscribe(() => this.hide()));
       if (this.popoverDismissTimeout > 0) {
         setTimeout(() => this.hide(), this.popoverDismissTimeout);
       }
@@ -154,7 +161,7 @@ export class PopOverDirective implements OnChanges {
         popover.title = this.popoverTitle;
       }
 
-      popover.onCloseFromOutside.subscribe(() => this.hide());
+      this.subscriptions.add(popover.onCloseFromOutside.subscribe(() => this.hide()));
       if (this.popoverDismissTimeout > 0) {
         setTimeout(() => this.hide(), this.popoverDismissTimeout);
       }

--- a/projects/novo-elements/src/elements/toast/ToastService.spec.ts
+++ b/projects/novo-elements/src/elements/toast/ToastService.spec.ts
@@ -4,8 +4,7 @@ import { NovoToastService } from './ToastService';
 
 describe('Elements: NovoToastService', () => {
   describe('Service: ', () => {
-    const resolver: any = null;
-    const utils = new ComponentUtils(resolver);
+    const utils = new ComponentUtils();
     const service = new NovoToastService(utils);
 
     it('should be defined.', () => {

--- a/projects/novo-elements/src/elements/unless/Unless.spec.ts
+++ b/projects/novo-elements/src/elements/unless/Unless.spec.ts
@@ -483,6 +483,12 @@ describe('Unless Directive', () => {
       expect(viewContainer.createEmbeddedView).toHaveBeenCalledWith(templateRef);
     });
 
+    it('should safely dispose even if Security is using old void implementation', () => {
+      security.subscribe.mockImplementation((() => {}) as any);
+      (destroyRef.onDestroy as jest.Mock).mock.calls[0][0]();
+      // Expect no error
+    });
+
     it('should handle OR and AND combinations', () => {
       security.has.mockImplementation((perm: string) => {
         return perm === 'admin' || perm === 'user';

--- a/projects/novo-elements/src/elements/unless/Unless.spec.ts
+++ b/projects/novo-elements/src/elements/unless/Unless.spec.ts
@@ -1,4 +1,4 @@
-import { TemplateRef, ViewContainerRef } from '@angular/core';
+import { DestroyRef, TemplateRef, ViewContainerRef } from '@angular/core';
 import { Security } from 'novo-elements/services';
 import { Unless } from './Unless';
 
@@ -9,6 +9,7 @@ describe('Unless Directive', () => {
   let templateRef: jest.Mocked<TemplateRef<any>>;
   let viewContainer: jest.Mocked<ViewContainerRef>;
   let security: jest.Mocked<Security>;
+  let destroyRef: jest.Mocked<DestroyRef>;
 
   beforeEach(() => {
     templateRef = {
@@ -25,7 +26,11 @@ describe('Unless Directive', () => {
       has: jest.fn(),
     } as any;
 
-    directive = new Unless(templateRef, viewContainer, security);
+    destroyRef = {
+      onDestroy: jest.fn(),
+    }
+
+    directive = new Unless(templateRef, viewContainer, security, destroyRef);
   });
 
   describe('constructor', () => {

--- a/projects/novo-elements/src/elements/unless/Unless.ts
+++ b/projects/novo-elements/src/elements/unless/Unless.ts
@@ -18,7 +18,10 @@ export class Unless {
     private destroyRef: DestroyRef) {
     const sub = this.security.subscribe(this.check.bind(this));
     this.destroyRef.onDestroy(() => {
-      sub.unsubscribe();
+      // If Security uses an old definition, subscribe will return void/undefined.
+      try {
+        sub?.unsubscribe();
+      } catch {}
     });
   }
 

--- a/projects/novo-elements/src/elements/unless/Unless.ts
+++ b/projects/novo-elements/src/elements/unless/Unless.ts
@@ -1,5 +1,5 @@
 // NG2
-import { Directive, Input, TemplateRef, ViewContainerRef } from '@angular/core';
+import { DestroyRef, Directive, Input, TemplateRef, ViewContainerRef } from '@angular/core';
 // App
 import { Security } from 'novo-elements/services';
 
@@ -11,8 +11,15 @@ export class Unless {
   permissions: string = '';
   isDisplayed: boolean = false;
 
-  constructor(public templateRef: TemplateRef<any>, public viewContainer: ViewContainerRef, public security: Security) {
-    this.security.subscribe(this.check.bind(this));
+  constructor(
+    public templateRef: TemplateRef<any>,
+    public viewContainer: ViewContainerRef,
+    public security: Security,
+    private destroyRef: DestroyRef) {
+    const sub = this.security.subscribe(this.check.bind(this));
+    this.destroyRef.onDestroy(() => {
+      sub.unsubscribe();
+    });
   }
 
   @Input()

--- a/projects/novo-elements/src/services/component-utils/ComponentUtils.spec.ts
+++ b/projects/novo-elements/src/services/component-utils/ComponentUtils.spec.ts
@@ -1,5 +1,4 @@
 // APP
-import { ComponentFactoryResolver } from '@angular/core';
 import { waitForAsync } from '@angular/core/testing';
 import { ComponentUtils } from './ComponentUtils';
 
@@ -8,13 +7,12 @@ describe('Utils: ComponentUtils', () => {
 
   beforeAll(waitForAsync(() => {
     const resolve = { resolveComponentFactory: ({}) => {} };
-    service = new ComponentUtils(resolve as ComponentFactoryResolver);
+    service = new ComponentUtils();
   }));
 
   it('function append() should call location.createComponent', () => {
-    jest.spyOn(service.componentFactoryResolver, 'resolveComponentFactory');
-    const location = { createComponent: () => {} };
+    const location = { createComponent: jest.fn() };
     service.append(ComponentUtils, location as any);
-    expect(service.componentFactoryResolver.resolveComponentFactory).toHaveBeenCalled();
+    expect(location.createComponent).toHaveBeenCalled();
   });
 });

--- a/projects/novo-elements/src/services/component-utils/ComponentUtils.ts
+++ b/projects/novo-elements/src/services/component-utils/ComponentUtils.ts
@@ -1,14 +1,16 @@
 // NG2
-import { ComponentFactoryResolver, ComponentRef, Injectable, Injector, StaticProvider, Type, ViewContainerRef } from '@angular/core';
+import { ComponentRef, Injectable, Injector, StaticProvider, Type, ViewContainerRef } from '@angular/core';
 
 @Injectable()
 export class ComponentUtils<T = any> {
-  constructor(public componentFactoryResolver: ComponentFactoryResolver) {}
 
   append<T>(ComponentClass: Type<T>, location: ViewContainerRef, providers?: StaticProvider[], onTop?: boolean): ComponentRef<T> { //eslint-disable-line
-    const componentFactory = this.componentFactoryResolver.resolveComponentFactory(ComponentClass);
     const parent = location.injector;
     const index = onTop ? 0 : location.length;
-    return location.createComponent(componentFactory, index, Injector.create({ providers, parent }));
+    const injector = Injector.create({ providers, parent });
+    return location.createComponent(ComponentClass, {
+      index,
+      injector,
+    });
   }
 }

--- a/projects/novo-elements/src/services/security/Security.ts
+++ b/projects/novo-elements/src/services/security/Security.ts
@@ -1,5 +1,6 @@
 // NG2
 import { EventEmitter, Injectable } from '@angular/core';
+import { Subscription } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class Security {
@@ -40,8 +41,8 @@ export class Security {
     this.change.emit(this.credentials);
   }
 
-  subscribe(fn: any): void {
-    this.change.subscribe(fn);
+  subscribe(fn: any): Subscription {
+    return this.change.subscribe(fn);
   }
 
   checkRoutes(


### PR DESCRIPTION
## **Description**

Properly unsub from listeners in some unique cases

Adjusts ComponentUtils to remove a deprecated factory

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**