### PR TITLE
test(Automation): Add calendar demo automation

### DIFF
--- a/projects/novo-e2e/src/e2e/calendar.e2e.ts
+++ b/projects/novo-e2e/src/e2e/calendar.e2e.ts
@@ -1,0 +1,66 @@
+import { click, scrollIntoView } from '../utils/ElementActionUtil';
+import { COMPONENT_URLS, examplesUrl, getURLs } from '../utils/EnvironmentUtil';
+import { elements } from '../utils/SelectorUtil';
+import { verifyPresent, verifyText, verifyClassPresent, verifyClassAbsent } from '../utils/VerifyUtil';
+import { calendarDate, firstVisibleCalendarDate, lastVisibleCalendarDate, verifyCalendarDateSelected } from '../utils/CalendarUtil';
+
+describe('Calendar Demo Page', () => {
+  const url = examplesUrl(COMPONENT_URLS.CALENDAR);
+
+  before(async () => {
+    await browser.navigateTo(url);
+  });
+
+  after(async () => {
+    await browser.navigateTo(getURLs().HOME);
+  });
+
+  describe('Page Elements', () => {
+    it('should display page title', async () => {
+      await verifyPresent(elements.title);
+      await verifyText(elements.title, 'Calendar', 'Calendar example page title');
+    });
+
+    it('should display calendar component', async () => {
+      await verifyPresent('novo-calendar');
+    });
+  });
+
+  describe('Single Selection Mode', () => {
+    it('should select a single date and display it in the output', async () => {
+      await scrollIntoView('novo-calendar');
+      await click(calendarDate(15));
+      await verifyClassPresent(calendarDate(15), 'selected', 'calendar date 15');
+      await verifyCalendarDateSelected(15);
+    });
+
+    it('should replace selection with a new date', async () => {
+      await click(calendarDate(20));
+      await verifyClassPresent(calendarDate(20), 'selected', 'calendar date 20');
+      await verifyClassAbsent(calendarDate(15), 'selected', 'calendar date 15');
+      await verifyCalendarDateSelected(20);
+    });
+
+    it('should select the first day of the month', async () => {
+      await click(calendarDate(1));
+      await verifyClassPresent(calendarDate(1), 'selected', 'calendar date 1');
+      await verifyCalendarDateSelected(1);
+    });
+
+    it('should select the last day of the month', async () => {
+      await click(calendarDate(30));
+      await verifyClassPresent(calendarDate(30), 'selected', 'calendar date 30');
+      await verifyCalendarDateSelected(30);
+    });
+
+    it('should select the first visible day in the calendar grid', async () => {
+      await click(firstVisibleCalendarDate());
+      await verifyClassPresent(firstVisibleCalendarDate(), 'selected', 'first visible day');
+    });
+
+    it('should select the last visible day in the calendar grid', async () => {
+      await click(lastVisibleCalendarDate());
+      await verifyClassPresent(lastVisibleCalendarDate(), 'selected', 'last visible day');
+    });
+  });
+});

--- a/projects/novo-e2e/src/e2e/calendar.e2e.ts
+++ b/projects/novo-e2e/src/e2e/calendar.e2e.ts
@@ -1,6 +1,6 @@
 import { click, scrollIntoView } from '../utils/ElementActionUtil';
 import { COMPONENT_URLS, examplesUrl, getURLs } from '../utils/EnvironmentUtil';
-import { elements, radioByValue } from '../utils/SelectorUtil';
+import { elements, radioByValue, radioByIndex } from '../utils/SelectorUtil';
 import { verifyPresent, verifyText, verifyClassPresent, verifyClassAbsent } from '../utils/VerifyUtil';
 import {
   calendarDate,
@@ -115,57 +115,29 @@ describe('Calendar Demo Page', () => {
     });
   });
 
