### PR TITLE
chore(Dependencies): Lock dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: 22.22.0
       - name: Install Dependencies
         run: |
-          npm install
+          npm ci
       - name: Test
         run: |
           npm run lint

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
     cd novo-elements
 
     # Install
-    npm install
+    npm ci
 
     # Start (you will need two terminals)
     npm run build (builds the library, alternatively you can use npm run build:watch for live-reload)


### PR DESCRIPTION
## **Description**

Using `npm ci` instead of `npm install` to ensure no transitive dependency updates without permission

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**