### PR TITLE
fix(Memory): Change modalService and toastService for memory optimization

### DIFF
--- a/projects/novo-elements/src/elements/modal/modal.service.ts
+++ b/projects/novo-elements/src/elements/modal/modal.service.ts
@@ -20,12 +20,10 @@ const DEFAULT_CONFIG: ModalConfig = {
 
 @Injectable({ providedIn: 'root' })
 export class NovoModalService {
-  _parentViewContainer: ViewContainerRef;
   overlayRef: OverlayRef;
 
   set parentViewContainer(view: ViewContainerRef) {
-    console.warn('parentViewContainer is deprecated');
-    this._parentViewContainer = view;
+    console.warn('parentViewContainer is deprecated - will be ignored');
   }
 
   constructor(private injector: Injector, private overlay: Overlay) {}

--- a/projects/novo-elements/src/elements/toast/ToastService.ts
+++ b/projects/novo-elements/src/elements/toast/ToastService.ts
@@ -1,5 +1,5 @@
 // NG2
-import { Injectable } from '@angular/core';
+import { DestroyRef, Injectable, ViewContainerRef } from '@angular/core';
 import { ComponentUtils } from 'novo-elements/services';
 // APP
 import { NovoToastElement } from './Toast';
@@ -31,7 +31,18 @@ export class NovoToastService {
   constructor(private componentUtils: ComponentUtils) {}
 
   set parentViewContainer(view) {
+    console.warn('parentViewContainer is deprecated. Use ownViewContainer(view, destroyRef) to promote lifecycle management');
     this._parentViewContainer = view;
+  }
+
+  ownViewContainer(view: ViewContainerRef, destroyRef: DestroyRef) {
+    this._parentViewContainer = view;
+    const weakView = new WeakRef(view);
+    destroyRef.onDestroy(() => {
+      if (this._parentViewContainer === weakView.deref()) {
+        this._parentViewContainer = null;
+      }
+    })
   }
 
   alert(options: ToastOptions, toastElement: any = NovoToastElement): Promise<any> {

--- a/projects/novo-elements/src/package.json
+++ b/projects/novo-elements/src/package.json
@@ -18,7 +18,7 @@
     "codemirror": "6.0.1",
     "date-fns": ">=2",
     "novo-design-tokens": "^0.0.9",
-    "post-robot": "^8.0.0",
+    "post-robot": ">=8.0.0 <10.0.0",
     "rxjs": ">=7",
     "timezone-support": "^3.1.0"
   },

--- a/projects/novo-elements/src/utils/outside-click/OutsideClick.ts
+++ b/projects/novo-elements/src/utils/outside-click/OutsideClick.ts
@@ -27,6 +27,8 @@ export class OutsideClick implements OnDestroy {
    */
   ngOnDestroy() {
     window.removeEventListener('click', this.onOutsideClick);
+    delete this.onOutsideClick;
+    delete this.otherElement;
   }
 
   /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "outDir": "./dist",
     "target": "ES2022",
     "module": "esnext",
-    "lib": ["es2020", "dom"],
+    "lib": ["es2020", "dom", "esnext.WeakRef"],
     "typeRoots": ["node_modules/@types"],
     "sourceMap": true,
     "declaration": false,


### PR DESCRIPTION
## **Description**

Do not hold ViewContainerRefs longer than needed. Added a function on toastService: ownViewContainer

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**