### PR TITLE
test(Automation): Add automation for loading example page

### DIFF
--- a/projects/novo-e2e/src/e2e/calendar.e2e.ts
+++ b/projects/novo-e2e/src/e2e/calendar.e2e.ts
@@ -5,20 +5,13 @@ import { verifyPresent, verifyText, verifyClassPresent, verifyClassAbsent } from
 import {
   calendarDate,
   calendarDateInMonth,
-  firstVisibleCalendarDate,
-  lastVisibleCalendarDate,
+  calendar,
   verifyCalendarDateSelected,
   verifyCalendarDatesSelected,
   verifyCalendarDateRangeSelected,
   verifyCalendarWeekRangeDays,
   calendarMonth,
   calendarYear,
-  calendarMonthHeader,
-  calendarYearHeader,
-  calendarNextButton,
-  calendarPreviousButton,
-  calendarMonthText,
-  calendarYearText,
   getMonthByOffset,
   getYearByOffset,
   calendarSelectionMode,
@@ -52,34 +45,34 @@ describe('Calendar Demo Page', () => {
   describe('Calendar Navigation', () => {
     it('should navigate to next month using calendar-next button', async () => {
       await scrollIntoView(elements.calendar);
-      const prevMonthHeader = await $(calendarMonthText()).getText();
-      await click(calendarNextButton());
-      const nextMonthHeader = await $(calendarMonthText()).getText();
+      const prevMonthHeader = await $(calendar.monthText).getText();
+      await click(calendar.nextButton);
+      const nextMonthHeader = await $(calendar.monthText).getText();
       expect(prevMonthHeader).not.toEqual(nextMonthHeader);
     });
 
     it('should navigate to previous month using calendar-previous button', async () => {
-      const currentMonthHeader = await $(calendarMonthText()).getText();
-      await click(calendarPreviousButton());
-      const prevMonthHeader = await $(calendarMonthText()).getText();
+      const currentMonthHeader = await $(calendar.monthText).getText();
+      await click(calendar.previousButton);
+      const prevMonthHeader = await $(calendar.monthText).getText();
       expect(currentMonthHeader).not.toEqual(prevMonthHeader);
     });
 
     it('should open and change month', async () => {
-      const initialMonth = await $(calendarMonthText()).getText();
-      await click(calendarMonthHeader());
+      const initialMonth = await $(calendar.monthText).getText();
+      await click(calendar.monthHeader);
       const targetMonth = getMonthByOffset(-2);
       await click(calendarMonth(targetMonth));
-      const newMonth = await $(calendarMonthText()).getText();
+      const newMonth = await $(calendar.monthText).getText();
       expect(initialMonth).not.toEqual(newMonth);
     });
 
     it('should open and change year', async () => {
-      const initialYear = await $(calendarYearText()).getText();
-      await click(calendarYearHeader());
+      const initialYear = await $(calendar.yearText).getText();
+      await click(calendar.yearHeader);
       const targetYear = getYearByOffset(-1);
       await click(calendarYear(targetYear));
-      const newYear = await $(calendarYearText()).getText();
+      const newYear = await $(calendar.yearText).getText();
       expect(initialYear).not.toEqual(newYear);
     });
   });
@@ -112,13 +105,13 @@ describe('Calendar Demo Page', () => {
     });
 
     it('should select the first visible day in the calendar grid', async () => {
-      await click(firstVisibleCalendarDate());
-      await verifyClassPresent(firstVisibleCalendarDate(), 'selected', 'first visible day');
+      await click(calendar.firstVisibleDate);
+      await verifyClassPresent(calendar.firstVisibleDate, 'selected', 'first visible day');
     });
 
     it('should select the last visible day in the calendar grid', async () => {
-      await click(lastVisibleCalendarDate());
-      await verifyClassPresent(lastVisibleCalendarDate(), 'selected', 'last visible day');
+      await click(calendar.lastVisibleDate);
+      await verifyClassPresent(calendar.lastVisibleDate, 'selected', 'last visible day');
     });
   });
 
@@ -206,7 +199,7 @@ describe('Calendar Demo Page', () => {
 
     it('should display two months', async () => {
       await scrollIntoView(elements.calendar);
-      const monthElements = await $$(calendarMonthText());
+      const monthElements = await $$(calendar.monthText);
       expect(monthElements.length).toBe(2);
     });
 

--- a/projects/novo-e2e/src/e2e/icon.e2e.ts
+++ b/projects/novo-e2e/src/e2e/icon.e2e.ts
@@ -1,0 +1,109 @@
+import { scrollIntoView } from '../utils/ElementActionUtil';
+import { COMPONENT_URLS, examplesUrl, getURLs } from '../utils/EnvironmentUtil';
+import { elements } from '../utils/SelectorUtil';
+import { verifyPresent, verifyText, verifyClassPresent } from '../utils/VerifyUtil';
+import { getAttribute } from '../utils/ElementPropertiesUtil';
+import {
+    iconSections,
+    basicIcon,
+    basicIconClass,
+    themedIconColor,
+    themedIconTheme,
+    raisedIcon,
+} from '../utils/IconUtil';
+
+describe('Icon Demo Page', () => {
+    const url = examplesUrl(COMPONENT_URLS.ICON);
+
+    before(async () => {
+        await browser.navigateTo(url);
+    });
+
+    after(async () => {
+        await browser.navigateTo(getURLs().HOME);
+    });
+
+    describe('Page Elements', () => {
+        it('should display page title', async () => {
+            await verifyPresent(elements.title);
+            await verifyText(elements.title, 'Icon', 'Icon example page title');
+        });
+
+        it('should display Basic Usage section', async () => {
+            await scrollIntoView(iconSections.basicUsage);
+            await verifyPresent(iconSections.basicUsage);
+        });
+
+        it('should display Themes & Colors section', async () => {
+            await scrollIntoView(iconSections.themedColors);
+            await verifyPresent(iconSections.themedColors);
+        });
+
+        it('should display Raised Icons section', async () => {
+            await scrollIntoView(iconSections.raisedIcons);
+            await verifyPresent(iconSections.raisedIcons);
+        });
+    });
+
+    describe('Basic Icons', () => {
+        beforeEach(async () => {
+            await scrollIntoView(iconSections.basicUsage);
+        });
+
+        it('should display novo-icon component variants', async () => {
+            const icons = ['candidate', 'job', 'company', 'lead', 'opportunity'];
+            for (const name of icons) {
+                await verifyPresent(basicIcon(name));
+            }
+        });
+
+        it('should display class-based icon variants', async () => {
+            const icons = ['candidate', 'person', 'job', 'company', 'lead', 'opportunity'];
+            for (const name of icons) {
+                await verifyPresent(basicIconClass(name));
+            }
+        });
+    });
+
+    describe('Themed & Colored Icons', () => {
+        beforeEach(async () => {
+            await scrollIntoView(iconSections.themedColors);
+        });
+
+        it('should display color variant icons with correct color attribute and class', async () => {
+            const icons = ['candidate', 'job', 'company', 'submission', 'placement'];
+            for (const name of icons) {
+                await verifyPresent(themedIconColor(name));
+                const colorAttr = await getAttribute(themedIconColor(name), 'color');
+                await expect(colorAttr).toBe(name);
+                await verifyClassPresent(themedIconColor(name), `text-color-${name}`);
+            }
+        });
+
+        it('should display theme variant icons with correct theme attribute and class', async () => {
+            const icons = ['candidate', 'job', 'company', 'submission', 'placement'];
+            for (const name of icons) {
+                await verifyPresent(themedIconTheme(name));
+                const themeAttr = await getAttribute(themedIconTheme(name), 'theme');
+                await expect(themeAttr).toBe(name);
+                await verifyClassPresent(themedIconTheme(name), `novo-theme-${name}`);
+            }
+        });
+    });
+
+    describe('Raised Icons', () => {
+        beforeEach(async () => {
+            await scrollIntoView(iconSections.raisedIcons);
+        });
+
+        it('should display all raised icon variants with raised attribute and class', async () => {
+            const icons = ['candidate', 'job', 'company', 'submission', 'placement'];
+            for (const name of icons) {
+                await verifyPresent(raisedIcon(name));
+                const raisedAttr = await getAttribute(raisedIcon(name), 'raised');
+                await expect(raisedAttr).toBe('true');
+                await verifyClassPresent(raisedIcon(name), 'novo-icon-raised');
+            }
+        });
+    });
+});

--- a/projects/novo-e2e/src/e2e/loading.e2e.ts
+++ b/projects/novo-e2e/src/e2e/loading.e2e.ts
@@ -3,10 +3,11 @@ import { COMPONENT_URLS, examplesUrl, getURLs } from '../utils/EnvironmentUtil';
 import { elements } from '../utils/SelectorUtil';
 import { verifyPresent, verifyText } from '../utils/VerifyUtil';
 import {
-    loadingLineComponent,
-    loadingLineExample,
+    loading,
     loadingSizeLineRadio,
     loadingColorLineRadio,
+    loadingSizeSpinnerRadio,
+    loadingColorSpinnerRadio,
 } from '../utils/LoadingUtil';
 
 describe('Loading Demo Page', () => {
@@ -27,87 +28,63 @@ describe('Loading Demo Page', () => {
         });
 
         it('should display loading-line example section', async () => {
-            await verifyPresent(loadingLineExample());
+            await scrollIntoView(loading.lineExample);
+            await verifyPresent(loading.lineExample);
+            await verifyPresent(loading.lineComponent);
         });
 
-        it('should display loading-line component', async () => {
-            await scrollIntoView(loadingLineExample());
-            await verifyPresent(loadingLineComponent());
-        });
-    });
-
-    describe('Line Loader - Size Control', () => {
-        beforeEach(async () => {
-            await scrollIntoView(loadingLineExample());
-        });
-
-        it('should have small size option', async () => {
-            await verifyPresent(loadingSizeLineRadio('small'));
-        });
-
-        it('should have medium size option', async () => {
-            await verifyPresent(loadingSizeLineRadio('medium'));
-        });
-
-        it('should have large size option', async () => {
-            await verifyPresent(loadingSizeLineRadio('large'));
-        });
-
-        it('should select small size', async () => {
-            await click(loadingSizeLineRadio('small'));
-            await verifyPresent(loadingLineComponent());
-        });
-
-        it('should select medium size', async () => {
-            await click(loadingSizeLineRadio('medium'));
-            await verifyPresent(loadingLineComponent());
-        });
-
-        it('should select large size', async () => {
-            await click(loadingSizeLineRadio('large'));
-            await verifyPresent(loadingLineComponent());
+        it('should display loading-circle example section', async () => {
+            await scrollIntoView(loading.circleExample);
+            await verifyPresent(loading.circleExample);
+            await verifyPresent(loading.spinnerComponent);
         });
     });
 
-    describe('Line Loader - Color Control', () => {
+    describe('Line Loader', () => {
         beforeEach(async () => {
-            await scrollIntoView(loadingLineExample());
+            await scrollIntoView(loading.lineExample);
         });
 
-        it('should have grapefruit color option', async () => {
-            await verifyPresent(loadingColorLineRadio('grapefruit'));
+        it('should allow selecting all size options', async () => {
+            const sizes = ['small', 'medium', 'large'];
+            for (const size of sizes) {
+                await verifyPresent(loadingSizeLineRadio(size));
+                await click(loadingSizeLineRadio(size));
+                await verifyPresent(loading.lineComponent);
+            }
         });
 
-        it('should have aqua color option', async () => {
-            await verifyPresent(loadingColorLineRadio('aqua'));
+        it('should allow selecting all color options', async () => {
+            const colors = ['grapefruit', 'aqua', 'mint', 'ocean'];
+            for (const color of colors) {
+                await verifyPresent(loadingColorLineRadio(color));
+                await click(loadingColorLineRadio(color));
+                await verifyPresent(loading.lineComponent);
+            }
+        });
+    });
+
+    describe('Spinner', () => {
+        beforeEach(async () => {
+            await scrollIntoView(loading.circleExample);
         });
 
-        it('should have mint color option', async () => {
-            await verifyPresent(loadingColorLineRadio('mint'));
+        it('should allow selecting all size options', async () => {
+            const sizes = ['small', 'medium', 'large'];
+            for (const size of sizes) {
+                await verifyPresent(loadingSizeSpinnerRadio(size));
+                await click(loadingSizeSpinnerRadio(size));
+                await verifyPresent(loading.spinnerComponent);
+            }
         });
 
-        it('should have ocean color option', async () => {
-            await verifyPresent(loadingColorLineRadio('ocean'));
-        });
-
-        it('should select grapefruit color', async () => {
-            await click(loadingColorLineRadio('grapefruit'));
-            await verifyPresent(loadingLineComponent());
-        });
-
-        it('should select aqua color', async () => {
-            await click(loadingColorLineRadio('aqua'));
-            await verifyPresent(loadingLineComponent());
-        });
-
-        it('should select mint color', async () => {
-            await click(loadingColorLineRadio('mint'));
-            await verifyPresent(loadingLineComponent());
-        });
-
-        it('should select ocean color', async () => {
-            await click(loadingColorLineRadio('ocean'));
-            await verifyPresent(loadingLineComponent());
+        it('should allow selecting all color options', async () => {
+            const colors = ['grapefruit', 'aqua', 'mint', 'ocean'];
+            for (const color of colors) {
+                await verifyPresent(loadingColorSpinnerRadio(color));
+                await click(loadingColorSpinnerRadio(color));
+                await verifyPresent(loading.spinnerComponent);
+            }
         });
     });
 });

--- a/projects/novo-e2e/src/e2e/loading.e2e.ts
+++ b/projects/novo-e2e/src/e2e/loading.e2e.ts
@@ -1,0 +1,113 @@
+import { click, scrollIntoView } from '../utils/ElementActionUtil';
+import { COMPONENT_URLS, examplesUrl, getURLs } from '../utils/EnvironmentUtil';
+import { elements } from '../utils/SelectorUtil';
+import { verifyPresent, verifyText } from '../utils/VerifyUtil';
+import {
+    loadingLineComponent,
+    loadingLineExample,
+    loadingSizeLineRadio,
+    loadingColorLineRadio,
+} from '../utils/LoadingUtil';
+
+describe('Loading Demo Page', () => {
+    const url = examplesUrl(COMPONENT_URLS.LOADING);
+
+    before(async () => {
+        await browser.navigateTo(url);
+    });
+
+    after(async () => {
+        await browser.navigateTo(getURLs().HOME);
+    });
+
+    describe('Page Elements', () => {
+        it('should display page title', async () => {
+            await verifyPresent(elements.title);
+            await verifyText(elements.title, 'Loading', 'Loading example page title');
+        });
+
+        it('should display loading-line example section', async () => {
+            await verifyPresent(loadingLineExample());
+        });
+
+        it('should display loading-line component', async () => {
+            await scrollIntoView(loadingLineExample());
+            await verifyPresent(loadingLineComponent());
+        });
+    });
+
+    describe('Line Loader - Size Control', () => {
+        beforeEach(async () => {
+            await scrollIntoView(loadingLineExample());
+        });
+
+        it('should have small size option', async () => {
+            await verifyPresent(loadingSizeLineRadio('small'));
+        });
+
+        it('should have medium size option', async () => {
+            await verifyPresent(loadingSizeLineRadio('medium'));
+        });
+
+        it('should have large size option', async () => {
+            await verifyPresent(loadingSizeLineRadio('large'));
+        });
+
+        it('should select small size', async () => {
+            await click(loadingSizeLineRadio('small'));
+            await verifyPresent(loadingLineComponent());
+        });
+
+        it('should select medium size', async () => {
+            await click(loadingSizeLineRadio('medium'));
+            await verifyPresent(loadingLineComponent());
+        });
+
+        it('should select large size', async () => {
+            await click(loadingSizeLineRadio('large'));
+            await verifyPresent(loadingLineComponent());
+        });
+    });
+
+    describe('Line Loader - Color Control', () => {
+        beforeEach(async () => {
+            await scrollIntoView(loadingLineExample());
+        });
+
+        it('should have grapefruit color option', async () => {
+            await verifyPresent(loadingColorLineRadio('grapefruit'));
+        });
+
+        it('should have aqua color option', async () => {
+            await verifyPresent(loadingColorLineRadio('aqua'));
+        });
+
+        it('should have mint color option', async () => {
+            await verifyPresent(loadingColorLineRadio('mint'));
+        });
+
+        it('should have ocean color option', async () => {
+            await verifyPresent(loadingColorLineRadio('ocean'));
+        });
+
+        it('should select grapefruit color', async () => {
+            await click(loadingColorLineRadio('grapefruit'));
+            await verifyPresent(loadingLineComponent());
+        });
+
+        it('should select aqua color', async () => {
+            await click(loadingColorLineRadio('aqua'));
+            await verifyPresent(loadingLineComponent());
+        });
+
+        it('should select mint color', async () => {
+            await click(loadingColorLineRadio('mint'));
+            await verifyPresent(loadingLineComponent());
+        });
+
+        it('should select ocean color', async () => {
+            await click(loadingColorLineRadio('ocean'));
+            await verifyPresent(loadingLineComponent());
+        });
+    });
+});

--- a/projects/novo-e2e/src/e2e/menu.e2e.ts
+++ b/projects/novo-e2e/src/e2e/menu.e2e.ts
@@ -3,6 +3,7 @@ import { COMPONENT_URLS, examplesUrl, getURLs } from '../utils/EnvironmentUtil';
 import { elements } from '../utils/SelectorUtil';
 import { verifyPresent, verifyText, verifyDisabled, verifyEnabled } from '../utils/VerifyUtil';
 import { menu, closeMenu } from '../utils/MenuUtil';
+import { acceptAlertIfPresent } from '../utils/AutomationHelpers';
 
 describe('Menu Demo Page', () => {
     const url = examplesUrl(COMPONENT_URLS.MENU);
@@ -49,14 +50,14 @@ describe('Menu Demo Page', () => {
         it('should allow clicking preview menu item action', async () => {
             await click(menu.basicMenuButton);
             await click(menu.basicMenuPreview);
-            await browser.acceptAlert();
+            await acceptAlertIfPresent();
             await closeMenu();
         });
 
         it('should allow clicking delete menu item action', async () => {
             await click(menu.basicMenuButton);
             await click(menu.basicMenuDelete);
-            await browser.acceptAlert();
+            await acceptAlertIfPresent();
             await closeMenu();
         });
     });
@@ -75,14 +76,14 @@ describe('Menu Demo Page', () => {
         it('should allow clicking icon menu preview action', async () => {
             await click(menu.iconMenuButton);
             await click(menu.iconMenuPreview);
-            await browser.acceptAlert();
+            await acceptAlertIfPresent();
             await closeMenu();
         });
 
         it('should allow clicking icon menu delete action', async () => {
             await click(menu.iconMenuButton);
             await click(menu.iconMenuDelete);
-            await browser.acceptAlert();
+            await acceptAlertIfPresent();
             await closeMenu();
         });
     });
@@ -110,7 +111,7 @@ describe('Menu Demo Page', () => {
         it('should allow clicking nested menu preview action', async () => {
             await click(menu.nestedMenuButton);
             await click(menu.nestedMenuPreview);
-            await browser.acceptAlert();
+            await acceptAlertIfPresent();
             await closeMenu();
         });
     });
@@ -138,7 +139,7 @@ describe('Menu Demo Page', () => {
         it('should allow clicking context menu preview for apples', async () => {
             await click(menu.contextMenuButton('apple'));
             await click(menu.contextMenuPreview);
-            await browser.acceptAlert();
+            await acceptAlertIfPresent();
             await closeMenu();
         });
 
@@ -154,7 +155,7 @@ describe('Menu Demo Page', () => {
         it('should allow clicking context menu preview for oranges', async () => {
             await click(menu.contextMenuButton('orange'));
             await click(menu.contextMenuPreview);
-            await browser.acceptAlert();
+            await acceptAlertIfPresent();
             await closeMenu();
         });
     });

--- a/projects/novo-e2e/src/e2e/menu.e2e.ts
+++ b/projects/novo-e2e/src/e2e/menu.e2e.ts
@@ -1,0 +1,161 @@
+import { click } from '../utils/ElementActionUtil';
+import { COMPONENT_URLS, examplesUrl, getURLs } from '../utils/EnvironmentUtil';
+import { elements } from '../utils/SelectorUtil';
+import { verifyPresent, verifyText, verifyDisabled, verifyEnabled } from '../utils/VerifyUtil';
+import { menu, closeMenu } from '../utils/MenuUtil';
+
+describe('Menu Demo Page', () => {
+    const url = examplesUrl(COMPONENT_URLS.MENU);
+
+    before(async () => {
+        await browser.navigateTo(url);
+    });
+
+    after(async () => {
+        await browser.navigateTo(getURLs().HOME);
+    });
+
+    describe('Page Elements', () => {
+        it('should display page title', async () => {
+            await verifyPresent(elements.title);
+            await verifyText(elements.title, 'Menu', 'Menu example page title');
+        });
+    });
+
+    describe('Basic Menu', () => {
+        it('should display basic menu example section', async () => {
+            await verifyPresent(menu.basicMenuExample);
+        });
+
+        it('should open menu and display all menu items', async () => {
+            await click(menu.basicMenuButton);
+            await verifyPresent(menu.basicMenu);
+            await verifyPresent(menu.basicMenuPreview);
+            await verifyPresent(menu.basicMenuEdit);
+            await verifyPresent(menu.basicMenuDisabled);
+            await verifyPresent(menu.basicMenuDelete);
+            await closeMenu();
+        });
+
+        it('should have disabled and enabled menu items', async () => {
+            await click(menu.basicMenuButton);
+            await verifyEnabled(menu.basicMenuPreview, 'preview menu item');
+            await verifyEnabled(menu.basicMenuEdit, 'edit menu item');
+            await verifyDisabled(menu.basicMenuDisabled, 'disabled menu item');
+            await verifyEnabled(menu.basicMenuDelete, 'delete menu item');
+            await closeMenu();
+        });
+
+        it('should allow clicking preview menu item action', async () => {
+            await click(menu.basicMenuButton);
+            await click(menu.basicMenuPreview);
+            await browser.acceptAlert();
+            await closeMenu();
+        });
+
+        it('should allow clicking delete menu item action', async () => {
+            await click(menu.basicMenuButton);
+            await click(menu.basicMenuDelete);
+            await browser.acceptAlert();
+            await closeMenu();
+        });
+    });
+
+    describe('Icon Menu', () => {
+        it('should display icon menu button and open menu with all items', async () => {
+            await verifyPresent(menu.iconMenuButton);
+            await click(menu.iconMenuButton);
+            await verifyPresent(menu.iconMenu);
+            await verifyPresent(menu.iconMenuPreview);
+            await verifyPresent(menu.iconMenuEdit);
+            await verifyPresent(menu.iconMenuDelete);
+            await closeMenu();
+        });
+
+        it('should allow clicking icon menu preview action', async () => {
+            await click(menu.iconMenuButton);
+            await click(menu.iconMenuPreview);
+            await browser.acceptAlert();
+            await closeMenu();
+        });
+
+        it('should allow clicking icon menu delete action', async () => {
+            await click(menu.iconMenuButton);
+            await click(menu.iconMenuDelete);
+            await browser.acceptAlert();
+            await closeMenu();
+        });
+    });
+
+    describe('Nested Menu', () => {
+        it('should display nested menu example section', async () => {
+            await verifyPresent(menu.nestedMenuExample);
+        });
+
+        it('should open nested menu and display all items', async () => {
+            await click(menu.nestedMenuButton);
+            await verifyPresent(menu.nestedMenu);
+            await verifyPresent(menu.nestedMenuPreview);
+            await verifyPresent(menu.nestedMenuEdit);
+            await verifyPresent(menu.nestedMenuChoose);
+            await closeMenu();
+        });
+
+        it('should display submenu trigger item', async () => {
+            await click(menu.nestedMenuButton);
+            await verifyPresent(menu.nestedMenuChoose);
+            await closeMenu();
+        });
+
+        it('should allow clicking nested menu preview action', async () => {
+            await click(menu.nestedMenuButton);
+            await click(menu.nestedMenuPreview);
+            await browser.acceptAlert();
+            await closeMenu();
+        });
+    });
+
+    describe('Context Menu', () => {
+        it('should display context menu example section', async () => {
+            await verifyPresent(menu.contextMenuExample);
+        });
+
+        it('should display context menu buttons', async () => {
+            await verifyPresent(menu.contextMenuButton('apple'));
+            await verifyPresent(menu.contextMenuButton('orange'));
+        });
+
+        it('should open context menu for apples and display all items', async () => {
+            await click(menu.contextMenuButton('apple'));
+            await verifyPresent(menu.contextMenu);
+            await verifyPresent(menu.contextMenuPreview);
+            await verifyPresent(menu.contextMenuEdit);
+            await verifyPresent(menu.contextMenuDelete);
+            await verifyPresent(menu.contextMenuDisabled);
+            await closeMenu();
+        });
+
+        it('should allow clicking context menu preview for apples', async () => {
+            await click(menu.contextMenuButton('apple'));
+            await click(menu.contextMenuPreview);
+            await browser.acceptAlert();
+            await closeMenu();
+        });
+
+        it('should open context menu for oranges and display all items', async () => {
+            await click(menu.contextMenuButton('orange'));
+            await verifyPresent(menu.contextMenu);
+            await verifyPresent(menu.contextMenuPreview);
+            await verifyPresent(menu.contextMenuEdit);
+            await verifyPresent(menu.contextMenuDelete);
+            await closeMenu();
+        });
+
+        it('should allow clicking context menu preview for oranges', async () => {
+            await click(menu.contextMenuButton('orange'));
+            await click(menu.contextMenuPreview);
+            await browser.acceptAlert();
+            await closeMenu();
+        });
+    });
+});

--- a/projects/novo-e2e/src/e2e/popover.e2e.ts
+++ b/projects/novo-e2e/src/e2e/popover.e2e.ts
@@ -1,8 +1,7 @@
 import { moveMouseToElement, click, scrollIntoView, moveMouse } from '../utils/ElementActionUtil';
 import { getURLs } from '../utils/EnvironmentUtil';
 import { verifyPresent, verifyText, verifyClassPresent, verifyAbsent } from '../utils/VerifyUtil';
-import { popoverTrigger, popoverContent, popover, popoverSelectors, testAlignmentPopover, placementData, horizontalAlignmentData, verticalAlignmentData, autoPlacementData } from '../utils/PopoverUtil';
-import { codeExampleExpandButton } from '../utils/SelectorUtil';
+import { popoverTrigger, popoverContent, popover, popoverSelectors, testAlignmentPopover, placementData, horizontalAlignmentData, verticalAlignmentData } from '../utils/PopoverUtil';
 import { sleep } from '../utils/SleepUtil';
 
 describe('PopOver Placement Demo Page', () => {
@@ -108,30 +107,4 @@ describe('PopOver Placement Demo Page', () => {
         });
     });
 
-    describe('Auto Placement', () => {
-        const popoverName = 'pop-over-auto-placement';
-
-        autoPlacementData.forEach((placement) => {
-            it(`should adjust popover placement based on available screen space for ${placement.id}`, async () => {
-                const trigger = popoverTrigger(popoverName, placement.id);
-                await verifyPresent(trigger);
-                await moveMouseToElement(trigger);
-                await verifyPresent(popoverContent(popoverName));
-                await verifyClassPresent(popover(popoverName), placement.initialPlacement);
-                await moveMouse(100, 100);
-                await verifyAbsent(popoverContent(popoverName));
-
-                const expandButton = codeExampleExpandButton(popoverName);
-                await click(expandButton);
-                await scrollIntoView(expandButton, false);
-                await verifyPresent(trigger);
-                await moveMouseToElement(trigger);
-                await verifyPresent(popoverContent(popoverName));
-                await verifyClassPresent(popover(popoverName), placement.expandedPlacement);
-                await moveMouse(100, 100);
-                await verifyAbsent(popoverContent(popoverName));
-                await click(expandButton);
-            });
-        });
-    });
 });

--- a/projects/novo-e2e/src/e2e/popover.e2e.ts
+++ b/projects/novo-e2e/src/e2e/popover.e2e.ts
@@ -1,7 +1,7 @@
 import { moveMouseToElement, click, scrollIntoView, moveMouse } from '../utils/ElementActionUtil';
-import { COMPONENT_URLS, examplesUrl, getURLs } from '../utils/EnvironmentUtil';
+import { getURLs } from '../utils/EnvironmentUtil';
 import { verifyPresent, verifyText, verifyClassPresent, verifyAbsent } from '../utils/VerifyUtil';
-import { popoverTrigger, popoverContent, popover, popoverArrow, popoverSelectors, popoverScope, testAlignmentPopover, placementData, horizontalAlignmentData, verticalAlignmentData, autoPlacementData } from '../utils/PopoverUtil';
+import { popoverTrigger, popoverContent, popover, popoverSelectors, testAlignmentPopover, placementData, horizontalAlignmentData, verticalAlignmentData, autoPlacementData } from '../utils/PopoverUtil';
 import { codeExampleExpandButton } from '../utils/SelectorUtil';
 import { sleep } from '../utils/SleepUtil';
 

--- a/projects/novo-e2e/src/e2e/popover.e2e.ts
+++ b/projects/novo-e2e/src/e2e/popover.e2e.ts
@@ -1,0 +1,137 @@
+import { moveMouseToElement, click, scrollIntoView, moveMouse } from '../utils/ElementActionUtil';
+import { COMPONENT_URLS, examplesUrl, getURLs } from '../utils/EnvironmentUtil';
+import { verifyPresent, verifyText, verifyClassPresent, verifyAbsent } from '../utils/VerifyUtil';
+import { popoverTrigger, popoverContent, popover, popoverArrow, popoverSelectors, popoverScope, testAlignmentPopover, placementData, horizontalAlignmentData, verticalAlignmentData, autoPlacementData } from '../utils/PopoverUtil';
+import { codeExampleExpandButton } from '../utils/SelectorUtil';
+import { sleep } from '../utils/SleepUtil';
+
+describe('PopOver Placement Demo Page', () => {
+    const baseUrl = (global as any).E2E_BASE_URL || 'https://bullhorn.github.io/novo-elements/docs';
+    const url = `${baseUrl}/#/components/pop%20over/examples`;
+
+    before(async () => {
+        await browser.navigateTo(url);
+    });
+
+    after(async () => {
+        await browser.navigateTo(getURLs().HOME);
+    });
+
+    describe('Placement', () => {
+        const popoverName = 'pop-over-placement';
+
+        placementData.forEach((placement) => {
+            it(`should display and hide ${placement.placement} popover on hover`, async () => {
+                const trigger = popoverTrigger(popoverName, placement.id);
+                await verifyPresent(trigger);
+                await moveMouseToElement(trigger);
+                await verifyPresent(popoverContent(popoverName));
+                await verifyClassPresent(popover(popoverName), placement.placement);
+                await verifyText(popoverSelectors.contentText, placement.text);
+                await moveMouse(100, 100);
+                await verifyAbsent(popoverContent(popoverName));
+            });
+        });
+    });
+
+    describe('Horizontal Alignment', () => {
+        const popoverName = 'pop-over-horizontal';
+
+        horizontalAlignmentData.forEach((alignment) => {
+            it(`should display and hide ${alignment.display} popover on hover`, async () => {
+                await testAlignmentPopover(popoverName, alignment);
+            });
+        });
+    });
+
+    describe('Vertical Alignment', () => {
+        const popoverName = 'pop-over-vertical';
+
+        verticalAlignmentData.forEach((alignment) => {
+            it(`should display and hide ${alignment.display} popover on hover`, async () => {
+                await testAlignmentPopover(popoverName, alignment);
+            });
+        });
+    });
+
+    describe('Behavior', () => {
+        const popoverName = 'pop-over-behaviors';
+
+        it('should display and hide on hover', async () => {
+            const trigger = popoverTrigger(popoverName, 'popover-on-hover');
+            await verifyPresent(trigger);
+            await moveMouseToElement(trigger);
+            await verifyPresent(popoverContent(popoverName));
+            await verifyText(popoverSelectors.contentText, 'PopOver appears when hovering over the element. When the mouse is no longer over the element or the PopOver, then it will be dismissed.');
+            await moveMouse(100, 100);
+            await verifyAbsent(popoverContent(popoverName));
+        });
+
+        it('should display and hide on click', async () => {
+            const trigger = popoverTrigger(popoverName, 'popover-on-click');
+            await verifyPresent(trigger);
+            await click(trigger);
+            await verifyPresent(popoverContent(popoverName));
+            await verifyText(popoverSelectors.contentText, 'PopOver appears when clicking on the element. Dismiss it by clicking the element again.');
+            await click(trigger);
+            await verifyAbsent(popoverContent(popoverName));
+        });
+
+        it('should display and hide on click with timeout', async () => {
+            const trigger = popoverTrigger(popoverName, 'popover-on-click-timeout');
+            await verifyPresent(trigger);
+            await click(trigger);
+            await verifyPresent(popoverContent(popoverName));
+            await verifyText(popoverSelectors.contentText, 'This PopOver has a 2000 ms or 2 second timeout on it. Dismiss it by clicking on the element or waiting for the timeout.');
+            await sleep(2000); // Wait for popoverDismissTimeout to trigger auto-dismiss
+            await verifyAbsent(popoverContent(popoverName));
+        });
+
+        it('should not display when disabled', async () => {
+            const trigger = popoverTrigger(popoverName, 'popover-disabled');
+            await verifyPresent(trigger);
+            await click(trigger);
+            await verifyAbsent(popoverContent(popoverName));
+            await moveMouseToElement(trigger);
+            await verifyAbsent(popoverContent(popoverName));
+        });
+    });
+
+    describe('Dynamic HTML', () => {
+        const popoverName = 'pop-over-dynamic';
+
+        it('should display dynamic HTML content on click', async () => {
+            const trigger = popoverTrigger(popoverName, 'popover-dynamic-trigger');
+            await verifyPresent(trigger);
+            await click(trigger);
+            await verifyPresent(popoverContent(popoverName));
+        });
+    });
+
+    describe('Auto Placement', () => {
+        const popoverName = 'pop-over-auto-placement';
+
+        autoPlacementData.forEach((placement) => {
+            it(`should adjust popover placement based on available screen space for ${placement.id}`, async () => {
+                const trigger = popoverTrigger(popoverName, placement.id);
+                await verifyPresent(trigger);
+                await moveMouseToElement(trigger);
+                await verifyPresent(popoverContent(popoverName));
+                await verifyClassPresent(popover(popoverName), placement.initialPlacement);
+                await moveMouse(100, 100);
+                await verifyAbsent(popoverContent(popoverName));
+
+                const expandButton = codeExampleExpandButton(popoverName);
+                await click(expandButton);
+                await scrollIntoView(expandButton, false);
+                await verifyPresent(trigger);
+                await moveMouseToElement(trigger);
+                await verifyPresent(popoverContent(popoverName));
+                await verifyClassPresent(popover(popoverName), placement.expandedPlacement);
+                await moveMouse(100, 100);
+                await verifyAbsent(popoverContent(popoverName));
+                await click(expandButton);
+            });
+        });
+    });
+});

--- a/projects/novo-e2e/src/e2e/popover.e2e.ts
+++ b/projects/novo-e2e/src/e2e/popover.e2e.ts
@@ -1,12 +1,11 @@
 import { moveMouseToElement, click, moveMouse } from '../utils/ElementActionUtil';
-import { getURLs } from '../utils/EnvironmentUtil';
+import { COMPONENT_URLS, examplesUrl, getURLs } from '../utils/EnvironmentUtil';
 import { verifyPresent, verifyText, verifyClassPresent, verifyAbsent } from '../utils/VerifyUtil';
 import { popoverTrigger, popoverContent, popover, popoverSelectors, testAlignmentPopover, placementData, horizontalAlignmentData, verticalAlignmentData } from '../utils/PopoverUtil';
 import { sleep } from '../utils/SleepUtil';
 
 describe('PopOver Placement Demo Page', () => {
-    const baseUrl = (global as any).E2E_BASE_URL || 'https://bullhorn.github.io/novo-elements/docs';
-    const url = `${baseUrl}/#/components/pop%20over/examples`;
+    const url = examplesUrl(COMPONENT_URLS.POPOVER);
 
     before(async () => {
         await browser.navigateTo(url);

--- a/projects/novo-e2e/src/e2e/popover.e2e.ts
+++ b/projects/novo-e2e/src/e2e/popover.e2e.ts
@@ -1,4 +1,4 @@
-import { moveMouseToElement, click, scrollIntoView, moveMouse } from '../utils/ElementActionUtil';
+import { moveMouseToElement, click, moveMouse } from '../utils/ElementActionUtil';
 import { getURLs } from '../utils/EnvironmentUtil';
 import { verifyPresent, verifyText, verifyClassPresent, verifyAbsent } from '../utils/VerifyUtil';
 import { popoverTrigger, popoverContent, popover, popoverSelectors, testAlignmentPopover, placementData, horizontalAlignmentData, verticalAlignmentData } from '../utils/PopoverUtil';

--- a/projects/novo-e2e/src/e2e/progress.e2e.ts
+++ b/projects/novo-e2e/src/e2e/progress.e2e.ts
@@ -1,0 +1,156 @@
+import { scrollIntoView } from '../utils/ElementActionUtil';
+import { COMPONENT_URLS, examplesUrl, getURLs } from '../utils/EnvironmentUtil';
+import { elements } from '../utils/SelectorUtil';
+import { verifyPresent, verifyText, verifyClassPresent } from '../utils/VerifyUtil';
+import { getAttribute } from '../utils/ElementPropertiesUtil';
+import {
+    linearProgressSelectors,
+    radialProgressSelectors,
+    getRadialSvgElement,
+    getRadialCircleElement,
+} from '../utils/ProgressUtil';
+
+describe('Progress Demo Page', () => {
+    const url = examplesUrl(COMPONENT_URLS.PROGRESS);
+
+    before(async () => {
+        await browser.navigateTo(url);
+    });
+
+    after(async () => {
+        await browser.navigateTo(getURLs().HOME);
+    });
+
+    describe('Page Elements', () => {
+        it('should display page title', async () => {
+            await verifyPresent(elements.title);
+            await verifyText(elements.title, 'Progress', 'Progress example page title');
+        });
+    });
+
+    describe('Linear Progress Bars', () => {
+        it('should display flash effect progress bar', async () => {
+            await verifyPresent(linearProgressSelectors.flashContainer());
+            await verifyPresent(linearProgressSelectors.flashBar());
+            await verifyClassPresent(linearProgressSelectors.flashBar(), 'flash');
+        });
+
+        it('should display indeterminate progress bar with animated class', async () => {
+            await verifyPresent(linearProgressSelectors.indeterminateContainer());
+            await verifyPresent(linearProgressSelectors.indeterminateBar());
+            await verifyClassPresent(linearProgressSelectors.indeterminateBar(), 'animated');
+        });
+
+        it('should display striped progress bar with striped class', async () => {
+            await verifyPresent(linearProgressSelectors.stripedContainer());
+            await verifyPresent(linearProgressSelectors.stripedBar());
+            await verifyClassPresent(linearProgressSelectors.stripedContainer(), 'striped');
+            await verifyClassPresent(linearProgressSelectors.stripedBar(), 'linear');
+        });
+
+        it('should display multi-color progress bars with success color', async () => {
+            await verifyPresent(linearProgressSelectors.multiColorContainer());
+            await verifyPresent(linearProgressSelectors.multiColorSuccessBar());
+            const successColor = await getAttribute(linearProgressSelectors.multiColorSuccessBar(), 'color');
+            await expect(successColor).toBe('success');
+        });
+
+        it('should display multi-color progress bars with negative color', async () => {
+            await verifyPresent(linearProgressSelectors.multiColorNegativeBar());
+            const negativeColor = await getAttribute(linearProgressSelectors.multiColorNegativeBar(), 'color');
+            await expect(negativeColor).toBe('negative');
+        });
+
+        it('should verify linear progress bars have linear class', async () => {
+            await verifyClassPresent(linearProgressSelectors.flashBar(), 'linear');
+            await verifyClassPresent(linearProgressSelectors.indeterminateBar(), 'linear');
+            await verifyClassPresent(linearProgressSelectors.multiColorSuccessBar(), 'linear');
+        });
+
+        it('should verify progress bars display with proper values', async () => {
+            // Verify striped bar has value attribute
+            const stripedValue = await getAttribute(linearProgressSelectors.stripedBar(), 'value');
+            await expect(stripedValue).toBe('40');
+
+            // Verify multi-color bars have correct values
+            const successValue = await getAttribute(linearProgressSelectors.multiColorSuccessBar(), 'value');
+            await expect(successValue).toBe('120');
+
+            const negativeValue = await getAttribute(linearProgressSelectors.multiColorNegativeBar(), 'value');
+            await expect(negativeValue).toBe('40');
+        });
+    });
+
+    describe('Radial Progress Bars', () => {
+        it('should display single radial progress bar', async () => {
+            await verifyPresent(radialProgressSelectors.singleContainer());
+            await verifyPresent(radialProgressSelectors.singleBar());
+            await verifyClassPresent(radialProgressSelectors.singleContainer(), 'radial');
+        });
+
+        it('should display single radial progress bar with radial class on bar', async () => {
+            await verifyClassPresent(radialProgressSelectors.singleBar(), 'radial');
+        });
+
+        it('should display SVG element in single radial progress bar', async () => {
+            const svg = await getRadialSvgElement(radialProgressSelectors.singleBar());
+            await expect(svg).toBeTruthy();
+        });
+
+        it('should display SVG circle element in single radial progress bar', async () => {
+            const circle = await getRadialCircleElement(radialProgressSelectors.singleBar());
+            await expect(circle).toBeTruthy();
+        });
+
+        it('should verify single radial progress bar has correct value', async () => {
+            const singleValue = await getAttribute(radialProgressSelectors.singleBar(), 'value');
+            await expect(singleValue).toBe('70');
+        });
+
+        it('should display multi-color radial progress bars', async () => {
+            await verifyPresent(radialProgressSelectors.multiContainer());
+            await verifyPresent(radialProgressSelectors.multiSuccessBar());
+            await verifyPresent(radialProgressSelectors.multiNegativeBar());
+            await verifyPresent(radialProgressSelectors.multiWarningBar());
+        });
+
+        it('should display multi-color radial bars with radial class', async () => {
+            await verifyClassPresent(radialProgressSelectors.multiSuccessBar(), 'radial');
+            await verifyClassPresent(radialProgressSelectors.multiNegativeBar(), 'radial');
+            await verifyClassPresent(radialProgressSelectors.multiWarningBar(), 'radial');
+        });
+
+        it('should verify multi-color radial bars have correct color attributes', async () => {
+            const successColor = await getAttribute(radialProgressSelectors.multiSuccessBar(), 'color');
+            await expect(successColor).toBe('success');
+
+            const negativeColor = await getAttribute(radialProgressSelectors.multiNegativeBar(), 'color');
+            await expect(negativeColor).toBe('negative');
+
+            const warningColor = await getAttribute(radialProgressSelectors.multiWarningBar(), 'color');
+            await expect(warningColor).toBe('warning');
+        });
+
+        it('should verify multi-color radial bars have correct values', async () => {
+            const successValue = await getAttribute(radialProgressSelectors.multiSuccessBar(), 'value');
+            await expect(successValue).toBe('50');
+
+            const negativeValue = await getAttribute(radialProgressSelectors.multiNegativeBar(), 'value');
+            await expect(negativeValue).toBe('40');
+
+            const warningValue = await getAttribute(radialProgressSelectors.multiWarningBar(), 'value');
+            await expect(warningValue).toBe('30');
+        });
+
+        it('should display SVG elements in multi-color radial progress bars', async () => {
+            const successSvg = await getRadialSvgElement(radialProgressSelectors.multiSuccessBar());
+            await expect(successSvg).toBeTruthy();
+
+            const negativeSvg = await getRadialSvgElement(radialProgressSelectors.multiNegativeBar());
+            await expect(negativeSvg).toBeTruthy();
+
+            const warningSvg = await getRadialSvgElement(radialProgressSelectors.multiWarningBar());
+            await expect(warningSvg).toBeTruthy();
+        });
+    });
+});

--- a/projects/novo-e2e/src/e2e/progressBar.e2e.ts
+++ b/projects/novo-e2e/src/e2e/progressBar.e2e.ts
@@ -5,8 +5,6 @@ import { getAttribute } from '../utils/ElementPropertiesUtil';
 import {
     linearProgressSelectors,
     radialProgressSelectors,
-    getRadialSvgElement,
-    getRadialCircleElement,
 } from '../utils/ProgressUtil';
 
 describe('Progress Demo Page', () => {
@@ -29,127 +27,86 @@ describe('Progress Demo Page', () => {
 
     describe('Linear Progress Bars', () => {
         it('should display flash effect progress bar', async () => {
-            await verifyPresent(linearProgressSelectors.flashContainer());
-            await verifyPresent(linearProgressSelectors.flashBar());
-            await verifyClassPresent(linearProgressSelectors.flashBar(), 'flash');
+            await verifyPresent(linearProgressSelectors.flashContainer);
+            await verifyPresent(linearProgressSelectors.flashBar);
+            await verifyClassPresent(linearProgressSelectors.flashBar, 'flash');
+            await verifyClassPresent(linearProgressSelectors.flashBar, 'linear');
+            const flashAttr = await getAttribute(linearProgressSelectors.flashBar, 'flash');
+            await expect(flashAttr).toBe('true');
         });
 
         it('should display indeterminate progress bar with animated class', async () => {
-            await verifyPresent(linearProgressSelectors.indeterminateContainer());
-            await verifyPresent(linearProgressSelectors.indeterminateBar());
-            await verifyClassPresent(linearProgressSelectors.indeterminateBar(), 'animated');
+            await verifyPresent(linearProgressSelectors.indeterminateContainer);
+            await verifyPresent(linearProgressSelectors.indeterminateBar);
+            await verifyClassPresent(linearProgressSelectors.indeterminateBar, 'animated');
+            await verifyClassPresent(linearProgressSelectors.indeterminateBar, 'linear');
         });
 
         it('should display striped progress bar with striped class', async () => {
-            await verifyPresent(linearProgressSelectors.stripedContainer());
-            await verifyPresent(linearProgressSelectors.stripedBar());
-            await verifyClassPresent(linearProgressSelectors.stripedContainer(), 'striped');
-            await verifyClassPresent(linearProgressSelectors.stripedBar(), 'linear');
+            await verifyPresent(linearProgressSelectors.stripedContainer);
+            await verifyPresent(linearProgressSelectors.stripedBar);
+            await verifyClassPresent(linearProgressSelectors.stripedContainer, 'striped');
+            await verifyClassPresent(linearProgressSelectors.stripedBar, 'linear');
+            const stripedValue = await getAttribute(linearProgressSelectors.stripedBar, 'value');
+            await expect(stripedValue).toBe('40');
         });
 
         it('should display multi-color progress bars with success color', async () => {
-            await verifyPresent(linearProgressSelectors.multiColorContainer());
-            await verifyPresent(linearProgressSelectors.multiColorSuccessBar());
-            const successColor = await getAttribute(linearProgressSelectors.multiColorSuccessBar(), 'color');
+            await verifyPresent(linearProgressSelectors.multiColorContainer);
+            await verifyPresent(linearProgressSelectors.multiColorSuccessBar);
+            await verifyClassPresent(linearProgressSelectors.multiColorSuccessBar, 'linear');
+            const successColor = await getAttribute(linearProgressSelectors.multiColorSuccessBar, 'color');
             await expect(successColor).toBe('success');
+            const successValue = await getAttribute(linearProgressSelectors.multiColorSuccessBar, 'value');
+            await expect(successValue).toBe('120');
         });
 
         it('should display multi-color progress bars with negative color', async () => {
-            await verifyPresent(linearProgressSelectors.multiColorNegativeBar());
-            const negativeColor = await getAttribute(linearProgressSelectors.multiColorNegativeBar(), 'color');
+            await verifyPresent(linearProgressSelectors.multiColorNegativeBar);
+            await verifyClassPresent(linearProgressSelectors.multiColorNegativeBar, 'linear');
+            const negativeColor = await getAttribute(linearProgressSelectors.multiColorNegativeBar, 'color');
             await expect(negativeColor).toBe('negative');
-        });
-
-        it('should verify linear progress bars have linear class', async () => {
-            await verifyClassPresent(linearProgressSelectors.flashBar(), 'linear');
-            await verifyClassPresent(linearProgressSelectors.indeterminateBar(), 'linear');
-            await verifyClassPresent(linearProgressSelectors.multiColorSuccessBar(), 'linear');
-        });
-
-        it('should verify progress bars display with proper values', async () => {
-            // Verify striped bar has value attribute
-            const stripedValue = await getAttribute(linearProgressSelectors.stripedBar(), 'value');
-            await expect(stripedValue).toBe('40');
-
-            // Verify multi-color bars have correct values
-            const successValue = await getAttribute(linearProgressSelectors.multiColorSuccessBar(), 'value');
-            await expect(successValue).toBe('120');
-
-            const negativeValue = await getAttribute(linearProgressSelectors.multiColorNegativeBar(), 'value');
+            const negativeValue = await getAttribute(linearProgressSelectors.multiColorNegativeBar, 'value');
             await expect(negativeValue).toBe('40');
         });
     });
 
     describe('Radial Progress Bars', () => {
         it('should display single radial progress bar', async () => {
-            await verifyPresent(radialProgressSelectors.singleContainer());
-            await verifyPresent(radialProgressSelectors.singleBar());
-            await verifyClassPresent(radialProgressSelectors.singleContainer(), 'radial');
-        });
-
-        it('should display single radial progress bar with radial class on bar', async () => {
-            await verifyClassPresent(radialProgressSelectors.singleBar(), 'radial');
-        });
-
-        it('should display SVG element in single radial progress bar', async () => {
-            const svg = await getRadialSvgElement(radialProgressSelectors.singleBar());
-            await expect(svg).toBeTruthy();
-        });
-
-        it('should display SVG circle element in single radial progress bar', async () => {
-            const circle = await getRadialCircleElement(radialProgressSelectors.singleBar());
-            await expect(circle).toBeTruthy();
-        });
-
-        it('should verify single radial progress bar has correct value', async () => {
-            const singleValue = await getAttribute(radialProgressSelectors.singleBar(), 'value');
+            await verifyPresent(radialProgressSelectors.singleContainer);
+            await verifyPresent(radialProgressSelectors.singleBar);
+            await verifyClassPresent(radialProgressSelectors.singleContainer, 'radial');
+            await verifyClassPresent(radialProgressSelectors.singleBar, 'radial');
+            const singleValue = await getAttribute(radialProgressSelectors.singleBar, 'value');
             await expect(singleValue).toBe('70');
         });
 
-        it('should display multi-color radial progress bars', async () => {
-            await verifyPresent(radialProgressSelectors.multiContainer());
-            await verifyPresent(radialProgressSelectors.multiSuccessBar());
-            await verifyPresent(radialProgressSelectors.multiNegativeBar());
-            await verifyPresent(radialProgressSelectors.multiWarningBar());
-        });
-
-        it('should display multi-color radial bars with radial class', async () => {
-            await verifyClassPresent(radialProgressSelectors.multiSuccessBar(), 'radial');
-            await verifyClassPresent(radialProgressSelectors.multiNegativeBar(), 'radial');
-            await verifyClassPresent(radialProgressSelectors.multiWarningBar(), 'radial');
-        });
-
-        it('should verify multi-color radial bars have correct color attributes', async () => {
-            const successColor = await getAttribute(radialProgressSelectors.multiSuccessBar(), 'color');
+        it('should display multi-color radial progress bars with success', async () => {
+            await verifyPresent(radialProgressSelectors.multiContainer);
+            await verifyPresent(radialProgressSelectors.multiSuccessBar);
+            await verifyClassPresent(radialProgressSelectors.multiSuccessBar, 'radial');
+            const successColor = await getAttribute(radialProgressSelectors.multiSuccessBar, 'color');
             await expect(successColor).toBe('success');
-
-            const negativeColor = await getAttribute(radialProgressSelectors.multiNegativeBar(), 'color');
-            await expect(negativeColor).toBe('negative');
-
-            const warningColor = await getAttribute(radialProgressSelectors.multiWarningBar(), 'color');
-            await expect(warningColor).toBe('warning');
-        });
-
-        it('should verify multi-color radial bars have correct values', async () => {
-            const successValue = await getAttribute(radialProgressSelectors.multiSuccessBar(), 'value');
+            const successValue = await getAttribute(radialProgressSelectors.multiSuccessBar, 'value');
             await expect(successValue).toBe('50');
-
-            const negativeValue = await getAttribute(radialProgressSelectors.multiNegativeBar(), 'value');
-            await expect(negativeValue).toBe('40');
-
-            const warningValue = await getAttribute(radialProgressSelectors.multiWarningBar(), 'value');
-            await expect(warningValue).toBe('30');
         });
 
-        it('should display SVG elements in multi-color radial progress bars', async () => {
-            const successSvg = await getRadialSvgElement(radialProgressSelectors.multiSuccessBar());
-            await expect(successSvg).toBeTruthy();
+        it('should display multi-color radial progress bars with negative', async () => {
+            await verifyPresent(radialProgressSelectors.multiNegativeBar);
+            await verifyClassPresent(radialProgressSelectors.multiNegativeBar, 'radial');
+            const negativeColor = await getAttribute(radialProgressSelectors.multiNegativeBar, 'color');
+            await expect(negativeColor).toBe('negative');
+            const negativeValue = await getAttribute(radialProgressSelectors.multiNegativeBar, 'value');
+            await expect(negativeValue).toBe('40');
+        });
 
-            const negativeSvg = await getRadialSvgElement(radialProgressSelectors.multiNegativeBar());
-            await expect(negativeSvg).toBeTruthy();
-
-            const warningSvg = await getRadialSvgElement(radialProgressSelectors.multiWarningBar());
-            await expect(warningSvg).toBeTruthy();
+        it('should display multi-color radial progress bars with warning', async () => {
+            await verifyPresent(radialProgressSelectors.multiWarningBar);
+            await verifyClassPresent(radialProgressSelectors.multiWarningBar, 'radial');
+            const warningColor = await getAttribute(radialProgressSelectors.multiWarningBar, 'color');
+            await expect(warningColor).toBe('warning');
+            const warningValue = await getAttribute(radialProgressSelectors.multiWarningBar, 'value');
+            await expect(warningValue).toBe('30');
         });
     });
 });

--- a/projects/novo-e2e/src/e2e/progressBar.e2e.ts
+++ b/projects/novo-e2e/src/e2e/progressBar.e2e.ts
@@ -1,4 +1,3 @@
-import { scrollIntoView } from '../utils/ElementActionUtil';
 import { COMPONENT_URLS, examplesUrl, getURLs } from '../utils/EnvironmentUtil';
 import { elements } from '../utils/SelectorUtil';
 import { verifyPresent, verifyText, verifyClassPresent } from '../utils/VerifyUtil';

--- a/projects/novo-e2e/src/e2e/switch.e2e.ts
+++ b/projects/novo-e2e/src/e2e/switch.e2e.ts
@@ -1,0 +1,78 @@
+import { click } from '../utils/ElementActionUtil';
+import { COMPONENT_URLS, componentsUrl, getURLs } from '../utils/EnvironmentUtil';
+import { verifyPresent, verifyText, verifyDisabled } from '../utils/VerifyUtil';
+import { switchSelectors } from '../utils/SwitchUtil';
+import { getElementText } from '../utils/ElementPropertiesUtil';
+
+describe('Switch Demo Page', () => {
+    const url = componentsUrl(COMPONENT_URLS.SWITCH);
+
+    before(async () => {
+        await browser.navigateTo(url);
+    });
+
+    after(async () => {
+        await browser.navigateTo(getURLs().HOME);
+    });
+
+
+    describe('Switch Interactions', () => {
+        it('should display switch label with value', async () => {
+            await verifyPresent(switchSelectors.label());
+            const labelText = await getElementText(switchSelectors.label());
+            await expect(labelText).toContain('Toggled');
+        });
+
+        it('should display default switch', async () => {
+            await verifyPresent(switchSelectors.defaultSwitch());
+        });
+
+        it('should display grapefruit themed switch', async () => {
+            await verifyPresent(switchSelectors.grapefruitSwitch());
+        });
+
+        it('should display disabled switch with label text', async () => {
+            await verifyPresent(switchSelectors.disabledSwitch());
+            await verifyDisabled(switchSelectors.disabledSwitch(), 'disabled switch');
+            await verifyText(switchSelectors.disabledSwitch(), 'THIS IS DISABLED', 'disabled switch text');
+        });
+
+        it('should toggle default switch and update value display', async () => {
+            // Get initial state
+            const initialText = await getElementText(switchSelectors.value());
+
+            // Click to toggle
+            await click(switchSelectors.defaultSwitch());
+            await browser.pause(500);
+
+            // Value should change
+            const toggledText = await getElementText(switchSelectors.value());
+
+            // Click again to toggle back
+            await click(switchSelectors.defaultSwitch());
+            await browser.pause(500);
+
+            // Value should return to initial
+            const finalText = await getElementText(switchSelectors.value());
+            await expect(finalText).toBe(initialText);
+        });
+
+        it('should toggle grapefruit themed switch', async () => {
+            await click(switchSelectors.grapefruitSwitch());
+            await browser.pause(500);
+            // Verify switch can be toggled multiple times
+            await click(switchSelectors.grapefruitSwitch());
+            await browser.pause(500);
+            await verifyPresent(switchSelectors.grapefruitSwitch());
+        });
+
+        it('should not toggle disabled switch', async () => {
+            const initialValue = await getElementText(switchSelectors.value());
+            await click(switchSelectors.disabledSwitch());
+            await browser.pause(500);
+            const valueAfterClick = await getElementText(switchSelectors.value());
+            // Value should not change when clicking disabled switch
+            await expect(initialValue).toBe(valueAfterClick);
+        });
+    });
+});

--- a/projects/novo-e2e/src/e2e/switch.e2e.ts
+++ b/projects/novo-e2e/src/e2e/switch.e2e.ts
@@ -1,7 +1,7 @@
 import { click } from '../utils/ElementActionUtil';
 import { COMPONENT_URLS, componentsUrl, getURLs } from '../utils/EnvironmentUtil';
 import { verifyPresent, verifyText, verifyDisabled } from '../utils/VerifyUtil';
-import { switchSelectors } from '../utils/SwitchUtil';
+import { switchSelectors, switchIcon, isSwitchChecked } from '../utils/SwitchUtil';
 import { getElementText } from '../utils/ElementPropertiesUtil';
 
 describe('Switch Demo Page', () => {
@@ -17,62 +17,43 @@ describe('Switch Demo Page', () => {
 
 
     describe('Switch Interactions', () => {
-        it('should display switch label with value', async () => {
-            await verifyPresent(switchSelectors.label());
-            const labelText = await getElementText(switchSelectors.label());
-            await expect(labelText).toContain('Toggled');
-        });
+        it('should toggle default switch and update label', async () => {
+            await verifyPresent(switchSelectors.defaultSwitch);
+            const initialLabel = await getElementText(switchSelectors.label);
+            const isChecked = isSwitchChecked(initialLabel);
+            await verifyPresent(switchIcon(switchSelectors.defaultSwitch, isChecked));
 
-        it('should display default switch', async () => {
-            await verifyPresent(switchSelectors.defaultSwitch());
-        });
-
-        it('should display grapefruit themed switch', async () => {
-            await verifyPresent(switchSelectors.grapefruitSwitch());
-        });
-
-        it('should display disabled switch with label text', async () => {
-            await verifyPresent(switchSelectors.disabledSwitch());
-            await verifyDisabled(switchSelectors.disabledSwitch(), 'disabled switch');
-            await verifyText(switchSelectors.disabledSwitch(), 'THIS IS DISABLED', 'disabled switch text');
-        });
-
-        it('should toggle default switch and update value display', async () => {
-            // Get initial state
-            const initialText = await getElementText(switchSelectors.value());
-
-            // Click to toggle
-            await click(switchSelectors.defaultSwitch());
-            await browser.pause(500);
-
-            // Value should change
-            const toggledText = await getElementText(switchSelectors.value());
-
-            // Click again to toggle back
-            await click(switchSelectors.defaultSwitch());
-            await browser.pause(500);
-
-            // Value should return to initial
-            const finalText = await getElementText(switchSelectors.value());
-            await expect(finalText).toBe(initialText);
+            await click(switchSelectors.defaultSwitch);
+            const afterClick = await getElementText(switchSelectors.label);
+            await verifyPresent(switchIcon(switchSelectors.defaultSwitch, !isChecked));
+            await expect(afterClick).not.toBe(initialLabel);
         });
 
         it('should toggle grapefruit themed switch', async () => {
-            await click(switchSelectors.grapefruitSwitch());
-            await browser.pause(500);
-            // Verify switch can be toggled multiple times
-            await click(switchSelectors.grapefruitSwitch());
-            await browser.pause(500);
-            await verifyPresent(switchSelectors.grapefruitSwitch());
+            await verifyPresent(switchSelectors.grapefruitSwitch);
+            const initialLabel = await getElementText(switchSelectors.label);
+            const isChecked = isSwitchChecked(initialLabel);
+            await verifyPresent(switchIcon(switchSelectors.grapefruitSwitch, isChecked));
+
+            await click(switchSelectors.grapefruitSwitch);
+            const afterFirstClick = await getElementText(switchSelectors.label);
+            await verifyPresent(switchIcon(switchSelectors.grapefruitSwitch, !isChecked));
+            await expect(afterFirstClick).not.toBe(initialLabel);
+
+            await click(switchSelectors.grapefruitSwitch);
+            const afterSecondClick = await getElementText(switchSelectors.label);
+            await verifyPresent(switchIcon(switchSelectors.grapefruitSwitch, isChecked));
+            await expect(afterSecondClick).toBe(initialLabel);
         });
 
         it('should not toggle disabled switch', async () => {
-            const initialValue = await getElementText(switchSelectors.value());
-            await click(switchSelectors.disabledSwitch());
-            await browser.pause(500);
-            const valueAfterClick = await getElementText(switchSelectors.value());
-            // Value should not change when clicking disabled switch
-            await expect(initialValue).toBe(valueAfterClick);
+            await verifyPresent(switchSelectors.disabledSwitch);
+            await verifyDisabled(switchSelectors.disabledSwitch, 'disabled switch');
+            await verifyText(switchSelectors.disabledSwitch, 'THIS IS DISABLED', 'disabled switch text');
+            const initialLabel = await getElementText(switchSelectors.label);
+            await click(switchSelectors.disabledSwitch);
+            const afterClick = await getElementText(switchSelectors.label);
+            await expect(afterClick).toBe(initialLabel);
         });
     });
 });

--- a/projects/novo-e2e/src/utils/AutomationHelpers.ts
+++ b/projects/novo-e2e/src/utils/AutomationHelpers.ts
@@ -34,3 +34,11 @@ export async function asyncMap(array: any[], mapper: Function): Promise<any> {
 export function failureMessage(message: any) {
     console.warn('      ×', message);
 }
+
+export async function acceptAlertIfPresent(): Promise<void> {
+    try {
+        await browser.acceptAlert();
+    } catch (error) {
+        console.log('No alert present.');
+    }
+}

--- a/projects/novo-e2e/src/utils/AutomationHelpers.ts
+++ b/projects/novo-e2e/src/utils/AutomationHelpers.ts
@@ -39,6 +39,6 @@ export async function acceptAlertIfPresent(): Promise<void> {
     try {
         await browser.acceptAlert();
     } catch (error) {
-        console.log('No alert present.');
+        console.error('No alert present.');
     }
 }

--- a/projects/novo-e2e/src/utils/CalendarUtil.ts
+++ b/projects/novo-e2e/src/utils/CalendarUtil.ts
@@ -17,6 +17,19 @@ export const CALENDAR_MONTHS = [
     'December',
 ];
 
+export const calendar = {
+    monthHeader: automationId('header-month'),
+    yearHeader: automationId('header-year'),
+    nextButton: automationId('calendar-next'),
+    previousButton: automationId('calendar-previous'),
+    monthText: `${elements.calendar} .month`,
+    yearText: `${elements.calendar} .year`,
+    weekdayHeaders: `${elements.calendar} .calendar-th`,
+    firstVisibleDate: `${elements.calendar} .calendar-date:first-child`,
+    lastVisibleDate: `${elements.calendar} .calendar-date:last-child`,
+    selectedValues: automationId('calendar-selected-values'),
+};
+
 /**
  * Gets a month name offset from the current month
  * @param offset number of months to offset (negative for past, positive for future)
@@ -55,46 +68,6 @@ export function calendarDateInMonth(dayNumber: number | string, monthIndex: numb
     return `${elements.calendar} .month-view:nth-of-type(${monthIndex + 1}) .calendar-date${automationId(dayNumber)}`;
 }
 
-/**
- * Returns the selector for the first visible day in the calendar grid
- * (may include overflow days from previous month)
- */
-export function firstVisibleCalendarDate(): string {
-    return `${elements.calendar} .calendar-date:first-child`;
-}
-
-/**
- * Returns the selector for the last visible day in the calendar grid
- * (may include overflow days from next month)
- */
-export function lastVisibleCalendarDate(): string {
-    return `${elements.calendar} .calendar-date:last-child`;
-}
-
-export function calendarMonthHeader(): string {
-    return automationId('header-month');
-}
-
-export function calendarYearHeader(): string {
-    return automationId('header-year');
-}
-
-export function calendarNextButton(): string {
-    return automationId('calendar-next');
-}
-
-export function calendarPreviousButton(): string {
-    return automationId('calendar-previous');
-}
-
-export function calendarMonthText(): string {
-    return `${elements.calendar} .month`;
-}
-
-export function calendarYearText(): string {
-    return `${elements.calendar} .year`;
-}
-
 export function calendarMonth(monthName: string): string {
     return `div${automationId(monthName)}`;
 }
@@ -103,12 +76,26 @@ export function calendarYear(yearNumber: number): string {
     return `div${automationId(yearNumber)}`;
 }
 
+export function calendarSelectionMode(mode: string): string {
+    return `${automationId(`mode-${mode}`)} i`;
+}
+
+export function calendarNumberOfMonths(months: number): string {
+    return `${automationId(`months-${months}`)} i`;
+}
+
+/**
+ * Returns the selector for the week start radio button by day (0 for Sunday, 1 for Monday)
+ */
+export function calendarWeekStart(day: number): string {
+    return `${automationId(`weekstart-${day}`)} i`;
+}
 
 /**
  * Gets the selected values from the calendar display as a Date array
  */
 export async function getCalendarSelectedValues(): Promise<Date[]> {
-    const valueText = await $(automationId('calendar-selected-values')).getText();
+    const valueText = await $(calendar.selectedValues).getText();
     return JSON.parse(valueText);
 }
 
@@ -127,27 +114,8 @@ export async function verifyCalendarDatesSelected(dayNumbers: number[]): Promise
     expect(selectedDays).toEqual(expectedDays);
 }
 
-export function calendarSelectionMode(mode: string): string {
-    return `${automationId(`mode-${mode}`)} i`;
-}
-
-export function calendarNumberOfMonths(months: number): string {
-    return `${automationId(`months-${months}`)} i`;
-}
-
-/**
- * Returns the selector for the week start radio button by day (0 for Sunday, 1 for Monday)
- */
-export function calendarWeekStart(day: number): string {
-    return `${automationId(`weekstart-${day}`)} i`;
-}
-
-export function calendarWeekdayHeaders(): string {
-    return `${elements.calendar} .calendar-th`;
-}
-
 export async function getCalendarWeekdayHeaders(): Promise<WebdriverIO.ElementArray> {
-    return await getAllElements(calendarWeekdayHeaders());
+    return await getAllElements(calendar.weekdayHeaders);
 }
 
 export async function verifyCalendarDateRangeSelected(startDay: number, endDay: number): Promise<void> {

--- a/projects/novo-e2e/src/utils/EnvironmentUtil.ts
+++ b/projects/novo-e2e/src/utils/EnvironmentUtil.ts
@@ -22,6 +22,7 @@ export const COMPONENT_URLS = {
     PROGRESS: 'progress',
     QUERY_BUILDER: 'query builder',
     SWITCH: 'switch',
+    POPOVER_PLACEMENT: 'popover',
 };
 
 export function examplesUrl(component: string): string {

--- a/projects/novo-e2e/src/utils/EnvironmentUtil.ts
+++ b/projects/novo-e2e/src/utils/EnvironmentUtil.ts
@@ -19,6 +19,7 @@ export const COMPONENT_URLS = {
     LOADING: 'loading',
     MENU: 'menu',
     NON_IDEAL_STATE: 'non ideal state',
+    PROGRESS: 'progress',
     QUERY_BUILDER: 'query builder',
 };
 

--- a/projects/novo-e2e/src/utils/EnvironmentUtil.ts
+++ b/projects/novo-e2e/src/utils/EnvironmentUtil.ts
@@ -31,3 +31,8 @@ export function componentsUrl(component: string): string {
     const urls = getURLs();
     return `${urls.BASE}${component}`;
 }
+
+export function formControlsExamplesUrl(control: string): string {
+    const baseUrl = (global as any).E2E_BASE_URL || 'https://bullhorn.github.io/novo-elements/docs';
+    return `${baseUrl}/#/form-controls/${control}/examples`;
+}

--- a/projects/novo-e2e/src/utils/EnvironmentUtil.ts
+++ b/projects/novo-e2e/src/utils/EnvironmentUtil.ts
@@ -22,7 +22,7 @@ export const COMPONENT_URLS = {
     PROGRESS: 'progress',
     QUERY_BUILDER: 'query builder',
     SWITCH: 'switch',
-    POPOVER_PLACEMENT: 'popover',
+    POPOVER: 'pop over',
 };
 
 export function examplesUrl(component: string): string {

--- a/projects/novo-e2e/src/utils/EnvironmentUtil.ts
+++ b/projects/novo-e2e/src/utils/EnvironmentUtil.ts
@@ -21,6 +21,7 @@ export const COMPONENT_URLS = {
     NON_IDEAL_STATE: 'non ideal state',
     PROGRESS: 'progress',
     QUERY_BUILDER: 'query builder',
+    SWITCH: 'switch',
 };
 
 export function examplesUrl(component: string): string {

--- a/projects/novo-e2e/src/utils/EnvironmentUtil.ts
+++ b/projects/novo-e2e/src/utils/EnvironmentUtil.ts
@@ -15,6 +15,7 @@ export const COMPONENT_URLS = {
     CALENDAR: 'calendar',
     DATA_TABLE: 'data-table',
     DROPDOWN: 'dropdown',
+    LOADING: 'loading',
     NON_IDEAL_STATE: 'non ideal state',
     QUERY_BUILDER: 'query builder',
 };

--- a/projects/novo-e2e/src/utils/EnvironmentUtil.ts
+++ b/projects/novo-e2e/src/utils/EnvironmentUtil.ts
@@ -16,6 +16,7 @@ export const COMPONENT_URLS = {
     DATA_TABLE: 'data-table',
     DROPDOWN: 'dropdown',
     LOADING: 'loading',
+    MENU: 'menu',
     NON_IDEAL_STATE: 'non ideal state',
     QUERY_BUILDER: 'query builder',
 };

--- a/projects/novo-e2e/src/utils/EnvironmentUtil.ts
+++ b/projects/novo-e2e/src/utils/EnvironmentUtil.ts
@@ -15,6 +15,7 @@ export const COMPONENT_URLS = {
     CALENDAR: 'calendar',
     DATA_TABLE: 'data-table',
     DROPDOWN: 'dropdown',
+    ICON: 'icon',
     LOADING: 'loading',
     MENU: 'menu',
     NON_IDEAL_STATE: 'non ideal state',

--- a/projects/novo-e2e/src/utils/IconUtil.ts
+++ b/projects/novo-e2e/src/utils/IconUtil.ts
@@ -1,0 +1,27 @@
+import { automationId, codeExample } from './SelectorUtil';
+
+export const iconSections = {
+    basicUsage: codeExample('basic-icons'),
+    themedColors: codeExample('themed-icons'),
+    raisedIcons: codeExample('raised-icons'),
+};
+
+export function basicIcon(name: string): string {
+    return `${iconSections.basicUsage} ${automationId(`basic-icon-${name}`)}`;
+}
+
+export function basicIconClass(name: string): string {
+    return `${iconSections.basicUsage} ${automationId(`basic-icon-class-${name}`)}`;
+}
+
+export function themedIconColor(name: string): string {
+    return `${iconSections.themedColors} ${automationId(`themed-icon-color-${name}`)}`;
+}
+
+export function themedIconTheme(name: string): string {
+    return `${iconSections.themedColors} ${automationId(`themed-icon-theme-${name}`)}`;
+}
+
+export function raisedIcon(name: string): string {
+    return `${iconSections.raisedIcons} ${automationId(`raised-icon-${name}`)}`;
+}

--- a/projects/novo-e2e/src/utils/LoadingUtil.ts
+++ b/projects/novo-e2e/src/utils/LoadingUtil.ts
@@ -1,0 +1,25 @@
+import { automationId, codeExample } from './SelectorUtil';
+
+export function loadingLineComponent(): string {
+    return automationId('loading-line-component');
+}
+
+export function loadingLineExample(): string {
+    return codeExample('loading-line');
+}
+
+export function loadingSizeLineRadio(size: string): string {
+    return `${automationId(`size-line-${size}`)} i`;
+}
+
+export function loadingColorLineRadio(color: string): string {
+    return `${automationId(`color-line-${color}`)} i`;
+}
+
+export function loadingLineSizeGroup(): string {
+    return automationId('size-line-group');
+}
+
+export function loadingLineColorGroup(): string {
+    return automationId('color-line-group');
+}

--- a/projects/novo-e2e/src/utils/LoadingUtil.ts
+++ b/projects/novo-e2e/src/utils/LoadingUtil.ts
@@ -1,12 +1,15 @@
 import { automationId, codeExample } from './SelectorUtil';
 
-export function loadingLineComponent(): string {
-    return automationId('loading-line-component');
-}
-
-export function loadingLineExample(): string {
-    return codeExample('loading-line');
-}
+export const loading = {
+    lineComponent: automationId('loading-line-component'),
+    lineExample: codeExample('loading-line'),
+    lineSizeGroup: automationId('size-line-group'),
+    lineColorGroup: automationId('color-line-group'),
+    spinnerComponent: automationId('spinner-component'),
+    circleExample: codeExample('loading-circle'),
+    spinnerSizeGroup: automationId('size-spinner-group'),
+    spinnerColorGroup: automationId('color-spinner-group'),
+};
 
 export function loadingSizeLineRadio(size: string): string {
     return `${automationId(`size-line-${size}`)} i`;
@@ -16,10 +19,10 @@ export function loadingColorLineRadio(color: string): string {
     return `${automationId(`color-line-${color}`)} i`;
 }
 
-export function loadingLineSizeGroup(): string {
-    return automationId('size-line-group');
+export function loadingSizeSpinnerRadio(size: string): string {
+    return `${automationId(`size-spinner-${size}`)} i`;
 }
 
-export function loadingLineColorGroup(): string {
-    return automationId('color-line-group');
+export function loadingColorSpinnerRadio(color: string): string {
+    return `${automationId(`color-spinner-${color}`)} i`;
 }

--- a/projects/novo-e2e/src/utils/MenuUtil.ts
+++ b/projects/novo-e2e/src/utils/MenuUtil.ts
@@ -1,0 +1,38 @@
+import { automationId, codeExample } from './SelectorUtil';
+import { clickOutsideOfElement } from './ElementActionUtil';
+
+export const menu = {
+    basicMenu: automationId('basic-menu'),
+    basicMenuButton: automationId('menu-actions-button'),
+    basicMenuPreview: automationId('menu-preview'),
+    basicMenuEdit: automationId('menu-edit'),
+    basicMenuDisabled: automationId('menu-disabled'),
+    basicMenuDelete: automationId('menu-delete'),
+    iconMenu: automationId('icon-menu'),
+    iconMenuButton: automationId('menu-icon-button'),
+    iconMenuPreview: automationId('menu-icon-preview'),
+    iconMenuEdit: automationId('menu-icon-edit'),
+    iconMenuDelete: automationId('menu-icon-delete'),
+    basicMenuExample: codeExample('basic-menu'),
+    nestedMenuButton: automationId('nested-menu-button'),
+    nestedMenu: automationId('nested-menu'),
+    nestedMenuPreview: automationId('nested-menu-preview'),
+    nestedMenuEdit: automationId('nested-menu-edit'),
+    nestedMenuChoose: automationId('nested-menu-choose'),
+    nestedSubmenu: automationId('nested-submenu'),
+    nestedMenuAvailable: automationId('nested-menu-available'),
+    nestedMenuNotAvailable: automationId('nested-menu-not-available'),
+    nestedMenuExample: codeExample('nested-menu'),
+    contextMenuButton: (fruit: string) => automationId(`menu-context-${fruit}s-button`),
+    contextMenu: automationId('context-menu'),
+    contextMenuPreview: automationId('menu-context-preview'),
+    contextMenuEdit: automationId('menu-context-edit'),
+    contextMenuDelete: automationId('menu-context-delete'),
+    contextMenuDisabled: automationId('menu-context-disabled'),
+    contextMenuVisible: automationId('menu-context-visible'),
+    contextMenuExample: codeExample('menu-context'),
+};
+
+export async function closeMenu(): Promise<void> {
+    await clickOutsideOfElement(menu.basicMenuExample, -100, -100);
+}

--- a/projects/novo-e2e/src/utils/PopoverUtil.ts
+++ b/projects/novo-e2e/src/utils/PopoverUtil.ts
@@ -1,0 +1,67 @@
+import { automationId, codeExample } from './SelectorUtil';
+import { moveMouseToElement, moveMouse } from './ElementActionUtil';
+import { verifyPresent, verifyText, verifyClassPresent, verifyAbsent } from './VerifyUtil';
+
+export const popoverSelectors = {
+    placementExample: codeExample('pop-over-placement'),
+    left: automationId('popover-left'),
+    right: automationId('popover-right'),
+    top: automationId('popover-top'),
+    bottom: automationId('popover-bottom'),
+    contentText: '.popover-content-text',
+    pageHeading: 'h2',
+};
+
+export function popoverScope(popoverName: string): string {
+    return `code-example[example="${popoverName}"]`;
+}
+
+export function popoverTrigger(popoverName: string, triggerId: string): string {
+    return `${popoverScope(popoverName)} [data-automation-id="${triggerId}"]`;
+}
+
+export function popoverContent(popoverName: string): string {
+    return `${popoverScope(popoverName)} popover-content`;
+}
+
+export function popover(popoverName: string): string {
+    return `${popoverScope(popoverName)} popover-content .popover`;
+}
+
+export function popoverArrow(popoverName: string): string {
+    return `${popoverScope(popoverName)} popover-content .arrow`;
+}
+
+export const placementData = [
+    { id: 'popover-left', placement: 'left', text: 'Popover is to left of element' },
+    { id: 'popover-right', placement: 'right', text: 'Popover is to right of element' },
+    { id: 'popover-top', placement: 'top', text: 'Popover is above the element' },
+    { id: 'popover-bottom', placement: 'bottom', text: 'Popover is below the element' },
+];
+
+export const horizontalAlignmentData = [
+    { id: 'popover-top-right', display: 'top-right', primaryDirection: 'top', alignment: 'right', text: 'Popover is on the top side and to the right of the element. Can also apply \'left\' to \'top\' placement PopOvers.' },
+    { id: 'popover-bottom-left', display: 'bottom-left', primaryDirection: 'bottom', alignment: 'left', text: 'Popover is on the bottom side and to the left of the element. Can also apply \'right\' to \'bottom\' placement PopOvers.' },
+];
+
+export const verticalAlignmentData = [
+    { id: 'popover-right-bottom', display: 'right-bottom', primaryDirection: 'right', alignment: 'bottom', text: 'Popover is on the right side and below the element. Can also apply \'top\' to \'right\' placement PopOvers.' },
+    { id: 'popover-left-top', display: 'left-top', primaryDirection: 'left', alignment: 'top', text: 'Popover is on the left side and above the element. Can also apply \'bottom\' to \'left\' placement PopOvers.' },
+];
+
+export const autoPlacementData = [
+    { id: 'popover-auto-placement-first', initialPlacement: 'top', expandedPlacement: 'bottom' },
+    { id: 'popover-auto-placement-second', initialPlacement: 'top', expandedPlacement: 'bottom' },
+];
+
+export async function testAlignmentPopover(popoverName: string, alignment: any): Promise<void> {
+    const trigger = popoverTrigger(popoverName, alignment.id);
+    await verifyPresent(trigger);
+    await moveMouseToElement(trigger);
+    await verifyPresent(popoverContent(popoverName));
+    await verifyClassPresent(popover(popoverName), alignment.primaryDirection);
+    await verifyClassPresent(popoverArrow(popoverName), alignment.alignment);
+    await verifyText(popoverSelectors.contentText, alignment.text);
+    await moveMouse(100, 100);
+    await verifyAbsent(popoverContent(popoverName));
+}

--- a/projects/novo-e2e/src/utils/PopoverUtil.ts
+++ b/projects/novo-e2e/src/utils/PopoverUtil.ts
@@ -49,10 +49,6 @@ export const verticalAlignmentData = [
     { id: 'popover-left-top', display: 'left-top', primaryDirection: 'left', alignment: 'top', text: 'Popover is on the left side and above the element. Can also apply \'bottom\' to \'left\' placement PopOvers.' },
 ];
 
-export const autoPlacementData = [
-    { id: 'popover-auto-placement-first', initialPlacement: 'top', expandedPlacement: 'bottom' },
-    { id: 'popover-auto-placement-second', initialPlacement: 'top', expandedPlacement: 'bottom' },
-];
 
 export async function testAlignmentPopover(popoverName: string, alignment: any): Promise<void> {
     const trigger = popoverTrigger(popoverName, alignment.id);

--- a/projects/novo-e2e/src/utils/ProgressUtil.ts
+++ b/projects/novo-e2e/src/utils/ProgressUtil.ts
@@ -1,38 +1,22 @@
 import { automationId } from './SelectorUtil';
 
-// Linear Progress Bar Selectors
 export const linearProgressSelectors = {
-    flashContainer: () => automationId('progress-bar-flash'),
-    flashBar: () => automationId('progress-bar-flash-bar'),
-    indeterminateContainer: () => automationId('progress-bar-indeterminate'),
-    indeterminateBar: () => automationId('progress-bar-indeterminate-bar'),
-    stripedContainer: () => automationId('progress-bar-striped'),
-    stripedBar: () => automationId('progress-bar-striped-bar'),
-    multiColorContainer: () => automationId('progress-bar-multi-color'),
-    multiColorSuccessBar: () => automationId('progress-bar-multi-color-success'),
-    multiColorNegativeBar: () => automationId('progress-bar-multi-color-negative'),
+    flashContainer: automationId('progress-bar-flash'),
+    flashBar: automationId('progress-bar-flash-bar'),
+    indeterminateContainer: automationId('progress-bar-indeterminate'),
+    indeterminateBar: automationId('progress-bar-indeterminate-bar'),
+    stripedContainer: automationId('progress-bar-striped'),
+    stripedBar: automationId('progress-bar-striped-bar'),
+    multiColorContainer: automationId('progress-bar-multi-color'),
+    multiColorSuccessBar: automationId('progress-bar-multi-color-success'),
+    multiColorNegativeBar: automationId('progress-bar-multi-color-negative'),
 };
 
-// Radial Progress Bar Selectors
 export const radialProgressSelectors = {
-    singleContainer: () => automationId('progress-radial-single'),
-    singleBar: () => automationId('progress-radial-single-bar'),
-    multiContainer: () => automationId('progress-radial-multi'),
-    multiSuccessBar: () => automationId('progress-radial-multi-success'),
-    multiNegativeBar: () => automationId('progress-radial-multi-negative'),
-    multiWarningBar: () => automationId('progress-radial-multi-warning'),
+    singleContainer: automationId('progress-radial-single'),
+    singleBar: automationId('progress-radial-single-bar'),
+    multiContainer: automationId('progress-radial-multi'),
+    multiSuccessBar: automationId('progress-radial-multi-success'),
+    multiNegativeBar: automationId('progress-radial-multi-negative'),
+    multiWarningBar: automationId('progress-radial-multi-warning'),
 };
-
-// Helper function to get SVG element for a radial progress bar
-export async function getRadialSvgElement(progressBarSelector: string): Promise<any> {
-    const progressBar = await $(progressBarSelector);
-    const svg = await progressBar.$('svg');
-    return svg;
-}
-
-// Helper function to get SVG circle element for a radial progress bar
-export async function getRadialCircleElement(progressBarSelector: string): Promise<any> {
-    const svg = await getRadialSvgElement(progressBarSelector);
-    const circle = await svg.$('circle');
-    return circle;
-}

--- a/projects/novo-e2e/src/utils/ProgressUtil.ts
+++ b/projects/novo-e2e/src/utils/ProgressUtil.ts
@@ -1,0 +1,38 @@
+import { automationId } from './SelectorUtil';
+
+// Linear Progress Bar Selectors
+export const linearProgressSelectors = {
+    flashContainer: () => automationId('progress-bar-flash'),
+    flashBar: () => automationId('progress-bar-flash-bar'),
+    indeterminateContainer: () => automationId('progress-bar-indeterminate'),
+    indeterminateBar: () => automationId('progress-bar-indeterminate-bar'),
+    stripedContainer: () => automationId('progress-bar-striped'),
+    stripedBar: () => automationId('progress-bar-striped-bar'),
+    multiColorContainer: () => automationId('progress-bar-multi-color'),
+    multiColorSuccessBar: () => automationId('progress-bar-multi-color-success'),
+    multiColorNegativeBar: () => automationId('progress-bar-multi-color-negative'),
+};
+
+// Radial Progress Bar Selectors
+export const radialProgressSelectors = {
+    singleContainer: () => automationId('progress-radial-single'),
+    singleBar: () => automationId('progress-radial-single-bar'),
+    multiContainer: () => automationId('progress-radial-multi'),
+    multiSuccessBar: () => automationId('progress-radial-multi-success'),
+    multiNegativeBar: () => automationId('progress-radial-multi-negative'),
+    multiWarningBar: () => automationId('progress-radial-multi-warning'),
+};
+
+// Helper function to get SVG element for a radial progress bar
+export async function getRadialSvgElement(progressBarSelector: string): Promise<any> {
+    const progressBar = await $(progressBarSelector);
+    const svg = await progressBar.$('svg');
+    return svg;
+}
+
+// Helper function to get SVG circle element for a radial progress bar
+export async function getRadialCircleElement(progressBarSelector: string): Promise<any> {
+    const svg = await getRadialSvgElement(progressBarSelector);
+    const circle = await svg.$('circle');
+    return circle;
+}

--- a/projects/novo-e2e/src/utils/SelectorUtil.ts
+++ b/projects/novo-e2e/src/utils/SelectorUtil.ts
@@ -191,6 +191,10 @@ export function codeExample(exampleName: string): string {
     return `code-example[example="${exampleName}"]`;
 }
 
+export function codeExampleExpandButton(exampleName: string): string {
+    return `${codeExample(exampleName)} novo-button[icon="bhi-book"]`;
+}
+
 /**
  * For a switch control, returns the switch
  */

--- a/projects/novo-e2e/src/utils/SwitchUtil.ts
+++ b/projects/novo-e2e/src/utils/SwitchUtil.ts
@@ -1,0 +1,9 @@
+import { automationId } from './SelectorUtil';
+
+export const switchSelectors = {
+    label: () => automationId('switch-label'),
+    value: () => automationId('switch-value'),
+    defaultSwitch: () => automationId('switch-default'),
+    grapefruitSwitch: () => automationId('switch-grapefruit'),
+    disabledSwitch: () => automationId('switch-disabled'),
+};

--- a/projects/novo-e2e/src/utils/SwitchUtil.ts
+++ b/projects/novo-e2e/src/utils/SwitchUtil.ts
@@ -1,9 +1,18 @@
 import { automationId } from './SelectorUtil';
 
 export const switchSelectors = {
-    label: () => automationId('switch-label'),
-    value: () => automationId('switch-value'),
-    defaultSwitch: () => automationId('switch-default'),
-    grapefruitSwitch: () => automationId('switch-grapefruit'),
-    disabledSwitch: () => automationId('switch-disabled'),
+    label: automationId('switch-label'),
+    value: automationId('switch-value'),
+    defaultSwitch: `${automationId('switch-default')} > div`,
+    grapefruitSwitch: `${automationId('switch-grapefruit')} > div`,
+    disabledSwitch: automationId('switch-disabled'),
 };
+
+export function switchIcon(switchSelector: string, checked: boolean): string {
+    const icon = checked ? 'check' : 'x';
+    return `${switchSelector} i.bhi-${icon}`;
+}
+
+export function isSwitchChecked(labelText: string): boolean {
+    return labelText.includes('true');
+}

--- a/projects/novo-examples/src/components/menu/basic-menu/basic-menu-example.ts
+++ b/projects/novo-examples/src/components/menu/basic-menu/basic-menu-example.ts
@@ -10,7 +10,8 @@ import { Component } from '@angular/core';
     standalone: false,
 })
 export class BasicMenuExample {
-  public clickMe(event?: string) {
-    window.alert(event);
+  public clickMe(event?: any) {
+    const menuItem = event?.target?.textContent || 'Menu item';
+    window.alert(`You selected: ${menuItem.trim()}`);
   }
 }

--- a/projects/novo-examples/src/components/menu/menu-context/menu-context-example.ts
+++ b/projects/novo-examples/src/components/menu/menu-context/menu-context-example.ts
@@ -14,7 +14,9 @@ export class MenuContextExample {
   public orange = 'Context is Orange';
   public isOrange = (item) => item === this.orange;
 
-  public clickMe(event?: string) {
-    window.alert(event);
+  public clickMe(item?: any, event?: any) {
+    const menuItem = event?.target?.textContent || 'Menu item';
+    const context = item || 'unknown';
+    window.alert(`You selected: ${menuItem.trim()} (${context})`);
   }
 }

--- a/projects/novo-examples/src/components/menu/nested-menu/nested-menu-example.ts
+++ b/projects/novo-examples/src/components/menu/nested-menu/nested-menu-example.ts
@@ -10,7 +10,8 @@ import { Component } from '@angular/core';
     standalone: false,
 })
 export class NestedMenuExample {
-  public clickMe(event?: string) {
-    window.alert(event);
+  public clickMe(event?: any) {
+    const menuItem = event?.target?.textContent || 'Menu item';
+    window.alert(`You selected: ${menuItem.trim()}`);
   }
 }


### PR DESCRIPTION
## **Description**

Adding e2e automation tests for:
- Icon
- Loading
- Menu
- Progress Bar
- Calendar (update)
- Popover (covers all but last section)
- Switch

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**