### PR TITLE
test(Automation): Add data-automation-ids across all example pages to…

### DIFF
--- a/projects/novo-examples/src/components/agenda/agenda/agenda-example.html
+++ b/projects/novo-examples/src/components/agenda/agenda/agenda-example.html
@@ -1,18 +1,18 @@
-<div>
-  <novo-agenda-date-change [view]="view" [(viewDate)]="viewDate">
+<div data-automation-id="agenda-container">
+  <novo-agenda-date-change [view]="view" [(viewDate)]="viewDate" data-automation-id="agenda-date-change">
   </novo-agenda-date-change>
 
-  <novo-tiles [options]="views" [(ngModel)]="view"></novo-tiles>
+  <novo-tiles [options]="views" [(ngModel)]="view" data-automation-id="agenda-view-selector"></novo-tiles>
 </div>
-<div [ngSwitch]="view" class="cal-demo-content">
+<div [ngSwitch]="view" class="cal-demo-content" data-automation-id="agenda-content">
   <novo-agenda-month *ngSwitchCase="'month'" [(viewDate)]="viewDate" [events]="events"
-    (dayClicked)="dayClicked($event.day.date)">
+    (dayClicked)="dayClicked($event.day.date)" data-automation-id="agenda-month-view">
   </novo-agenda-month>
 
   <novo-agenda-week *ngSwitchCase="'week'" [(viewDate)]="viewDate" [events]="events"
-    (dayClicked)="dayClicked($event.date)" [dayStartHour]="0" [dayEndHour]="23">
+    (dayClicked)="dayClicked($event.date)" [dayStartHour]="0" [dayEndHour]="23" data-automation-id="agenda-week-view">
   </novo-agenda-week>
 
-  <novo-agenda-day *ngSwitchCase="'day'" [(viewDate)]="viewDate" [events]="events" [dayStartHour]="0" [dayEndHour]="23">
+  <novo-agenda-day *ngSwitchCase="'day'" [(viewDate)]="viewDate" [events]="events" [dayStartHour]="0" [dayEndHour]="23" data-automation-id="agenda-day-view">
   </novo-agenda-day>
 </div>

--- a/projects/novo-examples/src/components/autocomplete/autocomplete-stacked-chips/autocomplete-stacked-chips-example.html
+++ b/projects/novo-examples/src/components/autocomplete/autocomplete-stacked-chips/autocomplete-stacked-chips-example.html
@@ -1,14 +1,16 @@
-<novo-field class="example-chip-list">
+<novo-field class="example-chip-list" data-automation-id="stacked-chips-field">
   <novo-label>Shifts</novo-label>
   <novo-chip-list
     #chipList
     stacked
     aria-label="Shift selection"
     [formControl]="shiftCtrl"
-    [compareWith]="compareById">
+    [compareWith]="compareById"
+    data-automation-id="stacked-chips-list">
     <novo-chip
       *ngFor="let shift of chipList.value"
-      (removed)="remove(shift)">
+      (removed)="remove(shift)"
+      [attr.data-automation-id]="'stacked-chip-' + $index">
       <novo-flex gap="1rem">
         <novo-text>
           <novo-icon>calendar</novo-icon>
@@ -31,10 +33,11 @@
       autocomplete="off"
       placeholder="add shift..."
       [formControl]="searchCtrl"
-      (novoChipInputTokenEnd)="add($event)" />
+      (novoChipInputTokenEnd)="add($event)"
+      data-automation-id="stacked-chips-input" />
   </novo-chip-list>
-  <novo-autocomplete (optionSelected)="selected($event)" multiple>
-    <novo-option *ngFor="let shift of filteredShifts | async" [value]="shift">
+  <novo-autocomplete (optionSelected)="selected($event)" multiple data-automation-id="stacked-chips-autocomplete">
+    <novo-option *ngFor="let shift of filteredShifts | async; index as i" [value]="shift" [attr.data-automation-id]="'stacked-chips-option-' + i">
       <novo-text>
         <novo-icon>calendar</novo-icon>
         {{shift.startTime | isoDate}}

--- a/projects/novo-examples/src/components/autocomplete/autocomplete-stacked-chips/autocomplete-stacked-chips-example.html
+++ b/projects/novo-examples/src/components/autocomplete/autocomplete-stacked-chips/autocomplete-stacked-chips-example.html
@@ -8,9 +8,9 @@
     [compareWith]="compareById"
     data-automation-id="stacked-chips-list">
     <novo-chip
-      *ngFor="let shift of chipList.value"
+      *ngFor="let shift of chipList.value; index as i"
       (removed)="remove(shift)"
-      [attr.data-automation-id]="'stacked-chip-' + $index">
+      [attr.data-automation-id]="'stacked-chip-' + i">
       <novo-flex gap="1rem">
         <novo-text>
           <novo-icon>calendar</novo-icon>

--- a/projects/novo-examples/src/components/autocomplete/autocomplete-stacked-chips/autocomplete-stacked-chips-example.html
+++ b/projects/novo-examples/src/components/autocomplete/autocomplete-stacked-chips/autocomplete-stacked-chips-example.html
@@ -47,4 +47,4 @@
   </novo-autocomplete>
 </novo-field>
 
-<div>{{chipList.value}}</div>
+<div data-automation-id="stacked-chips-value">{{chipList.value}}</div>

--- a/projects/novo-examples/src/components/autocomplete/autocomplete-textarea/autocomplete-textarea-example.html
+++ b/projects/novo-examples/src/components/autocomplete/autocomplete-textarea/autocomplete-textarea-example.html
@@ -1,22 +1,23 @@
 <form class="example-form">
-  <novo-field class="example-full-width">
+  <novo-field class="example-full-width" data-automation-id="textarea-field">
     <novo-label>Number</novo-label>
     <textarea
       novoInput
       [formControl]="myControl"
       placeholder="Type $ to trigger autocomplete"
-      autocomplete="off"></textarea>
-    <novo-autocomplete [triggerOn]="triggerFn()" #auto>
-      <novo-option *ngFor="let option of filteredOptions | async" [value]="option">
+      autocomplete="off"
+      data-automation-id="textarea-input"></textarea>
+    <novo-autocomplete [triggerOn]="triggerFn()" #auto data-automation-id="textarea-autocomplete">
+      <novo-option *ngFor="let option of filteredOptions | async; index as i" [value]="option" [attr.data-automation-id]="'textarea-option-' + i">
         {{option}}
       </novo-option>
     </novo-autocomplete>
   </novo-field>
 
-  <novo-field appearance="fill">
+  <novo-field appearance="fill" data-automation-id="toppings-field">
     <novo-label>Toppings</novo-label>
-    <novo-select [formControl]="myOtherControl" multiple>
-      <novo-option *ngFor="let option of filteredOptions | async" [value]="option">{{option}}</novo-option>
+    <novo-select [formControl]="myOtherControl" multiple data-automation-id="toppings-select">
+      <novo-option *ngFor="let option of filteredOptions | async; index as i" [value]="option" [attr.data-automation-id]="'toppings-option-' + i">{{option}}</novo-option>
     </novo-select>
   </novo-field>
 </form>

--- a/projects/novo-examples/src/components/autocomplete/autocomplete-usage/autocomplete-usage-example.html
+++ b/projects/novo-examples/src/components/autocomplete/autocomplete-usage/autocomplete-usage-example.html
@@ -1,13 +1,14 @@
 <form class="example-form">
-  <novo-field class="example-full-width">
+  <novo-field class="example-full-width" data-automation-id="autocomplete-usage-field">
     <novo-label>Number</novo-label>
     <input type="text"
       novoInput
       [formControl]="myControl"
       placeholder="Pick one"
-      autocomplete="off" />
-    <novo-autocomplete #auto>
-      <novo-option *ngFor="let option of filteredOptions | async" [value]="option">
+      autocomplete="off"
+      data-automation-id="autocomplete-usage-input" />
+    <novo-autocomplete #auto data-automation-id="autocomplete-usage">
+      <novo-option *ngFor="let option of filteredOptions | async; index as i" [value]="option" [attr.data-automation-id]="'autocomplete-usage-option-' + i">
         {{option}}
       </novo-option>
     </novo-autocomplete>

--- a/projects/novo-examples/src/components/autocomplete/autocomplete-with-chips/autocomplete-with-chips-example.html
+++ b/projects/novo-examples/src/components/autocomplete/autocomplete-with-chips/autocomplete-with-chips-example.html
@@ -26,5 +26,5 @@
   </novo-autocomplete>
 </novo-field>
 
-<div>Chip List Value: {{fieldCtrl.value}}</div>
-<div>Search Input Control Value: {{searchCtrl.value}}</div>
+<div data-automation-id="chips-with-autocomplete-field-value">Chip List Value: {{fieldCtrl.value}}</div>
+<div data-automation-id="chips-with-autocomplete-search-value">Search Input Control Value: {{searchCtrl.value}}</div>

--- a/projects/novo-examples/src/components/autocomplete/autocomplete-with-chips/autocomplete-with-chips-example.html
+++ b/projects/novo-examples/src/components/autocomplete/autocomplete-with-chips/autocomplete-with-chips-example.html
@@ -1,10 +1,11 @@
-<novo-field class="example-chip-list">
+<novo-field class="example-chip-list" data-automation-id="chips-with-autocomplete-field">
   <novo-label>Favorite Fruits</novo-label>
-  <novo-chip-list #chipList aria-label="Fruit selection" [formControl]="fieldCtrl">
+  <novo-chip-list #chipList aria-label="Fruit selection" [formControl]="fieldCtrl" data-automation-id="chips-with-autocomplete-list">
     <novo-chip
-      *ngFor="let fruit of chipList.value"
+      *ngFor="let fruit of chipList.value; index as i"
       [value]="fruit"
-      (removed)="remove(fruit)">
+      (removed)="remove(fruit)"
+      [attr.data-automation-id]="'chips-with-autocomplete-chip-' + i">
       {{fruit}}
       <novo-icon novoChipRemove>close</novo-icon>
     </novo-chip>
@@ -15,10 +16,11 @@
       autocomplete="off"
       [formControl]="searchCtrl"
       [novoChipInputSeparatorKeyCodes]="separatorKeysCodes"
-      (novoChipInputTokenEnd)="add($event)" />
+      (novoChipInputTokenEnd)="add($event)"
+      data-automation-id="chips-with-autocomplete-input" />
   </novo-chip-list>
-  <novo-autocomplete makeFirstItemActive (optionSelected)="selected($event)" multiple>
-    <novo-option *ngFor="let fruit of filteredFruits | async" [value]="fruit">
+  <novo-autocomplete makeFirstItemActive (optionSelected)="selected($event)" multiple data-automation-id="chips-with-autocomplete">
+    <novo-option *ngFor="let fruit of filteredFruits | async; index as i" [value]="fruit" [attr.data-automation-id]="'chips-with-autocomplete-option-' + i">
       {{fruit}}
     </novo-option>
   </novo-autocomplete>

--- a/projects/novo-examples/src/components/breadcrumb/breadcrumb-source-usage/breadcrumb-source-usage-example.html
+++ b/projects/novo-examples/src/components/breadcrumb/breadcrumb-source-usage/breadcrumb-source-usage-example.html
@@ -1,3 +1,3 @@
-<section>
-  <novo-breadcrumb [source]="source"></novo-breadcrumb>
+<section data-automation-id="breadcrumb-source-section">
+  <novo-breadcrumb [source]="source" data-automation-id="breadcrumb-source"></novo-breadcrumb>
 </section>

--- a/projects/novo-examples/src/components/buttons/button-dialogue/button-dialogue-example.html
+++ b/projects/novo-examples/src/components/buttons/button-dialogue/button-dialogue-example.html
@@ -1,9 +1,9 @@
 <section>
   <div class="example-label">Default</div>
   <div class="example-button-row">
-    <button theme="dialogue" icon="addcard">Add Card</button>
-    <button theme="dialogue" icon="check" color="success">Dialogue</button>
-    <button theme="dialogue" disabled>Dialogue</button>
+    <button theme="dialogue" icon="addcard" data-automation-id="dialogue-add-card-button">Add Card</button>
+    <button theme="dialogue" icon="check" color="success" data-automation-id="dialogue-success-button">Dialogue</button>
+    <button theme="dialogue" disabled data-automation-id="dialogue-disabled-button">Dialogue</button>
   </div>
 </section>
 
@@ -12,9 +12,9 @@
 <section>
   <div class="example-label">Small</div>
   <div class="example-button-row">
-    <button theme="dialogue" icon="addcard" size="small">Add Card</button>
-    <button theme="dialogue" icon="check" color="success" size="small">Dialogue</button>
-    <button theme="dialogue" size="small" disabled>Dialogue</button>
+    <button theme="dialogue" icon="addcard" size="small" data-automation-id="dialogue-small-add-card-button">Add Card</button>
+    <button theme="dialogue" icon="check" color="success" size="small" data-automation-id="dialogue-small-success-button">Dialogue</button>
+    <button theme="dialogue" size="small" disabled data-automation-id="dialogue-small-disabled-button">Dialogue</button>
   </div>
 </section>
 
@@ -23,9 +23,9 @@
 <section>
   <div class="example-label">Large</div>
   <div class="example-button-row">
-    <button theme="dialogue" icon="addcard" size="large">Add Card</button>
-    <button theme="dialogue" icon="check" color="success" size="large">Dialogue</button>
-    <button theme="dialogue" size="large" disabled>Dialogue</button>
+    <button theme="dialogue" icon="addcard" size="large" data-automation-id="dialogue-large-add-card-button">Add Card</button>
+    <button theme="dialogue" icon="check" color="success" size="large" data-automation-id="dialogue-large-success-button">Dialogue</button>
+    <button theme="dialogue" size="large" disabled data-automation-id="dialogue-large-disabled-button">Dialogue</button>
   </div>
 </section>
 
@@ -34,9 +34,9 @@
 <section class="bgc-ocean">
   <div class="example-label tc-white">Inverse</div>
   <div class="example-button-row">
-    <button theme="dialogue" icon="list-o" side="left" color="white" inverse>Add/Remove</button>
-    <button theme="dialogue" icon="addcard" color="white" inverse>Add Card</button>
-    <button theme="dialogue" icon="check" color="success" inverse>Dialogue</button>
-    <button theme="dialogue" color="white" inverse disabled>Dialogue</button>
+    <button theme="dialogue" icon="list-o" side="left" color="white" inverse data-automation-id="dialogue-inverse-add-remove-button">Add/Remove</button>
+    <button theme="dialogue" icon="addcard" color="white" inverse data-automation-id="dialogue-inverse-add-card-button">Add Card</button>
+    <button theme="dialogue" icon="check" color="success" inverse data-automation-id="dialogue-inverse-success-button">Dialogue</button>
+    <button theme="dialogue" color="white" inverse disabled data-automation-id="dialogue-inverse-disabled-button">Dialogue</button>
   </div>
 </section>

--- a/projects/novo-examples/src/components/buttons/button-fab/button-fab-example.html
+++ b/projects/novo-examples/src/components/buttons/button-fab/button-fab-example.html
@@ -1,5 +1,5 @@
-<button theme="fab" color="success" icon="check"></button>
-<button theme="fab" color="warning" icon="caution-o"></button>
-<button theme="fab" color="pulse" icon="next"></button>
-<button theme="fab" color="grapefruit" icon="print" inverse></button>
-<button theme="fab" icon="neutral" inverse disabled></button>
+<button theme="fab" color="success" icon="check" data-automation-id="fab-success-button"></button>
+<button theme="fab" color="warning" icon="caution-o" data-automation-id="fab-warning-button"></button>
+<button theme="fab" color="pulse" icon="next" data-automation-id="fab-pulse-button"></button>
+<button theme="fab" color="grapefruit" icon="print" inverse data-automation-id="fab-grapefruit-button"></button>
+<button theme="fab" icon="neutral" inverse disabled data-automation-id="fab-disabled-button"></button>

--- a/projects/novo-examples/src/components/buttons/button-icon/button-icon-example.html
+++ b/projects/novo-examples/src/components/buttons/button-icon/button-icon-example.html
@@ -1,2 +1,2 @@
-<button theme="icon" icon="print"></button>
-<button theme="icon" icon="print"></button>
+<button theme="icon" icon="print" data-automation-id="icon-print-button-1"></button>
+<button theme="icon" icon="print" data-automation-id="icon-print-button-2"></button>

--- a/projects/novo-examples/src/components/buttons/button-inverse/button-inverse-example.html
+++ b/projects/novo-examples/src/components/buttons/button-inverse/button-inverse-example.html
@@ -1,5 +1,5 @@
 <div class="background candidate">
-  <button theme="secondary" icon="collapse" inverse>Actions</button>
-  <button theme="secondary" icon="convert" inverse>Convert</button>
-  <button theme="secondary" icon="convert" inverse disabled>Convert</button>
+  <button theme="secondary" icon="collapse" inverse data-automation-id="inverse-actions-button">Actions</button>
+  <button theme="secondary" icon="convert" inverse data-automation-id="inverse-convert-button">Convert</button>
+  <button theme="secondary" icon="convert" inverse disabled data-automation-id="inverse-convert-disabled-button">Convert</button>
 </div>

--- a/projects/novo-examples/src/components/buttons/button-overview/button-overview-example.html
+++ b/projects/novo-examples/src/components/buttons/button-overview/button-overview-example.html
@@ -1,11 +1,11 @@
 <section>
   <div class="example-label">Basic</div>
   <div class="example-button-row">
-    <button theme="dialogue">Default</button>
-    <button theme="dialogue" color="success">Success</button>
-    <button theme="dialogue" color="negative">Error</button>
-    <button theme="dialogue" color="warning">Warning</button>
-    <button theme="dialogue" disabled>Disabled</button>
+    <button theme="dialogue" data-automation-id="overview-dialogue-default-button">Default</button>
+    <button theme="dialogue" color="success" data-automation-id="overview-dialogue-success-button">Success</button>
+    <button theme="dialogue" color="negative" data-automation-id="overview-dialogue-error-button">Error</button>
+    <button theme="dialogue" color="warning" data-automation-id="overview-dialogue-warning-button">Warning</button>
+    <button theme="dialogue" disabled data-automation-id="overview-dialogue-disabled-button">Disabled</button>
   </div>
 </section>
 
@@ -14,11 +14,11 @@
 <section>
   <div class="example-label">Primary</div>
   <div class="example-button-row">
-    <button theme="primary">Default</button>
-    <button theme="primary" color="success">Success</button>
-    <button theme="primary" color="negative">Error</button>
-    <button theme="primary" color="warning">Warning</button>
-    <button theme="primary" disabled>Disabled</button>
+    <button theme="primary" data-automation-id="overview-primary-default-button">Default</button>
+    <button theme="primary" color="success" data-automation-id="overview-primary-success-button">Success</button>
+    <button theme="primary" color="negative" data-automation-id="overview-primary-error-button">Error</button>
+    <button theme="primary" color="warning" data-automation-id="overview-primary-warning-button">Warning</button>
+    <button theme="primary" disabled data-automation-id="overview-primary-disabled-button">Disabled</button>
   </div>
 </section>
 
@@ -27,11 +27,11 @@
 <section>
   <div class="example-label">Secondary</div>
   <div class="example-button-row">
-    <button theme="secondary">Default</button>
-    <button theme="secondary" color="success">Success</button>
-    <button theme="secondary" color="negative">Error</button>
-    <button theme="secondary" color="warning">Warning</button>
-    <button theme="secondary" disabled>Disabled</button>
+    <button theme="secondary" data-automation-id="overview-secondary-default-button">Default</button>
+    <button theme="secondary" color="success" data-automation-id="overview-secondary-success-button">Success</button>
+    <button theme="secondary" color="negative" data-automation-id="overview-secondary-error-button">Error</button>
+    <button theme="secondary" color="warning" data-automation-id="overview-secondary-warning-button">Warning</button>
+    <button theme="secondary" disabled data-automation-id="overview-secondary-disabled-button">Disabled</button>
   </div>
 </section>
 
@@ -40,11 +40,11 @@
 <section>
   <div class="example-label">Icon</div>
   <div class="example-button-row">
-    <button theme="icon" icon="print"></button>
-    <button theme="icon" icon="check" color="success"></button>
-    <button theme="icon" icon="bell" color="negative"></button>
-    <button theme="icon" icon="caution" color="warning"></button>
-    <button theme="icon" icon="rocket" disabled></button>
+    <button theme="icon" icon="print" data-automation-id="overview-icon-print-button"></button>
+    <button theme="icon" icon="check" color="success" data-automation-id="overview-icon-check-button"></button>
+    <button theme="icon" icon="bell" color="negative" data-automation-id="overview-icon-bell-button"></button>
+    <button theme="icon" icon="caution" color="warning" data-automation-id="overview-icon-caution-button"></button>
+    <button theme="icon" icon="rocket" disabled data-automation-id="overview-icon-rocket-button"></button>
   </div>
 </section>
 
