### PR TITLE
chore(deps): Update bullhorn-icons version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@angular/cli": "^20.3.22",
         "@angular/compiler-cli": "^20.3.18",
         "@angular/language-service": "^20.3.18",
-        "@bullhorn/bullhorn-icons": "^2.39.0",
+        "@bullhorn/bullhorn-icons": "^2.42.2",
         "@codemirror/lang-javascript": "^6.2.4",
         "@eslint/js": "^10.0.1",
         "@github-docs/frontmatter": "^1.3.1",
@@ -1375,9 +1375,9 @@
       "license": "MIT"
     },
     "node_modules/@bullhorn/bullhorn-icons": {
-      "version": "2.39.0",
-      "resolved": "https://registry.npmjs.org/@bullhorn/bullhorn-icons/-/bullhorn-icons-2.39.0.tgz",
-      "integrity": "sha512-pJwOGsiisSULhK8MU0zlBv61A8Vxt7iwqQrKZX9f7PruGMTIqjY+sLNcQle8uK+Y3B7M+kHob4Re8xEnbYmLzg==",
+      "version": "2.42.2",
+      "resolved": "https://registry.npmjs.org/@bullhorn/bullhorn-icons/-/bullhorn-icons-2.42.2.tgz",
+      "integrity": "sha512-9HQWDETR+Ya9+FvFFzYeEMQaQf2b4WwVzBfGpx8d4T1dv1RlfrbpKG4QSMJsP5NMA8qcgiNwrsj/jptC7zW4tw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@angular/cli": "^20.3.22",
     "@angular/compiler-cli": "^20.3.18",
     "@angular/language-service": "^20.3.18",
-    "@bullhorn/bullhorn-icons": "^2.39.0",
+    "@bullhorn/bullhorn-icons": "^2.42.2",
     "@codemirror/lang-javascript": "^6.2.4",
     "@eslint/js": "^10.0.1",
     "@github-docs/frontmatter": "^1.3.1",


### PR DESCRIPTION
## **Description**

Update the bullhorn-icons version to the latest

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**