-  describe.skip('Multiple Selection Mode', () => {
+  describe('Multiple Selection Mode', () => {
     before(async () => {
-      // Switch to multiple selection mode
-      await click(radioByValue('multiple'));
+      await browser.refresh();
+      await click(radioByIndex(2));
     });
 
     it('should select multiple dates and keep them all selected', async () => {
-      // Select the 10th
       await click(calendarDate(10));
       await verifyClassPresent(calendarDate(10), 'selected', 'calendar date 10');
-      await verifyCalendarDateSelected(10);
+      await verifyCalendarDatesSelected([10]);
 
-      // Select the 15th
       await click(calendarDate(15));
       await verifyClassPresent(calendarDate(15), 'selected', 'calendar date 15');
       await verifyCalendarDatesSelected([10, 15]);
 
-      // Select the 20th
       await click(calendarDate(20));
       await verifyClassPresent(calendarDate(20), 'selected', 'calendar date 20');
       await verifyCalendarDatesSelected([10, 15, 20]);
     });
 
     it('should deselect a date when clicking it again in multiple mode', async () => {
-      // Click the 15th again to deselect it
       await click(calendarDate(15));
       await verifyClassAbsent(calendarDate(15), 'selected', 'calendar date 15');
-      await verifyCalendarDatesSelected([10, 20]);
-    });
-
-    it('should select and deselect the first day of the month', async () => {
-      // Select the 1st
-      await click(calendarDate(1));
-      await verifyClassPresent(calendarDate(1), 'selected', 'calendar date 1');
-      await verifyCalendarDatesSelected([1, 10, 20]);
-
-      // Deselect the 1st
-      await click(calendarDate(1));
-      await verifyClassAbsent(calendarDate(1), 'selected', 'calendar date 1');
-      await verifyCalendarDatesSelected([10, 20]);
-    });
-
-    it('should select and deselect the last day of the month', async () => {
-      // Select the 30th
-      await click(calendarDate(30));
-      await verifyClassPresent(calendarDate(30), 'selected', 'calendar date 30');
-      await verifyCalendarDatesSelected([10, 20, 30]);
-
-      // Deselect the 30th
-      await click(calendarDate(30));
-      await verifyClassAbsent(calendarDate(30), 'selected', 'calendar date 30');
       await verifyCalendarDatesSelected([10, 20]);
     });
   });

--- a/projects/novo-e2e/src/e2e/calendar.e2e.ts
+++ b/projects/novo-e2e/src/e2e/calendar.e2e.ts
@@ -1,8 +1,22 @@
 import { click, scrollIntoView } from '../utils/ElementActionUtil';
 import { COMPONENT_URLS, examplesUrl, getURLs } from '../utils/EnvironmentUtil';
-import { elements } from '../utils/SelectorUtil';
+import { elements, radioByValue } from '../utils/SelectorUtil';
 import { verifyPresent, verifyText, verifyClassPresent, verifyClassAbsent } from '../utils/VerifyUtil';
-import { calendarDate, firstVisibleCalendarDate, lastVisibleCalendarDate, verifyCalendarDateSelected } from '../utils/CalendarUtil';
+import {
+  calendarDate,
+  firstVisibleCalendarDate,
+  lastVisibleCalendarDate,
+  verifyCalendarDateSelected,
+  verifyCalendarDatesSelected,
+  calendarMonth,
+  calendarYear,
+  calendarMonthHeader,
+  calendarYearHeader,
+  calendarNextButton,
+  calendarPreviousButton,
+  calendarMonthText,
+  calendarYearText
+} from '../utils/CalendarUtil';
 
 describe('Calendar Demo Page', () => {
   const url = examplesUrl(COMPONENT_URLS.CALENDAR);
@@ -22,13 +36,58 @@ describe('Calendar Demo Page', () => {
     });
 
     it('should display calendar component', async () => {
-      await verifyPresent('novo-calendar');
+      await verifyPresent(elements.calendar);
+    });
+  });
+
+  describe('Calendar Navigation', () => {
+    it('should navigate to next month using calendar-next button', async () => {
+      await scrollIntoView(elements.calendar);
+      const prevMonthHeader = await $(calendarMonthText()).getText();
+      await click(calendarNextButton());
+      const nextMonthHeader = await $(calendarMonthText()).getText();
+      expect(prevMonthHeader).not.toEqual(nextMonthHeader);
+    });
+
+    it('should navigate to previous month using calendar-previous button', async () => {
+      const currentMonthHeader = await $(calendarMonthText()).getText();
+      await click(calendarPreviousButton());
+      const prevMonthHeader = await $(calendarMonthText()).getText();
+      expect(currentMonthHeader).not.toEqual(prevMonthHeader);
+    });
+
+    it('should open and change month', async () => {
+      const initialMonth = await $(calendarMonthText()).getText();
+
+      // Click month header to open month view
+      await click(calendarMonthHeader());
+
+      // Select May
+      await click(calendarMonth('May'));
+
+      // Verify month changed
+      const newMonth = await $(calendarMonthText()).getText();
+      expect(initialMonth).not.toEqual(newMonth);
+    });
+
+    it('should open and change year', async () => {
+      const initialYear = await $(calendarYearText()).getText();
+
+      // Click year header to open year view
+      await click(calendarYearHeader());
+
+      // Select 2025
+      await click(calendarYear(2025));
+
+      // Verify year changed
+      const newYear = await $(calendarYearText()).getText();
+      expect(initialYear).not.toEqual(newYear);
     });
   });
 
   describe('Single Selection Mode', () => {
     it('should select a single date and display it in the output', async () => {
-      await scrollIntoView('novo-calendar');
+      await scrollIntoView(elements.calendar);
       await click(calendarDate(15));
       await verifyClassPresent(calendarDate(15), 'selected', 'calendar date 15');
       await verifyCalendarDateSelected(15);
@@ -61,6 +120,61 @@ describe('Calendar Demo Page', () => {
     it('should select the last visible day in the calendar grid', async () => {
       await click(lastVisibleCalendarDate());
       await verifyClassPresent(lastVisibleCalendarDate(), 'selected', 'last visible day');
+    });
+  });
+
+  describe.skip('Multiple Selection Mode', () => {
+    before(async () => {
+      // Switch to multiple selection mode
+      await click(radioByValue('multiple'));
+    });
+
+    it('should select multiple dates and keep them all selected', async () => {
+      // Select the 10th
+      await click(calendarDate(10));
+      await verifyClassPresent(calendarDate(10), 'selected', 'calendar date 10');
+      await verifyCalendarDateSelected(10);
+
+      // Select the 15th
+      await click(calendarDate(15));
+      await verifyClassPresent(calendarDate(15), 'selected', 'calendar date 15');
+      await verifyCalendarDatesSelected([10, 15]);
+
+      // Select the 20th
+      await click(calendarDate(20));
+      await verifyClassPresent(calendarDate(20), 'selected', 'calendar date 20');
+      await verifyCalendarDatesSelected([10, 15, 20]);
+    });
+
+    it('should deselect a date when clicking it again in multiple mode', async () => {
+      // Click the 15th again to deselect it
+      await click(calendarDate(15));
+      await verifyClassAbsent(calendarDate(15), 'selected', 'calendar date 15');
+      await verifyCalendarDatesSelected([10, 20]);
+    });
+
+    it('should select and deselect the first day of the month', async () => {
+      // Select the 1st
+      await click(calendarDate(1));
+      await verifyClassPresent(calendarDate(1), 'selected', 'calendar date 1');
+      await verifyCalendarDatesSelected([1, 10, 20]);
+
+      // Deselect the 1st
+      await click(calendarDate(1));
+      await verifyClassAbsent(calendarDate(1), 'selected', 'calendar date 1');
+      await verifyCalendarDatesSelected([10, 20]);
+    });
+
+    it('should select and deselect the last day of the month', async () => {
+      // Select the 30th
+      await click(calendarDate(30));
+      await verifyClassPresent(calendarDate(30), 'selected', 'calendar date 30');
+      await verifyCalendarDatesSelected([10, 20, 30]);
+
+      // Deselect the 30th
+      await click(calendarDate(30));
+      await verifyClassAbsent(calendarDate(30), 'selected', 'calendar date 30');
+      await verifyCalendarDatesSelected([10, 20]);
     });
   });
 });

--- a/projects/novo-e2e/src/e2e/calendar.e2e.ts
+++ b/projects/novo-e2e/src/e2e/calendar.e2e.ts
@@ -4,6 +4,7 @@ import { elements } from '../utils/SelectorUtil';
 import { verifyPresent, verifyText, verifyClassPresent, verifyClassAbsent } from '../utils/VerifyUtil';
 import {
   calendarDate,
+  calendarDateInMonth,
   firstVisibleCalendarDate,
   lastVisibleCalendarDate,
   verifyCalendarDateSelected,
@@ -21,6 +22,9 @@ import {
   getMonthByOffset,
   getYearByOffset,
   calendarSelectionMode,
+  calendarNumberOfMonths,
+  calendarWeekStart,
+  getCalendarWeekdayHeaders,
 } from '../utils/CalendarUtil';
 
 describe('Calendar Demo Page', () => {
@@ -190,6 +194,53 @@ describe('Calendar Demo Page', () => {
       await click(calendarDate(20));
       await verifyClassPresent(calendarDate(20), 'inRange', 'calendar date 20 is in the selected week');
       await verifyCalendarWeekRangeDays();
+    });
+  });
+
+  describe('Two Month Display', () => {
+    before(async () => {
+      await browser.refresh();
+      await click(calendarSelectionMode('single'));
+      await click(calendarNumberOfMonths(2));
+    });
+
+    it('should display two months', async () => {
+      await scrollIntoView(elements.calendar);
+      const monthElements = await $$(calendarMonthText());
+      expect(monthElements.length).toBe(2);
+    });
+
+    it('should select a date from the first month', async () => {
+      await click(calendarDate(15));
+      await verifyClassPresent(calendarDate(15), 'selected', 'calendar date 15');
+      await verifyCalendarDateSelected(15);
+    });
+
+    it('should select a date from the second month', async () => {
+      await click(calendarDateInMonth(10, 1));
+      await verifyClassPresent(calendarDateInMonth(10, 1), 'selected', 'calendar date 10 in second month');
+      await verifyCalendarDateSelected(10);
+    });
+  });
+
+  describe('Week Start on Monday', () => {
+    before(async () => {
+      await browser.refresh();
+      await click(calendarSelectionMode('single'));
+      await click(calendarWeekStart(1));
+    });
+
+    it('should have Monday as the first day of the week', async () => {
+      await scrollIntoView(elements.calendar);
+      const weekdayHeaders = await getCalendarWeekdayHeaders();
+      const firstDayText = await weekdayHeaders[0].getText();
+      expect(firstDayText).toBe('Mo');
+    });
+
+    it('should select a date with Monday week start', async () => {
+      await click(calendarDate(15));
+      await verifyClassPresent(calendarDate(15), 'selected', 'calendar date 15');
+      await verifyCalendarDateSelected(15);
     });
   });
 });

--- a/projects/novo-e2e/src/e2e/calendar.e2e.ts
+++ b/projects/novo-e2e/src/e2e/calendar.e2e.ts
@@ -15,7 +15,9 @@ import {
   calendarNextButton,
   calendarPreviousButton,
   calendarMonthText,
-  calendarYearText
+  calendarYearText,
+  getMonthByOffset,
+  getYearByOffset
 } from '../utils/CalendarUtil';
 
 describe('Calendar Demo Page', () => {
@@ -58,28 +60,18 @@ describe('Calendar Demo Page', () => {
 
     it('should open and change month', async () => {
       const initialMonth = await $(calendarMonthText()).getText();
-
-      // Click month header to open month view
       await click(calendarMonthHeader());
-
-      // Select May
-      await click(calendarMonth('May'));
-
-      // Verify month changed
+      const targetMonth = getMonthByOffset(-2);
+      await click(calendarMonth(targetMonth));
       const newMonth = await $(calendarMonthText()).getText();
       expect(initialMonth).not.toEqual(newMonth);
     });
 
     it('should open and change year', async () => {
       const initialYear = await $(calendarYearText()).getText();
-
-      // Click year header to open year view
       await click(calendarYearHeader());
-
-      // Select 2025
-      await click(calendarYear(2025));
-
-      // Verify year changed
+      const targetYear = getYearByOffset(-1);
+      await click(calendarYear(targetYear));
       const newYear = await $(calendarYearText()).getText();
       expect(initialYear).not.toEqual(newYear);
     });

--- a/projects/novo-e2e/src/e2e/calendar.e2e.ts
+++ b/projects/novo-e2e/src/e2e/calendar.e2e.ts
@@ -1,6 +1,6 @@
 import { click, scrollIntoView } from '../utils/ElementActionUtil';
 import { COMPONENT_URLS, examplesUrl, getURLs } from '../utils/EnvironmentUtil';
-import { elements, radioByValue, radioByIndex } from '../utils/SelectorUtil';
+import { elements, radioByIndex } from '../utils/SelectorUtil';
 import { verifyPresent, verifyText, verifyClassPresent, verifyClassAbsent } from '../utils/VerifyUtil';
 import {
   calendarDate,
@@ -17,7 +17,7 @@ import {
   calendarMonthText,
   calendarYearText,
   getMonthByOffset,
-  getYearByOffset
+  getYearByOffset,
 } from '../utils/CalendarUtil';
 
 describe('Calendar Demo Page', () => {

--- a/projects/novo-e2e/src/e2e/calendar.e2e.ts
+++ b/projects/novo-e2e/src/e2e/calendar.e2e.ts
@@ -1,6 +1,6 @@
 import { click, scrollIntoView } from '../utils/ElementActionUtil';
 import { COMPONENT_URLS, examplesUrl, getURLs } from '../utils/EnvironmentUtil';
-import { elements, radioByIndex } from '../utils/SelectorUtil';
+import { elements } from '../utils/SelectorUtil';
 import { verifyPresent, verifyText, verifyClassPresent, verifyClassAbsent } from '../utils/VerifyUtil';
 import {
   calendarDate,
@@ -8,6 +8,8 @@ import {
   lastVisibleCalendarDate,
   verifyCalendarDateSelected,
   verifyCalendarDatesSelected,
+  verifyCalendarDateRangeSelected,
+  verifyCalendarWeekRangeDays,
   calendarMonth,
   calendarYear,
   calendarMonthHeader,
@@ -18,6 +20,7 @@ import {
   calendarYearText,
   getMonthByOffset,
   getYearByOffset,
+  calendarSelectionMode,
 } from '../utils/CalendarUtil';
 
 describe('Calendar Demo Page', () => {
@@ -118,7 +121,7 @@ describe('Calendar Demo Page', () => {
   describe('Multiple Selection Mode', () => {
     before(async () => {
       await browser.refresh();
-      await click(radioByIndex(2));
+      await click(calendarSelectionMode('multiple'));
     });
 
     it('should select multiple dates and keep them all selected', async () => {
@@ -139,6 +142,54 @@ describe('Calendar Demo Page', () => {
       await click(calendarDate(15));
       await verifyClassAbsent(calendarDate(15), 'selected', 'calendar date 15');
       await verifyCalendarDatesSelected([10, 20]);
+    });
+  });
+
+  describe('Range Selection Mode', () => {
+    before(async () => {
+      await browser.refresh();
+      await click(calendarSelectionMode('range'));
+    });
+
+    it('should select a date range with start and end dates', async () => {
+      await scrollIntoView(elements.calendar);
+      await click(calendarDate(10));
+      await verifyClassPresent(calendarDate(10), 'selected', 'calendar date 10');
+
+      await click(calendarDate(20));
+      await verifyClassPresent(calendarDate(10), 'rangeStart', 'calendar date 10');
+      await verifyClassPresent(calendarDate(20), 'rangeEnd', 'calendar date 20');
+      await verifyCalendarDateRangeSelected(10, 20);
+    });
+
+    it('should replace the range with a new selection', async () => {
+      await click(calendarDate(5));
+      await verifyClassPresent(calendarDate(5), 'selected', 'calendar date 5');
+
+      await click(calendarDate(15));
+      await verifyClassPresent(calendarDate(5), 'rangeStart', 'calendar date 5');
+      await verifyClassPresent(calendarDate(15), 'rangeEnd', 'calendar date 15');
+      await verifyCalendarDateRangeSelected(5, 15);
+    });
+  });
+
+  describe('Week Selection Mode', () => {
+    before(async () => {
+      await browser.refresh();
+      await click(calendarSelectionMode('week'));
+    });
+
+    it('should select a full week when clicking a date', async () => {
+      await scrollIntoView(elements.calendar);
+      await click(calendarDate(10));
+      await verifyClassPresent(calendarDate(10), 'inRange', 'calendar date 10 is in the selected week');
+      await verifyCalendarWeekRangeDays();
+    });
+
+    it('should replace the week selection with a new week', async () => {
+      await click(calendarDate(20));
+      await verifyClassPresent(calendarDate(20), 'inRange', 'calendar date 20 is in the selected week');
+      await verifyCalendarWeekRangeDays();
     });
   });
 });

--- a/projects/novo-e2e/src/utils/CalendarUtil.ts
+++ b/projects/novo-e2e/src/utils/CalendarUtil.ts
@@ -1,9 +1,11 @@
+import { automationId, elements } from './SelectorUtil';
+
 /**
  * Returns the selector for a calendar date by day number
  * @param dayNumber the day number to select (1-31)
  */
 export function calendarDate(dayNumber: number | string): string {
-    return `novo-calendar .calendar-date[data-automation-id="${dayNumber}"]`;
+    return `${elements.calendar} .calendar-date${automationId(dayNumber)}`;
 }
 
 /**
@@ -11,7 +13,7 @@ export function calendarDate(dayNumber: number | string): string {
  * (may include overflow days from previous month)
  */
 export function firstVisibleCalendarDate(): string {
-    return 'novo-calendar .calendar-date:first-child';
+    return `${elements.calendar} .calendar-date:first-child`;
 }
 
 /**
@@ -19,14 +21,72 @@ export function firstVisibleCalendarDate(): string {
  * (may include overflow days from next month)
  */
 export function lastVisibleCalendarDate(): string {
-    return 'novo-calendar .calendar-date:last-child';
+    return `${elements.calendar} .calendar-date:last-child`;
 }
+
+/**
+ * Returns the selector for the month header
+ */
+export function calendarMonthHeader(): string {
+    return automationId('header-month');
+}
+
+/**
+ * Returns the selector for the year header
+ */
+export function calendarYearHeader(): string {
+    return automationId('header-year');
+}
+
+/**
+ * Returns the selector for the next month button
+ */
+export function calendarNextButton(): string {
+    return automationId('calendar-next');
+}
+
+/**
+ * Returns the selector for the previous month button
+ */
+export function calendarPreviousButton(): string {
+    return automationId('calendar-previous');
+}
+
+/**
+ * Returns the selector for the month text element
+ */
+export function calendarMonthText(): string {
+    return `${elements.calendar} .month`;
+}
+
+/**
+ * Returns the selector for the year text element
+ */
+export function calendarYearText(): string {
+    return `${elements.calendar} .year`;
+}
+
+/**
+ * Returns the selector for a month by name in month view
+ */
+export function calendarMonth(monthName: string): string {
+    return `div${automationId(monthName)}`;
+}
+
+/**
+ * Returns the selector for a year by number in year view
+ */
+export function calendarYear(yearNumber: number): string {
+    return `div${automationId(yearNumber)}`;
+}
+
 
 /**
  * Gets the selected values from the calendar display as a Date array
  */
 export async function getCalendarSelectedValues(): Promise<Date[]> {
-    const elements = await $('[data-automation-id="calendar-selected-values"]');
+    // const element = await $(automationId('calendar-selected-values'));
+    const elements = await $$('novo-label ~ div');
     const text = await elements[0].getText();
     return JSON.parse(text);
 }
@@ -39,4 +99,15 @@ export async function verifyCalendarDateSelected(dayNumber: number): Promise<voi
     expect(selectedValues.length).toBe(1);
     const selectedDate = new Date(selectedValues[0]);
     expect(selectedDate.getDate()).toBe(dayNumber);
+}
+
+/**
+ * Verifies that multiple specific days are selected in the calendar output
+ */
+export async function verifyCalendarDatesSelected(dayNumbers: number[]): Promise<void> {
+    const selectedValues = await getCalendarSelectedValues();
+    expect(selectedValues.length).toBe(dayNumbers.length);
+    const selectedDays = selectedValues.map(val => new Date(val).getDate()).sort((a, b) => a - b);
+    const expectedDays = dayNumbers.sort((a, b) => a - b);
+    expect(selectedDays).toEqual(expectedDays);
 }

--- a/projects/novo-e2e/src/utils/CalendarUtil.ts
+++ b/projects/novo-e2e/src/utils/CalendarUtil.ts
@@ -12,7 +12,7 @@ export const CALENDAR_MONTHS = [
     'September',
     'October',
     'November',
-    'December'
+    'December',
 ];
 
 /**
@@ -127,8 +127,8 @@ export function calendarYear(yearNumber: number): string {
 export async function getCalendarSelectedValues(): Promise<Date[]> {
     // TODO: swap this back
     // const element = await $(automationId('calendar-selected-values'));
-    const elements = await $$('novo-label ~ div');
-    const text = await elements[0].getText();
+    const values = await $$('novo-label ~ div');
+    const text = await values[0].getText();
     return JSON.parse(text);
 }
 

--- a/projects/novo-e2e/src/utils/CalendarUtil.ts
+++ b/projects/novo-e2e/src/utils/CalendarUtil.ts
@@ -42,18 +42,14 @@ export function getYearByOffset(offset: number): number {
     return new Date().getFullYear() + offset;
 }
 
-/**
- * Returns the selector for a calendar date by day number
- * @param dayNumber the day number to select (1-31)
- */
 export function calendarDate(dayNumber: number | string): string {
     return `${elements.calendar} .calendar-date${automationId(dayNumber)}`;
 }
 
 /**
  * Returns the selector for a calendar date in a specific month
- * @param dayNumber the day number to select (1-31)
- * @param monthIndex the index of the month (0 for first, 1 for second, etc.)
+ * @param dayNumber the day number to select
+ * @param monthIndex the index of the month
  */
 export function calendarDateInMonth(dayNumber: number | string, monthIndex: number): string {
     return `${elements.calendar} .month-view:nth-of-type(${monthIndex + 1}) .calendar-date${automationId(dayNumber)}`;
@@ -75,58 +71,34 @@ export function lastVisibleCalendarDate(): string {
     return `${elements.calendar} .calendar-date:last-child`;
 }
 
-/**
- * Returns the selector for the month header
- */
 export function calendarMonthHeader(): string {
     return automationId('header-month');
 }
 
-/**
- * Returns the selector for the year header
- */
 export function calendarYearHeader(): string {
     return automationId('header-year');
 }
 
-/**
- * Returns the selector for the next month button
- */
 export function calendarNextButton(): string {
     return automationId('calendar-next');
 }
 
-/**
- * Returns the selector for the previous month button
- */
 export function calendarPreviousButton(): string {
     return automationId('calendar-previous');
 }
 
-/**
- * Returns the selector for the month text element
- */
 export function calendarMonthText(): string {
     return `${elements.calendar} .month`;
 }
 
-/**
- * Returns the selector for the year text element
- */
 export function calendarYearText(): string {
     return `${elements.calendar} .year`;
 }
 
-/**
- * Returns the selector for a month by name in month view
- */
 export function calendarMonth(monthName: string): string {
     return `div${automationId(monthName)}`;
 }
 
-/**
- * Returns the selector for a year by number in year view
- */
 export function calendarYear(yearNumber: number): string {
     return `div${automationId(yearNumber)}`;
 }
@@ -140,9 +112,6 @@ export async function getCalendarSelectedValues(): Promise<Date[]> {
     return JSON.parse(valueText);
 }
 
-/**
- * Verifies that a specific day is selected in the calendar output
- */
 export async function verifyCalendarDateSelected(dayNumber: number): Promise<void> {
     const selectedValues = await getCalendarSelectedValues();
     expect(selectedValues.length).toBe(1);
@@ -150,9 +119,6 @@ export async function verifyCalendarDateSelected(dayNumber: number): Promise<voi
     expect(selectedDate.getDate()).toBe(dayNumber);
 }
 
-/**
- * Verifies that multiple specific days are selected in the calendar output
- */
 export async function verifyCalendarDatesSelected(dayNumbers: number[]): Promise<void> {
     const selectedValues = await getCalendarSelectedValues();
     expect(selectedValues.length).toBe(dayNumbers.length);
@@ -161,16 +127,10 @@ export async function verifyCalendarDatesSelected(dayNumbers: number[]): Promise
     expect(selectedDays).toEqual(expectedDays);
 }
 
-/**
- * Returns the selector for the selection mode radio button by mode name
- */
 export function calendarSelectionMode(mode: string): string {
     return `${automationId(`mode-${mode}`)} i`;
 }
 
-/**
- * Returns the selector for the number of months radio button by value
- */
 export function calendarNumberOfMonths(months: number): string {
     return `${automationId(`months-${months}`)} i`;
 }
@@ -182,23 +142,14 @@ export function calendarWeekStart(day: number): string {
     return `${automationId(`weekstart-${day}`)} i`;
 }
 
-/**
- * Returns the selector for calendar weekday headers
- */
 export function calendarWeekdayHeaders(): string {
     return `${elements.calendar} .calendar-th`;
 }
 
-/**
- * Gets the weekday header elements from the calendar
- */
 export async function getCalendarWeekdayHeaders(): Promise<WebdriverIO.ElementArray> {
     return await getAllElements(calendarWeekdayHeaders());
 }
 
-/**
- * Verifies that a date range is selected in the calendar output
- */
 export async function verifyCalendarDateRangeSelected(startDay: number, endDay: number): Promise<void> {
     const selectedValues = await getCalendarSelectedValues();
     expect(selectedValues.length).toBe(2);
@@ -206,9 +157,6 @@ export async function verifyCalendarDateRangeSelected(startDay: number, endDay: 
     expect(selectedDates).toEqual([startDay, endDay].sort((a, b) => a - b));
 }
 
-/**
- * Verifies that a week is selected with correct styling and selected values
- */
 export async function verifyCalendarWeekRangeDays(): Promise<void> {
     const selectedValues = await getCalendarSelectedValues();
     const startDay = new Date(selectedValues[0]).getDate();

--- a/projects/novo-e2e/src/utils/CalendarUtil.ts
+++ b/projects/novo-e2e/src/utils/CalendarUtil.ts
@@ -1,5 +1,6 @@
 import { automationId, elements } from './SelectorUtil';
 import { verifyClassPresent } from './VerifyUtil';
+import { getAllElements } from './GetElementUtil';
 
 export const CALENDAR_MONTHS = [
     'January',
@@ -47,6 +48,15 @@ export function getYearByOffset(offset: number): number {
  */
 export function calendarDate(dayNumber: number | string): string {
     return `${elements.calendar} .calendar-date${automationId(dayNumber)}`;
+}
+
+/**
+ * Returns the selector for a calendar date in a specific month
+ * @param dayNumber the day number to select (1-31)
+ * @param monthIndex the index of the month (0 for first, 1 for second, etc.)
+ */
+export function calendarDateInMonth(dayNumber: number | string, monthIndex: number): string {
+    return `${elements.calendar} .month-view:nth-of-type(${monthIndex + 1}) .calendar-date${automationId(dayNumber)}`;
 }
 
 /**
@@ -156,6 +166,34 @@ export async function verifyCalendarDatesSelected(dayNumbers: number[]): Promise
  */
 export function calendarSelectionMode(mode: string): string {
     return `${automationId(`mode-${mode}`)} i`;
+}
+
+/**
+ * Returns the selector for the number of months radio button by value
+ */
+export function calendarNumberOfMonths(months: number): string {
+    return `${automationId(`months-${months}`)} i`;
+}
+
+/**
+ * Returns the selector for the week start radio button by day (0 for Sunday, 1 for Monday)
+ */
+export function calendarWeekStart(day: number): string {
+    return `${automationId(`weekstart-${day}`)} i`;
+}
+
+/**
+ * Returns the selector for calendar weekday headers
+ */
+export function calendarWeekdayHeaders(): string {
+    return `${elements.calendar} .calendar-th`;
+}
+
+/**
+ * Gets the weekday header elements from the calendar
+ */
+export async function getCalendarWeekdayHeaders(): Promise<WebdriverIO.ElementArray> {
+    return await getAllElements(calendarWeekdayHeaders());
 }
 
 /**

--- a/projects/novo-e2e/src/utils/CalendarUtil.ts
+++ b/projects/novo-e2e/src/utils/CalendarUtil.ts
@@ -1,0 +1,42 @@
+/**
+ * Returns the selector for a calendar date by day number
+ * @param dayNumber the day number to select (1-31)
+ */
+export function calendarDate(dayNumber: number | string): string {
+    return `novo-calendar .calendar-date[data-automation-id="${dayNumber}"]`;
+}
+
+/**
+ * Returns the selector for the first visible day in the calendar grid
+ * (may include overflow days from previous month)
+ */
+export function firstVisibleCalendarDate(): string {
+    return 'novo-calendar .calendar-date:first-child';
+}
+
+/**
+ * Returns the selector for the last visible day in the calendar grid
+ * (may include overflow days from next month)
+ */
+export function lastVisibleCalendarDate(): string {
+    return 'novo-calendar .calendar-date:last-child';
+}
+
+/**
+ * Gets the selected values from the calendar display as a Date array
+ */
+export async function getCalendarSelectedValues(): Promise<Date[]> {
+    const element = await $('[data-automation-id="calendar-selected-values"]');
+    const text = await elements[0].getText();
+    return JSON.parse(text);
+}
+
+/**
+ * Verifies that a specific day is selected in the calendar output
+ */
+export async function verifyCalendarDateSelected(dayNumber: number): Promise<void> {
+    const selectedValues = await getCalendarSelectedValues();
+    expect(selectedValues.length).toBe(1);
+    const selectedDate = new Date(selectedValues[0]);
+    expect(selectedDate.getDate()).toBe(dayNumber);
+}

--- a/projects/novo-e2e/src/utils/CalendarUtil.ts
+++ b/projects/novo-e2e/src/utils/CalendarUtil.ts
@@ -26,7 +26,7 @@ export function lastVisibleCalendarDate(): string {
  * Gets the selected values from the calendar display as a Date array
  */
 export async function getCalendarSelectedValues(): Promise<Date[]> {
-    const element = await $('[data-automation-id="calendar-selected-values"]');
+    const elements = await $('[data-automation-id="calendar-selected-values"]');
     const text = await elements[0].getText();
     return JSON.parse(text);
 }

--- a/projects/novo-e2e/src/utils/CalendarUtil.ts
+++ b/projects/novo-e2e/src/utils/CalendarUtil.ts
@@ -1,5 +1,45 @@
 import { automationId, elements } from './SelectorUtil';
 
+export const CALENDAR_MONTHS = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December'
+];
+
+/**
+ * Gets a month name offset from the current month
+ * @param offset number of months to offset (negative for past, positive for future)
+ * @returns the month name
+ */
+export function getMonthByOffset(offset: number): string {
+    const currentDate = new Date();
+    let targetMonthIndex = currentDate.getMonth() + offset;
+    if (targetMonthIndex < 0) {
+        targetMonthIndex += 12;
+    } else if (targetMonthIndex > 11) {
+        targetMonthIndex -= 12;
+    }
+    return CALENDAR_MONTHS[targetMonthIndex];
+}
+
+/**
+ * Gets a year offset from the current year
+ * @param offset number of years to offset (negative for past, positive for future)
+ * @returns the year number
+ */
+export function getYearByOffset(offset: number): number {
+    return new Date().getFullYear() + offset;
+}
+
 /**
  * Returns the selector for a calendar date by day number
  * @param dayNumber the day number to select (1-31)
@@ -85,6 +125,7 @@ export function calendarYear(yearNumber: number): string {
  * Gets the selected values from the calendar display as a Date array
  */
 export async function getCalendarSelectedValues(): Promise<Date[]> {
+    // TODO: swap this back
     // const element = await $(automationId('calendar-selected-values'));
     const elements = await $$('novo-label ~ div');
     const text = await elements[0].getText();

--- a/projects/novo-e2e/src/utils/CalendarUtil.ts
+++ b/projects/novo-e2e/src/utils/CalendarUtil.ts
@@ -1,4 +1,5 @@
 import { automationId, elements } from './SelectorUtil';
+import { verifyClassPresent } from './VerifyUtil';
 
 export const CALENDAR_MONTHS = [
     'January',
@@ -125,11 +126,8 @@ export function calendarYear(yearNumber: number): string {
  * Gets the selected values from the calendar display as a Date array
  */
 export async function getCalendarSelectedValues(): Promise<Date[]> {
-    // TODO: swap this back
-    // const element = await $(automationId('calendar-selected-values'));
-    const values = await $$('novo-label ~ div');
-    const text = await values[0].getText();
-    return JSON.parse(text);
+    const valueText = await $(automationId('calendar-selected-values')).getText();
+    return JSON.parse(valueText);
 }
 
 /**
@@ -151,4 +149,39 @@ export async function verifyCalendarDatesSelected(dayNumbers: number[]): Promise
     const selectedDays = selectedValues.map(val => new Date(val).getDate()).sort((a, b) => a - b);
     const expectedDays = dayNumbers.sort((a, b) => a - b);
     expect(selectedDays).toEqual(expectedDays);
+}
+
+/**
+ * Returns the selector for the selection mode radio button by mode name
+ */
+export function calendarSelectionMode(mode: string): string {
+    return `${automationId(`mode-${mode}`)} i`;
+}
+
+/**
+ * Verifies that a date range is selected in the calendar output
+ */
+export async function verifyCalendarDateRangeSelected(startDay: number, endDay: number): Promise<void> {
+    const selectedValues = await getCalendarSelectedValues();
+    expect(selectedValues.length).toBe(2);
+    const selectedDates = selectedValues.map(val => new Date(val).getDate()).sort((a, b) => a - b);
+    expect(selectedDates).toEqual([startDay, endDay].sort((a, b) => a - b));
+}
+
+/**
+ * Verifies that a week is selected with correct styling and selected values
+ */
+export async function verifyCalendarWeekRangeDays(): Promise<void> {
+    const selectedValues = await getCalendarSelectedValues();
+    const startDay = new Date(selectedValues[0]).getDate();
+    const endDay = new Date(selectedValues[1]).getDate();
+
+    await verifyCalendarDateRangeSelected(startDay, endDay);
+
+    await verifyClassPresent(calendarDate(startDay), 'rangeStart', `calendar date ${startDay} (range start)`);
+    await verifyClassPresent(calendarDate(endDay), 'rangeEnd', `calendar date ${endDay} (range end)`);
+
+    for (let day = startDay + 1; day < endDay; day++) {
+        await verifyClassPresent(calendarDate(day), 'inRange', `calendar date ${day} (in range)`);
+    }
 }

--- a/projects/novo-e2e/src/utils/EnvironmentUtil.ts
+++ b/projects/novo-e2e/src/utils/EnvironmentUtil.ts
@@ -12,6 +12,7 @@ export const COMPONENT_URLS = {
     AVATAR: 'avatar',
     BREADCRUMB: 'breadcrumbs',
     BUTTON: 'button',
+    CALENDAR: 'calendar',
     DATA_TABLE: 'data-table',
     DROPDOWN: 'dropdown',
     NON_IDEAL_STATE: 'non ideal state',

--- a/projects/novo-e2e/src/utils/SelectorUtil.ts
+++ b/projects/novo-e2e/src/utils/SelectorUtil.ts
@@ -287,10 +287,11 @@ export function radioButton(fieldName: string, labelOrValue: string | number | b
 }
 
 /**
- * Returns the selector for a radio button by value attribute
+ * Returns the selector for a radio button in a radio group by index (1-based)
+ * @param index the position of the radio button in the group (1 = first, 2 = second, etc.)
  */
-export function radioByValue(value: string | number): string {
-    return `novo-radio[value="${value}"]`;
+export function radioByIndex(index: number): string {
+    return `novo-radio-group novo-radio:nth-of-type(${index}) i`;
 }
 
 /**

--- a/projects/novo-e2e/src/utils/SelectorUtil.ts
+++ b/projects/novo-e2e/src/utils/SelectorUtil.ts
@@ -55,6 +55,7 @@ export const elements = {
     fab: 'button.novo-button.novo-theme-fab',
     dialogue: 'button.novo-button.novo-theme-dialogue',
     checkbox: 'novo-checkbox',
+    calendar: 'novo-calendar',
     pagination: 'novo-data-table-pagination',
     paginationDropdown: 'pager-select',
     headerButtons: '.custom-header-buttons',
@@ -283,6 +284,13 @@ export function radioButton(fieldName: string, labelOrValue: string | number | b
         return `${control(fieldName, allowDisabled)} ${automationId(fieldName, AttributeSelectors.beginsWith)}`;
     }
     return `${control(fieldName, allowDisabled)} ${automationId(fieldName + '-' + labelOrValue)}`;
+}
+
+/**
+ * Returns the selector for a radio button by value attribute
+ */
+export function radioByValue(value: string | number): string {
+    return `novo-radio[value="${value}"]`;
 }
 
 /**

--- a/projects/novo-e2e/src/utils/SelectorUtil.ts
+++ b/projects/novo-e2e/src/utils/SelectorUtil.ts
@@ -362,4 +362,3 @@ export function pickerChips(field: string): string {
 export function pickerChipValue(field: string): string {
     return `${control(field)} novo-chips novo-chip, ${control(field)} novo-chip-list novo-chip`;
 }
-

--- a/projects/novo-e2e/src/utils/SelectorUtil.ts
+++ b/projects/novo-e2e/src/utils/SelectorUtil.ts
@@ -287,14 +287,6 @@ export function radioButton(fieldName: string, labelOrValue: string | number | b
 }
 
 /**
- * Returns the selector for a radio button in a radio group by index (1-based)
- * @param index the position of the radio button in the group (1 = first, 2 = second, etc.)
- */
-export function radioByIndex(index: number): string {
-    return `novo-radio-group novo-radio:nth-of-type(${index}) i`;
-}
-
-/**
  * Returns the selector for opening a select control by clicking it
  * @param fieldName the name of the select field in meta
  * @param allowDisabled if set to true, then enabled and disabled form inputs will be allowed. defaults to true.

--- a/projects/novo-examples/src/components/calendar/calendar/calendar-example.html
+++ b/projects/novo-examples/src/components/calendar/calendar/calendar-example.html
@@ -7,7 +7,7 @@
     [weekStartsOn]="weekStart.value"></novo-calendar>
 
   <novo-label>Selected Values:</novo-label>
-  <div>{{selection | json}}</div>
+  <div data-automation-id="calendar-selected-values">{{selection | json}}</div>
 </novo-stack>
 <div>
   <novo-label>Selection mode</novo-label>

--- a/projects/novo-examples/src/components/calendar/calendar/calendar-example.html
+++ b/projects/novo-examples/src/components/calendar/calendar/calendar-example.html
@@ -11,11 +11,11 @@
 </novo-stack>
 <div>
   <novo-label>Selection mode</novo-label>
-  <novo-radio-group #mode appearance="vertical" value="single">
-    <novo-radio name="mode" value="single">single</novo-radio>
-    <novo-radio name="mode" value="multiple">multiple</novo-radio>
-    <novo-radio name="mode" value="range">range</novo-radio>
-    <novo-radio name="mode" value="week">week</novo-radio>
+  <novo-radio-group #mode appearance="vertical" value="single" data-automation-id="selection-mode">
+    <novo-radio name="mode" value="single" data-automation-id="mode-single">single</novo-radio>
+    <novo-radio name="mode" value="multiple" data-automation-id="mode-multiple">multiple</novo-radio>
+    <novo-radio name="mode" value="range" data-automation-id="mode-range">range</novo-radio>
+    <novo-radio name="mode" value="week" data-automation-id="mode-week">week</novo-radio>
   </novo-radio-group>
 
   <novo-label># of Months</novo-label>

--- a/projects/novo-examples/src/components/calendar/calendar/calendar-example.html
+++ b/projects/novo-examples/src/components/calendar/calendar/calendar-example.html
@@ -19,14 +19,14 @@
   </novo-radio-group>
 
   <novo-label># of Months</novo-label>
-  <novo-radio-group #months appearance="vertical" value="1">
-    <novo-radio name="months" value="1">1</novo-radio>
-    <novo-radio name="months" value="2">2</novo-radio>
+  <novo-radio-group #months appearance="vertical" value="1" data-automation-id="months-group">
+    <novo-radio name="months" value="1" data-automation-id="months-1">1</novo-radio>
+    <novo-radio name="months" value="2" data-automation-id="months-2">2</novo-radio>
   </novo-radio-group>
 
   <novo-label>Week Start</novo-label>
-  <novo-radio-group #weekStart appearance="vertical" value="0">
-    <novo-radio name="weekStart" value="0">Sun</novo-radio>
-    <novo-radio name="weekStart" value="1">Mon</novo-radio>
+  <novo-radio-group #weekStart appearance="vertical" value="0" data-automation-id="weekstart-group">
+    <novo-radio name="weekStart" value="0" data-automation-id="weekstart-0">Sun</novo-radio>
+    <novo-radio name="weekStart" value="1" data-automation-id="weekstart-1">Mon</novo-radio>
   </novo-radio-group>
 </div>


### PR DESCRIPTION
## **Description**

- Adds automation coverage for the calendar example

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**