@@ -53,14 +53,14 @@
 <section>
   <div class="example-label">Fab</div>
   <div class="example-button-row">
-    <button theme="fab">
+    <button theme="fab" data-automation-id="overview-fab-print-button">
       <novo-icon>print</novo-icon>
     </button>
-    <button theme="fab" color="success">
+    <button theme="fab" color="success" data-automation-id="overview-fab-check-button">
       <novo-icon>check</novo-icon>
     </button>
-    <button theme="fab" icon="bell" color="negative"></button>
-    <button theme="fab" icon="caution-o" color="warning"></button>
-    <button theme="fab" icon="rocket" disabled></button>
+    <button theme="fab" icon="bell" color="negative" data-automation-id="overview-fab-bell-button"></button>
+    <button theme="fab" icon="caution-o" color="warning" data-automation-id="overview-fab-caution-button"></button>
+    <button theme="fab" icon="rocket" disabled data-automation-id="overview-fab-rocket-button"></button>
   </div>
 </section>

--- a/projects/novo-examples/src/components/buttons/button-primary/button-primary-example.html
+++ b/projects/novo-examples/src/components/buttons/button-primary/button-primary-example.html
@@ -1,11 +1,11 @@
 <section>
   <div class="example-label">Default</div>
   <div class="example-button-row">
-    <button theme="primary" icon="next">Next</button>
-    <button theme="primary" [color]="negativeColor" icon="times">Cancel</button>
-    <button theme="primary" color="success" icon="check">Save</button>
-    <button theme="primary" color="warning" icon="caution-o">Caution</button>
-    <button theme="primary" color="pulse" icon="send" disabled>Submit</button>
+    <button theme="primary" icon="next" data-automation-id="primary-next-button">Next</button>
+    <button theme="primary" [color]="negativeColor" icon="times" data-automation-id="primary-cancel-button">Cancel</button>
+    <button theme="primary" color="success" icon="check" data-automation-id="primary-save-button">Save</button>
+    <button theme="primary" color="warning" icon="caution-o" data-automation-id="primary-caution-button">Caution</button>
+    <button theme="primary" color="pulse" icon="send" disabled data-automation-id="primary-submit-button">Submit</button>
   </div>
 </section>
 
@@ -14,11 +14,11 @@
 <section>
   <div class="example-label">Small</div>
   <div class="example-button-row">
-    <button theme="primary" icon="next" size="small">Next</button>
-    <button theme="primary" [color]="negativeColor" icon="x" size="small">Cancel</button>
-    <button theme="primary" color="success" icon="check" size="small">Save</button>
-    <button theme="primary" color="warning" icon="caution-o" size="small">Caution</button>
-    <button theme="primary" color="pulse" icon="send" size="small" disabled>Submit</button>
+    <button theme="primary" icon="next" size="small" data-automation-id="primary-small-next-button">Next</button>
+    <button theme="primary" [color]="negativeColor" icon="x" size="small" data-automation-id="primary-small-cancel-button">Cancel</button>
+    <button theme="primary" color="success" icon="check" size="small" data-automation-id="primary-small-save-button">Save</button>
+    <button theme="primary" color="warning" icon="caution-o" size="small" data-automation-id="primary-small-caution-button">Caution</button>
+    <button theme="primary" color="pulse" icon="send" size="small" disabled data-automation-id="primary-small-submit-button">Submit</button>
   </div>
 </section>
 
@@ -27,10 +27,10 @@
 <section>
   <div class="example-label">Large</div>
   <div class="example-button-row">
-    <button theme="primary" icon="next" size="large">Next</button>
-    <button theme="primary" [color]="negativeColor" icon="times" size="large">Cancel</button>
-    <button theme="primary" color="success" icon="check" size="large">Save</button>
-    <button theme="primary" color="warning" icon="caution-o" size="large">Caution</button>
-    <button theme="primary" color="pulse" icon="send" size="large" disabled>Submit</button>
+    <button theme="primary" icon="next" size="large" data-automation-id="primary-large-next-button">Next</button>
+    <button theme="primary" [color]="negativeColor" icon="times" size="large" data-automation-id="primary-large-cancel-button">Cancel</button>
+    <button theme="primary" color="success" icon="check" size="large" data-automation-id="primary-large-save-button">Save</button>
+    <button theme="primary" color="warning" icon="caution-o" size="large" data-automation-id="primary-large-caution-button">Caution</button>
+    <button theme="primary" color="pulse" icon="send" size="large" disabled data-automation-id="primary-large-submit-button">Submit</button>
   </div>
 </section>

--- a/projects/novo-examples/src/components/buttons/button-secondary/button-secondary-example.html
+++ b/projects/novo-examples/src/components/buttons/button-secondary/button-secondary-example.html
@@ -1,8 +1,8 @@
 <section>
   <div class="example-label">Default</div>
   <div class="example-button-row">
-    <button theme="secondary">Secondary</button>
-    <button theme="secondary" disabled>Secondary</button>
+    <button theme="secondary" data-automation-id="secondary-button">Secondary</button>
+    <button theme="secondary" disabled data-automation-id="secondary-disabled-button">Secondary</button>
   </div>
 </section>
 
@@ -11,8 +11,8 @@
 <section>
   <div class="example-label">Small</div>
   <div class="example-button-row">
-    <button theme="secondary" size="small">Secondary</button>
-    <button theme="secondary" size="small" disabled>Secondary</button>
+    <button theme="secondary" size="small" data-automation-id="secondary-small-button">Secondary</button>
+    <button theme="secondary" size="small" disabled data-automation-id="secondary-small-disabled-button">Secondary</button>
   </div>
 </section>
 
@@ -21,16 +21,16 @@
 <section>
   <div class="example-label">Large</div>
   <div class="example-button-row">
-    <button theme="secondary" size="large">Secondary</button>
-    <button theme="secondary" size="large" disabled>Secondary</button>
+    <button theme="secondary" size="large" data-automation-id="secondary-large-button">Secondary</button>
+    <button theme="secondary" size="large" disabled data-automation-id="secondary-large-disabled-button">Secondary</button>
   </div>
 </section>
 
 <section class="bgc-ocean">
   <div class="example-label tc-white">Inverse</div>
   <div class="example-button-row">
-    <button theme="secondary" inverse>Actions</button>
-    <button theme="secondary" color="negative" inverse>Issues</button>
-    <button theme="secondary" icon="convert" inverse disabled>Convert</button>
+    <button theme="secondary" inverse data-automation-id="secondary-inverse-actions-button">Actions</button>
+    <button theme="secondary" color="negative" inverse data-automation-id="secondary-inverse-issues-button">Issues</button>
+    <button theme="secondary" icon="convert" inverse disabled data-automation-id="secondary-inverse-convert-button">Convert</button>
   </div>
 </section>

--- a/projects/novo-examples/src/components/buttons/button-standard/button-standard-example.html
+++ b/projects/novo-examples/src/components/buttons/button-standard/button-standard-example.html
@@ -1,3 +1,3 @@
-<button theme="standard">Standard</button>
-<button theme="standard" color="light">Standard</button>
-<button theme="standard" color="light" disabled>Standard</button>
+<button theme="standard" data-automation-id="standard-button">Standard</button>
+<button theme="standard" color="light" data-automation-id="standard-light-button">Standard</button>
+<button theme="standard" color="light" disabled data-automation-id="standard-light-disabled-button">Standard</button>

--- a/projects/novo-examples/src/components/buttons/button-two-icon/button-two-icon-example.html
+++ b/projects/novo-examples/src/components/buttons/button-two-icon/button-two-icon-example.html
@@ -1,2 +1,2 @@
-<button theme="primary" icon="edit" secondIcon="arrow-right">Two Icons</button>
-<button theme="primary" icon="bolt" secondIcon="configure-o" side="right">Two Icons</button>
+<button theme="primary" icon="edit" secondIcon="arrow-right" data-automation-id="two-icon-edit-arrow-button">Two Icons</button>
+<button theme="primary" icon="bolt" secondIcon="configure-o" side="right" data-automation-id="two-icon-bolt-configure-button">Two Icons</button>

--- a/projects/novo-examples/src/components/calendar/time/time-example.html
+++ b/projects/novo-examples/src/components/calendar/time/time-example.html
@@ -1,7 +1,7 @@
-<div class="calendar-demo-side-by-side">
-    <p>
+<div class="calendar-demo-side-by-side" data-automation-id="time-picker-container">
+    <p data-automation-id="time-display">
         <label>Value</label> {{(time | date:'mediumTime') || 'N/A'}}
     </p>
-    <novo-time-picker [(ngModel)]="time"></novo-time-picker>
-    <novo-time-picker [(ngModel)]="time" military="true"></novo-time-picker>
+    <novo-time-picker [(ngModel)]="time" data-automation-id="time-picker-standard"></novo-time-picker>
+    <novo-time-picker [(ngModel)]="time" military="true" data-automation-id="time-picker-military"></novo-time-picker>
 </div>

--- a/projects/novo-examples/src/components/data-table/data-table-remote/data-table-remote-example.html
+++ b/projects/novo-examples/src/components/data-table/data-table-remote/data-table-remote-example.html
@@ -4,7 +4,8 @@
                  [hideGlobalSearch]="!globalSearchEnabled"
                  [displayedColumns]="sharedDisplayColumns"
                  [paginationOptions]="widePaginationOptions"
-                 [fixedHeader]="true">
+                 [fixedHeader]="true"
+                 data-automation-id="remote-data-table">
   <!-- Custom Cell -- passed with template property on Column -->
   <ng-template novoTemplate="custom"
                let-row

--- a/projects/novo-examples/src/components/data-table/data-table-rows/data-table-rows-example.html
+++ b/projects/novo-examples/src/components/data-table/data-table-rows/data-table-rows-example.html
@@ -1,22 +1,22 @@
 <h6>Change Dataset</h6>
-<novo-tiles [options]="dataSetOptions" (onChange)="loadDataset($event)" [(ngModel)]="loadedDataSet"></novo-tiles>
+<novo-tiles [options]="dataSetOptions" (onChange)="loadDataset($event)" [(ngModel)]="loadedDataSet" data-automation-id="dataset-tiles"></novo-tiles>
 <h6>Change Pagination Style</h6>
 <novo-tiles [options]="paginationTypeOptions" (onChange)="switchPaginationType($event)"
-  [(ngModel)]="loadedPaginationType"></novo-tiles>
+  [(ngModel)]="loadedPaginationType" data-automation-id="pagination-type-tiles"></novo-tiles>
 <h6>Change Pagination Placement</h6>
 <novo-tiles [options]="paginationPlacementOptions" (onChange)="switchPaginationPlacement($event)"
-  [(ngModel)]="loadedPaginationPlacement"></novo-tiles>
+  [(ngModel)]="loadedPaginationPlacement" data-automation-id="pagination-placement-tiles"></novo-tiles>
 <h6>Toggle Global Search</h6>
-<novo-tiles [options]="globalSearchOptions" (onChange)="toggleGlobalSearch($event)" [(ngModel)]="loadedGlobalSearch">
+<novo-tiles [options]="globalSearchOptions" (onChange)="toggleGlobalSearch($event)" [(ngModel)]="loadedGlobalSearch" data-automation-id="global-search-tiles">
 </novo-tiles>
 <h6>Configure Columns</h6>
-<button theme="primary" (click)="configureColumns()">Configure Columns</button>
+<button theme="primary" (click)="configureColumns()" data-automation-id="configure-columns-button">Configure Columns</button>
 <h6>Configure Columns</h6>
-<button theme="primary" (click)="toggleRowDetails(true)">Show Row Details (first table)</button>
-<button theme="primary" (click)="toggleRowDetails(false)">Hide Row Details (first table)</button>
+<button theme="primary" (click)="toggleRowDetails(true)" data-automation-id="show-row-details-button">Show Row Details (first table)</button>
+<button theme="primary" (click)="toggleRowDetails(false)" data-automation-id="hide-row-details-button">Hide Row Details (first table)</button>
 <h6>Enable Selection Retention</h6>
 <novo-checkbox label="Paginated Selection Retention Enabled" [(ngModel)]="retentionEnabled"
-  (ngModelChange)="toggle($event)"></novo-checkbox>
+  (ngModelChange)="toggle($event)" data-automation-id="retention-enabled-checkbox"></novo-checkbox>
 Selection retention can be configured to keep records selected across pagination, sorting, and filtering
 
 <div class="fixedWindowSize">
@@ -35,31 +35,33 @@ Selection retention can be configured to keep records selected across pagination
     (toggledFilter)="processCustomFilter($event)"
     [activeRowIdentifier]="selectedRecordId"
     [fixedHeader]="true"
+    data-automation-id="rows-data-table"
     #basic>
     <!-- Custom Header -->
     <ng-template novoTemplate="customHeader">
-      <div class="custom-header-buttons">
+      <div class="custom-header-buttons" data-automation-id="table-header">
         <button theme="secondary"
-        (click)="configureColumns()">Config</button>
-        <span>Total: {{ basic.dataSource.currentTotal }}</span>
+        (click)="configureColumns()" data-automation-id="header-config-button">Config</button>
+        <span data-automation-id="total-count">Total: {{ basic.dataSource.currentTotal }}</span>
       </div>
     </ng-template>
     <!-- Custom Actions -->
     <ng-template novoTemplate="customActions">
-      <novo-data-table-clear-button *ngIf="basic.state.userFiltered"></novo-data-table-clear-button>
+      <novo-data-table-clear-button *ngIf="basic.state.userFiltered" data-automation-id="clear-filter-button"></novo-data-table-clear-button>
       <button theme="secondary"
-        (click)="refresh()">Refresh</button>
-      <novo-dropdown side="right">
+        (click)="refresh()" data-automation-id="refresh-button">Refresh</button>
+      <novo-dropdown side="right" data-automation-id="actions-dropdown">
         <button theme="primary"
           icon="collapse"
-          inverse>
+          inverse
+          data-automation-id="actions-button">
           <span *ngIf="basic.state.selected.length === 0">Actions</span>
           <span *ngIf="basic.state.selected.length !== 0">{{ basic.state.selected.length }}!</span>
         </button>
         <list>
-          <item>Action 1</item>
-          <item>Action 2</item>
-          <item [disabled]="basic.state.selected.length === 0">Action 3</item>
+          <item data-automation-id="action-1">Action 1</item>
+          <item data-automation-id="action-2">Action 2</item>
+          <item [disabled]="basic.state.selected.length === 0" data-automation-id="action-3">Action 3</item>
         </list>
       </novo-dropdown>
     </ng-template>
@@ -87,7 +89,7 @@ Selection retention can be configured to keep records selected across pagination
     <!-- Custom Status Filter -->
     <ng-template novoTemplate="column-filter-status">
       <novo-tiles [options]="customStatusColumnOptions" (onChange)="filterList($event)" padding="md"
-        [(ngModel)]="customStatusColumnValue"></novo-tiles>
+        [(ngModel)]="customStatusColumnValue" data-automation-id="status-filter-tiles"></novo-tiles>
     </ng-template>
   </novo-data-table>
 </div>

--- a/projects/novo-examples/src/components/data-table/data-table-service/data-table-service-example.html
+++ b/projects/novo-examples/src/components/data-table/data-table-service/data-table-service-example.html
@@ -3,7 +3,8 @@
                  [allowMultipleFilters]="true"
                  [hideGlobalSearch]="!globalSearchEnabled"
                  [displayedColumns]="sharedDisplayColumns"
-                 [paginationOptions]="sharedPaginationOptions">
+                 [paginationOptions]="sharedPaginationOptions"
+                 data-automation-id="service-data-table">
   <!-- Custom Cell -- passed with template property on Column -->
   <ng-template novoTemplate="custom"
                let-row

--- a/projects/novo-examples/src/components/dropdown/custom-drop-down/custom-drop-down-example.html
+++ b/projects/novo-examples/src/components/dropdown/custom-drop-down/custom-drop-down-example.html
@@ -1,11 +1,13 @@
 <novo-dropdown containerClass="custom-class"
-  scrollStrategy="close">
+  scrollStrategy="close"
+  data-automation-id="custom-dropdown">
   <button type="button"
     theme="secondary"
     icon="collapse"
-    inverse>I Have A Custom Class!</button>
+    inverse
+    data-automation-id="custom-dropdown-button">I Have A Custom Class!</button>
   <novo-optgroup>
-    <novo-option (action)="clickMe('Hello!')">Action 1</novo-option>
-    <novo-option (action)="clickMe('Another!')">Action 2</novo-option>
+    <novo-option (action)="clickMe('Hello!')" data-automation-id="custom-action-1">Action 1</novo-option>
+    <novo-option (action)="clickMe('Another!')" data-automation-id="custom-action-2">Action 2</novo-option>
   </novo-optgroup>
 </novo-dropdown>

--- a/projects/novo-examples/src/components/dropdown/large-drop-down/large-drop-down-example.html
+++ b/projects/novo-examples/src/components/dropdown/large-drop-down/large-drop-down-example.html
@@ -1,10 +1,12 @@
-<novo-dropdown height="250">
+<novo-dropdown height="250" data-automation-id="large-dropdown">
   <button type="button"
     theme="secondary"
     icon="collapse"
-    inverse>Lots of Data Points!</button>
+    inverse
+    data-automation-id="large-dropdown-button">Lots of Data Points!</button>
   <novo-optgroup>
     <novo-option *ngFor="let name of MOCK_WORDS"
-      (action)="clickMe(name)">{{ name }}</novo-option>
+      (action)="clickMe(name)"
+      [attr.data-automation-id]="'large-option-' + name">{{ name }}</novo-option>
   </novo-optgroup>
 </novo-dropdown>

--- a/projects/novo-examples/src/components/dropdown/multi-drop-down/multi-drop-down-example.html
+++ b/projects/novo-examples/src/components/dropdown/multi-drop-down/multi-drop-down-example.html
@@ -1,33 +1,34 @@
-<novo-dropdown keepOpen>
+<novo-dropdown keepOpen data-automation-id="keep-open-dropdown">
   <novo-button type="button"
     theme="secondary"
     icon="collapse"
-    inverse>Keep Open</novo-button>
-  <novo-field class="dropdown-search">
-    <input novoInput placeholder="Search..." type="search" width="100%" />
+    inverse
+    data-automation-id="keep-open-button">Keep Open</novo-button>
+  <novo-field class="dropdown-search" data-automation-id="dropdown-search-field">
+    <input novoInput placeholder="Search..." type="search" width="100%" data-automation-id="dropdown-search-input" />
     <novo-icon novoPrefix>search</novo-icon>
   </novo-field>
   <novo-divider></novo-divider>
   <novo-optgroup>
-    <novo-option (click)="clickMe('Hello!')">Action 1</novo-option>
-    <novo-option (click)="clickMe('Another!')">Action 2</novo-option>
+    <novo-option (click)="clickMe('Hello!')" data-automation-id="action-1">Action 1</novo-option>
+    <novo-option (click)="clickMe('Another!')" data-automation-id="action-2">Action 2</novo-option>
   </novo-optgroup>
   <novo-divider></novo-divider>
-  <div class="dropdown-footer">
-    <button theme="dialogue" icon="add-thin">Add</button>
+  <div class="dropdown-footer" data-automation-id="dropdown-footer">
+    <button theme="dialogue" icon="add-thin" data-automation-id="add-button">Add</button>
   </div>
 </novo-dropdown>
 
-<novo-dropdown side="right" multiple>
-  <novo-button theme="secondary" icon="overview" side="left">Hide/Show</novo-button>
-  <novo-option>Action 1</novo-option>
-  <novo-option tooltip="Test tooltip :)" tooltipPosition="left">Action 2</novo-option>
-  <novo-option>Action 3</novo-option>
-  <novo-option>Action 4</novo-option>
-  <novo-option>Action 5</novo-option>
-  <novo-option>Action 6</novo-option>
-  <novo-option>Action 7</novo-option>
-  <novo-option>Action 8</novo-option>
-  <novo-option>Action 9</novo-option>
-  <novo-option>Action 10</novo-option>
+<novo-dropdown side="right" multiple data-automation-id="multi-select-dropdown">
+  <novo-button theme="secondary" icon="overview" side="left" data-automation-id="multi-select-button">Hide/Show</novo-button>
+  <novo-option data-automation-id="multi-action-1">Action 1</novo-option>
+  <novo-option tooltip="Test tooltip :)" tooltipPosition="left" data-automation-id="multi-action-2">Action 2</novo-option>
+  <novo-option data-automation-id="multi-action-3">Action 3</novo-option>
+  <novo-option data-automation-id="multi-action-4">Action 4</novo-option>
+  <novo-option data-automation-id="multi-action-5">Action 5</novo-option>
+  <novo-option data-automation-id="multi-action-6">Action 6</novo-option>
+  <novo-option data-automation-id="multi-action-7">Action 7</novo-option>
+  <novo-option data-automation-id="multi-action-8">Action 8</novo-option>
+  <novo-option data-automation-id="multi-action-9">Action 9</novo-option>
+  <novo-option data-automation-id="multi-action-10">Action 10</novo-option>
 </novo-dropdown>

