### PR TITLE
fix(QuickNote): Address a CKEditor bug with browser spellcheck menus

### DIFF
--- a/projects/novo-elements/src/addons/ckeditor/CKEditor.ts
+++ b/projects/novo-elements/src/addons/ckeditor/CKEditor.ts
@@ -1,6 +1,7 @@
 // NG2
 import { AfterViewInit, Component, EventEmitter, forwardRef, Input, NgZone, OnDestroy, Output, ViewChild } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { fixCkEditorInputEvent } from 'novo-elements/utils';
 
 // Value accessor for the component (supports ngModel)
 const CKEDITOR_CONTROL_VALUE_ACCESSOR = {
@@ -64,6 +65,7 @@ export class NovoCKEditorElement implements OnDestroy, AfterViewInit, ControlVal
   _value: string = '';
   instance;
   debounceTimeout;
+  private _ckEditorFixRemoveListener?: () => void;
 
   constructor(private zone: NgZone) {}
 
@@ -82,6 +84,7 @@ export class NovoCKEditorElement implements OnDestroy, AfterViewInit, ControlVal
   ngOnDestroy() {
     if (this.instance) {
       this.instance.focusManager.blur(true); // Remove focus from editor
+      this._ckEditorFixRemoveListener?.();
       setTimeout(() => {
         this.instance.removeAllListeners();
         const aInstance = CKEDITOR.instances[this.instance.name];
@@ -122,6 +125,7 @@ export class NovoCKEditorElement implements OnDestroy, AfterViewInit, ControlVal
 
     // CKEditor replace textarea
     this.instance = CKEDITOR.replace(this.host.nativeElement, config);
+    this._ckEditorFixRemoveListener = fixCkEditorInputEvent(this.instance);
 
     // Set initial value
     this.instance.setData(this.value);

--- a/projects/novo-elements/src/elements/quick-note/QuickNote.ts
+++ b/projects/novo-elements/src/elements/quick-note/QuickNote.ts
@@ -15,7 +15,7 @@ import {
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ComponentUtils } from 'novo-elements/services';
-import { Key, OutsideClick } from 'novo-elements/utils';
+import { Key, OutsideClick, fixCkEditorInputEvent } from 'novo-elements/utils';
 // APP
 import { QuickNoteResults } from './extras/quick-note-results/QuickNoteResults';
 
@@ -68,6 +68,7 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
   private debounceTimeout: any;
   private placeholderVisible: boolean = false;
   private _placeholderElement: any = null;
+  private _ckEditorFixRemoveListener?: () => void;
 
   private static TOOLBAR_HEIGHT = 40; // in pixels - configured by stylesheet
 
@@ -106,6 +107,7 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
   public ngOnDestroy(): void {
     // Tear down the CKEditor instance
     if (this.ckeInstance) {
+      this._ckEditorFixRemoveListener?.();
       this.ckeInstance.focusManager.blur(true); // Remove focus from editor
       setTimeout(() => {
         this.ckeInstance.removeAllListeners();
@@ -127,6 +129,7 @@ export class QuickNoteElement extends OutsideClick implements OnInit, OnDestroy,
 
     // Replace the textarea with an instance of CKEditor
     this.ckeInstance = CKEDITOR.replace(this.host.nativeElement, this.getCKEditorConfig());
+    fixCkEditorInputEvent(this.ckeInstance);
 
     // Set initial value of the note in the editor
     this.writeValue(this.model);

--- a/projects/novo-elements/src/utils/ckeditor-input-fix.ts
+++ b/projects/novo-elements/src/utils/ckeditor-input-fix.ts
@@ -1,0 +1,20 @@
+
+export function fixCkEditorInputEvent(ckEditorInstance: any): () => void {
+    let debounceInputTimeout: ReturnType<typeof setTimeout> | null;
+    const onCkBodyInput = (event: InputEvent) => {
+        if (debounceInputTimeout) {
+            clearTimeout(debounceInputTimeout);
+        }
+        debounceInputTimeout = setTimeout(() => {
+            // change event did not process this input event (first known from spellcheck menu options)
+            ckEditorInstance.fire('change');
+            debounceInputTimeout = null;
+        }, 250);
+    };
+    ckEditorInstance.on('instanceReady', (event: any) => {
+        ckEditorInstance.document.$.body.addEventListener('input', onCkBodyInput);
+    });
+    return () => {
+        ckEditorInstance.document.$.body.removeEventListener('input', onCkBodyInput);
+    }
+}

--- a/projects/novo-elements/src/utils/index.ts
+++ b/projects/novo-elements/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './app-bridge';
 export * from './base-renderer';
 export * from './calendar-utils';
+export * from './ckeditor-input-fix';
 export * from './color-utils';
 export * from './countries';
 export * from './date';


### PR DESCRIPTION
## **Description**

If a user spellchecks a word, no change event was processed. This triggers a change if an input event occurs, and no matching change event.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**