--- a/projects/novo-examples/src/components/dropdown/position-drop-down/position-drop-down-example.html
+++ b/projects/novo-examples/src/components/dropdown/position-drop-down/position-drop-down-example.html
@@ -1,8 +1,9 @@
-<novo-dropdown side="default">
+<novo-dropdown side="default" data-automation-id="position-default">
   <button type="button"
     theme="secondary"
     icon="collapse"
-    inverse>Default</button>
+    inverse
+    data-automation-id="position-default-button">Default</button>
   <novo-optgroup>
     <novo-option>Five</novo-option>
     <novo-option>Items</novo-option>
@@ -11,11 +12,12 @@
     <novo-option>Test</novo-option>
   </novo-optgroup>
 </novo-dropdown>
-<novo-dropdown side="right">
+<novo-dropdown side="right" data-automation-id="position-right">
   <button type="button"
     theme="secondary"
     icon="collapse"
-    inverse>Right</button>
+    inverse
+    data-automation-id="position-right-button">Right</button>
   <novo-optgroup>
     <novo-option>Five</novo-option>
     <novo-option>Items</novo-option>
@@ -24,11 +26,12 @@
     <novo-option>Test</novo-option>
   </novo-optgroup>
 </novo-dropdown>
-<novo-dropdown side="above-below">
+<novo-dropdown side="above-below" data-automation-id="position-above-below">
   <button type="button"
     theme="secondary"
     icon="collapse"
-    inverse>Above-below</button>
+    inverse
+    data-automation-id="position-above-below-button">Above-below</button>
   <novo-optgroup>
     <novo-option>Five</novo-option>
     <novo-option>Items</novo-option>
@@ -37,11 +40,12 @@
     <novo-option>Test</novo-option>
   </novo-optgroup>
 </novo-dropdown>
-<novo-dropdown side="right-above-below">
+<novo-dropdown side="right-above-below" data-automation-id="position-right-above-below">
   <button type="button"
     theme="secondary"
     icon="collapse"
-    inverse>Right-Above-Below</button>
+    inverse
+    data-automation-id="position-right-above-below-button">Right-Above-Below</button>
   <novo-optgroup>
     <novo-option>Five</novo-option>
     <novo-option>Items</novo-option>
@@ -50,11 +54,12 @@
     <novo-option>Test</novo-option>
   </novo-optgroup>
 </novo-dropdown>
-<novo-dropdown side="center">
+<novo-dropdown side="center" data-automation-id="position-center">
   <button type="button"
     theme="secondary"
     icon="collapse"
-    inverse>Center</button>
+    inverse
+    data-automation-id="position-center-button">Center</button>
   <novo-optgroup>
     <novo-option>Five</novo-option>
     <novo-option>Items</novo-option>
@@ -63,11 +68,12 @@
     <novo-option>Test</novo-option>
   </novo-optgroup>
 </novo-dropdown>
-<novo-dropdown side="bottom">
+<novo-dropdown side="bottom" data-automation-id="position-bottom">
   <button type="button"
     theme="secondary"
     icon="collapse"
-    inverse>Bottom</button>
+    inverse
+    data-automation-id="position-bottom-button">Bottom</button>
   <novo-optgroup>
     <novo-option>Five</novo-option>
     <novo-option>Items</novo-option>
@@ -76,11 +82,12 @@
     <novo-option>Test</novo-option>
   </novo-optgroup>
 </novo-dropdown>
-<novo-dropdown side="bottom-left">
+<novo-dropdown side="bottom-left" data-automation-id="position-bottom-left">
   <button type="button"
     theme="secondary"
     icon="collapse"
-    inverse>Bottom-Left</button>
+    inverse
+    data-automation-id="position-bottom-left-button">Bottom-Left</button>
   <novo-optgroup>
     <novo-option>Five</novo-option>
     <novo-option>Items</novo-option>
@@ -89,11 +96,12 @@
     <novo-option>Test</novo-option>
   </novo-optgroup>
 </novo-dropdown>
-<novo-dropdown side="bottom-right">
+<novo-dropdown side="bottom-right" data-automation-id="position-bottom-right">
   <button type="button"
     theme="secondary"
     icon="collapse"
-    inverse>Bottom-Right</button>
+    inverse
+    data-automation-id="position-bottom-right-button">Bottom-Right</button>
   <novo-optgroup>
     <novo-option>Five</novo-option>
     <novo-option>Items</novo-option>
@@ -102,11 +110,12 @@
     <novo-option>Test</novo-option>
   </novo-optgroup>
 </novo-dropdown>
-<novo-dropdown side="top-left">
+<novo-dropdown side="top-left" data-automation-id="position-top-left">
   <button type="button"
     theme="secondary"
     icon="collapse"
-    inverse>Top-Left</button>
+    inverse
+    data-automation-id="position-top-left-button">Top-Left</button>
   <novo-optgroup>
     <novo-option>Five</novo-option>
     <novo-option>Items</novo-option>
@@ -115,11 +124,12 @@
     <novo-option>Test</novo-option>
   </novo-optgroup>
 </novo-dropdown>
-<novo-dropdown side="top-right">
+<novo-dropdown side="top-right" data-automation-id="position-top-right">
   <button type="button"
     theme="secondary"
     icon="collapse"
-    inverse>Top-Right</button>
+    inverse
+    data-automation-id="position-top-right-button">Top-Right</button>
   <novo-optgroup>
     <novo-option>Five</novo-option>
     <novo-option>Items</novo-option>

--- a/projects/novo-examples/src/components/dropdown/position-drop-down/position-drop-down-example.html
+++ b/projects/novo-examples/src/components/dropdown/position-drop-down/position-drop-down-example.html
@@ -5,11 +5,11 @@
     inverse
     data-automation-id="position-default-button">Default</button>
   <novo-optgroup>
-    <novo-option>Five</novo-option>
-    <novo-option>Items</novo-option>
-    <novo-option>For</novo-option>
-    <novo-option>Position</novo-option>
-    <novo-option>Test</novo-option>
+    <novo-option data-automation-id="position-default-option-five">Five</novo-option>
+    <novo-option data-automation-id="position-default-option-items">Items</novo-option>
+    <novo-option data-automation-id="position-default-option-for">For</novo-option>
+    <novo-option data-automation-id="position-default-option-position">Position</novo-option>
+    <novo-option data-automation-id="position-default-option-test">Test</novo-option>
   </novo-optgroup>
 </novo-dropdown>
 <novo-dropdown side="right" data-automation-id="position-right">
@@ -19,11 +19,11 @@
     inverse
     data-automation-id="position-right-button">Right</button>
   <novo-optgroup>
-    <novo-option>Five</novo-option>
-    <novo-option>Items</novo-option>
-    <novo-option>For</novo-option>
-    <novo-option>Position</novo-option>
-    <novo-option>Test</novo-option>
+    <novo-option data-automation-id="position-right-option-five">Five</novo-option>
+    <novo-option data-automation-id="position-right-option-items">Items</novo-option>
+    <novo-option data-automation-id="position-right-option-for">For</novo-option>
+    <novo-option data-automation-id="position-right-option-position">Position</novo-option>
+    <novo-option data-automation-id="position-right-option-test">Test</novo-option>
   </novo-optgroup>
 </novo-dropdown>
 <novo-dropdown side="above-below" data-automation-id="position-above-below">
@@ -33,11 +33,11 @@
     inverse
     data-automation-id="position-above-below-button">Above-below</button>
   <novo-optgroup>
-    <novo-option>Five</novo-option>
-    <novo-option>Items</novo-option>
-    <novo-option>For</novo-option>
-    <novo-option>Position</novo-option>
-    <novo-option>Test</novo-option>
+    <novo-option data-automation-id="position-above-below-option-five">Five</novo-option>
+    <novo-option data-automation-id="position-above-below-option-items">Items</novo-option>
+    <novo-option data-automation-id="position-above-below-option-for">For</novo-option>
+    <novo-option data-automation-id="position-above-below-option-position">Position</novo-option>
+    <novo-option data-automation-id="position-above-below-option-test">Test</novo-option>
   </novo-optgroup>
 </novo-dropdown>
 <novo-dropdown side="right-above-below" data-automation-id="position-right-above-below">
@@ -47,11 +47,11 @@
     inverse
     data-automation-id="position-right-above-below-button">Right-Above-Below</button>
   <novo-optgroup>
-    <novo-option>Five</novo-option>
-    <novo-option>Items</novo-option>
-    <novo-option>For</novo-option>
-    <novo-option>Position</novo-option>
-    <novo-option>Test</novo-option>
+    <novo-option data-automation-id="position-right-above-below-option-five">Five</novo-option>
+    <novo-option data-automation-id="position-right-above-below-option-items">Items</novo-option>
+    <novo-option data-automation-id="position-right-above-below-option-for">For</novo-option>
+    <novo-option data-automation-id="position-right-above-below-option-position">Position</novo-option>
+    <novo-option data-automation-id="position-right-above-below-option-test">Test</novo-option>
   </novo-optgroup>
 </novo-dropdown>
 <novo-dropdown side="center" data-automation-id="position-center">
@@ -61,11 +61,11 @@
     inverse
     data-automation-id="position-center-button">Center</button>
   <novo-optgroup>
-    <novo-option>Five</novo-option>
-    <novo-option>Items</novo-option>
-    <novo-option>For</novo-option>
-    <novo-option>Position</novo-option>
-    <novo-option>Test</novo-option>
+    <novo-option data-automation-id="position-center-option-five">Five</novo-option>
+    <novo-option data-automation-id="position-center-option-items">Items</novo-option>
+    <novo-option data-automation-id="position-center-option-for">For</novo-option>
+    <novo-option data-automation-id="position-center-option-position">Position</novo-option>
+    <novo-option data-automation-id="position-center-option-test">Test</novo-option>
   </novo-optgroup>
 </novo-dropdown>
 <novo-dropdown side="bottom" data-automation-id="position-bottom">
@@ -75,11 +75,11 @@
     inverse
     data-automation-id="position-bottom-button">Bottom</button>
   <novo-optgroup>
-    <novo-option>Five</novo-option>
-    <novo-option>Items</novo-option>
-    <novo-option>For</novo-option>
-    <novo-option>Position</novo-option>
-    <novo-option>Test</novo-option>
+    <novo-option data-automation-id="position-bottom-option-five">Five</novo-option>
+    <novo-option data-automation-id="position-bottom-option-items">Items</novo-option>
+    <novo-option data-automation-id="position-bottom-option-for">For</novo-option>
+    <novo-option data-automation-id="position-bottom-option-position">Position</novo-option>
+    <novo-option data-automation-id="position-bottom-option-test">Test</novo-option>
   </novo-optgroup>
 </novo-dropdown>
 <novo-dropdown side="bottom-left" data-automation-id="position-bottom-left">
@@ -89,11 +89,11 @@
     inverse
     data-automation-id="position-bottom-left-button">Bottom-Left</button>
   <novo-optgroup>
-    <novo-option>Five</novo-option>
-    <novo-option>Items</novo-option>
-    <novo-option>For</novo-option>
-    <novo-option>Position</novo-option>
-    <novo-option>Test</novo-option>
+    <novo-option data-automation-id="position-bottom-left-option-five">Five</novo-option>
+    <novo-option data-automation-id="position-bottom-left-option-items">Items</novo-option>
+    <novo-option data-automation-id="position-bottom-left-option-for">For</novo-option>
+    <novo-option data-automation-id="position-bottom-left-option-position">Position</novo-option>
+    <novo-option data-automation-id="position-bottom-left-option-test">Test</novo-option>
   </novo-optgroup>
 </novo-dropdown>
 <novo-dropdown side="bottom-right" data-automation-id="position-bottom-right">
@@ -103,11 +103,11 @@
     inverse
     data-automation-id="position-bottom-right-button">Bottom-Right</button>
   <novo-optgroup>
-    <novo-option>Five</novo-option>
-    <novo-option>Items</novo-option>
-    <novo-option>For</novo-option>
-    <novo-option>Position</novo-option>
-    <novo-option>Test</novo-option>
+    <novo-option data-automation-id="position-bottom-right-option-five">Five</novo-option>
+    <novo-option data-automation-id="position-bottom-right-option-items">Items</novo-option>
+    <novo-option data-automation-id="position-bottom-right-option-for">For</novo-option>
+    <novo-option data-automation-id="position-bottom-right-option-position">Position</novo-option>
+    <novo-option data-automation-id="position-bottom-right-option-test">Test</novo-option>
   </novo-optgroup>
 </novo-dropdown>
 <novo-dropdown side="top-left" data-automation-id="position-top-left">
@@ -117,11 +117,11 @@
     inverse
     data-automation-id="position-top-left-button">Top-Left</button>
   <novo-optgroup>
-    <novo-option>Five</novo-option>
-    <novo-option>Items</novo-option>
-    <novo-option>For</novo-option>
-    <novo-option>Position</novo-option>
-    <novo-option>Test</novo-option>
+    <novo-option data-automation-id="position-top-left-option-five">Five</novo-option>
+    <novo-option data-automation-id="position-top-left-option-items">Items</novo-option>
+    <novo-option data-automation-id="position-top-left-option-for">For</novo-option>
+    <novo-option data-automation-id="position-top-left-option-position">Position</novo-option>
+    <novo-option data-automation-id="position-top-left-option-test">Test</novo-option>
   </novo-optgroup>
 </novo-dropdown>
 <novo-dropdown side="top-right" data-automation-id="position-top-right">
@@ -131,10 +131,10 @@
     inverse
     data-automation-id="position-top-right-button">Top-Right</button>
   <novo-optgroup>
-    <novo-option>Five</novo-option>
-    <novo-option>Items</novo-option>
-    <novo-option>For</novo-option>
-    <novo-option>Position</novo-option>
-    <novo-option>Test</novo-option>
+    <novo-option data-automation-id="position-top-right-option-five">Five</novo-option>
+    <novo-option data-automation-id="position-top-right-option-items">Items</novo-option>
+    <novo-option data-automation-id="position-top-right-option-for">For</novo-option>
+    <novo-option data-automation-id="position-top-right-option-position">Position</novo-option>
+    <novo-option data-automation-id="position-top-right-option-test">Test</novo-option>
   </novo-optgroup>
 </novo-dropdown>

--- a/projects/novo-examples/src/components/dropdown/scroll-to-item-drop-down/scroll-to-item-drop-down-example.html
+++ b/projects/novo-examples/src/components/dropdown/scroll-to-item-drop-down/scroll-to-item-drop-down-example.html
@@ -1,16 +1,17 @@
-<novo-dropdown side="default" height="300" [scrollToActiveItemOnOpen]="true">
-  <novo-stack dropdownTrigger [style.width.px]="160" align="stretch" gap="sm">
+<novo-dropdown side="default" height="300" [scrollToActiveItemOnOpen]="true" data-automation-id="scroll-to-item-dropdown">
+  <novo-stack dropdownTrigger [style.width.px]="160" align="stretch" gap="sm" data-automation-id="scroll-to-item-trigger">
     <novo-row class="button-row" justify="space-between">
       <novo-label>{{ 'Selected Word:' }}</novo-label>
     </novo-row>
     <novo-row class="button-row" justify="space-between">
-      <novo-text>{{ selectedWord }}</novo-text>
+      <novo-text data-automation-id="scroll-to-item-selected">{{ selectedWord }}</novo-text>
       <novo-icon size="sm">collapse</novo-icon>
     </novo-row>
   </novo-stack>
   <novo-optgroup>
     <novo-option *ngFor="let word of MOCK_WORDS; index as i"
-                 (click)="clickMe(word)">
+                 (click)="clickMe(word)"
+                 [attr.data-automation-id]="'scroll-to-item-option-' + i">
       <span class="value">{{ word }}</span>
       <span class="value-active">
         <i class="bhi-check ng-star-inserted"

--- a/projects/novo-examples/src/components/dropdown/scrollable-drop-down/scrollable-drop-down-example.html
+++ b/projects/novo-examples/src/components/dropdown/scrollable-drop-down/scrollable-drop-down-example.html
@@ -1,15 +1,18 @@
-<div class="scrollable-container" cdkScrollable>
+<div class="scrollable-container" cdkScrollable data-automation-id="scrollable-container">
   <div class="scrollable-content">
-    <novo-dropdown>
+    <novo-dropdown data-automation-id="scrollable-dropdown">
       <novo-button
         theme="secondary"
         icon="collapse"
-        inverse>Inside a Scrollable Container</novo-button>
+        inverse
+        data-automation-id="scrollable-dropdown-button">Inside a Scrollable Container</novo-button>
       <novo-optgroup>
         <novo-option (click)="clickMe('This')"
-          keepOpen="true">This</novo-option>
+          keepOpen="true"
+          data-automation-id="scrollable-this-option">This</novo-option>
         <novo-option (click)="clickMe('Scrolls!')"
-          keepOpen="true">Scrolls!</novo-option>
+          keepOpen="true"
+          data-automation-id="scrollable-scrolls-option">Scrolls!</novo-option>
       </novo-optgroup>
     </novo-dropdown>
   </div>

--- a/projects/novo-examples/src/components/field/field-anatomy/field-anatomy-example.html
+++ b/projects/novo-examples/src/components/field/field-anatomy/field-anatomy-example.html
@@ -1,13 +1,13 @@
 <div class="example-container">
-  <novo-field layout="horizontal">
+  <novo-field layout="horizontal" data-automation-id="password-field">
     <novo-label>Enter your password</novo-label>
-    <input novoInput [type]="hide ? 'password' : 'text'" />
-    <novo-icon (click)="hide = !hide">{{hide ? 'overview' : 'hidden'}}</novo-icon>
+    <input novoInput [type]="hide ? 'password' : 'text'" data-automation-id="password-input" />
+    <novo-icon (click)="hide = !hide" data-automation-id="password-toggle">{{hide ? 'overview' : 'hidden'}}</novo-icon>
   </novo-field>
 
-  <novo-field layout="horizontal">
+  <novo-field layout="horizontal" data-automation-id="amount-field">
     <novo-label>Amount</novo-label>
-    <input novoInput type="number" class="example-right-align" />
+    <input novoInput type="number" class="example-right-align" data-automation-id="amount-input" />
     <span novoPrefix>$&nbsp;</span>
     <span novoSuffix>.00</span>
     <novo-hint>Enter some money</novo-hint>

--- a/projects/novo-examples/src/components/field/field-anatomy/field-anatomy-example.html
+++ b/projects/novo-examples/src/components/field/field-anatomy/field-anatomy-example.html
@@ -10,7 +10,7 @@
     <input novoInput type="number" class="example-right-align" data-automation-id="amount-input" />
     <span novoPrefix>$&nbsp;</span>
     <span novoSuffix>.00</span>
-    <novo-hint>Enter some money</novo-hint>
+    <novo-hint data-automation-id="amount-hint">Enter some money</novo-hint>
   </novo-field>
 
 </div>

--- a/projects/novo-examples/src/components/field/field-components/field-components-example.html
+++ b/projects/novo-examples/src/components/field/field-components/field-components-example.html
@@ -1,72 +1,72 @@
 <div class="example-container">
 
   <novo-label>Layout</novo-label>
-  <novo-radio-group [(ngModel)]="direction">
-    <novo-radio value="horizontal">Horizontal</novo-radio>
-    <novo-radio value="vertical">Vertical</novo-radio>
+  <novo-radio-group [(ngModel)]="direction" data-automation-id="layout-group">
+    <novo-radio value="horizontal" data-automation-id="layout-horizontal">Horizontal</novo-radio>
+    <novo-radio value="vertical" data-automation-id="layout-vertical">Vertical</novo-radio>
   </novo-radio-group>
 
   <novo-label>Full Width?</novo-label>
-  <novo-radio-group [(ngModel)]="fullWidth">
-    <novo-radio [value]="false">Condensed</novo-radio>
-    <novo-radio [value]="true">Full Width</novo-radio>
+  <novo-radio-group [(ngModel)]="fullWidth" data-automation-id="fullwidth-group">
+    <novo-radio [value]="false" data-automation-id="fullwidth-condensed">Condensed</novo-radio>
+    <novo-radio [value]="true" data-automation-id="fullwidth-full">Full Width</novo-radio>
   </novo-radio-group>
 
   <novo-fields [layout]="direction" [fullWidth]="fullWidth">
 
-    <novo-field>
+    <novo-field data-automation-id="username-field">
       <novo-label>Username</novo-label>
-      <input novoInput type="text" />
+      <input novoInput type="text" data-automation-id="username-input" />
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="email-field">
       <novo-label>Email</novo-label>
-      <input novoInput type="email" />
+      <input novoInput type="email" data-automation-id="email-input" />
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="password-field">
       <novo-label>Enter your password</novo-label>
-      <input novoInput [type]="hide ? 'password' : 'text'" />
-      <novo-icon (click)="hide = !hide">{{hide ? 'overview' : 'hidden'}}</novo-icon>
+      <input novoInput [type]="hide ? 'password' : 'text'" data-automation-id="password-input" />
+      <novo-icon (click)="hide = !hide" data-automation-id="password-toggle">{{hide ? 'overview' : 'hidden'}}</novo-icon>
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="color-select-field">
       <novo-label>Select your favorite color?</novo-label>
-      <select required novoInput>
+      <select required novoInput data-automation-id="color-select">
         <option value="pink">Pink</option>
         <option value="purple">Purple</option>
         <option value="sparkles">Sparkles</option>
       </select>
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="description-field">
       <novo-label>Short description...</novo-label>
-      <textarea novoInput></textarea>
+      <textarea novoInput data-automation-id="description-textarea"></textarea>
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="color-picker-field">
       <novo-label>Choose your favorite color?</novo-label>
-      <input novoInput type="color" />
+      <input novoInput type="color" data-automation-id="color-picker-input" />
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="volume-field">
       <novo-label>Set Volume</novo-label>
-      <input novoInput type="range" min="0" max="100" value="90" step="10" />
+      <input novoInput type="range" min="0" max="100" value="90" step="10" data-automation-id="volume-input" />
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="birthday-field">
       <novo-label>Birthday</novo-label>
-      <input novoInput type="date" />
+      <input novoInput type="date" data-automation-id="birthday-input" />
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="endtime-field">
       <novo-label>Scheduled End Time</novo-label>
-      <input novoInput type="time" />
+      <input novoInput type="time" data-automation-id="endtime-input" />
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="appointment-field">
       <novo-label>Next Appointment Time?</novo-label>
-      <input novoInput type="datetime-local" />
+      <input novoInput type="datetime-local" data-automation-id="appointment-input" />
     </novo-field>
   </novo-fields>
 </div>

--- a/projects/novo-examples/src/components/field/field-components/field-components-example.html
+++ b/projects/novo-examples/src/components/field/field-components/field-components-example.html
@@ -33,9 +33,9 @@
     <novo-field data-automation-id="color-select-field">
       <novo-label>Select your favorite color?</novo-label>
       <select required novoInput data-automation-id="color-select">
-        <option value="pink">Pink</option>
-        <option value="purple">Purple</option>
-        <option value="sparkles">Sparkles</option>
+        <option value="pink" data-automation-id="color-select-option-pink">Pink</option>
+        <option value="purple" data-automation-id="color-select-option-purple">Purple</option>
+        <option value="sparkles" data-automation-id="color-select-option-sparkles">Sparkles</option>
       </select>
     </novo-field>
 

--- a/projects/novo-examples/src/components/field/field-native/field-native-example.html
+++ b/projects/novo-examples/src/components/field/field-native/field-native-example.html
@@ -1,82 +1,82 @@
 <div class="example-container">
 
   <novo-label>Appearance</novo-label>
-  <novo-radio-group [(ngModel)]="appearance">
-    <novo-radio value="standard">Standard</novo-radio>
-    <novo-radio value="fill">Filled</novo-radio>
-    <novo-radio value="outline">Outlined</novo-radio>
-    <novo-radio value="list">List</novo-radio>
+  <novo-radio-group [(ngModel)]="appearance" data-automation-id="appearance-group">
+    <novo-radio value="standard" data-automation-id="appearance-standard">Standard</novo-radio>
+    <novo-radio value="fill" data-automation-id="appearance-fill">Filled</novo-radio>
+    <novo-radio value="outline" data-automation-id="appearance-outline">Outlined</novo-radio>
+    <novo-radio value="list" data-automation-id="appearance-list">List</novo-radio>
   </novo-radio-group>
 
   <novo-label>Layout</novo-label>
-  <novo-radio-group [(ngModel)]="direction">
-    <novo-radio value="horizontal">Horizontal</novo-radio>
-    <novo-radio value="vertical">Vertical</novo-radio>
+  <novo-radio-group [(ngModel)]="direction" data-automation-id="layout-group">
+    <novo-radio value="horizontal" data-automation-id="layout-horizontal">Horizontal</novo-radio>
+    <novo-radio value="vertical" data-automation-id="layout-vertical">Vertical</novo-radio>
   </novo-radio-group>
 
 
   <novo-fields [appearance]="appearance" [layout]="direction" [fullWidth]="fullWidth">
-    <novo-field>
+    <novo-field data-automation-id="fullwidth-field">
       <novo-label>Full Width?</novo-label>
-      <novo-radio-group [(ngModel)]="fullWidth">
-        <novo-radio [value]="false">Condensed</novo-radio>
-        <novo-radio [value]="true">Full Width</novo-radio>
+      <novo-radio-group [(ngModel)]="fullWidth" data-automation-id="fullwidth-group">
+        <novo-radio [value]="false" data-automation-id="fullwidth-condensed">Condensed</novo-radio>
+        <novo-radio [value]="true" data-automation-id="fullwidth-full">Full Width</novo-radio>
       </novo-radio-group>
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="username-field">
       <novo-label>Username</novo-label>
-      <input novoInput type="text" />
+      <input novoInput type="text" data-automation-id="username-input" />
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="email-field">
       <novo-label>Email</novo-label>
-      <input novoInput type="email" />
+      <input novoInput type="email" data-automation-id="email-input" />
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="password-field">
       <novo-label>Enter your password</novo-label>
-      <input novoInput [type]="hide ? 'password' : 'text'" />
-      <novo-icon (click)="hide = !hide">{{hide ? 'overview' : 'hidden'}}</novo-icon>
+      <input novoInput [type]="hide ? 'password' : 'text'" data-automation-id="password-input" />
+      <novo-icon (click)="hide = !hide" data-automation-id="password-toggle">{{hide ? 'overview' : 'hidden'}}</novo-icon>
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="color-select-field">
       <novo-label>Select your favorite color?</novo-label>
-      <select required novoInput>
+      <select required novoInput data-automation-id="color-select">
         <option value="pink">Pink</option>
         <option value="purple">Purple</option>
         <option value="sparkles">Sparkles</option>
       </select>
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="description-field">
       <novo-label>Short description...</novo-label>
-      <textarea novoInput></textarea>
+      <textarea novoInput data-automation-id="description-textarea"></textarea>
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="color-picker-field">
       <novo-label>Choose your favorite color?</novo-label>
-      <input novoInput type="color" />
+      <input novoInput type="color" data-automation-id="color-picker-input" />
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="volume-field">
       <novo-label>Set Volume</novo-label>
-      <input novoInput type="range" min="0" max="100" value="90" step="10" />
+      <input novoInput type="range" min="0" max="100" value="90" step="10" data-automation-id="volume-input" />
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="birthday-field">
       <novo-label>Birthday</novo-label>
-      <input novoInput type="date" />
+      <input novoInput type="date" data-automation-id="birthday-input" />
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="endtime-field">
       <novo-label>Scheduled End Time</novo-label>
-      <input novoInput type="time" />
+      <input novoInput type="time" data-automation-id="endtime-input" />
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="appointment-field">
       <novo-label>Next Appointment Time?</novo-label>
-      <input novoInput type="datetime-local" />
+      <input novoInput type="datetime-local" data-automation-id="appointment-input" />
     </novo-field>
   </novo-fields>
 </div>

--- a/projects/novo-examples/src/components/field/field-native/field-native-example.html
+++ b/projects/novo-examples/src/components/field/field-native/field-native-example.html
@@ -43,9 +43,9 @@
     <novo-field data-automation-id="color-select-field">
       <novo-label>Select your favorite color?</novo-label>
       <select required novoInput data-automation-id="color-select">
-        <option value="pink">Pink</option>
-        <option value="purple">Purple</option>
-        <option value="sparkles">Sparkles</option>
+        <option value="pink" data-automation-id="color-select-option-pink">Pink</option>
+        <option value="purple" data-automation-id="color-select-option-purple">Purple</option>
+        <option value="sparkles" data-automation-id="color-select-option-sparkles">Sparkles</option>
       </select>
     </novo-field>
 

--- a/projects/novo-examples/src/components/field/field-usage/field-usage-example.html
+++ b/projects/novo-examples/src/components/field/field-usage/field-usage-example.html
@@ -1,27 +1,27 @@
 <h4>Basic Field Usage</h4>
 
-<novo-field>
+<novo-field data-automation-id="food-field">
   <novo-label>Favorite food</novo-label>
-  <input novoInput placeholder="Ex. Pizza" value="Sushi" />
+  <input novoInput placeholder="Ex. Pizza" value="Sushi" data-automation-id="food-input" />
 </novo-field>
 
-<novo-field>
+<novo-field data-automation-id="comment-field">
   <novo-label>Leave a comment</novo-label>
-  <textarea novoInput placeholder="Ex. It makes me feel..."></textarea>
+  <textarea novoInput placeholder="Ex. It makes me feel..." data-automation-id="comment-textarea"></textarea>
 </novo-field>
 
-<novo-field>
+<novo-field data-automation-id="alarm-field">
   <novo-label>Set an Alarm</novo-label>
-  <input novoInput [(ngModel)]="time" timeFormat="iso8601" [picker]="timepicker" />
+  <input novoInput [(ngModel)]="time" timeFormat="iso8601" [picker]="timepicker" data-automation-id="alarm-input" />
   <novo-picker-toggle novoSuffix icon="clock">
     <novo-time-picker #timepicker></novo-time-picker>
   </novo-picker-toggle>
   <novo-hint>value is: {{time}}</novo-hint>
 </novo-field>
 
-<novo-field>
+<novo-field data-automation-id="dob-field">
   <novo-label>Date of Birth</novo-label>
-  <input novoInput dateFormat="iso8601" [picker]="datepicker" [(ngModel)]="date" />
+  <input novoInput dateFormat="iso8601" [picker]="datepicker" [(ngModel)]="date" data-automation-id="dob-input" />
   <novo-picker-toggle novoSuffix icon="calendar">
     <novo-date-picker #datepicker></novo-date-picker>
   </novo-picker-toggle>
@@ -29,9 +29,9 @@
 
 </novo-field>
 
-<novo-field>
+<novo-field data-automation-id="datetime-field">
   <novo-label>Datetime</novo-label>
-  <input novoInput dateFormat="iso8601" [picker]="datetimepicker" [(ngModel)]="datetime" />
+  <input novoInput dateFormat="iso8601" [picker]="datetimepicker" [(ngModel)]="datetime" data-automation-id="datetime-input" />
   <novo-picker-toggle novoSuffix icon="calendar">
     <novo-date-time-picker #datetimepicker></novo-date-time-picker>
   </novo-picker-toggle>
@@ -39,9 +39,9 @@
 
 </novo-field>
 
-<novo-field>
+<novo-field data-automation-id="vacation-field">
   <novo-label>Need a Vacation?</novo-label>
-  <input novoInput dateRangeFormat="iso8601" [picker]="daterangepicker" [(ngModel)]="daterange" />
+  <input novoInput dateRangeFormat="iso8601" [picker]="daterangepicker" [(ngModel)]="daterange" data-automation-id="vacation-input" />
   <novo-picker-toggle novoSuffix icon="calendar">
     <novo-date-picker #daterangepicker mode="range" numberOfMonths="2"></novo-date-picker>
   </novo-picker-toggle>
@@ -51,28 +51,28 @@
 
 
 
-<novo-fieldset-header icon="calendar" title="Add Day Of Week"></novo-fieldset-header>
+<novo-fieldset-header icon="calendar" title="Add Day Of Week" data-automation-id="dayofweek-header"></novo-fieldset-header>
 
-<novo-field>
+<novo-field data-automation-id="dob-display-field">
   <novo-label>Date of Birth</novo-label>
-  <novo-text novoPrefix mr="sm">{{date2 | date : 'EEE' }}</novo-text>
-  <input novoInput dateFormat="iso8601" [picker]="datepicker2" [(ngModel)]="date2" disabled readonly />
+  <novo-text novoPrefix mr="sm" data-automation-id="day-display">{{date2 | date : 'EEE' }}</novo-text>
+  <input novoInput dateFormat="iso8601" [picker]="datepicker2" [(ngModel)]="date2" disabled readonly data-automation-id="dob-display-input" />
   <novo-picker-toggle novoSuffix icon="calendar">
     <novo-date-picker #datepicker2></novo-date-picker>
   </novo-picker-toggle>
   <novo-hint>value is: {{date2}}</novo-hint>
 </novo-field>
 
-<novo-fieldset-header icon="section" title="Section Header"></novo-fieldset-header>
+<novo-fieldset-header icon="section" title="Section Header" data-automation-id="section-header"></novo-fieldset-header>
 
-<novo-field>
+<novo-field data-automation-id="effective-on-field">
   <novo-label>
     <novo-flex justify="space-between">
       <span>Effective On</span>
       <novo-chip size="sm" accent="success">current</novo-chip>
     </novo-flex>
   </novo-label>
-  <novo-select value="08/01/2021">
+  <novo-select value="08/01/2021" data-automation-id="effective-on-select">
     <novo-option value="08/01/2021">
       <novo-text>08/01/2021</novo-text>
       <novo-chip accent="success">current</novo-chip>

--- a/projects/novo-examples/src/components/field/field-usage/field-usage-example.html
+++ b/projects/novo-examples/src/components/field/field-usage/field-usage-example.html
@@ -16,7 +16,7 @@
   <novo-picker-toggle novoSuffix icon="clock">
     <novo-time-picker #timepicker></novo-time-picker>
   </novo-picker-toggle>
-  <novo-hint>value is: {{time}}</novo-hint>
+  <novo-hint data-automation-id="alarm-value">value is: {{time}}</novo-hint>
 </novo-field>
 
 <novo-field data-automation-id="dob-field">
@@ -25,7 +25,7 @@
   <novo-picker-toggle novoSuffix icon="calendar">
     <novo-date-picker #datepicker></novo-date-picker>
   </novo-picker-toggle>
-  <novo-hint>value is: {{date}}</novo-hint>
+  <novo-hint data-automation-id="dob-value">value is: {{date}}</novo-hint>
 
 </novo-field>
 
@@ -35,7 +35,7 @@
   <novo-picker-toggle novoSuffix icon="calendar">
     <novo-date-time-picker #datetimepicker></novo-date-time-picker>
   </novo-picker-toggle>
-  <novo-hint>value is: {{datetime}}</novo-hint>
+  <novo-hint data-automation-id="datetime-value">value is: {{datetime}}</novo-hint>
 
 </novo-field>
 
@@ -45,7 +45,7 @@
   <novo-picker-toggle novoSuffix icon="calendar">
     <novo-date-picker #daterangepicker mode="range" numberOfMonths="2"></novo-date-picker>
   </novo-picker-toggle>
-  <novo-hint>value is: {{daterange}}</novo-hint>
+  <novo-hint data-automation-id="vacation-value">value is: {{daterange}}</novo-hint>
 
 </novo-field>
 
@@ -60,7 +60,7 @@
   <novo-picker-toggle novoSuffix icon="calendar">
     <novo-date-picker #datepicker2></novo-date-picker>
   </novo-picker-toggle>
-  <novo-hint>value is: {{date2}}</novo-hint>
+  <novo-hint data-automation-id="dob-display-value">value is: {{date2}}</novo-hint>
 </novo-field>
 
 <novo-fieldset-header icon="section" title="Section Header" data-automation-id="section-header"></novo-fieldset-header>

--- a/projects/novo-examples/src/components/field/form-usage/form-usage-example.html
+++ b/projects/novo-examples/src/components/field/form-usage/form-usage-example.html
@@ -3,7 +3,7 @@
     <novo-field data-automation-id="number-field">
       <novo-label>Pick a Number?</novo-label>
       <input novoInput type="number" placeholder="Ex. 12" [formControl]="numberControl" min="10" data-automation-id="number-input" />
-      <novo-error *ngIf="numberControl.invalid">Minimum: 10</novo-error>
+      <novo-error *ngIf="numberControl.invalid" data-automation-id="number-error">Minimum: 10</novo-error>
     </novo-field>
 
     <novo-field data-automation-id="alarm-field">

--- a/projects/novo-examples/src/components/field/form-usage/form-usage-example.html
+++ b/projects/novo-examples/src/components/field/form-usage/form-usage-example.html
@@ -1,40 +1,40 @@
-<form class="example-container" [formGroup]="options">
+<form class="example-container" [formGroup]="options" data-automation-id="form-usage">
   <novo-fields>
-    <novo-field>
+    <novo-field data-automation-id="number-field">
       <novo-label>Pick a Number?</novo-label>
-      <input novoInput type="number" placeholder="Ex. 12" [formControl]="numberControl" min="10" />
+      <input novoInput type="number" placeholder="Ex. 12" [formControl]="numberControl" min="10" data-automation-id="number-input" />
       <novo-error *ngIf="numberControl.invalid">Minimum: 10</novo-error>
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="alarm-field">
       <novo-label>Set an Alarm</novo-label>
-      <input novoInput timeFormat [picker]="timepicker" [formControl]="timeControl" />
+      <input novoInput timeFormat [picker]="timepicker" [formControl]="timeControl" data-automation-id="alarm-input" />
       <novo-picker-toggle novoSuffix icon="clock">
         <novo-time-picker #timepicker></novo-time-picker>
       </novo-picker-toggle>
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="dob-field">
       <novo-label>Date of Birth</novo-label>
-      <input novoInput dateFormat [picker]="datepicker" [formControl]="dateControl" disabled="true" readonly />
+      <input novoInput dateFormat [picker]="datepicker" [formControl]="dateControl" disabled="true" readonly data-automation-id="dob-input" />
       <novo-picker-toggle novoSuffix icon="calendar">
         <novo-date-picker #datepicker></novo-date-picker>
       </novo-picker-toggle>
     </novo-field>
 
-    <novo-field>
+    <novo-field data-automation-id="appointment-field">
       <novo-label>Appointment</novo-label>
-      <input novoInput dateTimeFormat [picker]="datetimepicker" [military]="false" [formControl]="dateTimeControl" readonly />
+      <input novoInput dateTimeFormat [picker]="datetimepicker" [military]="false" [formControl]="dateTimeControl" readonly data-automation-id="appointment-input" />
       <novo-picker-toggle novoSuffix icon="calendar">
         <novo-date-time-picker #datetimepicker></novo-date-time-picker>
       </novo-picker-toggle>
     </novo-field>
 
-    <button theme="primary" [disabled]="!options.valid" (click)="onSubmit(options.value)">Submit
+    <button theme="primary" [disabled]="!options.valid" (click)="onSubmit(options.value)" data-automation-id="submit-button">Submit
       Form</button>
   </novo-fields>
 </form>
 
-<div class="example-container">
+<div class="example-container" data-automation-id="form-output">
   {{ post | json }}
 </div>

--- a/projects/novo-examples/src/components/icon/basic-icons/basic-icons-example.html
+++ b/projects/novo-examples/src/components/icon/basic-icons/basic-icons-example.html
@@ -1,12 +1,12 @@
-<novo-icon>candidate</novo-icon>
-<novo-icon>job</novo-icon>
-<novo-icon>company</novo-icon>
-<novo-icon>lead</novo-icon>
-<novo-icon>opportunity</novo-icon>
+<novo-icon data-automation-id="basic-icon-candidate">candidate</novo-icon>
+<novo-icon data-automation-id="basic-icon-job">job</novo-icon>
+<novo-icon data-automation-id="basic-icon-company">company</novo-icon>
+<novo-icon data-automation-id="basic-icon-lead">lead</novo-icon>
+<novo-icon data-automation-id="basic-icon-opportunity">opportunity</novo-icon>
 <br />
-<i class="bhi-candidate"></i>
-<i class="bhi-person"></i>
-<i class="bhi-job"></i>
-<i class="bhi-company"></i>
-<i class="bhi-lead"></i>
-<i class="bhi-opportunity"></i>
+<i class="bhi-candidate" data-automation-id="basic-icon-class-candidate"></i>
+<i class="bhi-person" data-automation-id="basic-icon-class-person"></i>
+<i class="bhi-job" data-automation-id="basic-icon-class-job"></i>
+<i class="bhi-company" data-automation-id="basic-icon-class-company"></i>
+<i class="bhi-lead" data-automation-id="basic-icon-class-lead"></i>
+<i class="bhi-opportunity" data-automation-id="basic-icon-class-opportunity"></i>

--- a/projects/novo-examples/src/components/icon/raised-icons/raised-icons-example.html
+++ b/projects/novo-examples/src/components/icon/raised-icons/raised-icons-example.html
@@ -1,5 +1,5 @@
-<novo-icon theme="candidate" raised="true">candidate</novo-icon>
-<novo-icon theme="job" raised="true">job</novo-icon>
-<novo-icon theme="company" raised="true">company</novo-icon>
-<novo-icon theme="submission" raised="true">star-o</novo-icon>
-<novo-icon theme="placement" raised="true">star</novo-icon>
+<novo-icon theme="candidate" raised="true" data-automation-id="raised-icon-candidate">candidate</novo-icon>
+<novo-icon theme="job" raised="true" data-automation-id="raised-icon-job">job</novo-icon>
+<novo-icon theme="company" raised="true" data-automation-id="raised-icon-company">company</novo-icon>
+<novo-icon theme="submission" raised="true" data-automation-id="raised-icon-submission">star-o</novo-icon>
+<novo-icon theme="placement" raised="true" data-automation-id="raised-icon-placement">star</novo-icon>

--- a/projects/novo-examples/src/components/icon/themed-icons/themed-icons-example.html
+++ b/projects/novo-examples/src/components/icon/themed-icons/themed-icons-example.html
@@ -1,11 +1,11 @@
-<novo-icon color="candidate">candidate</novo-icon>
-<novo-icon color="job">job</novo-icon>
-<novo-icon color="company">company</novo-icon>
-<novo-icon color="submission">star-o</novo-icon>
-<novo-icon color="placement">star</novo-icon>
+<novo-icon color="candidate" data-automation-id="themed-icon-color-candidate">candidate</novo-icon>
+<novo-icon color="job" data-automation-id="themed-icon-color-job">job</novo-icon>
+<novo-icon color="company" data-automation-id="themed-icon-color-company">company</novo-icon>
+<novo-icon color="submission" data-automation-id="themed-icon-color-submission">star-o</novo-icon>
+<novo-icon color="placement" data-automation-id="themed-icon-color-placement">star</novo-icon>
 <br />
-<novo-icon theme="candidate">candidate</novo-icon>
-<novo-icon theme="job">job</novo-icon>
-<novo-icon theme="company">company</novo-icon>
-<novo-icon theme="submission">star-o</novo-icon>
-<novo-icon theme="placement">star</novo-icon>
+<novo-icon theme="candidate" data-automation-id="themed-icon-theme-candidate">candidate</novo-icon>
+<novo-icon theme="job" data-automation-id="themed-icon-theme-job">job</novo-icon>
+<novo-icon theme="company" data-automation-id="themed-icon-theme-company">company</novo-icon>
+<novo-icon theme="submission" data-automation-id="themed-icon-theme-submission">star-o</novo-icon>
+<novo-icon theme="placement" data-automation-id="themed-icon-theme-placement">star</novo-icon>

--- a/projects/novo-examples/src/components/loading/loading-circle/loading-circle-example.html
+++ b/projects/novo-examples/src/components/loading/loading-circle/loading-circle-example.html
@@ -1,4 +1,4 @@
-<novo-spinner [size]="size.value" [color]="color.value"></novo-spinner>
+<novo-spinner data-automation-id="loading-circle-spinner" [size]="size.value" [color]="color.value"></novo-spinner>
 
 <section>
   <novo-label>Size</novo-label>

--- a/projects/novo-examples/src/components/loading/loading-circle/loading-circle-example.html
+++ b/projects/novo-examples/src/components/loading/loading-circle/loading-circle-example.html
@@ -1,19 +1,19 @@
-<novo-spinner data-automation-id="loading-circle-spinner" [size]="size.value" [color]="color.value"></novo-spinner>
+<novo-spinner [size]="size.value" [color]="color.value" data-automation-id="spinner-component"></novo-spinner>
 
 <section>
   <novo-label>Size</novo-label>
-  <novo-radio-group #size appearance="vertical" value="medium">
-    <novo-radio name="size" value="small">small</novo-radio>
-    <novo-radio name="size" value="medium">medium</novo-radio>
-    <novo-radio name="size" value="large">large</novo-radio>
+  <novo-radio-group #size appearance="vertical" value="medium" data-automation-id="size-spinner-group">
+    <novo-radio name="size" value="small" data-automation-id="size-spinner-small">small</novo-radio>
+    <novo-radio name="size" value="medium" data-automation-id="size-spinner-medium">medium</novo-radio>
+    <novo-radio name="size" value="large" data-automation-id="size-spinner-large">large</novo-radio>
   </novo-radio-group>
 
   <novo-label>Color</novo-label>
-  <novo-radio-group #color appearance="vertical">
-    <novo-radio name="color" value="grapefruit">grapefruit</novo-radio>
-    <novo-radio name="color" value="aqua">aqua</novo-radio>
-    <novo-radio name="color" value="mint">mint</novo-radio>
-    <novo-radio name="color" value="ocean">ocean</novo-radio>
+  <novo-radio-group #color appearance="vertical" data-automation-id="color-spinner-group">
+    <novo-radio name="color" value="grapefruit" data-automation-id="color-spinner-grapefruit">grapefruit</novo-radio>
+    <novo-radio name="color" value="aqua" data-automation-id="color-spinner-aqua">aqua</novo-radio>
+    <novo-radio name="color" value="mint" data-automation-id="color-spinner-mint">mint</novo-radio>
+    <novo-radio name="color" value="ocean" data-automation-id="color-spinner-ocean">ocean</novo-radio>
   </novo-radio-group>
 
 </section>

--- a/projects/novo-examples/src/components/loading/loading-line/loading-line-example.html
+++ b/projects/novo-examples/src/components/loading/loading-line/loading-line-example.html
@@ -1,18 +1,18 @@
-<novo-loading data-automation-id="loading-line-loader" [size]="size.value" [color]="color.value"></novo-loading>
+<novo-loading [size]="size.value" [color]="color.value" data-automation-id="loading-line-component"></novo-loading>
 
 <section>
   <novo-label>Size</novo-label>
-  <novo-radio-group #size appearance="vertical" value="medium">
-    <novo-radio name="size" value="small">small</novo-radio>
-    <novo-radio name="size" value="medium">medium</novo-radio>
-    <novo-radio name="size" value="large">large</novo-radio>
+  <novo-radio-group #size appearance="vertical" value="medium" data-automation-id="size-line-group">
+    <novo-radio name="size" value="small" data-automation-id="size-line-small">small</novo-radio>
+    <novo-radio name="size" value="medium" data-automation-id="size-line-medium">medium</novo-radio>
+    <novo-radio name="size" value="large" data-automation-id="size-line-large">large</novo-radio>
   </novo-radio-group>
 
   <novo-label>Color</novo-label>
-  <novo-radio-group #color appearance="vertical">
-    <novo-radio name="color" value="grapefruit">grapefruit</novo-radio>
-    <novo-radio name="color" value="aqua">aqua</novo-radio>
-    <novo-radio name="color" value="mint">mint</novo-radio>
-    <novo-radio name="color" value="ocean">ocean</novo-radio>
+  <novo-radio-group #color appearance="vertical" data-automation-id="color-line-group">
+    <novo-radio name="color" value="grapefruit" data-automation-id="color-line-grapefruit">grapefruit</novo-radio>
+    <novo-radio name="color" value="aqua" data-automation-id="color-line-aqua">aqua</novo-radio>
+    <novo-radio name="color" value="mint" data-automation-id="color-line-mint">mint</novo-radio>
+    <novo-radio name="color" value="ocean" data-automation-id="color-line-ocean">ocean</novo-radio>
   </novo-radio-group>
 </section>

--- a/projects/novo-examples/src/components/loading/loading-line/loading-line-example.html
+++ b/projects/novo-examples/src/components/loading/loading-line/loading-line-example.html
@@ -1,4 +1,4 @@
-<novo-loading [size]="size.value" [color]="color.value"></novo-loading>
+<novo-loading data-automation-id="loading-line-loader" [size]="size.value" [color]="color.value"></novo-loading>
 
 <section>
   <novo-label>Size</novo-label>

--- a/projects/novo-examples/src/components/menu/basic-menu/basic-menu-example.html
+++ b/projects/novo-examples/src/components/menu/basic-menu/basic-menu-example.html
@@ -1,32 +1,32 @@
-<novo-button theme="secondary" icon="collapse" [menu]="menu">Actions</novo-button>
+<novo-button theme="secondary" icon="collapse" [menu]="menu" data-automation-id="menu-actions-button">Actions</novo-button>
 
 <!-- Menu Template -->
-<novo-menu #menu>
-  <novo-option id="mi-preview" *menuItem (click)="clickMe($event)">Preview</novo-option>
-  <novo-option id="mi-edit" *menuItem (click)="clickMe($event)">Edit</novo-option>
-  <novo-option id="mi-disabled" *menuItem (click)="clickMe($event)" disabled>Disabled</novo-option>
+<novo-menu #menu data-automation-id="basic-menu">
+  <novo-option id="mi-preview" *menuItem (click)="clickMe($event)" data-automation-id="menu-preview">Preview</novo-option>
+  <novo-option id="mi-edit" *menuItem (click)="clickMe($event)" data-automation-id="menu-edit">Edit</novo-option>
+  <novo-option id="mi-disabled" *menuItem (click)="clickMe($event)" disabled data-automation-id="menu-disabled">Disabled</novo-option>
   <novo-divider *menuItem></novo-divider>
-  <novo-option id="mi-delete" *menuItem (click)="clickMe($event)">
+  <novo-option id="mi-delete" *menuItem (click)="clickMe($event)" data-automation-id="menu-delete">
     <span>Delete</span>
     <novo-icon novoSuffix>delete-o</novo-icon>
   </novo-option>
 </novo-menu>
 
 
-<novo-button theme="icon" icon="more" [menu]="icons"></novo-button>
+<novo-button theme="icon" icon="more" [menu]="icons" data-automation-id="menu-icon-button"></novo-button>
 
 <!-- Menu Template -->
-<novo-menu #icons>
-  <novo-option *menuItem (click)="clickMe($event)">
+<novo-menu #icons data-automation-id="icon-menu">
+  <novo-option *menuItem (click)="clickMe($event)" data-automation-id="menu-icon-preview">
     <novo-icon>preview</novo-icon>
     <span>Preview</span>
   </novo-option>
-  <novo-option *menuItem (click)="clickMe($event)">
+  <novo-option *menuItem (click)="clickMe($event)" data-automation-id="menu-icon-edit">
     <novo-icon>edit</novo-icon>
     <span>Edit</span>
   </novo-option>
   <novo-divider *menuItem></novo-divider>
-  <novo-option *menuItem class="red" (click)="clickMe($event)">
+  <novo-option *menuItem class="red" (click)="clickMe($event)" data-automation-id="menu-icon-delete">
     <novo-icon>delete-o</novo-icon>
     <span>Delete</span>
   </novo-option>

--- a/projects/novo-examples/src/components/menu/menu-context/menu-context-example.html
+++ b/projects/novo-examples/src/components/menu/menu-context/menu-context-example.html
@@ -1,10 +1,10 @@
-<button type="button" theme="secondary" icon="collapse" [menu]="menu" [menuContext]="apple">Apples</button>
-<button type="button" theme="secondary" icon="collapse" [menu]="menu" [menuContext]="orange">Oranges</button>
+<button type="button" theme="secondary" icon="collapse" [menu]="menu" [menuContext]="apple" data-automation-id="menu-context-apples-button">Apples</button>
+<button type="button" theme="secondary" icon="collapse" [menu]="menu" [menuContext]="orange" data-automation-id="menu-context-oranges-button">Oranges</button>
 <!-- Menu Template -->
-<novo-menu #menu>
-  <novo-option *menuItem="let item" (click)="clickMe(item)">Preview</novo-option>
-  <novo-option *menuItem="let item" (click)="clickMe(item)">Edit</novo-option>
-  <novo-option *menuItem="let item" (click)="clickMe(item)">Delete</novo-option>
-  <novo-option *menuItem="let item" [disabled]="isOrange(item)">Disabled if Orange</novo-option>
-  <novo-option *menuItem="let item;visible:isOrange;">Visible if Orange</novo-option>
+<novo-menu #menu data-automation-id="context-menu">
+  <novo-option *menuItem="let item" (click)="clickMe(item)" data-automation-id="menu-context-preview">Preview</novo-option>
+  <novo-option *menuItem="let item" (click)="clickMe(item)" data-automation-id="menu-context-edit">Edit</novo-option>
+  <novo-option *menuItem="let item" (click)="clickMe(item)" data-automation-id="menu-context-delete">Delete</novo-option>
+  <novo-option *menuItem="let item" [disabled]="isOrange(item)" data-automation-id="menu-context-disabled">Disabled if Orange</novo-option>
+  <novo-option *menuItem="let item;visible:isOrange;" data-automation-id="menu-context-visible">Visible if Orange</novo-option>
 </novo-menu>

--- a/projects/novo-examples/src/components/menu/nested-menu/nested-menu-example.html
+++ b/projects/novo-examples/src/components/menu/nested-menu/nested-menu-example.html
@@ -1,12 +1,12 @@
-<button type="button" theme="secondary" icon="collapse" [menu]="menu">Actions</button>
+<button type="button" theme="secondary" icon="collapse" [menu]="menu" data-automation-id="nested-menu-button">Actions</button>
 
 <!-- Menu Template -->
-<novo-menu #menu>
-  <novo-option *menuItem (click)="clickMe($event)">Preview</novo-option>
-  <novo-option *menuItem (click)="clickMe($event)">Edit</novo-option>
-  <novo-option *menuItem [menu]="subMenu">Choose...</novo-option>
-  <novo-menu #subMenu>
-    <novo-option *menuItem (click)="clickMe($event)">Available</novo-option>
-    <novo-option *menuItem (click)="clickMe($event)">Not Available</novo-option>
+<novo-menu #menu data-automation-id="nested-menu">
+  <novo-option *menuItem (click)="clickMe($event)" data-automation-id="nested-menu-preview">Preview</novo-option>
+  <novo-option *menuItem (click)="clickMe($event)" data-automation-id="nested-menu-edit">Edit</novo-option>
+  <novo-option *menuItem [menu]="subMenu" data-automation-id="nested-menu-choose">Choose...</novo-option>
+  <novo-menu #subMenu data-automation-id="nested-submenu">
+    <novo-option *menuItem (click)="clickMe($event)" data-automation-id="nested-menu-available">Available</novo-option>
+    <novo-option *menuItem (click)="clickMe($event)" data-automation-id="nested-menu-not-available">Not Available</novo-option>
   </novo-menu>
 </novo-menu>

--- a/projects/novo-examples/src/components/non-ideal-state/non-ideal-state-loading-usage/non-ideal-state-loading-usage-example.html
+++ b/projects/novo-examples/src/components/non-ideal-state/non-ideal-state-loading-usage/non-ideal-state-loading-usage-example.html
@@ -1,6 +1,6 @@
-<novo-non-ideal-state>
-  <novo-loading></novo-loading>
+<novo-non-ideal-state data-automation-id="non-ideal-state-loading">
+  <novo-loading data-automation-id="non-ideal-state-loading-spinner"></novo-loading>
   <novo-text lineLength="large" marginAfter>We are currently experiencing technical difficulties and your wait time is
     taking a bit longer than expected. Thank you for your patience. </novo-text>
-  <button theme="primary" icon="refresh-o">Refresh</button>
+  <button theme="primary" icon="refresh-o" data-automation-id="non-ideal-state-loading-refresh-btn">Refresh</button>
 </novo-non-ideal-state>

--- a/projects/novo-examples/src/components/non-ideal-state/non-ideal-state-search-usage/non-ideal-state-search-usage-example.html
+++ b/projects/novo-examples/src/components/non-ideal-state/non-ideal-state-search-usage/non-ideal-state-search-usage-example.html
@@ -1,4 +1,4 @@
-<novo-non-ideal-state icon="search" title="No results found."
+<novo-non-ideal-state data-automation-id="non-ideal-state-search" icon="search" title="No results found."
   description="Your search didn't match any files.\nTry searching for something else.">
-  <novo-search alwaysOpen="true"></novo-search>
+  <novo-search alwaysOpen="true" data-automation-id="non-ideal-state-search-input"></novo-search>
 </novo-non-ideal-state>

--- a/projects/novo-examples/src/components/non-ideal-state/non-ideal-state-usage/non-ideal-state-usage-example.html
+++ b/projects/novo-examples/src/components/non-ideal-state/non-ideal-state-usage/non-ideal-state-usage-example.html
@@ -1,8 +1,8 @@
-<novo-non-ideal-state icon="file" title="This folder is empty" description="Upload a new file to populate the folder.">
-  <button theme="primary" icon="upload">Upload</button>
+<novo-non-ideal-state data-automation-id="non-ideal-state-basic" icon="file" title="This folder is empty" description="Upload a new file to populate the folder.">
+  <button theme="primary" icon="upload" data-automation-id="non-ideal-state-basic-upload-btn">Upload</button>
 </novo-non-ideal-state>
 
-<novo-non-ideal-state>
+<novo-non-ideal-state data-automation-id="non-ideal-state-custom">
   <novo-icon size="xl" color="grapefruit">file</novo-icon>
   <novo-title>This folder is empty</novo-title>
   <novo-text>Upload a new file to populate the folder.</novo-text>
@@ -10,5 +10,5 @@
     <novo-text>Sed sodales ligula et fermentum bibendum. Aliquam tincidunt sagittis leo eget auctor. Fusce eu sagittis
       metus, ut viverra magna. Mauris mollis nisl nec libero tincidunt posuere.</novo-text>
   </novo-tip-well>
-  <button theme="primary" icon="upload">Upload</button>
+  <button theme="primary" icon="upload" data-automation-id="non-ideal-state-custom-upload-btn">Upload</button>
 </novo-non-ideal-state>

--- a/projects/novo-examples/src/components/pop-over/pop-over-auto-placement/pop-over-auto-placement-example.html
+++ b/projects/novo-examples/src/components/pop-over/pop-over-auto-placement/pop-over-auto-placement-example.html
@@ -1,12 +1,14 @@
 <span novoPopover="If the placement of the PopOver will make it appear off-screen, then it will be automatically adjusted to appear on the opposite side. For example: this PopOver should appear below the element.&#13;&#10; &#13;&#10; &#13;&#10;Need to make extra space so this PopOver would actually appear below the screen."
     popoverTitle="PopOver Moves to Top if near Bottom of Screen"
     popoverPlacement="bottom"
-    [popoverOnHover]="true">
+    [popoverOnHover]="true"
+    data-automation-id="popover-auto-placement-first">
     Hover Me
 </span>
 <span novoPopover="Too small to drop below screen."
     popoverTitle="PopOver Won't Change"
     popoverPlacement="bottom"
-    [popoverOnHover]="true">
+    [popoverOnHover]="true"
+    data-automation-id="popover-auto-placement-second">
     Hover Me Next
 </span>

--- a/projects/novo-examples/src/components/pop-over/pop-over-behaviors/pop-over-behaviors-example.html
+++ b/projects/novo-examples/src/components/pop-over/pop-over-behaviors/pop-over-behaviors-example.html
@@ -2,14 +2,16 @@
     novoPopover="PopOver appears when hovering over the element. When the mouse is no longer over the element or the PopOver, then it will be dismissed."
     popoverTitle="ON HOVER"
     popoverPlacement="right"
-    [popoverOnHover]="true">
+    [popoverOnHover]="true"
+    data-automation-id="popover-on-hover">
 ON HOVER
 </span>
 
 <span class="popover-element"
     novoPopover="PopOver appears when clicking on the element. Dismiss it by clicking the element again."
     popoverTitle="ON CLICK"
-    popoverPlacement="right">
+    popoverPlacement="right"
+    data-automation-id="popover-on-click">
 ON CLICK
 </span>
 
@@ -17,7 +19,8 @@ ON CLICK
     novoPopover="This PopOver has a 2000 ms or 2 second timeout on it. Dismiss it by clicking on the element or waiting for the timeout."
     popoverTitle="ON CLICK WITH TIMEOUT"
     popoverPlacement="right"
-    [popoverDismissTimeout]="2000">
+    [popoverDismissTimeout]="2000"
+    data-automation-id="popover-on-click-timeout">
 ON CLICK WITH TIMEOUT
 </span>
 
@@ -25,6 +28,7 @@ ON CLICK WITH TIMEOUT
     novoPopover="This PopOver will never appear when clicking on the element or when hovering over the element."
     popoverTitle="popoverDisabled"
     popoverPlacement="right"
-    [popoverDisabled]="true">
+    [popoverDisabled]="true"
+    data-automation-id="popover-disabled">
 DISABLED POPOVER
 </span>

--- a/projects/novo-examples/src/components/pop-over/pop-over-dynamic/pop-over-dynamic-example.html
+++ b/projects/novo-examples/src/components/pop-over/pop-over-dynamic/pop-over-dynamic-example.html
@@ -1,7 +1,8 @@
 <popover-content
   #dynamicHtmlPopOver
   title="this header can be omitted"
-  placement="right">
+  placement="right"
+  data-automation-id="popover-dynamic-content">
 
   <b>Very</b> <span [style.color]="'#C21F39'">Dynamic</span> <span [style.color]="'#00b3ee'">Reusable</span>
   <b><i><span [style.color]="'#ffc520'">Popover With</span></i></b> <small>Html support</small>. Click outside of this
@@ -10,4 +11,4 @@
   onHidden or onShown events to perform additional tasks.
 </popover-content>
 
-<span [novoPopover]="dynamicHtmlPopOver">Click to see a popover with dynamic html</span>
+<span [novoPopover]="dynamicHtmlPopOver" data-automation-id="popover-dynamic-trigger">Click to see a popover with dynamic html</span>

--- a/projects/novo-examples/src/components/pop-over/pop-over-horizontal/pop-over-horizontal-example.html
+++ b/projects/novo-examples/src/components/pop-over/pop-over-horizontal/pop-over-horizontal-example.html
@@ -1,12 +1,14 @@
 <span novoPopover="Popover is on the top side and to the right of the element. Can also apply 'left' to 'top' placement PopOvers."
     popoverTitle="Top-Right PopOver"
     popoverPlacement="top-right"
-    [popoverOnHover]="true">
+    [popoverOnHover]="true"
+    data-automation-id="popover-top-right">
     TOP-RIGHT
 </span>
 <span novoPopover="Popover is on the bottom side and to the left of the element. Can also apply 'right' to 'bottom' placement PopOvers."
     popoverTitle="Bottom-Left PopOver"
     popoverPlacement="bottom-left"
-    [popoverOnHover]="true">
+    [popoverOnHover]="true"
+    data-automation-id="popover-bottom-left">
     BOTTOM-LEFT
 </span>

--- a/projects/novo-examples/src/components/pop-over/pop-over-placement/pop-over-placement-example.html
+++ b/projects/novo-examples/src/components/pop-over/pop-over-placement/pop-over-placement-example.html
@@ -1,4 +1,4 @@
-<span novoPopover="Popover is to left of element" popoverTitle="Left PopOver" popoverPlacement="left" [popoverOnHover]="true">LEFT</span>
-<span novoPopover="Popover is to right of element" popoverTitle="Right PopOver" popoverPlacement="right" [popoverOnHover]="true">RIGHT</span>
-<span novoPopover="Popover is above the element" popoverTitle="Top PopOver" popoverPlacement="top" [popoverOnHover]="true">TOP</span>
-<span novoPopover="Popover is below the element" popoverTitle="Bottom PopOver" popoverPlacement="bottom" [popoverOnHover]="true">BOTTOM</span>
+<span novoPopover="Popover is to left of element" popoverTitle="Left PopOver" popoverPlacement="left" [popoverOnHover]="true" data-automation-id="popover-left">LEFT</span>
+<span novoPopover="Popover is to right of element" popoverTitle="Right PopOver" popoverPlacement="right" [popoverOnHover]="true" data-automation-id="popover-right">RIGHT</span>
+<span novoPopover="Popover is above the element" popoverTitle="Top PopOver" popoverPlacement="top" [popoverOnHover]="true" data-automation-id="popover-top">TOP</span>
+<span novoPopover="Popover is below the element" popoverTitle="Bottom PopOver" popoverPlacement="bottom" [popoverOnHover]="true" data-automation-id="popover-bottom">BOTTOM</span>

--- a/projects/novo-examples/src/components/pop-over/pop-over-vertical/pop-over-vertical-example.html
+++ b/projects/novo-examples/src/components/pop-over/pop-over-vertical/pop-over-vertical-example.html
@@ -1,12 +1,14 @@
 <span novoPopover="Popover is on the right side and below the element. Can also apply 'top' to 'right' placement PopOvers."
     popoverTitle="Right-Bottom PopOver"
     popoverPlacement="right-bottom"
-    [popoverOnHover]="true">
+    [popoverOnHover]="true"
+    data-automation-id="popover-right-bottom">
     RIGHT-BOTTOM
 </span>
 <span novoPopover="Popover is on the left side and above the element. Can also apply 'bottom' to 'left' placement PopOvers."
     popoverTitle="Left-Top PopOver"
     popoverPlacement="left-top"
-    [popoverOnHover]="true">
+    [popoverOnHover]="true"
+    data-automation-id="popover-left-top">
     LEFT-TOP
 </span>

--- a/projects/novo-examples/src/components/progress/progress-bar-radial-usage/progress-bar-radial-usage-example.html
+++ b/projects/novo-examples/src/components/progress/progress-bar-radial-usage/progress-bar-radial-usage-example.html
@@ -1,11 +1,11 @@
 <novo-progress appearance="radial" data-automation-id="progress-radial-single">
-  <novo-progress-bar value="70"></novo-progress-bar>
+  <novo-progress-bar value="70" data-automation-id="progress-radial-single-bar"></novo-progress-bar>
 </novo-progress>
 
 <br />
 
 <novo-progress appearance="radial" total="60" data-automation-id="progress-radial-multi">
-  <novo-progress-bar value="50" color="success"></novo-progress-bar>
-  <novo-progress-bar value="40" color="negative"></novo-progress-bar>
-  <novo-progress-bar value="30" color="warning"></novo-progress-bar>
+  <novo-progress-bar value="50" color="success" data-automation-id="progress-radial-multi-success"></novo-progress-bar>
+  <novo-progress-bar value="40" color="negative" data-automation-id="progress-radial-multi-negative"></novo-progress-bar>
+  <novo-progress-bar value="30" color="warning" data-automation-id="progress-radial-multi-warning"></novo-progress-bar>
 </novo-progress>

--- a/projects/novo-examples/src/components/progress/progress-bar-radial-usage/progress-bar-radial-usage-example.html
+++ b/projects/novo-examples/src/components/progress/progress-bar-radial-usage/progress-bar-radial-usage-example.html
@@ -1,10 +1,10 @@
-<novo-progress appearance="radial">
+<novo-progress appearance="radial" data-automation-id="progress-radial-single">
   <novo-progress-bar value="70"></novo-progress-bar>
 </novo-progress>
 
 <br />
 
-<novo-progress appearance="radial" total="60">
+<novo-progress appearance="radial" total="60" data-automation-id="progress-radial-multi">
   <novo-progress-bar value="50" color="success"></novo-progress-bar>
   <novo-progress-bar value="40" color="negative"></novo-progress-bar>
   <novo-progress-bar value="30" color="warning"></novo-progress-bar>

--- a/projects/novo-examples/src/components/progress/progress-bar-usage/progress-bar-usage-example.html
+++ b/projects/novo-examples/src/components/progress/progress-bar-usage/progress-bar-usage-example.html
@@ -1,24 +1,24 @@
 <div class="resizable">
   <novo-progress data-automation-id="progress-bar-flash">
-    <novo-progress-bar flash="true"></novo-progress-bar>
+    <novo-progress-bar flash="true" data-automation-id="progress-bar-flash-bar"></novo-progress-bar>
   </novo-progress>
 </div>
 
 <br />
 
 <novo-progress data-automation-id="progress-bar-indeterminate">
-  <novo-progress-bar indeterminate="true"></novo-progress-bar>
+  <novo-progress-bar indeterminate="true" data-automation-id="progress-bar-indeterminate-bar"></novo-progress-bar>
 </novo-progress>
 
 <br />
 
 <novo-progress striped="true" data-automation-id="progress-bar-striped">
-  <novo-progress-bar value="40"></novo-progress-bar>
+  <novo-progress-bar value="40" data-automation-id="progress-bar-striped-bar"></novo-progress-bar>
 </novo-progress>
 
 <br />
 
 <novo-progress total="300" data-automation-id="progress-bar-multi-color">
-  <novo-progress-bar value="120" color="success" [tooltip]="largeTooltip" tooltipSize="large"></novo-progress-bar>
-  <novo-progress-bar value="40" color="negative"></novo-progress-bar>
+  <novo-progress-bar value="120" color="success" [tooltip]="largeTooltip" tooltipSize="large" data-automation-id="progress-bar-multi-color-success"></novo-progress-bar>
+  <novo-progress-bar value="40" color="negative" data-automation-id="progress-bar-multi-color-negative"></novo-progress-bar>
 </novo-progress>

--- a/projects/novo-examples/src/components/progress/progress-bar-usage/progress-bar-usage-example.html
+++ b/projects/novo-examples/src/components/progress/progress-bar-usage/progress-bar-usage-example.html
@@ -1,24 +1,24 @@
 <div class="resizable">
-  <novo-progress>
+  <novo-progress data-automation-id="progress-bar-flash">
     <novo-progress-bar flash="true"></novo-progress-bar>
   </novo-progress>
 </div>
 
 <br />
 
-<novo-progress>
+<novo-progress data-automation-id="progress-bar-indeterminate">
   <novo-progress-bar indeterminate="true"></novo-progress-bar>
 </novo-progress>
 
 <br />
 
-<novo-progress striped="true">
+<novo-progress striped="true" data-automation-id="progress-bar-striped">
   <novo-progress-bar value="40"></novo-progress-bar>
 </novo-progress>
 
 <br />
 
-<novo-progress total="300">
+<novo-progress total="300" data-automation-id="progress-bar-multi-color">
   <novo-progress-bar value="120" color="success" [tooltip]="largeTooltip" tooltipSize="large"></novo-progress-bar>
   <novo-progress-bar value="40" color="negative"></novo-progress-bar>
 </novo-progress>

--- a/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.html
+++ b/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.html
@@ -22,10 +22,10 @@
 <novo-row align="start" gap="xl" margin="xl">
   <section>
     <novo-label>Join Operators</novo-label>
-    <novo-radio-group #mode [value]="andOrNot">
-      <novo-radio name="mode" [value]="and">Only And</novo-radio>
-      <novo-radio name="mode" [value]="andOr">And, Or</novo-radio>
-      <novo-radio name="mode" [value]="andOrNot">And, Or, Not</novo-radio>
+    <novo-radio-group #mode [value]="andOrNot" data-automation-id="criteria-mode-group">
+      <novo-radio name="mode" [value]="and" data-automation-id="criteria-mode-and">Only And</novo-radio>
+      <novo-radio name="mode" [value]="andOr" data-automation-id="criteria-mode-and-or">And, Or</novo-radio>
+      <novo-radio name="mode" [value]="andOrNot" data-automation-id="criteria-mode-and-or-not">And, Or, Not</novo-radio>
     </novo-radio-group>
   </section>
 </novo-row>
@@ -71,9 +71,9 @@
                 [(ngModel)]="addressRadiusEnabled"/>
     <novo-row *ngIf="addressRadiusEnabled" align="start" gap="xl" marginLeft="xl">
       <novo-label margin="lg">Units:</novo-label>
-      <novo-select margin="lg" value="miles" (onSelect)="addressRadiusUnitsSelected($event.selected)">
-        <novo-option value="miles">Miles</novo-option>
-        <novo-option value="km">Km</novo-option>
+      <novo-select margin="lg" value="miles" (onSelect)="addressRadiusUnitsSelected($event.selected)" data-automation-id="criteria-radius-units-select">
+        <novo-option value="miles" data-automation-id="criteria-radius-units-miles">Miles</novo-option>
+        <novo-option value="km" data-automation-id="criteria-radius-units-km">Km</novo-option>
       </novo-select>
     </novo-row>
   </section>

--- a/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.html
+++ b/projects/novo-examples/src/components/query-builder/just-criteria/just-criteria-example.html
@@ -1,5 +1,6 @@
-<form [formGroup]="queryForm" (ngSubmit)="onSubmit()">
+<form [formGroup]="queryForm" (ngSubmit)="onSubmit()" data-automation-id="criteria-builder-form">
   <novo-criteria-builder
+    data-automation-id="criteria-builder"
     #builder
     controlName="criteria"
     [allowedGroupings]="mode.value"
@@ -11,10 +12,10 @@
     <custom-picker-condition-def name="CUSTOM"></custom-picker-condition-def>
   </novo-criteria-builder>
 
-  <novo-row gap="md" justify="end">
-    <button theme="primary" size="sm" *ngIf="!useNoteMeta" (click)="builder.addConditionGroup()">Add a group</button>
-    <button theme="secondary" size="sm" (click)="resetGroups()">Reset</button>
-    <button theme="secondary" size="sm" (click)="resetQueryForm(useNoteMeta)">Repopulate</button>
+  <novo-row gap="md" justify="end" data-automation-id="criteria-builder-actions">
+    <button theme="primary" size="sm" data-automation-id="criteria-builder-add-group-btn" *ngIf="!useNoteMeta" (click)="builder.addConditionGroup()">Add a group</button>
+    <button theme="secondary" size="sm" data-automation-id="criteria-builder-reset-btn" (click)="resetGroups()">Reset</button>
+    <button theme="secondary" size="sm" data-automation-id="criteria-builder-repopulate-btn" (click)="resetQueryForm(useNoteMeta)">Repopulate</button>
   </novo-row>
 </form>
 

--- a/projects/novo-examples/src/components/query-builder/single-field-criteria-example/single-field-criteria-example.html
+++ b/projects/novo-examples/src/components/query-builder/single-field-criteria-example/single-field-criteria-example.html
@@ -1,17 +1,18 @@
-<form [formGroup]="queryForm" (ngSubmit)="onSubmit()">
+<form [formGroup]="queryForm" (ngSubmit)="onSubmit()" data-automation-id="condition-builder-form">
   <novo-condition-builder
+    data-automation-id="condition-builder"
     #builder
     [config]="config"
     [editTypeFn]="editTypeFn">
   </novo-condition-builder>
 </form>
 
-<novo-field mb="lg">
+<novo-field mb="lg" data-automation-id="field-selector-container">
   <novo-label>Choose single field to auto-select for criteria</novo-label>
-  <novo-select placeholder="Single field" [ngModel]="config.staticFieldSelection" (ngModelChange)="updateConfig({ staticFieldSelection: $event })">
+  <novo-select data-automation-id="field-selector" placeholder="Single field" [ngModel]="config.staticFieldSelection" (ngModelChange)="updateConfig({ staticFieldSelection: $event })">
     <novo-option value="">Show All Fields</novo-option>
     <novo-option *ngFor="let field of mockMetaFields" [value]="field.name">{{ field.label || field.name }}</novo-option>
   </novo-select>
 </novo-field>
 
-<pre><code>{{queryForm.value | json}}</code></pre>
+<pre data-automation-id="condition-builder-output"><code>{{queryForm.value | json}}</code></pre>

--- a/projects/novo-examples/src/components/search/search-usage/search-usage-example.html
+++ b/projects/novo-examples/src/components/search/search-usage/search-usage-example.html
@@ -1,10 +1,10 @@
-<novo-search></novo-search>
+<novo-search data-automation-id="search-default"></novo-search>
 
-<novo-search size="small" placeholder="Small Search..."></novo-search>
+<novo-search data-automation-id="search-small" size="small" placeholder="Small Search..."></novo-search>
 
-<novo-search size="large" placeholder="Large Search..."></novo-search>
+<novo-search data-automation-id="search-large" size="large" placeholder="Large Search..."></novo-search>
 
-<novo-search theme="positive" [ngModel]="test" (ngModelChange)="search($event)">
+<novo-search data-automation-id="search-positive" theme="positive" [ngModel]="test" (ngModelChange)="search($event)">
   <novo-list direction="vertical">
     <novo-list-item *ngFor="let item of searchResults | async" (click)="onSelectMatch(item)">
       <item-header>
@@ -15,11 +15,11 @@
   </novo-list>
 </novo-search>
 
-<novo-search icon="location" color="grapefruit" alwaysOpen="true" [(ngModel)]="geo" displayField="formatted_address" [closeOnSelect]="false" hint="Search Google to find your address.">
+<novo-search data-automation-id="search-location" icon="location" color="grapefruit" alwaysOpen="true" [(ngModel)]="geo" displayField="formatted_address" [closeOnSelect]="false" hint="Search Google to find your address.">
   <google-places-list [(term)]="geo"></google-places-list>
 </novo-search>
 <div>Value is: {{geo}}</div>
 
-<novo-search icon="candidate" color="candidate" alwaysOpen="true" [(ngModel)]="entity">
+<novo-search data-automation-id="search-candidate" icon="candidate" color="candidate" alwaysOpen="true" [(ngModel)]="entity">
   <entity-picker-results [matches]="searchData" (select)="onSelectEntity($event)"></entity-picker-results>
 </novo-search>

--- a/projects/novo-examples/src/components/search/search-usage/search-usage-example.html
+++ b/projects/novo-examples/src/components/search/search-usage/search-usage-example.html
@@ -18,7 +18,7 @@
 <novo-search data-automation-id="search-location" icon="location" color="grapefruit" alwaysOpen="true" [(ngModel)]="geo" displayField="formatted_address" [closeOnSelect]="false" hint="Search Google to find your address.">
   <google-places-list [(term)]="geo"></google-places-list>
 </novo-search>
-<div>Value is: {{geo}}</div>
+<div data-automation-id="search-location-value">Value is: {{geo}}</div>
 
 <novo-search data-automation-id="search-candidate" icon="candidate" color="candidate" alwaysOpen="true" [(ngModel)]="entity">
   <entity-picker-results [matches]="searchData" (select)="onSelectEntity($event)"></entity-picker-results>

--- a/projects/novo-examples/src/components/slides/basic-slide/basic-slide-example.html
+++ b/projects/novo-examples/src/components/slides/basic-slide/basic-slide-example.html
@@ -1,8 +1,8 @@
-<novo-slider [slides]="2">
-    <div slide="1">
+<novo-slider data-automation-id="basic-slide-container" [slides]="2">
+    <div slide="1" data-automation-id="slide-1">
         SLIDE #1
     </div>
-    <div slide="2">
+    <div slide="2" data-automation-id="slide-2">
         SLIDE #2
     </div>
 </novo-slider>

--- a/projects/novo-examples/src/components/switch/switch-usage/switch-usage-example.html
+++ b/projects/novo-examples/src/components/switch/switch-usage/switch-usage-example.html
@@ -1,6 +1,6 @@
 <label data-automation-id="switch-label">
   Toggled
-  <span>{{checked}}</span>
+  <span data-automation-id="switch-value">{{checked}}</span>
 </label>
 <novo-switch data-automation-id="switch-default" [(ngModel)]="checked" (onChange)="increment()"></novo-switch>
 <novo-switch data-automation-id="switch-grapefruit" [(ngModel)]="checked" theme="grapefruit"></novo-switch>

--- a/projects/novo-examples/src/components/switch/switch-usage/switch-usage-example.html
+++ b/projects/novo-examples/src/components/switch/switch-usage/switch-usage-example.html
@@ -1,7 +1,7 @@
-<label>
+<label data-automation-id="switch-label">
   Toggled
   <span>{{checked}}</span>
 </label>
-<novo-switch [(ngModel)]="checked" (onChange)="increment()"></novo-switch>
-<novo-switch [(ngModel)]="checked" theme="grapefruit"></novo-switch>
-<novo-switch [(ngModel)]="checked" disabled>THIS IS DISABLED</novo-switch>
+<novo-switch data-automation-id="switch-default" [(ngModel)]="checked" (onChange)="increment()"></novo-switch>
+<novo-switch data-automation-id="switch-grapefruit" [(ngModel)]="checked" theme="grapefruit"></novo-switch>
+<novo-switch data-automation-id="switch-disabled" [(ngModel)]="checked" disabled>THIS IS DISABLED</novo-switch>

--- a/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-basic/tabbed-group-picker-basic-example.html
+++ b/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-basic/tabbed-group-picker-basic-example.html
@@ -1,15 +1,16 @@
-<div class="tabbed-group-picker-example">
+<div class="tabbed-group-picker-example" data-automation-id="tabbed-picker-basic-example">
   <novo-tabbed-group-picker
+    data-automation-id="tabbed-picker-basic"
     [tabs]="example_tab"
     [buttonConfig]="example_buttonConfig"
     (selectionChange)="onSelectionChange($event)"
   ></novo-tabbed-group-picker>
-  <div class="selected-data-wrapper">
+  <div class="selected-data-wrapper" data-automation-id="selected-data-wrapper">
     <h6>Selected Animal IDs:</h6>
-    <div>{{ selectedAnimals.join(', ') }}</div>
+    <div data-automation-id="selected-animals">{{ selectedAnimals.join(', ') }}</div>
     <h6>Selected Local Place Names:</h6>
-    <div>{{ selectedPlaces.join(', ') }}</div>
+    <div data-automation-id="selected-places">{{ selectedPlaces.join(', ') }}</div>
     <h6>Selected Colors:</h6>
-    <div>{{ selectedColors.join(' | ') }}</div>
+    <div data-automation-id="selected-colors">{{ selectedColors.join(' | ') }}</div>
   </div>
 </div>

--- a/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-big-groups-example/tabbed-group-picker-big-groups-example.html
+++ b/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-big-groups-example/tabbed-group-picker-big-groups-example.html
@@ -1,15 +1,16 @@
-<div class="tabbed-group-picker-example">
+<div class="tabbed-group-picker-example" data-automation-id="tabbed-picker-big-groups-example">
   <novo-tabbed-group-picker
+    data-automation-id="tabbed-picker-big-groups"
     [tabs]="example_tab"
     [buttonConfig]="example_buttonConfig"
     (selectionChange)="onSelectionChange($event)"
   ></novo-tabbed-group-picker>
-  <div class="selected-data-wrapper">
+  <div class="selected-data-wrapper" data-automation-id="selected-data-wrapper">
     <h6>Selected Integers:</h6>
-    <div>{{ selectedIntegers.join(', ') }}</div>
+    <div data-automation-id="selected-integers">{{ selectedIntegers.join(', ') }}</div>
     <h6>Selected Divisibles:</h6>
-    <div>{{ selectedDivisibles.join(', ') }}</div>
+    <div data-automation-id="selected-divisibles">{{ selectedDivisibles.join(', ') }}</div>
     <h6>Selected Prime Factorizations:</h6>
-    <div>{{ selectedPrimeFactorizations.join(', ') }}</div>
+    <div data-automation-id="selected-prime-factorizations">{{ selectedPrimeFactorizations.join(', ') }}</div>
   </div>
 </div>

--- a/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-footer-example/tabbed-group-picker-footer-example.html
+++ b/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-footer-example/tabbed-group-picker-footer-example.html
@@ -1,5 +1,6 @@
-<div class="tabbed-group-picker-example">
+<div class="tabbed-group-picker-example" data-automation-id="tabbed-picker-footer-example">
   <novo-tabbed-group-picker
+    data-automation-id="tabbed-picker-footer"
     [tabs]="example_tab"
     [quickSelectConfig]="example_quickSelectConfig"
     [buttonConfig]="example_buttonConfig"
@@ -7,10 +8,10 @@
     (cancelChange)="onCancelChange($event)"
     [showFooter]="true"
   ></novo-tabbed-group-picker>
-  <div class="selected-data-wrapper">
+  <div class="selected-data-wrapper" data-automation-id="selected-data-wrapper">
     <h6>Selected Animal IDs:</h6>
-    <div>{{ selectedAnimals.join(', ') }}</div>
+    <div data-automation-id="selected-animals">{{ selectedAnimals.join(', ') }}</div>
     <h6>Selected Animal Category IDs:</h6>
-    <div>{{ selectedAnimalCategories.join(', ') }}</div>
+    <div data-automation-id="selected-animal-categories">{{ selectedAnimalCategories.join(', ') }}</div>
   </div>
 </div>

--- a/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-groups-example/tabbed-group-picker-groups-example.html
+++ b/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-groups-example/tabbed-group-picker-groups-example.html
@@ -1,14 +1,15 @@
-<div class="tabbed-group-picker-example">
+<div class="tabbed-group-picker-example" data-automation-id="tabbed-picker-groups-example">
   <novo-tabbed-group-picker
+    data-automation-id="tabbed-picker-groups"
     [tabs]="example_tab"
     [quickSelectConfig]="example_quickSelectConfig"
     [buttonConfig]="example_buttonConfig"
     (selectionChange)="onSelectionChange($event)"
   ></novo-tabbed-group-picker>
-  <div class="selected-data-wrapper">
+  <div class="selected-data-wrapper" data-automation-id="selected-data-wrapper">
     <h6>Selected Animal IDs:</h6>
-    <div>{{ selectedAnimals.join(', ') }}</div>
+    <div data-automation-id="selected-animals">{{ selectedAnimals.join(', ') }}</div>
     <h6>Selected Animal Category IDs:</h6>
-    <div>{{ selectedAnimalCategories.join(', ') }}</div>
+    <div data-automation-id="selected-animal-categories">{{ selectedAnimalCategories.join(', ') }}</div>
   </div>
 </div>

--- a/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-no-selection-example/tabbed-group-picker-no-selection-example.html
+++ b/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-no-selection-example/tabbed-group-picker-no-selection-example.html
@@ -1,12 +1,13 @@
-<div class="tabbed-group-picker-example">
+<div class="tabbed-group-picker-example" data-automation-id="tabbed-picker-no-selection-example">
   <novo-tabbed-group-picker
+    data-automation-id="tabbed-picker-no-selection"
     [tabs]="example_tab"
     [selectionEnabled]="false"
     [buttonConfig]="example_buttonConfig"
     (activation)="onActivation($event)"
   ></novo-tabbed-group-picker>
-  <div class="selected-data-wrapper">
+  <div class="selected-data-wrapper" data-automation-id="selected-data-wrapper">
     <h6>Last selection:</h6>
-    <div>{{ lastSelection }}</div>
+    <div data-automation-id="last-selection">{{ lastSelection }}</div>
   </div>
 </div>

--- a/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-quick-select-example/tabbed-group-picker-quick-select-example.html
+++ b/projects/novo-examples/src/components/tabbed-group-picker/tabbed-group-picker-quick-select-example/tabbed-group-picker-quick-select-example.html
@@ -1,12 +1,13 @@
-<div class="tabbed-group-picker-example">
+<div class="tabbed-group-picker-example" data-automation-id="tabbed-picker-quick-select-example">
   <novo-tabbed-group-picker
+    data-automation-id="tabbed-picker-quick-select"
     [tabs]="example_tab"
     [quickSelectConfig]="example_quickSelectConfig"
     [buttonConfig]="example_buttonConfig"
     (selectionChange)="onSelectionChange($event)"
   ></novo-tabbed-group-picker>
-  <div class="selected-data-wrapper">
+  <div class="selected-data-wrapper" data-automation-id="selected-data-wrapper">
     <h6>Selected Animal IDs:</h6>
-    <div>{{ selectedAnimals.join(', ') }}</div>
+    <div data-automation-id="selected-animals">{{ selectedAnimals.join(', ') }}</div>
   </div>
 </div>

--- a/projects/novo-examples/src/components/tip-well/basic-tip-well/basic-tip-well-example.html
+++ b/projects/novo-examples/src/components/tip-well/basic-tip-well/basic-tip-well-example.html
@@ -1,5 +1,5 @@
 <novo-tip-well data-automation-id="basic-tip-well" name="Demo" [tip]="demoTip"></novo-tip-well>
 
-<p>Did you hide the TipWell?</p>
+<p data-automation-id="basic-tip-well-message">Did you hide the TipWell?</p>
 
 <button theme="secondary" data-automation-id="basic-tip-well-reset-btn" (click)="clearLocalStorage()">Reset</button> localStorage and Reload

--- a/projects/novo-examples/src/components/tip-well/basic-tip-well/basic-tip-well-example.html
+++ b/projects/novo-examples/src/components/tip-well/basic-tip-well/basic-tip-well-example.html
@@ -1,5 +1,5 @@
-<novo-tip-well name="Demo" [tip]="demoTip"></novo-tip-well>
+<novo-tip-well data-automation-id="basic-tip-well" name="Demo" [tip]="demoTip"></novo-tip-well>
 
 <p>Did you hide the TipWell?</p>
 
-<button theme="secondary" (click)="clearLocalStorage()">Reset</button> localStorage and Reload
+<button theme="secondary" data-automation-id="basic-tip-well-reset-btn" (click)="clearLocalStorage()">Reset</button> localStorage and Reload

--- a/projects/novo-examples/src/components/tip-well/buttonless-tip-well/buttonless-tip-well-example.html
+++ b/projects/novo-examples/src/components/tip-well/buttonless-tip-well/buttonless-tip-well-example.html
@@ -1,5 +1,5 @@
-<novo-tip-well name="Demo" [tip]="demoTip" [button]="false"></novo-tip-well>
+<novo-tip-well data-automation-id="buttonless-tip-well" name="Demo" [tip]="demoTip" [button]="false"></novo-tip-well>
 
 <p>Did you hide the TipWell?</p>
 
-<button theme="secondary" (click)="clearLocalStorage()">Reset</button> localStorage and Reload
+<button theme="secondary" data-automation-id="buttonless-tip-well-reset-btn" (click)="clearLocalStorage()">Reset</button> localStorage and Reload

--- a/projects/novo-examples/src/components/tip-well/buttonless-tip-well/buttonless-tip-well-example.html
+++ b/projects/novo-examples/src/components/tip-well/buttonless-tip-well/buttonless-tip-well-example.html
@@ -1,5 +1,5 @@
 <novo-tip-well data-automation-id="buttonless-tip-well" name="Demo" [tip]="demoTip" [button]="false"></novo-tip-well>
 
-<p>Did you hide the TipWell?</p>
+<p data-automation-id="buttonless-tip-well-message">Did you hide the TipWell?</p>
 
 <button theme="secondary" data-automation-id="buttonless-tip-well-reset-btn" (click)="clearLocalStorage()">Reset</button> localStorage and Reload

--- a/projects/novo-examples/src/components/tip-well/html-tip-well/html-tip-well-example.html
+++ b/projects/novo-examples/src/components/tip-well/html-tip-well/html-tip-well-example.html
@@ -1,5 +1,5 @@
-<novo-tip-well name="Demo" [sanitize]="false" [tip]="demoHtmlTip"></novo-tip-well>
+<novo-tip-well data-automation-id="html-tip-well" name="Demo" [sanitize]="false" [tip]="demoHtmlTip"></novo-tip-well>
 
 <p>Did you hide the TipWell?</p>
 
-<button theme="secondary" (click)="clearLocalStorage()">Reset</button> localStorage and Reload
+<button theme="secondary" data-automation-id="html-tip-well-reset-btn" (click)="clearLocalStorage()">Reset</button> localStorage and Reload

--- a/projects/novo-examples/src/components/tip-well/html-tip-well/html-tip-well-example.html
+++ b/projects/novo-examples/src/components/tip-well/html-tip-well/html-tip-well-example.html
@@ -1,5 +1,5 @@
 <novo-tip-well data-automation-id="html-tip-well" name="Demo" [sanitize]="false" [tip]="demoHtmlTip"></novo-tip-well>
 
-<p>Did you hide the TipWell?</p>
+<p data-automation-id="html-tip-well-message">Did you hide the TipWell?</p>
 
 <button theme="secondary" data-automation-id="html-tip-well-reset-btn" (click)="clearLocalStorage()">Reset</button> localStorage and Reload

--- a/projects/novo-examples/src/components/tip-well/icon-tip-well/icon-tip-well-example.html
+++ b/projects/novo-examples/src/components/tip-well/icon-tip-well/icon-tip-well-example.html
@@ -1,5 +1,5 @@
 <novo-tip-well data-automation-id="icon-tip-well" name="Demo" [tip]="demoTip" icon="info"></novo-tip-well>
 
-<p>Did you hide the TipWell?</p>
+<p data-automation-id="icon-tip-well-message">Did you hide the TipWell?</p>
 
 <button theme="secondary" data-automation-id="icon-tip-well-reset-btn" (click)="clearLocalStorage()">Reset</button> localStorage and Reload

--- a/projects/novo-examples/src/components/tip-well/icon-tip-well/icon-tip-well-example.html
+++ b/projects/novo-examples/src/components/tip-well/icon-tip-well/icon-tip-well-example.html
@@ -1,5 +1,5 @@
-<novo-tip-well name="Demo" [tip]="demoTip" icon="info"></novo-tip-well>
+<novo-tip-well data-automation-id="icon-tip-well" name="Demo" [tip]="demoTip" icon="info"></novo-tip-well>
 
 <p>Did you hide the TipWell?</p>
 
-<button theme="secondary" (click)="clearLocalStorage()">Reset</button> localStorage and Reload
+<button theme="secondary" data-automation-id="icon-tip-well-reset-btn" (click)="clearLocalStorage()">Reset</button> localStorage and Reload

--- a/projects/novo-examples/src/components/toaster/toast-actions/toast-actions-example.html
+++ b/projects/novo-examples/src/components/toaster/toast-actions/toast-actions-example.html
@@ -1,6 +1,6 @@
 <button theme="dialogue" color="success" icon="coffee" (click)="toastToggled('top')" data-automation-id="toast-trigger">Fixed Top</button>
-<button theme="dialogue" color="primary" icon="check" (click)="toastToggled('bottom')">Fixed Bottom</button>
-<button theme="dialogue" color="negative" icon="times" (click)="toastToggled('growlTopRight')">Growl: Top Right</button>
-<button theme="dialogue" color="primary" icon="coffee" (click)="toastToggled('growlTopLeft')">Growl: Top Left</button>
-<button theme="dialogue" color="negative" icon="times" (click)="toastToggled('growlBottomRight')">Growl: Bottom Right</button>
-<button theme="dialogue" color="primary" icon="coffee" (click)="toastToggled('growlBottomLeft')">Growl: Bottom Left</button>
+<button theme="dialogue" color="primary" icon="check" (click)="toastToggled('bottom')" data-automation-id="toast-trigger-bottom">Fixed Bottom</button>
+<button theme="dialogue" color="negative" icon="times" (click)="toastToggled('growlTopRight')" data-automation-id="toast-trigger-growl-top-right">Growl: Top Right</button>
+<button theme="dialogue" color="primary" icon="coffee" (click)="toastToggled('growlTopLeft')" data-automation-id="toast-trigger-growl-top-left">Growl: Top Left</button>
+<button theme="dialogue" color="negative" icon="times" (click)="toastToggled('growlBottomRight')" data-automation-id="toast-trigger-growl-bottom-right">Growl: Bottom Right</button>
+<button theme="dialogue" color="primary" icon="coffee" (click)="toastToggled('growlBottomLeft')" data-automation-id="toast-trigger-growl-bottom-left">Growl: Bottom Left</button>

--- a/projects/novo-examples/src/components/toaster/toast-options/toast-options-example.html
+++ b/projects/novo-examples/src/components/toaster/toast-options/toast-options-example.html
@@ -1,4 +1,4 @@
-<div class="bgc-light">
+<div class="bgc-light" data-automation-id="toast-options-display">
   <novo-toast
     [theme]="style.value==='theme' ? color.value : null"
     [accent]="style.value==='accent' ? color.value : null"
@@ -7,26 +7,26 @@
     [title]="title.value ? 'Save Failed' : null"
     [margin]="margin.value ? '1rem' : 0"
     [isCloseable]="closeable.value"
-    message="Oops! Looks like you're missing some required fields"></novo-toast>
+    message="Oops! Looks like you're missing some required fields" data-automation-id="toast-options-preview"></novo-toast>
 </div>
-<novo-row gap="3rem" align="flex-start">
-  <novo-field>
+<novo-row gap="3rem" align="flex-start" data-automation-id="toast-options-controls">
+  <novo-field data-automation-id="toast-option-appearance">
     <novo-label>Appearance</novo-label>
-    <novo-radio-group #appearance appearance="vertical" value="banner">
+    <novo-radio-group #appearance appearance="vertical" value="banner" data-automation-id="toast-appearance-group">
       <novo-radio name="appearance" value="banner">banner</novo-radio>
       <novo-radio name="appearance" value="growl">growl</novo-radio>
     </novo-radio-group>
   </novo-field>
-  <novo-field>
+  <novo-field data-automation-id="toast-option-style">
     <novo-label>Style</novo-label>
-    <novo-radio-group #style appearance="vertical" value="theme">
+    <novo-radio-group #style appearance="vertical" value="theme" data-automation-id="toast-style-group">
       <novo-radio name="style" value="theme">theme</novo-radio>
       <novo-radio name="style" value="accent">accent</novo-radio>
     </novo-radio-group>
   </novo-field>
-  <novo-field>
+  <novo-field data-automation-id="toast-option-color">
     <novo-label>Color</novo-label>
-    <novo-radio-group #color appearance="vertical" value="info">
+    <novo-radio-group #color appearance="vertical" value="info" data-automation-id="toast-color-group">
       <novo-radio name="color" [value]="null">none</novo-radio>
       <novo-radio name="color" value="info">info</novo-radio>
       <novo-radio name="color" value="success">success</novo-radio>
@@ -34,32 +34,32 @@
       <novo-radio name="color" value="danger">danger</novo-radio>
     </novo-radio-group>
   </novo-field>
-  <novo-field>
+  <novo-field data-automation-id="toast-option-icon">
     <novo-label>Icon</novo-label>
-    <novo-radio-group #icon appearance="vertical" value="bell">
+    <novo-radio-group #icon appearance="vertical" value="bell" data-automation-id="toast-icon-group">
       <novo-radio name="icon" [value]="null">none</novo-radio>
       <novo-radio name="icon" value="check">check</novo-radio>
       <novo-radio name="icon" value="bell">bell</novo-radio>
       <novo-radio name="icon" value="caution">caution</novo-radio>
     </novo-radio-group>
   </novo-field>
-  <novo-field>
+  <novo-field data-automation-id="toast-option-title">
     <novo-label>Show Title</novo-label>
-    <novo-radio-group #title appearance="vertical" [value]="true">
+    <novo-radio-group #title appearance="vertical" [value]="true" data-automation-id="toast-title-group">
       <novo-radio name="title" [value]="true">Show</novo-radio>
       <novo-radio name="title" [value]="false">Hide</novo-radio>
     </novo-radio-group>
   </novo-field>
-  <novo-field>
+  <novo-field data-automation-id="toast-option-margin">
     <novo-label>Margin</novo-label>
-    <novo-radio-group #margin appearance="vertical" [value]="false">
+    <novo-radio-group #margin appearance="vertical" [value]="false" data-automation-id="toast-margin-group">
       <novo-radio name="margin" [value]="false">none</novo-radio>
       <novo-radio name="margin" [value]="true">inset</novo-radio>
     </novo-radio-group>
   </novo-field>
-  <novo-field>
+  <novo-field data-automation-id="toast-option-closeable">
     <novo-label>Closeable</novo-label>
-    <novo-radio-group #closeable appearance="vertical" [value]="false">
+    <novo-radio-group #closeable appearance="vertical" [value]="false" data-automation-id="toast-closeable-group">
       <novo-radio name="margin" [value]="false">false</novo-radio>
       <novo-radio name="margin" [value]="true">true</novo-radio>
     </novo-radio-group>

--- a/projects/novo-examples/src/components/toaster/toast-options/toast-options-example.html
+++ b/projects/novo-examples/src/components/toaster/toast-options/toast-options-example.html
@@ -13,55 +13,55 @@
   <novo-field data-automation-id="toast-option-appearance">
     <novo-label>Appearance</novo-label>
     <novo-radio-group #appearance appearance="vertical" value="banner" data-automation-id="toast-appearance-group">
-      <novo-radio name="appearance" value="banner">banner</novo-radio>
-      <novo-radio name="appearance" value="growl">growl</novo-radio>
+      <novo-radio name="appearance" value="banner" data-automation-id="toast-appearance-banner">banner</novo-radio>
+      <novo-radio name="appearance" value="growl" data-automation-id="toast-appearance-growl">growl</novo-radio>
     </novo-radio-group>
   </novo-field>
   <novo-field data-automation-id="toast-option-style">
     <novo-label>Style</novo-label>
     <novo-radio-group #style appearance="vertical" value="theme" data-automation-id="toast-style-group">
-      <novo-radio name="style" value="theme">theme</novo-radio>
-      <novo-radio name="style" value="accent">accent</novo-radio>
+      <novo-radio name="style" value="theme" data-automation-id="toast-style-theme">theme</novo-radio>
+      <novo-radio name="style" value="accent" data-automation-id="toast-style-accent">accent</novo-radio>
     </novo-radio-group>
   </novo-field>
   <novo-field data-automation-id="toast-option-color">
     <novo-label>Color</novo-label>
     <novo-radio-group #color appearance="vertical" value="info" data-automation-id="toast-color-group">
-      <novo-radio name="color" [value]="null">none</novo-radio>
-      <novo-radio name="color" value="info">info</novo-radio>
-      <novo-radio name="color" value="success">success</novo-radio>
-      <novo-radio name="color" value="warning">warning</novo-radio>
-      <novo-radio name="color" value="danger">danger</novo-radio>
+      <novo-radio name="color" [value]="null" data-automation-id="toast-color-none">none</novo-radio>
+      <novo-radio name="color" value="info" data-automation-id="toast-color-info">info</novo-radio>
+      <novo-radio name="color" value="success" data-automation-id="toast-color-success">success</novo-radio>
+      <novo-radio name="color" value="warning" data-automation-id="toast-color-warning">warning</novo-radio>
+      <novo-radio name="color" value="danger" data-automation-id="toast-color-danger">danger</novo-radio>
     </novo-radio-group>
   </novo-field>
   <novo-field data-automation-id="toast-option-icon">
     <novo-label>Icon</novo-label>
     <novo-radio-group #icon appearance="vertical" value="bell" data-automation-id="toast-icon-group">
-      <novo-radio name="icon" [value]="null">none</novo-radio>
-      <novo-radio name="icon" value="check">check</novo-radio>
-      <novo-radio name="icon" value="bell">bell</novo-radio>
-      <novo-radio name="icon" value="caution">caution</novo-radio>
+      <novo-radio name="icon" [value]="null" data-automation-id="toast-icon-none">none</novo-radio>
+      <novo-radio name="icon" value="check" data-automation-id="toast-icon-check">check</novo-radio>
+      <novo-radio name="icon" value="bell" data-automation-id="toast-icon-bell">bell</novo-radio>
+      <novo-radio name="icon" value="caution" data-automation-id="toast-icon-caution">caution</novo-radio>
     </novo-radio-group>
   </novo-field>
   <novo-field data-automation-id="toast-option-title">
     <novo-label>Show Title</novo-label>
     <novo-radio-group #title appearance="vertical" [value]="true" data-automation-id="toast-title-group">
-      <novo-radio name="title" [value]="true">Show</novo-radio>
-      <novo-radio name="title" [value]="false">Hide</novo-radio>
+      <novo-radio name="title" [value]="true" data-automation-id="toast-title-show">Show</novo-radio>
+      <novo-radio name="title" [value]="false" data-automation-id="toast-title-hide">Hide</novo-radio>
     </novo-radio-group>
   </novo-field>
   <novo-field data-automation-id="toast-option-margin">
     <novo-label>Margin</novo-label>
     <novo-radio-group #margin appearance="vertical" [value]="false" data-automation-id="toast-margin-group">
-      <novo-radio name="margin" [value]="false">none</novo-radio>
-      <novo-radio name="margin" [value]="true">inset</novo-radio>
+      <novo-radio name="margin" [value]="false" data-automation-id="toast-margin-none">none</novo-radio>
+      <novo-radio name="margin" [value]="true" data-automation-id="toast-margin-inset">inset</novo-radio>
     </novo-radio-group>
   </novo-field>
   <novo-field data-automation-id="toast-option-closeable">
     <novo-label>Closeable</novo-label>
     <novo-radio-group #closeable appearance="vertical" [value]="false" data-automation-id="toast-closeable-group">
-      <novo-radio name="margin" [value]="false">false</novo-radio>
-      <novo-radio name="margin" [value]="true">true</novo-radio>
+      <novo-radio name="margin" [value]="false" data-automation-id="toast-closeable-false">false</novo-radio>
+      <novo-radio name="margin" [value]="true" data-automation-id="toast-closeable-true">true</novo-radio>
     </novo-radio-group>
   </novo-field>
 </novo-row>

--- a/projects/novo-examples/src/components/toaster/toast-service/toast-service-example.html
+++ b/projects/novo-examples/src/components/toaster/toast-service/toast-service-example.html
@@ -1,7 +1,7 @@
 <button theme="dialogue" color="success" icon="coffee" (click)="toastToggled('top')" data-automation-id="toast-trigger">Fixed Top</button>
-<button theme="dialogue" color="primary" icon="check" (click)="toastToggled('bottom')">Fixed Bottom</button>
-<button theme="dialogue" color="negative" icon="times" (click)="toastToggled('growlTopRight')">Growl: Top Right</button>
-<button theme="dialogue" color="primary" icon="coffee" (click)="toastToggled('growlTopLeft')">Growl: Top Left</button>
-<button theme="dialogue" color="negative" icon="times" (click)="toastToggled('growlBottomRight')">Growl: Bottom Right</button>
-<button theme="dialogue" color="primary" icon="coffee" (click)="toastToggled('growlBottomLeft')">Growl: Bottom Left</button>
-<button theme="dialogue" color="success" icon="coffee" (click)="toastToggled('topAccent')" data-automation-id="toast-trigger">Fixed Top Accent</button>
+<button theme="dialogue" color="primary" icon="check" (click)="toastToggled('bottom')" data-automation-id="toast-trigger-bottom">Fixed Bottom</button>
+<button theme="dialogue" color="negative" icon="times" (click)="toastToggled('growlTopRight')" data-automation-id="toast-trigger-growl-top-right">Growl: Top Right</button>
+<button theme="dialogue" color="primary" icon="coffee" (click)="toastToggled('growlTopLeft')" data-automation-id="toast-trigger-growl-top-left">Growl: Top Left</button>
+<button theme="dialogue" color="negative" icon="times" (click)="toastToggled('growlBottomRight')" data-automation-id="toast-trigger-growl-bottom-right">Growl: Bottom Right</button>
+<button theme="dialogue" color="primary" icon="coffee" (click)="toastToggled('growlBottomLeft')" data-automation-id="toast-trigger-growl-bottom-left">Growl: Bottom Left</button>
+<button theme="dialogue" color="success" icon="coffee" (click)="toastToggled('topAccent')" data-automation-id="toast-trigger-top-accent">Fixed Top Accent</button>

--- a/projects/novo-examples/src/components/toaster/toast-usage/toast-usage-example.html
+++ b/projects/novo-examples/src/components/toaster/toast-usage/toast-usage-example.html
@@ -1,16 +1,16 @@
-<div class="fake-card">
-  <novo-header theme="job">
-    <novo-title larger>
+<div class="fake-card" data-automation-id="toast-usage-container">
+  <novo-header theme="job" data-automation-id="toast-usage-header">
+    <novo-title larger data-automation-id="toast-usage-title">
       <novo-icon>job</novo-icon>
       <span>Apply to Bull Rider</span>
     </novo-title>
-    <novo-action icon="flag"></novo-action>
-    <novo-action icon="refresh"></novo-action>
-    <novo-action icon="times"></novo-action>
+    <novo-action icon="flag" data-automation-id="toast-usage-action-flag"></novo-action>
+    <novo-action icon="refresh" data-automation-id="toast-usage-action-refresh"></novo-action>
+    <novo-action icon="times" data-automation-id="toast-usage-action-close"></novo-action>
   </novo-header>
   <novo-toast [accent]="toast.accent" [theme]="toast.theme" [icon]="toast.icon" title="Save Failed"
-    message="Oops! Looks like you're missing some required fields"></novo-toast>
-  <div class="content">
+    message="Oops! Looks like you're missing some required fields" data-automation-id="toast-display"></novo-toast>
+  <div class="content" data-automation-id="toast-usage-content">
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
       do eiusmod tempor incididunt ut labore et dolore
@@ -22,6 +22,6 @@
       sunt in culpa qui officia deserunt mollit anim id
       est laborum.
     </p>
-    <button (click)="changeToast()">Change toast!</button>
+    <button (click)="changeToast()" data-automation-id="toast-usage-change-button">Change toast!</button>
   </div>
 </div>

--- a/projects/novo-examples/src/components/toolbar/basic-toolbar/basic-toolbar-example.html
+++ b/projects/novo-examples/src/components/toolbar/basic-toolbar/basic-toolbar-example.html
@@ -1,11 +1,11 @@
 <p>
-  <novo-toolbar>
+  <novo-toolbar data-automation-id="basic-toolbar">
     <novo-title>My Application</novo-title>
   </novo-toolbar>
 </p>
 
 <p>
-  <novo-toolbar accent="candidate" gap="md">
+  <novo-toolbar accent="candidate" gap="md" data-automation-id="toolbar-accent">
     <novo-icon color="candidate">candidate</novo-icon>
     <novo-title>Ferdinand del Toro</novo-title>
   </novo-toolbar>
@@ -13,7 +13,7 @@
 
 
 <p>
-  <novo-toolbar color="company" gap="1rem">
+  <novo-toolbar color="company" gap="1rem" data-automation-id="toolbar-company">
     <novo-icon>company</novo-icon>
     <novo-title>Taurus Industries</novo-title>
     <novo-nav theme="color">
@@ -21,29 +21,29 @@
       <novo-tab>Files</novo-tab>
     </novo-nav>
     <span class="example-spacer"></span>
-    <novo-button theme="secondary">Button</novo-button>
-    <novo-action icon="share" tooltip="Share"></novo-action>
-    <novo-action icon="print" tooltip="Print"></novo-action>
-    <novo-action icon="times" tooltip="Close"></novo-action>
+    <novo-button theme="secondary" data-automation-id="toolbar-company-button">Button</novo-button>
+    <novo-action icon="share" tooltip="Share" data-automation-id="toolbar-company-share-action"></novo-action>
+    <novo-action icon="print" tooltip="Print" data-automation-id="toolbar-company-print-action"></novo-action>
+    <novo-action icon="times" tooltip="Close" data-automation-id="toolbar-company-close-action"></novo-action>
   </novo-toolbar>
 </p>
 
 <p>
-  <novo-toolbar color="navigation">
-    <novo-action icon="menu" tooltip="Main Menu"></novo-action>
+  <novo-toolbar color="navigation" data-automation-id="toolbar-navigation">
+    <novo-action icon="menu" tooltip="Main Menu" data-automation-id="toolbar-nav-menu-action"></novo-action>
     <novo-divider vertical></novo-divider>
-    <img src="assets/images/bullhorn-logo.svg" width="120" height="32" />
+    <img src="assets/images/bullhorn-logo.svg" width="120" height="32" data-automation-id="toolbar-nav-logo" />
     <novo-divider vertical></novo-divider>
-    <novo-action icon="add-thin" tooltip="Fast Add"></novo-action>
+    <novo-action icon="add-thin" tooltip="Fast Add" data-automation-id="toolbar-nav-add-action"></novo-action>
     <novo-divider vertical></novo-divider>
-    <novo-search></novo-search>
+    <novo-search data-automation-id="toolbar-nav-search"></novo-search>
 
     <span class="example-spacer"></span>
     <novo-divider vertical></novo-divider>
-    <novo-action icon="question" tooltip="Support"></novo-action>
+    <novo-action icon="question" tooltip="Support" data-automation-id="toolbar-nav-support-action"></novo-action>
     <novo-divider vertical></novo-divider>
-    <novo-action icon="configure-o" tooltip="Settings"></novo-action>
+    <novo-action icon="configure-o" tooltip="Settings" data-automation-id="toolbar-nav-settings-action"></novo-action>
     <novo-divider vertical></novo-divider>
-    <novo-avatar image="https://robohash.org/bvkimball" color="bittersweet"></novo-avatar>
+    <novo-avatar image="https://robohash.org/bvkimball" color="bittersweet" data-automation-id="toolbar-nav-avatar"></novo-avatar>
   </novo-toolbar>
 </p>

--- a/projects/novo-examples/src/components/toolbar/multi-row-toolbar/multi-row-toolbar-example.html
+++ b/projects/novo-examples/src/components/toolbar/multi-row-toolbar/multi-row-toolbar-example.html
@@ -1,12 +1,12 @@
-<novo-toolbar>
-  <novo-toolbar-row color="company" gap="md">
+<novo-toolbar data-automation-id="multi-row-toolbar">
+  <novo-toolbar-row color="company" gap="md" data-automation-id="toolbar-row-header">
     <novo-icon>company</novo-icon>
     <novo-title>My App</novo-title>
     <span class="example-spacer"></span>
-    <novo-action icon="menu" aria-label="Example icon-button with menu icon"></novo-action>
+    <novo-action icon="menu" aria-label="Example icon-button with menu icon" data-automation-id="toolbar-row-header-menu"></novo-action>
   </novo-toolbar-row>
 
-  <novo-toolbar-row>
+  <novo-toolbar-row data-automation-id="toolbar-row-nav">
     <novo-nav>
       <novo-tab>Overview</novo-tab>
       <novo-tab>Activity</novo-tab>
@@ -14,6 +14,6 @@
     </novo-nav>
     <span class="example-spacer"></span>
     <novo-divider vertical></novo-divider>
-    <novo-button theme="dialogue">Layout</novo-button>
+    <novo-button theme="dialogue" data-automation-id="toolbar-row-nav-layout-btn">Layout</novo-button>
   </novo-toolbar-row>
 </novo-toolbar>

--- a/projects/novo-examples/src/components/tooltip/tooltip-align/tooltip-align-example.html
+++ b/projects/novo-examples/src/components/tooltip/tooltip-align/tooltip-align-example.html
@@ -1,4 +1,4 @@
-<span tooltip="bottom-left" tooltipPosition="bottom-left">Bottom Left</span>
-<span tooltip="bottom-right" tooltipPosition="bottom-right">Bottom Right</span>
-<span tooltip="top-left" tooltipPosition="top-left">Top Left</span>
-<span tooltip="top-right" tooltipPosition="top-right">Top Right</span>
+<span tooltip="bottom-left" tooltipPosition="bottom-left" data-automation-id="tooltip-bottom-left">Bottom Left</span>
+<span tooltip="bottom-right" tooltipPosition="bottom-right" data-automation-id="tooltip-bottom-right">Bottom Right</span>
+<span tooltip="top-left" tooltipPosition="top-left" data-automation-id="tooltip-top-left">Top Left</span>
+<span tooltip="top-right" tooltipPosition="top-right" data-automation-id="tooltip-top-right">Top Right</span>

--- a/projects/novo-examples/src/components/tooltip/tooltip-options/tooltip-options-example.html
+++ b/projects/novo-examples/src/components/tooltip/tooltip-options/tooltip-options-example.html
@@ -1,5 +1,5 @@
-<span tooltip="ALWAYS" tooltipAlways="true">Always Shown</span>
-<span tooltip="ROUNDED" tooltipRounded="true">Rounded</span>
-<span tooltip="NO ANIMATE" tooltipNoAnimate="true">No Animation</span>
-<span tooltip="BOUNCE" tooltipBounce="true">Bounce</span>
-<span tooltip="<h2>Hello</h2><hr>I can <i>render</i><ul><li>HTML</li><li>CSS</li></ul>" tooltipIsHTML="true">HTML</span>
+<span tooltip="ALWAYS" tooltipAlways="true" data-automation-id="tooltip-always">Always Shown</span>
+<span tooltip="ROUNDED" tooltipRounded="true" data-automation-id="tooltip-rounded">Rounded</span>
+<span tooltip="NO ANIMATE" tooltipNoAnimate="true" data-automation-id="tooltip-no-animate">No Animation</span>
+<span tooltip="BOUNCE" tooltipBounce="true" data-automation-id="tooltip-bounce">Bounce</span>
+<span tooltip="<h2>Hello</h2><hr>I can <i>render</i><ul><li>HTML</li><li>CSS</li></ul>" tooltipIsHTML="true" data-automation-id="tooltip-html">HTML</span>

--- a/projects/novo-examples/src/components/tooltip/tooltip-overflow/tooltip-overflow-example.html
+++ b/projects/novo-examples/src/components/tooltip/tooltip-overflow/tooltip-overflow-example.html
@@ -1,6 +1,6 @@
 <novo-card padding="lg">
-  <novo-text ellipsis [tooltip]="longText" tooltipOnOverflow>{{ longText }}</novo-text>
+  <novo-text ellipsis [tooltip]="longText" tooltipOnOverflow data-automation-id="tooltip-overflow-long">{{ longText }}</novo-text>
 </novo-card>
 <novo-card padding="lg">
-  <novo-text ellipsis [tooltip]="shortText" tooltipOnOverflow>{{ shortText }}</novo-text>
+  <novo-text ellipsis [tooltip]="shortText" tooltipOnOverflow data-automation-id="tooltip-overflow-short">{{ shortText }}</novo-text>
 </novo-card>

--- a/projects/novo-examples/src/components/tooltip/tooltip-placement/tooltip-placement-example.html
+++ b/projects/novo-examples/src/components/tooltip/tooltip-placement/tooltip-placement-example.html
@@ -1,4 +1,4 @@
-<span tooltip="left" tooltipPosition="left">Left</span>
-<span tooltip="right" tooltipPosition="right">Right</span>
-<span tooltip="top" tooltipPosition="top">Top</span>
-<span tooltip="bottom" tooltipPosition="bottom">Bottom</span>
+<span tooltip="left" tooltipPosition="left" data-automation-id="tooltip-left">Left</span>
+<span tooltip="right" tooltipPosition="right" data-automation-id="tooltip-right">Right</span>
+<span tooltip="top" tooltipPosition="top" data-automation-id="tooltip-top">Top</span>
+<span tooltip="bottom" tooltipPosition="bottom" data-automation-id="tooltip-bottom">Bottom</span>

--- a/projects/novo-examples/src/components/tooltip/tooltip-sizes/tooltip-sizes-example.html
+++ b/projects/novo-examples/src/components/tooltip/tooltip-sizes/tooltip-sizes-example.html
@@ -1,4 +1,4 @@
-<span tooltip="Small Tooltip" tooltipSize="small" tooltipPosition="bottom" tooltipPreline="true">Small Tooltip</span>
-<span [tooltip]="mediumTooltip" tooltipSize="medium" tooltipPosition="left" tooltipPreline="true">Medium Tooltip</span>
-<span [tooltip]="largeTooltip" tooltipSize="large" tooltipPosition="top" tooltipPreline="true">Large Tooltip</span>
-<span [tooltip]="extraLargeTooltip" tooltipSize="extra-large" tooltipPosition="top" tooltipPreline="true" tooltipAutoPosition="true">Extra-Large Tooltip</span>
+<span tooltip="Small Tooltip" tooltipSize="small" tooltipPosition="bottom" tooltipPreline="true" data-automation-id="tooltip-small">Small Tooltip</span>
+<span [tooltip]="mediumTooltip" tooltipSize="medium" tooltipPosition="left" tooltipPreline="true" data-automation-id="tooltip-medium">Medium Tooltip</span>
+<span [tooltip]="largeTooltip" tooltipSize="large" tooltipPosition="top" tooltipPreline="true" data-automation-id="tooltip-large">Large Tooltip</span>
+<span [tooltip]="extraLargeTooltip" tooltipSize="extra-large" tooltipPosition="top" tooltipPreline="true" tooltipAutoPosition="true" data-automation-id="tooltip-extra-large">Extra-Large Tooltip</span>

--- a/projects/novo-examples/src/components/tooltip/tooltip-toggle/tooltip-toggle-example.html
+++ b/projects/novo-examples/src/components/tooltip/tooltip-toggle/tooltip-toggle-example.html
@@ -1,5 +1,5 @@
-<span tooltip="I HAVE A TOOLTIP!" [tooltipActive]="tooltipActive">
+<span tooltip="I HAVE A TOOLTIP!" [tooltipActive]="tooltipActive" data-automation-id="tooltip-toggle-element">
     <span *ngIf="tooltipActive">My tooltip can display!</span>
     <span *ngIf="!tooltipActive">My tooltip is disabled!</span>
 </span>
-<button theme="secondary" (click)="toggleTooltip()">Toggle</button>
+<button theme="secondary" (click)="toggleTooltip()" data-automation-id="tooltip-toggle-button">Toggle</button>

--- a/projects/novo-examples/src/components/tooltip/tooltip-types/tooltip-types-example.html
+++ b/projects/novo-examples/src/components/tooltip/tooltip-types/tooltip-types-example.html
@@ -1,4 +1,4 @@
-<span tooltip="ERROR" tooltipType="error">Error</span>
-<span tooltip="INFO" tooltipType="info">Info</span>
-<span tooltip="WARNING" tooltipType="warning">Warning</span>
-<span tooltip="SUCCESS" tooltipType="success">Success</span>
+<span tooltip="ERROR" tooltipType="error" data-automation-id="tooltip-error">Error</span>
+<span tooltip="INFO" tooltipType="info" data-automation-id="tooltip-info">Info</span>
+<span tooltip="WARNING" tooltipType="warning" data-automation-id="tooltip-warning">Warning</span>
+<span tooltip="SUCCESS" tooltipType="success" data-automation-id="tooltip-success">Success</span>


### PR DESCRIPTION
… make automation easier

## **Description**

- Adding data-automation-ids across the example pages to better enable writing automation.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**