### PR TITLE
test(Automation): Add data-automation-ids on form controls examples

### DIFF
--- a/projects/novo-examples/src/form-controls/checkbox/basic-checkbox/basic-checkbox-example.html
+++ b/projects/novo-examples/src/form-controls/checkbox/basic-checkbox/basic-checkbox-example.html
@@ -1,8 +1,9 @@
-<div *ngFor="let item of items">
+<div *ngFor="let item of items; let i = index">
   <novo-checkbox
     [label]="item.name"
     [(ngModel)]="item.isChecked"
     [disabled]="item.disabled"
     [indeterminate]="item.indeterminate"
-    (onSelect)="onChange($event, item)"></novo-checkbox>
+    (onSelect)="onChange($event, item)"
+    [attr.data-automation-id]="'checkbox-basic-' + i"></novo-checkbox>
 </div>

--- a/projects/novo-examples/src/form-controls/checkbox/checkbox-list/checkbox-list-example.html
+++ b/projects/novo-examples/src/form-controls/checkbox/checkbox-list/checkbox-list-example.html
@@ -1,5 +1,5 @@
 Enabled:
-<novo-check-list [options]="options1"></novo-check-list>
+<novo-check-list [options]="options1" data-automation-id="checkbox-list-enabled"></novo-check-list>
 <br />
 Disabled:
-<novo-check-list [options]="options2" [disabled]="true"></novo-check-list>
+<novo-check-list [options]="options2" [disabled]="true" data-automation-id="checkbox-list-disabled"></novo-check-list>

--- a/projects/novo-examples/src/form-controls/chips/async-chips/async-chips-example.html
+++ b/projects/novo-examples/src/form-controls/chips/async-chips/async-chips-example.html
@@ -1,2 +1,2 @@
-<div class="selected-value">Selected Value: {{value}}</div>
-<novo-chips [source]="async" [placeholder]="placeholder" [(ngModel)]="value" (changed)="onChanged($event)"></novo-chips>
+<div class="selected-value" data-automation-id="chips-async-value">Selected Value: {{value}}</div>
+<novo-chips [source]="async" [placeholder]="placeholder" [(ngModel)]="value" (changed)="onChanged($event)" data-automation-id="chips-async-input"></novo-chips>

--- a/projects/novo-examples/src/form-controls/chips/basic-chips/basic-chips-example.html
+++ b/projects/novo-examples/src/form-controls/chips/basic-chips/basic-chips-example.html
@@ -1,2 +1,2 @@
-<div class="selected-value">Selected Value: {{value}}</div>
-<novo-chips [source]="staticDemo" [placeholder]="placeholder" [(ngModel)]="value" (changed)="onChanged($event)"></novo-chips>
+<div class="selected-value" data-automation-id="chips-basic-value">Selected Value: {{value}}</div>
+<novo-chips [source]="staticDemo" [placeholder]="placeholder" [(ngModel)]="value" (changed)="onChanged($event)" data-automation-id="chips-basic-input"></novo-chips>

--- a/projects/novo-examples/src/form-controls/chips/chip-usage/chip-usage-example.html
+++ b/projects/novo-examples/src/form-controls/chips/chip-usage/chip-usage-example.html
@@ -1,42 +1,42 @@
 <novo-stack gap="md">
   <novo-row gap="md">
-    <novo-chip [size]="size.value">Standard</novo-chip>
-    <novo-chip [size]="size.value">
+    <novo-chip [size]="size.value" data-automation-id="chip-usage-standard">Standard</novo-chip>
+    <novo-chip [size]="size.value" data-automation-id="chip-usage-icon">
       <novo-icon>bell</novo-icon>
     </novo-chip>
-    <novo-chip [size]="size.value">
+    <novo-chip [size]="size.value" data-automation-id="chip-usage-removable">
       <novo-text>Removable</novo-text>
       <novo-icon novoChipRemove>x</novo-icon>
     </novo-chip>
-    <novo-chip [size]="size.value" disabled>
+    <novo-chip [size]="size.value" disabled data-automation-id="chip-usage-disabled">
       <novo-icon>candidate</novo-icon>
       <novo-text>Disabled</novo-text>
     </novo-chip>
   </novo-row>
   <novo-row gap="md">
-    <novo-chip color="success" [size]="size.value">Standard</novo-chip>
-    <novo-chip color="negative" [size]="size.value">
+    <novo-chip color="success" [size]="size.value" data-automation-id="chip-usage-success">Standard</novo-chip>
+    <novo-chip color="negative" [size]="size.value" data-automation-id="chip-usage-negative">
       <novo-icon>bell</novo-icon>
     </novo-chip>
-    <novo-chip color="ocean" [size]="size.value">
+    <novo-chip color="ocean" [size]="size.value" data-automation-id="chip-usage-ocean">
       <novo-text>Removable</novo-text>
       <novo-icon novoChipRemove>x</novo-icon>
     </novo-chip>
-    <novo-chip color="candidate" [size]="size.value" disabled>
+    <novo-chip color="candidate" [size]="size.value" disabled data-automation-id="chip-usage-candidate">
       <novo-icon>candidate</novo-icon>
       <novo-text>Disabled</novo-text>
     </novo-chip>
   </novo-row>
   <novo-row gap="md">
-    <novo-chip accent="success" [size]="size.value">Standard</novo-chip>
-    <novo-chip accent="negative" [size]="size.value">
+    <novo-chip accent="success" [size]="size.value" data-automation-id="chip-usage-accent-success">Standard</novo-chip>
+    <novo-chip accent="negative" [size]="size.value" data-automation-id="chip-usage-accent-negative">
       <novo-icon>bell</novo-icon>
     </novo-chip>
-    <novo-chip accent="ocean" [size]="size.value">
+    <novo-chip accent="ocean" [size]="size.value" data-automation-id="chip-usage-accent-ocean">
       <novo-text>Removable</novo-text>
       <novo-icon novoChipRemove>x</novo-icon>
     </novo-chip>
-    <novo-chip accent="candidate" [size]="size.value" disabled>
+    <novo-chip accent="candidate" [size]="size.value" disabled data-automation-id="chip-usage-accent-candidate">
       <novo-icon>candidate</novo-icon>
       <novo-text>Disabled</novo-text>
     </novo-chip>
@@ -44,14 +44,14 @@
 
 </novo-stack>
 
-<section>
+<section data-automation-id="chip-usage-size-section">
   <novo-label>Size</novo-label>
-  <novo-radio-group #size appearance="vertical" value="md">
-    <novo-radio name="size" value="xs">xs</novo-radio>
-    <novo-radio name="size" value="sm">sm</novo-radio>
-    <novo-radio name="size" value="md">md</novo-radio>
-    <novo-radio name="size" value="lg">lg</novo-radio>
-    <novo-radio name="size" value="xl">xl</novo-radio>
+  <novo-radio-group #size appearance="vertical" value="md" data-automation-id="chip-usage-size-group">
+    <novo-radio name="size" value="xs" data-automation-id="chip-usage-size-xs">xs</novo-radio>
+    <novo-radio name="size" value="sm" data-automation-id="chip-usage-size-sm">sm</novo-radio>
+    <novo-radio name="size" value="md" data-automation-id="chip-usage-size-md">md</novo-radio>
+    <novo-radio name="size" value="lg" data-automation-id="chip-usage-size-lg">lg</novo-radio>
+    <novo-radio name="size" value="xl" data-automation-id="chip-usage-size-xl">xl</novo-radio>
   </novo-radio-group>
 
 

--- a/projects/novo-examples/src/form-controls/chips/chip-usage/chip-usage-example.html
+++ b/projects/novo-examples/src/form-controls/chips/chip-usage/chip-usage-example.html
@@ -44,7 +44,7 @@
 
 </novo-stack>
 
-<section data-automation-id="chip-usage-size-section">
+<section>
   <novo-label>Size</novo-label>
   <novo-radio-group #size appearance="vertical" value="md" data-automation-id="chip-usage-size-group">
     <novo-radio name="size" value="xs" data-automation-id="chip-usage-size-xs">xs</novo-radio>

--- a/projects/novo-examples/src/form-controls/chips/close-on-select-chips/close-on-select-chips-example.html
+++ b/projects/novo-examples/src/form-controls/chips/close-on-select-chips/close-on-select-chips-example.html
@@ -1,2 +1,2 @@
-<div class="selected-value">Selected Value: {{value}}</div>
-<novo-chips [closeOnSelect]="true" [source]="formatted" [placeholder]="placeholder" [(ngModel)]="value" (changed)="onChanged($event)"></novo-chips>
+<div class="selected-value" data-automation-id="chips-close-select-value">Selected Value: {{value}}</div>
+<novo-chips [closeOnSelect]="true" [source]="formatted" [placeholder]="placeholder" [(ngModel)]="value" (changed)="onChanged($event)" data-automation-id="chips-close-select-input"></novo-chips>

--- a/projects/novo-examples/src/form-controls/chips/custom-values/custom-values-example.html
+++ b/projects/novo-examples/src/form-controls/chips/custom-values/custom-values-example.html
@@ -1,2 +1,2 @@
-<div class="selected-value">Selected Value: {{ value }}</div>
-<novo-chips [source]="staticDemo" [placeholder]="placeholder" [(ngModel)]="value" (changed)="onChanged($event)" [allowCustomValues]="true"></novo-chips>
+<div class="selected-value" data-automation-id="chips-custom-value">Selected Value: {{ value }}</div>
+<novo-chips [source]="staticDemo" [placeholder]="placeholder" [(ngModel)]="value" (changed)="onChanged($event)" [allowCustomValues]="true" data-automation-id="chips-custom-input"></novo-chips>

--- a/projects/novo-examples/src/form-controls/chips/formatted-chips/formatted-chips-example.html
+++ b/projects/novo-examples/src/form-controls/chips/formatted-chips/formatted-chips-example.html
@@ -1,2 +1,2 @@
-<div class="selected-value">Selected Value: {{value}}</div>
-<novo-chips [source]="formatted" [placeholder]="placeholder" [(ngModel)]="value" (changed)="onChanged($event)"></novo-chips>
+<div class="selected-value" data-automation-id="chips-formatted-value">Selected Value: {{value}}</div>
+<novo-chips [source]="formatted" [placeholder]="placeholder" [(ngModel)]="value" (changed)="onChanged($event)" data-automation-id="chips-formatted-input"></novo-chips>

--- a/projects/novo-examples/src/form-controls/chips/grouped-multi-picker/grouped-multi-picker-example.html
+++ b/projects/novo-examples/src/form-controls/chips/grouped-multi-picker/grouped-multi-picker-example.html
@@ -1,20 +1,20 @@
-<h6>Basic Static Example</h6>
+<h6 data-automation-id="chips-grouped-basic-heading">Basic Static Example</h6>
 <p>Fully static data, optional "all" category</p>
-<div class="selected-value">Selected Value: {{ groupedMultiPicker1Value }}</div>
-<novo-chips [source]="groupedMultiPicker1" [placeholder]="placeholder" [(ngModel)]="groupedMultiPicker1Value" (changed)="onChanged($event)"></novo-chips>
+<div class="selected-value" data-automation-id="chips-grouped-basic-value">Selected Value: {{ groupedMultiPicker1Value }}</div>
+<novo-chips [source]="groupedMultiPicker1" [placeholder]="placeholder" [(ngModel)]="groupedMultiPicker1Value" (changed)="onChanged($event)" data-automation-id="chips-grouped-basic-input"></novo-chips>
 
 <br/>
 <br/>
 
-<h6>Custom Static Example</h6>
+<h6 data-automation-id="chips-grouped-custom-heading">Custom Static Example</h6>
 <p>Fully static data, all category turned off</p>
-<div class="selected-value">Selected Value: {{ groupedMultiPicker2Value }}</div>
-<novo-chips [source]="groupedMultiPicker2" [placeholder]="placeholder" [(ngModel)]="groupedMultiPicker2Value" (changed)="onChanged($event)"></novo-chips>
+<div class="selected-value" data-automation-id="chips-grouped-custom-value">Selected Value: {{ groupedMultiPicker2Value }}</div>
+<novo-chips [source]="groupedMultiPicker2" [placeholder]="placeholder" [(ngModel)]="groupedMultiPicker2Value" (changed)="onChanged($event)" data-automation-id="chips-grouped-custom-input"></novo-chips>
 
 <br/>
 <br/>
 
-<h6>Basic Async Example</h6>
+<h6 data-automation-id="chips-grouped-async-heading">Basic Async Example</h6>
 <p>Category list is static (always has to be) with the items fetched via async call</p>
-<div class="selected-value">Selected Value: {{ groupedMultiPicker3Value }}</div>
-<novo-chips [source]="groupedMultiPicker3" [placeholder]="placeholder" [(ngModel)]="groupedMultiPicker3Value" (changed)="onChanged($event)"></novo-chips>
+<div class="selected-value" data-automation-id="chips-grouped-async-value">Selected Value: {{ groupedMultiPicker3Value }}</div>
+<novo-chips [source]="groupedMultiPicker3" [placeholder]="placeholder" [(ngModel)]="groupedMultiPicker3Value" (changed)="onChanged($event)" data-automation-id="chips-grouped-async-input"></novo-chips>

--- a/projects/novo-examples/src/form-controls/chips/grouped-multi-picker/grouped-multi-picker-example.html
+++ b/projects/novo-examples/src/form-controls/chips/grouped-multi-picker/grouped-multi-picker-example.html
@@ -1,4 +1,4 @@
-<h6 data-automation-id="chips-grouped-basic-heading">Basic Static Example</h6>
+<h6>Basic Static Example</h6>
 <p>Fully static data, optional "all" category</p>
 <div class="selected-value" data-automation-id="chips-grouped-basic-value">Selected Value: {{ groupedMultiPicker1Value }}</div>
 <novo-chips [source]="groupedMultiPicker1" [placeholder]="placeholder" [(ngModel)]="groupedMultiPicker1Value" (changed)="onChanged($event)" data-automation-id="chips-grouped-basic-input"></novo-chips>
@@ -6,7 +6,7 @@
 <br/>
 <br/>
 
-<h6 data-automation-id="chips-grouped-custom-heading">Custom Static Example</h6>
+<h6>Custom Static Example</h6>
 <p>Fully static data, all category turned off</p>
 <div class="selected-value" data-automation-id="chips-grouped-custom-value">Selected Value: {{ groupedMultiPicker2Value }}</div>
 <novo-chips [source]="groupedMultiPicker2" [placeholder]="placeholder" [(ngModel)]="groupedMultiPicker2Value" (changed)="onChanged($event)" data-automation-id="chips-grouped-custom-input"></novo-chips>
@@ -14,7 +14,7 @@
 <br/>
 <br/>
 
-<h6 data-automation-id="chips-grouped-async-heading">Basic Async Example</h6>
+<h6>Basic Async Example</h6>
 <p>Category list is static (always has to be) with the items fetched via async call</p>
 <div class="selected-value" data-automation-id="chips-grouped-async-value">Selected Value: {{ groupedMultiPicker3Value }}</div>
 <novo-chips [source]="groupedMultiPicker3" [placeholder]="placeholder" [(ngModel)]="groupedMultiPicker3Value" (changed)="onChanged($event)" data-automation-id="chips-grouped-async-input"></novo-chips>

--- a/projects/novo-examples/src/form-controls/chips/hide-chips/hide-chips-example.html
+++ b/projects/novo-examples/src/form-controls/chips/hide-chips/hide-chips-example.html
@@ -1,2 +1,2 @@
-<novo-chips [source]="hideDemo" [placeholder]="placeholder" [(ngModel)]="model" (changed)="onChanged($event)">
+<novo-chips [source]="hideDemo" [placeholder]="placeholder" [(ngModel)]="model" (changed)="onChanged($event)" data-automation-id="chips-hide-input">
 </novo-chips>

--- a/projects/novo-examples/src/form-controls/chips/row-chips/row-chips-example.html
+++ b/projects/novo-examples/src/form-controls/chips/row-chips/row-chips-example.html
@@ -1,5 +1,5 @@
-<novo-row-chips [source]="rowDemo" [placeholder]="placeholder" [(ngModel)]="rowValue" (changed)="onChanged($event)">
+<novo-row-chips [source]="rowDemo" [placeholder]="placeholder" [(ngModel)]="rowValue" (changed)="onChanged($event)" data-automation-id="chips-row-input">
 </novo-row-chips>
 
 <br />
-<div class="selected-value">Selected Value: {{rowValue | json}}</div>
+<div class="selected-value" data-automation-id="chips-row-value">Selected Value: {{rowValue | json}}</div>

--- a/projects/novo-examples/src/form-controls/ck-editor/basic-editor/basic-editor-example.html
+++ b/projects/novo-examples/src/form-controls/ck-editor/basic-editor/basic-editor-example.html
@@ -1,9 +1,9 @@
-<novo-editor [name]="'demoEditor'" [(ngModel)]="editorValue" #editor></novo-editor>
+<novo-editor [name]="'demoEditor'" [(ngModel)]="editorValue" #editor data-automation-id="ck-editor-basic"></novo-editor>
 
-<button theme="primary" (click)="insertText(editor)">Insert "Hello World" at Cursor</button>
+<button theme="primary" (click)="insertText(editor)" data-automation-id="ck-editor-basic-insert">Insert "Hello World" at Cursor</button>
 
-<p>Value:</p>
-<p [innerHtml]="editorValue"></p>
+<p data-automation-id="ck-editor-basic-value-label">Value:</p>
+<p [innerHtml]="editorValue" data-automation-id="ck-editor-basic-value"></p>
 
-<p>HTML:</p>
-<pre><code>{{editorValue}}</code></pre>
+<p data-automation-id="ck-editor-basic-html-label">HTML:</p>
+<pre data-automation-id="ck-editor-basic-html"><code>{{editorValue}}</code></pre>

--- a/projects/novo-examples/src/form-controls/ck-editor/basic-editor/basic-editor-example.html
+++ b/projects/novo-examples/src/form-controls/ck-editor/basic-editor/basic-editor-example.html
@@ -2,8 +2,8 @@
 
 <button theme="primary" (click)="insertText(editor)" data-automation-id="ck-editor-basic-insert">Insert "Hello World" at Cursor</button>
 
-<p data-automation-id="ck-editor-basic-value-label">Value:</p>
+<p>Value:</p>
 <p [innerHtml]="editorValue" data-automation-id="ck-editor-basic-value"></p>
 
-<p data-automation-id="ck-editor-basic-html-label">HTML:</p>
+<p>HTML:</p>
 <pre data-automation-id="ck-editor-basic-html"><code>{{editorValue}}</code></pre>

--- a/projects/novo-examples/src/form-controls/ck-editor/minimal-editor/minimal-editor-example.html
+++ b/projects/novo-examples/src/form-controls/ck-editor/minimal-editor/minimal-editor-example.html
@@ -1,9 +1,9 @@
-<novo-editor [name]="'demoEditor'" [(ngModel)]="editorValue" [minimal]="true" #editor></novo-editor>
+<novo-editor [name]="'demoEditor'" [(ngModel)]="editorValue" [minimal]="true" #editor data-automation-id="ck-editor-minimal"></novo-editor>
 
-<button theme="primary" (click)="insertText(editor)">Insert "Hello World" at Cursor</button>
+<button theme="primary" (click)="insertText(editor)" data-automation-id="ck-editor-minimal-insert">Insert "Hello World" at Cursor</button>
 
-<p>Value:</p>
-<p [innerHtml]="editorValue"></p>
+<p data-automation-id="ck-editor-minimal-value-label">Value:</p>
+<p [innerHtml]="editorValue" data-automation-id="ck-editor-minimal-value"></p>
 
-<p>HTML:</p>
-<pre><code>{{editorValue}}</code></pre>
+<p data-automation-id="ck-editor-minimal-html-label">HTML:</p>
+<pre data-automation-id="ck-editor-minimal-html"><code>{{editorValue}}</code></pre>

--- a/projects/novo-examples/src/form-controls/ck-editor/minimal-editor/minimal-editor-example.html
+++ b/projects/novo-examples/src/form-controls/ck-editor/minimal-editor/minimal-editor-example.html
@@ -2,8 +2,8 @@
 
 <button theme="primary" (click)="insertText(editor)" data-automation-id="ck-editor-minimal-insert">Insert "Hello World" at Cursor</button>
 
-<p data-automation-id="ck-editor-minimal-value-label">Value:</p>
+<p>Value:</p>
 <p [innerHtml]="editorValue" data-automation-id="ck-editor-minimal-value"></p>
 
-<p data-automation-id="ck-editor-minimal-html-label">HTML:</p>
+<p>HTML:</p>
 <pre data-automation-id="ck-editor-minimal-html"><code>{{editorValue}}</code></pre>

--- a/projects/novo-examples/src/form-controls/color-picker/color-input/color-input-example.html
+++ b/projects/novo-examples/src/form-controls/color-picker/color-input/color-input-example.html
@@ -1,5 +1,5 @@
-<novo-color-input [(ngModel)]="hex">
+<novo-color-input [(ngModel)]="hex" data-automation-id="color-input-hex">
 </novo-color-input>
 
-<novo-color-input [(ngModel)]="rgb">
+<novo-color-input [(ngModel)]="rgb" data-automation-id="color-input-rgb">
 </novo-color-input>

--- a/projects/novo-examples/src/form-controls/color-picker/color-picker/color-picker-example.html
+++ b/projects/novo-examples/src/form-controls/color-picker/color-picker/color-picker-example.html
@@ -1,4 +1,4 @@
-<div class="demo-side-by-side">
-  <novo-color-picker [(color)]="hex"></novo-color-picker>
-  <novo-color-picker [(color)]="rgb"></novo-color-picker>
+<div class="demo-side-by-side" data-automation-id="color-picker-container">
+  <novo-color-picker [(color)]="hex" data-automation-id="color-picker-hex"></novo-color-picker>
+  <novo-color-picker [(color)]="rgb" data-automation-id="color-picker-rgb"></novo-color-picker>
 </div>

--- a/projects/novo-examples/src/form-controls/date-picker/date-picker-input/date-picker-input-example.html
+++ b/projects/novo-examples/src/form-controls/date-picker/date-picker-input/date-picker-input-example.html
@@ -8,12 +8,12 @@
   </novo-date-picker-input>
 </div>
 
-<section data-automation-id="date-picker-input-value-section">
+<section>
   <novo-label>Selected Values:</novo-label>
   <div data-automation-id="date-picker-input-value">{{selected | json}}</div>
 </section>
 
-<section data-automation-id="date-picker-input-options">
+<section>
   <novo-label>Format</novo-label>
   <novo-radio-group #format appearance="vertical" value="ddd MMM DD, YYYY" data-automation-id="date-picker-input-format-group">
     <novo-radio name="format" value="MM-DD-YYYY" data-automation-id="date-picker-input-format-1">MM-DD-YYYY</novo-radio>

--- a/projects/novo-examples/src/form-controls/date-picker/date-picker-input/date-picker-input-example.html
+++ b/projects/novo-examples/src/form-controls/date-picker/date-picker-input/date-picker-input-example.html
@@ -1,35 +1,36 @@
-<div>
+<div data-automation-id="date-picker-input-container">
   <novo-date-picker-input
     [(ngModel)]="selected"
     [format]="format.value"
     [weekStart]="weekStart.value"
-    [disabled]="disabled.value">
+    [disabled]="disabled.value"
+    data-automation-id="date-picker-input">
   </novo-date-picker-input>
 </div>
 
-<section>
+<section data-automation-id="date-picker-input-value-section">
   <novo-label>Selected Values:</novo-label>
-  <div>{{selected | json}}</div>
+  <div data-automation-id="date-picker-input-value">{{selected | json}}</div>
 </section>
 
-<section>
+<section data-automation-id="date-picker-input-options">
   <novo-label>Format</novo-label>
-  <novo-radio-group #format appearance="vertical" value="ddd MMM DD, YYYY">
-    <novo-radio name="format" value="MM-DD-YYYY">MM-DD-YYYY</novo-radio>
-    <novo-radio name="format" value="DD-MM-YYYY">DD-MM-YYYY</novo-radio>
-    <novo-radio name="format" value="MMM DD, YYYY">MMM DD, YYYY</novo-radio>
-    <novo-radio name="format" value="ddd MMM DD, YYYY">ddd MMM DD, YYYY</novo-radio>
+  <novo-radio-group #format appearance="vertical" value="ddd MMM DD, YYYY" data-automation-id="date-picker-input-format-group">
+    <novo-radio name="format" value="MM-DD-YYYY" data-automation-id="date-picker-input-format-1">MM-DD-YYYY</novo-radio>
+    <novo-radio name="format" value="DD-MM-YYYY" data-automation-id="date-picker-input-format-2">DD-MM-YYYY</novo-radio>
+    <novo-radio name="format" value="MMM DD, YYYY" data-automation-id="date-picker-input-format-3">MMM DD, YYYY</novo-radio>
+    <novo-radio name="format" value="ddd MMM DD, YYYY" data-automation-id="date-picker-input-format-4">ddd MMM DD, YYYY</novo-radio>
   </novo-radio-group>
 
   <novo-label>Week Start</novo-label>
-  <novo-radio-group #weekStart appearance="vertical" value="0">
-    <novo-radio name="weekStart" value="0">Sun</novo-radio>
-    <novo-radio name="weekStart" value="1">Mon</novo-radio>
+  <novo-radio-group #weekStart appearance="vertical" value="0" data-automation-id="date-picker-input-weekstart-group">
+    <novo-radio name="weekStart" value="0" data-automation-id="date-picker-input-weekstart-sun">Sun</novo-radio>
+    <novo-radio name="weekStart" value="1" data-automation-id="date-picker-input-weekstart-mon">Mon</novo-radio>
   </novo-radio-group>
 
   <novo-label>Enabled</novo-label>
-  <novo-radio-group #disabled appearance="vertical" [value]="false">
-    <novo-radio name="disabled" [value]="false">Enabled</novo-radio>
-    <novo-radio name="disabled" [value]="true">Disabled</novo-radio>
+  <novo-radio-group #disabled appearance="vertical" [value]="false" data-automation-id="date-picker-input-state-group">
+    <novo-radio name="disabled" [value]="false" data-automation-id="date-picker-input-enabled">Enabled</novo-radio>
+    <novo-radio name="disabled" [value]="true" data-automation-id="date-picker-input-disabled">Disabled</novo-radio>
   </novo-radio-group>
 </section>

--- a/projects/novo-examples/src/form-controls/date-picker/date-picker-limits/date-picker-limits-example.html
+++ b/projects/novo-examples/src/form-controls/date-picker/date-picker-limits/date-picker-limits-example.html
@@ -1,30 +1,30 @@
-<section>
+<section data-automation-id="date-picker-limits-inputs">
   <novo-label>EFFECTIVE START DATE</novo-label>
-  <novo-date-picker-input [(ngModel)]="startDate"></novo-date-picker-input>
+  <novo-date-picker-input [(ngModel)]="startDate" data-automation-id="date-picker-limits-start"></novo-date-picker-input>
   <br/>
   <novo-label>EFFECTIVE END DATE</novo-label>
-  <novo-date-picker-input [(ngModel)]="endDate"></novo-date-picker-input>
+  <novo-date-picker-input [(ngModel)]="endDate" data-automation-id="date-picker-limits-end"></novo-date-picker-input>
 </section>
 
-<section>
+<section data-automation-id="date-picker-limits-values">
   <section>
     <novo-label>Effective Start Date Value:</novo-label>
-    <div>{{ startDate | json }}</div>
+    <div data-automation-id="date-picker-limits-start-value">{{ startDate | json }}</div>
   </section>
   <br/>
   <section>
     <novo-label>Effective End Date Value:</novo-label>
-    <div>{{ endDate | json }}</div>
+    <div data-automation-id="date-picker-limits-end-value">{{ endDate | json }}</div>
   </section>
 </section>
 
-<section>
-  <novo-date-picker [start]="startDate" [end]="endDate" [disabledDateMessage]="tooltip"></novo-date-picker>
+<section data-automation-id="date-picker-limits-picker">
+  <novo-date-picker [start]="startDate" [end]="endDate" [disabledDateMessage]="tooltip" data-automation-id="date-picker-limits-calendar"></novo-date-picker>
 
   <br/><br/>
-  <novo-form [form]="formGroup">
+  <novo-form [form]="formGroup" data-automation-id="date-picker-limits-form">
     <novo-control-group key="horizontal" [initialValue]="initValue" [form]="formGroup" [controls]="controls"></novo-control-group>
   </novo-form>
 
-  <button theme="primary" (click)="updateInitialValue()">Update tooltip</button>
+  <button theme="primary" (click)="updateInitialValue()" data-automation-id="date-picker-limits-update-button">Update tooltip</button>
 </section>

--- a/projects/novo-examples/src/form-controls/date-picker/date-picker-limits/date-picker-limits-example.html
+++ b/projects/novo-examples/src/form-controls/date-picker/date-picker-limits/date-picker-limits-example.html
@@ -1,4 +1,4 @@
-<section data-automation-id="date-picker-limits-inputs">
+<section>
   <novo-label>EFFECTIVE START DATE</novo-label>
   <novo-date-picker-input [(ngModel)]="startDate" data-automation-id="date-picker-limits-start"></novo-date-picker-input>
   <br/>
@@ -6,7 +6,7 @@
   <novo-date-picker-input [(ngModel)]="endDate" data-automation-id="date-picker-limits-end"></novo-date-picker-input>
 </section>
 
-<section data-automation-id="date-picker-limits-values">
+<section>
   <section>
     <novo-label>Effective Start Date Value:</novo-label>
     <div data-automation-id="date-picker-limits-start-value">{{ startDate | json }}</div>
@@ -18,7 +18,7 @@
   </section>
 </section>
 
-<section data-automation-id="date-picker-limits-picker">
+<section>
   <novo-date-picker [start]="startDate" [end]="endDate" [disabledDateMessage]="tooltip" data-automation-id="date-picker-limits-calendar"></novo-date-picker>
 
   <br/><br/>

--- a/projects/novo-examples/src/form-controls/date-picker/date-picker/date-picker-example.html
+++ b/projects/novo-examples/src/form-controls/date-picker/date-picker/date-picker-example.html
@@ -3,32 +3,33 @@
   [(ngModel)]="selectedDates"
   [mode]="mode.value"
   [numberOfMonths]="months.value"
-  [weekStart]="weekStart.value">
+  [weekStart]="weekStart.value"
+  data-automation-id="date-picker-picker">
 </novo-date-picker>
 
-<section>
+<section data-automation-id="date-picker-value-section">
   <novo-label>Selected Values:</novo-label>
-  <div>{{selectedDates | json}}</div>
+  <div data-automation-id="date-picker-value">{{selectedDates | json}}</div>
 </section>
 
-<section>
+<section data-automation-id="date-picker-options">
   <novo-label>Selection mode</novo-label>
-  <novo-radio-group #mode appearance="vertical" value="single">
-    <novo-radio name="mode" value="single">single</novo-radio>
-    <novo-radio name="mode" value="multiple">multiple</novo-radio>
-    <novo-radio name="mode" value="range">range</novo-radio>
-    <novo-radio name="mode" value="week">week</novo-radio>
+  <novo-radio-group #mode appearance="vertical" value="single" data-automation-id="date-picker-mode-group">
+    <novo-radio name="mode" value="single" data-automation-id="date-picker-mode-single">single</novo-radio>
+    <novo-radio name="mode" value="multiple" data-automation-id="date-picker-mode-multiple">multiple</novo-radio>
+    <novo-radio name="mode" value="range" data-automation-id="date-picker-mode-range">range</novo-radio>
+    <novo-radio name="mode" value="week" data-automation-id="date-picker-mode-week">week</novo-radio>
   </novo-radio-group>
 
   <novo-label># of Months</novo-label>
-  <novo-radio-group #months appearance="vertical" value="1">
-    <novo-radio name="months" value="1">1</novo-radio>
-    <novo-radio name="months" value="2">2</novo-radio>
+  <novo-radio-group #months appearance="vertical" value="1" data-automation-id="date-picker-months-group">
+    <novo-radio name="months" value="1" data-automation-id="date-picker-months-1">1</novo-radio>
+    <novo-radio name="months" value="2" data-automation-id="date-picker-months-2">2</novo-radio>
   </novo-radio-group>
 
   <novo-label>Week Start</novo-label>
-  <novo-radio-group #weekStart appearance="vertical" value="0">
-    <novo-radio name="weekStart" value="0">Sun</novo-radio>
-    <novo-radio name="weekStart" value="1">Mon</novo-radio>
+  <novo-radio-group #weekStart appearance="vertical" value="0" data-automation-id="date-picker-weekstart-group">
+    <novo-radio name="weekStart" value="0" data-automation-id="date-picker-weekstart-sun">Sun</novo-radio>
+    <novo-radio name="weekStart" value="1" data-automation-id="date-picker-weekstart-mon">Mon</novo-radio>
   </novo-radio-group>
 </section>

--- a/projects/novo-examples/src/form-controls/date-picker/date-picker/date-picker-example.html
+++ b/projects/novo-examples/src/form-controls/date-picker/date-picker/date-picker-example.html
@@ -7,12 +7,12 @@
   data-automation-id="date-picker-picker">
 </novo-date-picker>
 
-<section data-automation-id="date-picker-value-section">
+<section>
   <novo-label>Selected Values:</novo-label>
   <div data-automation-id="date-picker-value">{{selectedDates | json}}</div>
 </section>
 
-<section data-automation-id="date-picker-options">
+<section>
   <novo-label>Selection mode</novo-label>
   <novo-radio-group #mode appearance="vertical" value="single" data-automation-id="date-picker-mode-group">
     <novo-radio name="mode" value="single" data-automation-id="date-picker-mode-single">single</novo-radio>

--- a/projects/novo-examples/src/form-controls/date-picker/date-range-input/date-range-input-example.html
+++ b/projects/novo-examples/src/form-controls/date-picker/date-range-input/date-range-input-example.html
@@ -6,12 +6,12 @@
   data-automation-id="date-range-input">
 </novo-date-range-input>
 
-<section data-automation-id="date-range-value-section">
+<section>
   <novo-label>Selected Values:</novo-label>
   <div data-automation-id="date-range-value">{{selected | json}}</div>
 </section>
 
-<section data-automation-id="date-range-options">
+<section>
   <novo-label>Selection mode</novo-label>
   <novo-radio-group #mode appearance="vertical" value="week" data-automation-id="date-range-mode-group">
     <novo-radio name="mode" value="week" data-automation-id="date-range-mode-week">week</novo-radio>

--- a/projects/novo-examples/src/form-controls/date-picker/date-range-input/date-range-input-example.html
+++ b/projects/novo-examples/src/form-controls/date-picker/date-range-input/date-range-input-example.html
@@ -2,30 +2,31 @@
   [(ngModel)]="selected"
   [format]="format.value"
   [mode]="mode.value"
-  [weekStart]="weekStart.value">
+  [weekStart]="weekStart.value"
+  data-automation-id="date-range-input">
 </novo-date-range-input>
 
-<section>
+<section data-automation-id="date-range-value-section">
   <novo-label>Selected Values:</novo-label>
-  <div>{{selected | json}}</div>
+  <div data-automation-id="date-range-value">{{selected | json}}</div>
 </section>
 
-<section>
+<section data-automation-id="date-range-options">
   <novo-label>Selection mode</novo-label>
-  <novo-radio-group #mode appearance="vertical" value="week">
-    <novo-radio name="mode" value="week">week</novo-radio>
-    <novo-radio name="mode" value="range">range</novo-radio>
+  <novo-radio-group #mode appearance="vertical" value="week" data-automation-id="date-range-mode-group">
+    <novo-radio name="mode" value="week" data-automation-id="date-range-mode-week">week</novo-radio>
+    <novo-radio name="mode" value="range" data-automation-id="date-range-mode-range">range</novo-radio>
   </novo-radio-group>
 
   <novo-label>Format</novo-label>
-  <novo-radio-group #format appearance="vertical" value="MM-DD-YYYY">
-    <novo-radio name="format" value="MM-DD-YYYY">MM-dd-YYYY</novo-radio>
-    <novo-radio name="format" value="DD-MM-YYYY">dd-MM-YYYY</novo-radio>
+  <novo-radio-group #format appearance="vertical" value="MM-DD-YYYY" data-automation-id="date-range-format-group">
+    <novo-radio name="format" value="MM-DD-YYYY" data-automation-id="date-range-format-1">MM-dd-YYYY</novo-radio>
+    <novo-radio name="format" value="DD-MM-YYYY" data-automation-id="date-range-format-2">dd-MM-YYYY</novo-radio>
   </novo-radio-group>
 
   <novo-label>Week Start</novo-label>
-  <novo-radio-group #weekStart appearance="vertical" value="0">
-    <novo-radio name="weekStart" value="0">Sun</novo-radio>
-    <novo-radio name="weekStart" value="1">Mon</novo-radio>
+  <novo-radio-group #weekStart appearance="vertical" value="0" data-automation-id="date-range-weekstart-group">
+    <novo-radio name="weekStart" value="0" data-automation-id="date-range-weekstart-sun">Sun</novo-radio>
+    <novo-radio name="weekStart" value="1" data-automation-id="date-range-weekstart-mon">Mon</novo-radio>
   </novo-radio-group>
 </section>

--- a/projects/novo-examples/src/form-controls/date-picker/date-time/date-time-example.html
+++ b/projects/novo-examples/src/form-controls/date-picker/date-time/date-time-example.html
@@ -1,11 +1,11 @@
 <div class="date-picker-demo-side-by-side" data-automation-id="date-time-container">
-  <section data-automation-id="date-time-12hr">
-    <p>
+  <section>
+    <p data-automation-id="date-time-value-12hr">
       <label>Date-Time</label> {{(dateTime | date:'medium') || 'N/A'}}
     </p>
     <novo-date-time-picker [(ngModel)]="dateTime" data-automation-id="date-time-picker-12hr"></novo-date-time-picker>
   </section>
-  <section data-automation-id="date-time-24hr">
+  <section>
     <label>24hr Time</label>
     <novo-date-time-picker [(ngModel)]="dateTime" military="true" data-automation-id="date-time-picker-24hr"></novo-date-time-picker>
   </section>

--- a/projects/novo-examples/src/form-controls/date-picker/date-time/date-time-example.html
+++ b/projects/novo-examples/src/form-controls/date-picker/date-time/date-time-example.html
@@ -1,12 +1,12 @@
-<div class="date-picker-demo-side-by-side">
-  <section>
+<div class="date-picker-demo-side-by-side" data-automation-id="date-time-container">
+  <section data-automation-id="date-time-12hr">
     <p>
       <label>Date-Time</label> {{(dateTime | date:'medium') || 'N/A'}}
     </p>
-    <novo-date-time-picker [(ngModel)]="dateTime"></novo-date-time-picker>
+    <novo-date-time-picker [(ngModel)]="dateTime" data-automation-id="date-time-picker-12hr"></novo-date-time-picker>
   </section>
-  <section>
+  <section data-automation-id="date-time-24hr">
     <label>24hr Time</label>
-    <novo-date-time-picker [(ngModel)]="dateTime" military="true"></novo-date-time-picker>
+    <novo-date-time-picker [(ngModel)]="dateTime" military="true" data-automation-id="date-time-picker-24hr"></novo-date-time-picker>
   </section>
 </div>

--- a/projects/novo-examples/src/form-controls/date-picker/multi-date/multi-date-example.html
+++ b/projects/novo-examples/src/form-controls/date-picker/multi-date/multi-date-example.html
@@ -1,12 +1,12 @@
 <div class="date-picker-demo-side-by-side" data-automation-id="multi-date-container">
-  <section data-automation-id="multi-date-picker-section">
+  <section>
     <p>
       <label>Dates</label>
       <span *ngFor="let dt of multi; let i = index" [attr.data-automation-id]="'multi-date-value-' + i">{{(dt | date) || 'N/A'}}</span>
     </p>
     <novo-date-picker [(ngModel)]="multi" mode="multiple" data-automation-id="multi-date-picker"></novo-date-picker>
   </section>
-  <section data-automation-id="multi-date-input-section">
+  <section>
     <novo-multi-date-input [(ngModel)]="input" data-automation-id="multi-date-input"></novo-multi-date-input>
   </section>
 </div>

--- a/projects/novo-examples/src/form-controls/date-picker/multi-date/multi-date-example.html
+++ b/projects/novo-examples/src/form-controls/date-picker/multi-date/multi-date-example.html
@@ -1,12 +1,12 @@
-<div class="date-picker-demo-side-by-side">
-  <section>
+<div class="date-picker-demo-side-by-side" data-automation-id="multi-date-container">
+  <section data-automation-id="multi-date-picker-section">
     <p>
       <label>Dates</label>
-      <span *ngFor="let dt of multi">{{(dt | date) || 'N/A'}}</span>
+      <span *ngFor="let dt of multi; let i = index" [attr.data-automation-id]="'multi-date-value-' + i">{{(dt | date) || 'N/A'}}</span>
     </p>
-    <novo-date-picker [(ngModel)]="multi" mode="multiple"></novo-date-picker>
+    <novo-date-picker [(ngModel)]="multi" mode="multiple" data-automation-id="multi-date-picker"></novo-date-picker>
   </section>
-  <section>
-    <novo-multi-date-input [(ngModel)]="input"></novo-multi-date-input>
+  <section data-automation-id="multi-date-input-section">
+    <novo-multi-date-input [(ngModel)]="input" data-automation-id="multi-date-input"></novo-multi-date-input>
   </section>
 </div>

--- a/projects/novo-examples/src/form-controls/date-picker/week-start/week-start-example.html
+++ b/projects/novo-examples/src/form-controls/date-picker/week-start/week-start-example.html
@@ -1,15 +1,15 @@
-<button [theme]="weekStart === 0 ? 'primary' : 'secondary'" (click)="setWeekStart(0)">Sunday</button>
-<button [theme]="weekStart === 1 ? 'primary' : 'secondary'" (click)="setWeekStart(1)">Monday</button>
-<button [theme]="weekStart === 2 ? 'primary' : 'secondary'" (click)="setWeekStart(2)">Tuesday</button>
-<button [theme]="weekStart === 3 ? 'primary' : 'secondary'" (click)="setWeekStart(3)">Wednesday</button>
-<button [theme]="weekStart === 4 ? 'primary' : 'secondary'" (click)="setWeekStart(4)">Thursday</button>
-<button [theme]="weekStart === 5 ? 'primary' : 'secondary'" (click)="setWeekStart(5)">Friday</button>
-<button [theme]="weekStart === 6 ? 'primary' : 'secondary'" (click)="setWeekStart(6)">Saturday</button>
+<button [theme]="weekStart === 0 ? 'primary' : 'secondary'" (click)="setWeekStart(0)" data-automation-id="week-start-sun">Sunday</button>
+<button [theme]="weekStart === 1 ? 'primary' : 'secondary'" (click)="setWeekStart(1)" data-automation-id="week-start-mon">Monday</button>
+<button [theme]="weekStart === 2 ? 'primary' : 'secondary'" (click)="setWeekStart(2)" data-automation-id="week-start-tue">Tuesday</button>
+<button [theme]="weekStart === 3 ? 'primary' : 'secondary'" (click)="setWeekStart(3)" data-automation-id="week-start-wed">Wednesday</button>
+<button [theme]="weekStart === 4 ? 'primary' : 'secondary'" (click)="setWeekStart(4)" data-automation-id="week-start-thu">Thursday</button>
+<button [theme]="weekStart === 5 ? 'primary' : 'secondary'" (click)="setWeekStart(5)" data-automation-id="week-start-fri">Friday</button>
+<button [theme]="weekStart === 6 ? 'primary' : 'secondary'" (click)="setWeekStart(6)" data-automation-id="week-start-sat">Saturday</button>
 <br/>
 <br/>
-<div class="date-picker-demo-side-by-side">
+<div class="date-picker-demo-side-by-side" data-automation-id="week-start-picker-container">
     <p>
         <label>Value</label> {{(weekStartDate | date) || 'N/A'}}
     </p>
-    <novo-date-picker [(ngModel)]="weekStartDate" [weekStart]="weekStart"></novo-date-picker>
+    <novo-date-picker [(ngModel)]="weekStartDate" [weekStart]="weekStart" data-automation-id="week-start-picker"></novo-date-picker>
 </div>

--- a/projects/novo-examples/src/form-controls/date-picker/week-start/week-start-example.html
+++ b/projects/novo-examples/src/form-controls/date-picker/week-start/week-start-example.html
@@ -8,7 +8,7 @@
 <br/>
 <br/>
 <div class="date-picker-demo-side-by-side" data-automation-id="week-start-picker-container">
-    <p>
+    <p data-automation-id="week-start-value">
         <label>Value</label> {{(weekStartDate | date) || 'N/A'}}
     </p>
     <novo-date-picker [(ngModel)]="weekStartDate" [weekStart]="weekStart" data-automation-id="week-start-picker"></novo-date-picker>

--- a/projects/novo-examples/src/form-controls/date-time-picker/date-time-input/date-time-input-example.html
+++ b/projects/novo-examples/src/form-controls/date-time-picker/date-time-input/date-time-input-example.html
@@ -1,11 +1,11 @@
-<div class="date-picker-demo-side-by-side">
-    <p>
-        <label>Date-Time</label> {{(dateTimeInput | date:'medium') || 'N/A'}}
-        <label>Date-Time 2</label> {{(dateTimeInput2 | date:'medium') || 'N/A'}}
+<div class="date-picker-demo-side-by-side" data-automation-id="date-time-input-container">
+    <p data-automation-id="date-time-input-values">
+        <label data-automation-id="date-time-input-label-1">Date-Time</label> {{(dateTimeInput | date:'medium') || 'N/A'}}
+        <label data-automation-id="date-time-input-label-2">Date-Time 2</label> {{(dateTimeInput2 | date:'medium') || 'N/A'}}
     </p>
-    <div>
-        <novo-date-time-picker-input [(ngModel)]="dateTimeInput"></novo-date-time-picker-input>
-        <novo-date-time-picker-input [(ngModel)]="dateTimeInput2" [military]="true"></novo-date-time-picker-input>
+    <div data-automation-id="date-time-input-inputs">
+        <novo-date-time-picker-input [(ngModel)]="dateTimeInput" data-automation-id="date-time-input-1"></novo-date-time-picker-input>
+        <novo-date-time-picker-input [(ngModel)]="dateTimeInput2" [military]="true" data-automation-id="date-time-input-2"></novo-date-time-picker-input>
     </div>
-    <novo-date-time-picker [(ngModel)]="dateTimeInput3"></novo-date-time-picker> 
+    <novo-date-time-picker [(ngModel)]="dateTimeInput3" data-automation-id="date-time-input-picker"></novo-date-time-picker>
 </div>

--- a/projects/novo-examples/src/form-controls/date-time-picker/date-time-input/date-time-input-example.html
+++ b/projects/novo-examples/src/form-controls/date-time-picker/date-time-input/date-time-input-example.html
@@ -1,7 +1,7 @@
 <div class="date-picker-demo-side-by-side" data-automation-id="date-time-input-container">
     <p data-automation-id="date-time-input-values">
-        <label data-automation-id="date-time-input-label-1">Date-Time</label> {{(dateTimeInput | date:'medium') || 'N/A'}}
-        <label data-automation-id="date-time-input-label-2">Date-Time 2</label> {{(dateTimeInput2 | date:'medium') || 'N/A'}}
+        <label>Date-Time</label> {{(dateTimeInput | date:'medium') || 'N/A'}}
+        <label>Date-Time 2</label> {{(dateTimeInput2 | date:'medium') || 'N/A'}}
     </p>
     <div data-automation-id="date-time-input-inputs">
         <novo-date-time-picker-input [(ngModel)]="dateTimeInput" data-automation-id="date-time-input-1"></novo-date-time-picker-input>

--- a/projects/novo-examples/src/form-controls/dynamic-form/disabled-form/disabled-form-example.html
+++ b/projects/novo-examples/src/form-controls/dynamic-form/disabled-form/disabled-form-example.html
@@ -2,7 +2,7 @@
   #myform data-automation-id="dynamic-form-disabled"></novo-dynamic-form>
 <div class="final-value" data-automation-id="dynamic-form-disabled-values">Values: {{myform.values | json}}</div>
 <br />
-<h5 data-automation-id="dynamic-form-disabled-note-heading">QUICK NOTE</h5>
+<h5>QUICK NOTE</h5>
 <br />
 <novo-quick-note [(ngModel)]="disabledNote" [placeholder]="placeholder" [config]="disabledQuickNote" data-automation-id="dynamic-form-disabled-note"></novo-quick-note>
 <div class="data" data-automation-id="dynamic-form-disabled-note-output">

--- a/projects/novo-examples/src/form-controls/dynamic-form/disabled-form/disabled-form-example.html
+++ b/projects/novo-examples/src/form-controls/dynamic-form/disabled-form/disabled-form-example.html
@@ -1,10 +1,10 @@
 <novo-dynamic-form [autoFocusFirstField]="true" class="dynamic" [fieldsets]="disabledControls" [(form)]="disabledForm"
-  #myform></novo-dynamic-form>
-<div class="final-value">Values: {{myform.values | json}}</div>
+  #myform data-automation-id="dynamic-form-disabled"></novo-dynamic-form>
+<div class="final-value" data-automation-id="dynamic-form-disabled-values">Values: {{myform.values | json}}</div>
 <br />
-<h5>QUICK NOTE</h5>
+<h5 data-automation-id="dynamic-form-disabled-note-heading">QUICK NOTE</h5>
 <br />
-<novo-quick-note [(ngModel)]="disabledNote" [placeholder]="placeholder" [config]="disabledQuickNote"></novo-quick-note>
-<div class="data">
+<novo-quick-note [(ngModel)]="disabledNote" [placeholder]="placeholder" [config]="disabledQuickNote" data-automation-id="dynamic-form-disabled-note"></novo-quick-note>
+<div class="data" data-automation-id="dynamic-form-disabled-note-output">
   <p>Note: {{note | json}}</p>
 </div>

--- a/projects/novo-examples/src/form-controls/dynamic-form/dynamic-form-field-sets/dynamic-form-field-sets-example.html
+++ b/projects/novo-examples/src/form-controls/dynamic-form/dynamic-form-field-sets/dynamic-form-field-sets-example.html
@@ -1,19 +1,19 @@
 <button theme="secondary"
   *ngIf="!myFieldsetsForm.showingAllFields && !(myFieldsetsForm.allFieldsRequired || myFieldsetsForm.allFieldsNotRequired)"
-  (click)="myFieldsetsForm.showAllFields()">Show All Fields</button>
+  (click)="myFieldsetsForm.showAllFields()" data-automation-id="dynamic-form-fieldsets-show-all">Show All Fields</button>
 <button theme="secondary"
   *ngIf="!myFieldsetsForm.showingRequiredFields && !(myFieldsetsForm.allFieldsRequired || myFieldsetsForm.allFieldsNotRequired)"
-  (click)="myFieldsetsForm.showOnlyRequired(false)">Show Required Fields</button>
+  (click)="myFieldsetsForm.showOnlyRequired(false)" data-automation-id="dynamic-form-fieldsets-show-required">Show Required Fields</button>
 <novo-dynamic-form class="dynamic" layout="horizontal" [fieldsets]="fieldsets" [(form)]="fieldsetsForm"
-  #myFieldsetsForm>
+  #myFieldsetsForm data-automation-id="dynamic-form-fieldsets">
   <ng-template novoTemplate="custom-demo-component" let-control let-form="form">
     <custom-demo-control-example [control]="control" [form]="form"></custom-demo-control-example>
   </ng-template>
 </novo-dynamic-form>
-<footer class="dynamic-demo-footer">
-  <button (click)="save(myFieldsetsForm)" theme="primary" icon="check">Save</button>
-  <button (click)="clear()" theme="secondary" icon="check">Clear</button>
+<footer class="dynamic-demo-footer" data-automation-id="dynamic-form-fieldsets-footer">
+  <button (click)="save(myFieldsetsForm)" theme="primary" icon="check" data-automation-id="dynamic-form-fieldsets-save">Save</button>
+  <button (click)="clear()" theme="secondary" icon="check" data-automation-id="dynamic-form-fieldsets-clear">Clear</button>
 </footer>
-<div class="final-value">Valid: {{myFieldsetsForm.isValid | json}}</div>
-<div class="final-value">Values: {{myFieldsetsForm.values | json}}</div>
-<div class="final-value">Updated Values: {{myFieldsetsForm.updatedValues() | json}}</div>
+<div class="final-value" data-automation-id="dynamic-form-fieldsets-valid">Valid: {{myFieldsetsForm.isValid | json}}</div>
+<div class="final-value" data-automation-id="dynamic-form-fieldsets-values">Values: {{myFieldsetsForm.values | json}}</div>
+<div class="final-value" data-automation-id="dynamic-form-fieldsets-updated">Updated Values: {{myFieldsetsForm.updatedValues() | json}}</div>

--- a/projects/novo-examples/src/form-controls/dynamic-form/dynamic-form/dynamic-form-example.html
+++ b/projects/novo-examples/src/form-controls/dynamic-form/dynamic-form/dynamic-form-example.html
@@ -1,10 +1,10 @@
-<button theme="secondary" *ngIf="!myform.showingAllFields && !(myform.allFieldsRequired || myform.allFieldsNotRequired)" (click)="myform.showAllFields()">Show All Fields</button>
-<button theme="secondary" *ngIf="!myform.showingRequiredFields && !(myform.allFieldsRequired || myform.allFieldsNotRequired)" (click)="myform.showOnlyRequired(false)">Show Required Fields</button>
-<novo-dynamic-form [autoFocusFirstField]="true" class="dynamic" [fieldsets]="dynamic" [(form)]="dynamicForm" #myform></novo-dynamic-form>
-<footer class="dynamic-demo-footer">
-    <button (click)="save(myform)" theme="primary" icon="check">Save</button>
-    <button (click)="clear()" theme="secondary" icon="check">Clear</button>
+<button theme="secondary" *ngIf="!myform.showingAllFields && !(myform.allFieldsRequired || myform.allFieldsNotRequired)" (click)="myform.showAllFields()" data-automation-id="dynamic-form-show-all">Show All Fields</button>
+<button theme="secondary" *ngIf="!myform.showingRequiredFields && !(myform.allFieldsRequired || myform.allFieldsNotRequired)" (click)="myform.showOnlyRequired(false)" data-automation-id="dynamic-form-show-required">Show Required Fields</button>
+<novo-dynamic-form [autoFocusFirstField]="true" class="dynamic" [fieldsets]="dynamic" [(form)]="dynamicForm" #myform data-automation-id="dynamic-form"></novo-dynamic-form>
+<footer class="dynamic-demo-footer" data-automation-id="dynamic-form-footer">
+    <button (click)="save(myform)" theme="primary" icon="check" data-automation-id="dynamic-form-save">Save</button>
+    <button (click)="clear()" theme="secondary" icon="check" data-automation-id="dynamic-form-clear">Clear</button>
 </footer>
-<div class="final-value">Valid: {{myform.isValid | json}}</div>
-<div class="final-value">Values: {{myform.values | json}}</div>
-<div class="final-value">Updated Values: {{myform.updatedValues() | json}}</div>
+<div class="final-value" data-automation-id="dynamic-form-valid">Valid: {{myform.isValid | json}}</div>
+<div class="final-value" data-automation-id="dynamic-form-values">Values: {{myform.values | json}}</div>
+<div class="final-value" data-automation-id="dynamic-form-updated">Updated Values: {{myform.updatedValues() | json}}</div>

--- a/projects/novo-examples/src/form-controls/dynamic-form/enable-disable-all-fields-in-form/enable-disable-all-fields-in-form-example.html
+++ b/projects/novo-examples/src/form-controls/dynamic-form/enable-disable-all-fields-in-form/enable-disable-all-fields-in-form-example.html
@@ -1,2 +1,2 @@
-<novo-dynamic-form class="dynamic" [fieldsets]="controls" [(form)]="form" #myform></novo-dynamic-form>
-<button theme="primary" (click)="toggleEnableDisableAllFields()">Toggle fields</button>
+<novo-dynamic-form class="dynamic" [fieldsets]="controls" [(form)]="form" #myform data-automation-id="dynamic-form-toggle"></novo-dynamic-form>
+<button theme="primary" (click)="toggleEnableDisableAllFields()" data-automation-id="dynamic-form-toggle-button">Toggle fields</button>

--- a/projects/novo-examples/src/form-controls/dynamic-form/updating-form/updating-form-example.html
+++ b/projects/novo-examples/src/form-controls/dynamic-form/updating-form/updating-form-example.html
@@ -1,8 +1,8 @@
-<button theme="secondary" (click)="toggleEnabled()">Toggle Enabled</button>
-<button theme="secondary" (click)="toggleRequired()">Toggle Required</button>
-<button theme="secondary" (click)="markAsInvalid()">Mark As Invalid</button>
+<button theme="secondary" (click)="toggleEnabled()" data-automation-id="dynamic-form-update-enabled">Toggle Enabled</button>
+<button theme="secondary" (click)="toggleRequired()" data-automation-id="dynamic-form-update-required">Toggle Required</button>
+<button theme="secondary" (click)="markAsInvalid()" data-automation-id="dynamic-form-update-invalid">Mark As Invalid</button>
 <br/><br/>
-<novo-dynamic-form layout="vertical" [controls]="updatingFormControls" [(form)]="updatingForm" #updatingFormRef></novo-dynamic-form>
-<div class="final-value">Valid: {{updatingFormRef.isValid | json}}</div>
-<div class="final-value">Values: {{updatingFormRef.values | json}}</div>
-<div class="final-value">Updated Values: {{updatingFormRef.updatedValues() | json}}</div>
+<novo-dynamic-form layout="vertical" [controls]="updatingFormControls" [(form)]="updatingForm" #updatingFormRef data-automation-id="dynamic-form-updating"></novo-dynamic-form>
+<div class="final-value" data-automation-id="dynamic-form-updating-valid">Valid: {{updatingFormRef.isValid | json}}</div>
+<div class="final-value" data-automation-id="dynamic-form-updating-values">Values: {{updatingFormRef.values | json}}</div>
+<div class="final-value" data-automation-id="dynamic-form-updating-updated">Updated Values: {{updatingFormRef.updatedValues() | json}}</div>

--- a/projects/novo-examples/src/form-controls/dynamic-form/vertical-dynamic-form/vertical-dynamic-form-example.html
+++ b/projects/novo-examples/src/form-controls/dynamic-form/vertical-dynamic-form/vertical-dynamic-form-example.html
@@ -1,10 +1,10 @@
-<button theme="secondary" (click)="nomyform.showAllFields()">Show All Fields</button>
-<button theme="secondary" (click)="nomyform.showOnlyRequired(false)">Show Required Fields</button>
-<novo-dynamic-form layout="vertical" class="dynamic" [controls]="dynamicVertical" [(form)]="dynamicVerticalForm" #nomyform>
+<button theme="secondary" (click)="nomyform.showAllFields()" data-automation-id="dynamic-form-vertical-show-all">Show All Fields</button>
+<button theme="secondary" (click)="nomyform.showOnlyRequired(false)" data-automation-id="dynamic-form-vertical-show-required">Show Required Fields</button>
+<novo-dynamic-form layout="vertical" class="dynamic" [controls]="dynamicVertical" [(form)]="dynamicVerticalForm" #nomyform data-automation-id="dynamic-form-vertical">
   <ng-template novoTemplate="custom-demo-component" let-control let-form="form">
     <custom-demo-control-example [control]="control" [form]="form"></custom-demo-control-example>
   </ng-template>
 </novo-dynamic-form>
-<div class="final-value">Valid: {{nomyform.isValid | json}}</div>
-<div class="final-value">Values: {{nomyform.values | json}}</div>
-<div class="final-value">Updated Values: {{nomyform.updatedValues() | json}}</div>
+<div class="final-value" data-automation-id="dynamic-form-vertical-valid">Valid: {{nomyform.isValid | json}}</div>
+<div class="final-value" data-automation-id="dynamic-form-vertical-values">Values: {{nomyform.values | json}}</div>
+<div class="final-value" data-automation-id="dynamic-form-vertical-updated">Updated Values: {{nomyform.updatedValues() | json}}</div>

--- a/projects/novo-examples/src/form-controls/form-groups/custom-template/custom-template-example.html
+++ b/projects/novo-examples/src/form-controls/form-groups/custom-template/custom-template-example.html
@@ -12,9 +12,9 @@
     </div>
 </ng-template>
 
-<novo-form [form]="formGroup">
-    <novo-control-group remove="true" edit="true" [initialValue]="initValue" [controls]="controls" [rowTemplate]="customRowTemplate" [add]="simpleAddConfig" label="Custom Template" key="custom" [form]="formGroup" [emptyMessage]="emptyMessage"></novo-control-group>
+<novo-form [form]="formGroup" data-automation-id="form-groups-custom">
+    <novo-control-group remove="true" edit="true" [initialValue]="initValue" [controls]="controls" [rowTemplate]="customRowTemplate" [add]="simpleAddConfig" label="Custom Template" key="custom" [form]="formGroup" [emptyMessage]="emptyMessage" data-automation-id="form-groups-custom-group"></novo-control-group>
 </novo-form>
 
-<div class="final-value">Initial Value: {{ initValue | json }}</div>
-<div class="final-value">Value: {{ formGroup.value | json }}</div>
+<div class="final-value" data-automation-id="form-groups-custom-initial">Initial Value: {{ initValue | json }}</div>
+<div class="final-value" data-automation-id="form-groups-custom-value">Value: {{ formGroup.value | json }}</div>

--- a/projects/novo-examples/src/form-controls/form-groups/horizontal-options/horizontal-options-example.html
+++ b/projects/novo-examples/src/form-controls/form-groups/horizontal-options/horizontal-options-example.html
@@ -1,5 +1,5 @@
-<novo-form [form]="formGroup">
-    <novo-control-group [initialValue]="initialValue" collapsible="true" [add]="anotherAddConfig" remove="true" label="Horizontal" key="horizontal" description="Test Description" [form]="formGroup" [controls]="controls" [emptyMessage]="emptyMessage"></novo-control-group>
+<novo-form [form]="formGroup" data-automation-id="form-groups-horizontal-options">
+    <novo-control-group [initialValue]="initialValue" collapsible="true" [add]="anotherAddConfig" remove="true" label="Horizontal" key="horizontal" description="Test Description" [form]="formGroup" [controls]="controls" [emptyMessage]="emptyMessage" data-automation-id="form-groups-horizontal-options-group"></novo-control-group>
 </novo-form>
-<div class="final-value">Initial Value: {{ initialValue | json }}</div>
-<div class="final-value">Value: {{ formGroup.value | json }}</div>
+<div class="final-value" data-automation-id="form-groups-horizontal-options-initial">Initial Value: {{ initialValue | json }}</div>
+<div class="final-value" data-automation-id="form-groups-horizontal-options-value">Value: {{ formGroup.value | json }}</div>

--- a/projects/novo-examples/src/form-controls/form-groups/horizontal/horizontal-example.html
+++ b/projects/novo-examples/src/form-controls/form-groups/horizontal/horizontal-example.html
@@ -1,8 +1,8 @@
-<button theme="primary" (click)="updateInitialValue()">Update Initial Value</button>
+<button theme="primary" (click)="updateInitialValue()" data-automation-id="form-groups-horizontal-update">Update Initial Value</button>
 <br/>
 <br/>
-<novo-form [form]="formGroup">
-    <novo-control-group [canEdit]="canEditFunction" [canRemove]="canRemoveFunction" (onRemove)="onRemove($event)" (onEdit)="onEdit($event)" [initialValue]="initValue" [add]="simpleAddConfig" remove="true" edit="true" label="Horizontal" key="horizontal" [form]="formGroup" [controls]="controls" [emptyMessage]="emptyMessage"></novo-control-group>
+<novo-form [form]="formGroup" data-automation-id="form-groups-horizontal">
+    <novo-control-group [canEdit]="canEditFunction" [canRemove]="canRemoveFunction" (onRemove)="onRemove($event)" (onEdit)="onEdit($event)" [initialValue]="initValue" [add]="simpleAddConfig" remove="true" edit="true" label="Horizontal" key="horizontal" [form]="formGroup" [controls]="controls" [emptyMessage]="emptyMessage" data-automation-id="form-groups-horizontal-group"></novo-control-group>
 </novo-form>
-<div class="final-value">Initial Value: {{ initValue | json }}</div>
-<div class="final-value">Value: {{ formGroup.value | json }}</div>
+<div class="final-value" data-automation-id="form-groups-horizontal-initial">Initial Value: {{ initValue | json }}</div>
+<div class="final-value" data-automation-id="form-groups-horizontal-value">Value: {{ formGroup.value | json }}</div>

--- a/projects/novo-examples/src/form-controls/form-groups/vertical-options/vertical-options-example.html
+++ b/projects/novo-examples/src/form-controls/form-groups/vertical-options/vertical-options-example.html
@@ -1,5 +1,5 @@
-<novo-form [form]="formGroup">
-    <novo-control-group [initialValue]="initialValue" collapsible="true" [add]="anotherAddConfig" remove="true" icon="idea" label="Vertical" key="vertical" vertical="true" description="Test Description" [form]="formGroup" [controls]="controls" [emptyMessage]="emptyMessage"></novo-control-group>
+<novo-form [form]="formGroup" data-automation-id="form-groups-vertical-options">
+    <novo-control-group [initialValue]="initialValue" collapsible="true" [add]="anotherAddConfig" remove="true" icon="idea" label="Vertical" key="vertical" vertical="true" description="Test Description" [form]="formGroup" [controls]="controls" [emptyMessage]="emptyMessage" data-automation-id="form-groups-vertical-options-group"></novo-control-group>
 </novo-form>
-<div class="final-value">Initial Value: {{ initialValue | json }}</div>
-<div class="final-value">Value: {{ formGroup.value | json }}</div>
+<div class="final-value" data-automation-id="form-groups-vertical-options-initial">Initial Value: {{ initialValue | json }}</div>
+<div class="final-value" data-automation-id="form-groups-vertical-options-value">Value: {{ formGroup.value | json }}</div>

--- a/projects/novo-examples/src/form-controls/form-groups/vertical/vertical-example.html
+++ b/projects/novo-examples/src/form-controls/form-groups/vertical/vertical-example.html
@@ -1,5 +1,5 @@
-<novo-form [form]="formGroup">
-    <novo-control-group [initialValue]="initialValue" [add]="simpleAddConfig" remove="true" icon="idea" label="Vertical" key="vertical" vertical="true" [form]="formGroup" [controls]="controls" [emptyMessage]="emptyMessage"></novo-control-group>
+<novo-form [form]="formGroup" data-automation-id="form-groups-vertical">
+    <novo-control-group [initialValue]="initialValue" [add]="simpleAddConfig" remove="true" icon="idea" label="Vertical" key="vertical" vertical="true" [form]="formGroup" [controls]="controls" [emptyMessage]="emptyMessage" data-automation-id="form-groups-vertical-group"></novo-control-group>
 </novo-form>
-<div class="final-value">Initial Value: {{ initialValue | json }}</div>
-<div class="final-value">Value: {{ formGroup.value | json }}</div>
+<div class="final-value" data-automation-id="form-groups-vertical-initial">Initial Value: {{ initialValue | json }}</div>
+<div class="final-value" data-automation-id="form-groups-vertical-value">Value: {{ formGroup.value | json }}</div>

--- a/projects/novo-examples/src/form-controls/form/address-control/address-control-example.html
+++ b/projects/novo-examples/src/form-controls/form/address-control/address-control-example.html
@@ -1,10 +1,10 @@
-<novo-form [form]="addressForm">
-  <div class="novo-form-row">
+<novo-form [form]="addressForm" data-automation-id="form-address">
+  <div class="novo-form-row" data-automation-id="form-address-primary">
     <novo-control [form]="addressForm" [control]="addressControl"></novo-control>
   </div>
-  <div class="novo-form-row">
+  <div class="novo-form-row" data-automation-id="form-address-secondary">
     <novo-control [form]="addressForm" [control]="secondaryAddressControl"></novo-control>
   </div>
 </novo-form>
 
-<div class="final-value">Value: {{addressForm.value | json}}</div>
+<div class="final-value" data-automation-id="form-address-value">Value: {{addressForm.value | json}}</div>

--- a/projects/novo-examples/src/form-controls/form/calendar-input-controls/calendar-input-controls-example.html
+++ b/projects/novo-examples/src/form-controls/form/calendar-input-controls/calendar-input-controls-example.html
@@ -1,19 +1,19 @@
 <!--Check out the FormDemo.js for more information!-->
-<novo-form [form]="calendarForm" layout="vertical">
-  <div class="novo-form-row">
+<novo-form [form]="calendarForm" layout="vertical" data-automation-id="form-calendar">
+  <div class="novo-form-row" data-automation-id="form-calendar-date">
     <novo-control [form]="calendarForm" [control]="dateControl"></novo-control>
   </div>
-  <div class="novo-form-row">
+  <div class="novo-form-row" data-automation-id="form-calendar-user-date">
     <novo-control [form]="calendarForm" [control]="userDefinedDateControl"></novo-control>
   </div>
-  <div class="novo-form-row">
+  <div class="novo-form-row" data-automation-id="form-calendar-time">
     <novo-control [form]="calendarForm" [control]="timeControl"></novo-control>
   </div>
-  <div class="novo-form-row">
+  <div class="novo-form-row" data-automation-id="form-calendar-datetime">
     <novo-control [form]="calendarForm" [control]="dateTimeControl"></novo-control>
   </div>
-  <div class="novo-form-row">
+  <div class="novo-form-row" data-automation-id="form-calendar-timezone">
     <novo-control [form]="calendarForm" [control]="timezoneControl"></novo-control>
   </div>
 </novo-form>
-<div class="final-value">Value: {{calendarForm.value | json}}</div>
+<div class="final-value" data-automation-id="form-calendar-value">Value: {{calendarForm.value | json}}</div>

--- a/projects/novo-examples/src/form-controls/form/check-box-controls/check-box-controls-example.html
+++ b/projects/novo-examples/src/form-controls/form/check-box-controls/check-box-controls-example.html
@@ -1,19 +1,19 @@
 <!--Check out the FormDemo.js for more information!-->
-<novo-form [form]="checkForm">
-  <div class="novo-form-row">
+<novo-form [form]="checkForm" data-automation-id="form-check">
+  <div class="novo-form-row" data-automation-id="form-check-checkbox">
     <novo-control [form]="checkForm" [control]="checkControl"></novo-control>
   </div>
-  <div class="novo-form-row">
+  <div class="novo-form-row" data-automation-id="form-check-list">
     <novo-control [form]="checkForm" [control]="checkListControl"></novo-control>
   </div>
-  <div class="novo-form-row">
+  <div class="novo-form-row" data-automation-id="form-check-tiles">
     <novo-control [form]="checkForm" [control]="tilesControl" (change)="onChange($event)"></novo-control>
   </div>
-  <div class="novo-form-row">
+  <div class="novo-form-row" data-automation-id="form-check-tiles-disabled">
     <novo-control [form]="checkForm" [control]="disabledTilesControl" (change)="onChange($event)"></novo-control>
   </div>
-  <div class="novo-form-row">
+  <div class="novo-form-row" data-automation-id="form-check-switch">
     <novo-control [form]="checkForm" [control]="switchControl" (change)="onChange($event)"></novo-control>
   </div>
 </novo-form>
-<div class="final-value">Value: {{checkForm.value | json}}</div>
+<div class="final-value" data-automation-id="form-check-value">Value: {{checkForm.value | json}}</div>

--- a/projects/novo-examples/src/form-controls/form/file-input-controls/file-input-controls-example.html
+++ b/projects/novo-examples/src/form-controls/form/file-input-controls/file-input-controls-example.html
@@ -1,23 +1,23 @@
 <!--Check out the FormDemo.js for more information!-->
-<novo-form [form]="fileForm" layout="vertical">
-    <div class="novo-form-row">
+<novo-form [form]="fileForm" layout="vertical" data-automation-id="form-file">
+    <div class="novo-form-row" data-automation-id="form-file-single">
         <novo-control [form]="fileForm" [control]="fileControl"></novo-control>
     </div>
-    <div class="novo-form-row">
+    <div class="novo-form-row" data-automation-id="form-file-multi">
         <novo-control [form]="fileForm" [control]="multiFileControl" (edit)="handleEdit($event)" (save)="handleSave($event)" (delete)="handleDelete($event)" (upload)="handleUpload($event)"></novo-control>
     </div>
-    <div class="novo-form-row">
+    <div class="novo-form-row" data-automation-id="form-file-multi-mix">
         <novo-control [form]="fileForm" [control]="multiFileControlMixRemove"></novo-control>
     </div>
 </novo-form>
-<div class="final-value">Value: {{fileForm.value | json}}</div>
+<div class="final-value" data-automation-id="form-file-value">Value: {{fileForm.value | json}}</div>
 <br />
-<button class="clear-files-button" theme="secondary" (click)="clearFileLists()">Clear File Lists</button>
+<button class="clear-files-button" theme="secondary" (click)="clearFileLists()" data-automation-id="form-file-clear-button">Clear File Lists</button>
 <br />
 <br />
-<novo-form layout="vertical" [form]="customValidationFileForm">
-    <div class="novo-form-row">
+<novo-form layout="vertical" [form]="customValidationFileForm" data-automation-id="form-file-validation">
+    <div class="novo-form-row" data-automation-id="form-file-validation-input">
         <novo-control [form]="customValidationFileForm" [control]="customValidationFileControl"></novo-control>
     </div>
 </novo-form>
-<div>{{ message }}</div>
+<div data-automation-id="form-file-validation-message">{{ message }}</div>

--- a/projects/novo-examples/src/form-controls/form/number-range-control/number-range-control-example.html
+++ b/projects/novo-examples/src/form-controls/form/number-range-control/number-range-control-example.html
@@ -1,5 +1,5 @@
 <div [formGroup]="exampleForm" data-automation-id="form-number-range">
-  <h3 data-automation-id="form-number-range-heading">Example Number Range Controls</h3>
+  <h3>Example Number Range Controls</h3>
   <div class="row-wrapper" data-automation-id="form-number-range-controls">
     <div class="example-row" data-automation-id="form-number-range-1">
       <novo-label>Between: </novo-label>

--- a/projects/novo-examples/src/form-controls/form/number-range-control/number-range-control-example.html
+++ b/projects/novo-examples/src/form-controls/form/number-range-control/number-range-control-example.html
@@ -1,15 +1,15 @@
-<div [formGroup]="exampleForm">
-  <h3>Example Number Range Controls</h3>
-  <div class="row-wrapper">
-    <div class="example-row">
+<div [formGroup]="exampleForm" data-automation-id="form-number-range">
+  <h3 data-automation-id="form-number-range-heading">Example Number Range Controls</h3>
+  <div class="row-wrapper" data-automation-id="form-number-range-controls">
+    <div class="example-row" data-automation-id="form-number-range-1">
       <novo-label>Between: </novo-label>
-      <novo-number-range formControlName="numberRangeControl1"></novo-number-range>
+      <novo-number-range formControlName="numberRangeControl1" data-automation-id="form-number-range-input-1"></novo-number-range>
     </div>
-    <div class="example-row">
+    <div class="example-row" data-automation-id="form-number-range-2">
       <novo-label>Between: </novo-label>
-      <novo-number-range formControlName="numberRangeControl2"></novo-number-range>
+      <novo-number-range formControlName="numberRangeControl2" data-automation-id="form-number-range-input-2"></novo-number-range>
     </div>
   </div>
 </div>
 
-<pre class="final-value">Value: {{exampleForm?.value | json}}</pre>
+<pre class="final-value" data-automation-id="form-number-range-value">Value: {{exampleForm?.value | json}}</pre>

--- a/projects/novo-examples/src/form-controls/form/picker-controls/picker-controls-example.html
+++ b/projects/novo-examples/src/form-controls/form/picker-controls/picker-controls-example.html
@@ -1,24 +1,24 @@
 <!--Check out the FormDemo.js for more information!-->
-<novo-form [form]="pickerForm">
-    <div class="novo-form-row">
+<novo-form [form]="pickerForm" data-automation-id="form-picker">
+    <div class="novo-form-row" data-automation-id="form-picker-single">
         <novo-control [form]="pickerForm" [control]="singlePickerControl"></novo-control>
     </div>
-    <div class="novo-form-row">
+    <div class="novo-form-row" data-automation-id="form-picker-multi">
         <novo-control [form]="pickerForm" [control]="multiPickerControl"></novo-control>
     </div>
-    <div class="novo-form-row">
+    <div class="novo-form-row" data-automation-id="form-picker-multi-custom">
         <novo-control [form]="pickerForm" [control]="multiPickerWithCustomTextControl"></novo-control>
     </div>
-    <div class="novo-form-row">
+    <div class="novo-form-row" data-automation-id="form-picker-entity-multi">
         <novo-control [form]="pickerForm" [control]="entityMultiPickerControl"></novo-control>
     </div>
-    <div class="novo-form-row">
+    <div class="novo-form-row" data-automation-id="form-picker-row-multi">
       <novo-control [form]="pickerForm" [control]="rowMultiPickerControl"></novo-control>
     </div>
-    <div class="novo-form-row">
+    <div class="novo-form-row" data-automation-id="form-picker-multi-maxlength">
       <novo-control [form]="pickerForm" [control]="multiPickerControlWithMaxlength"></novo-control>
     </div>
-    <div class="novo-form-row">
+    <div class="novo-form-row" data-automation-id="form-picker-multi-preselect">
       <novo-control [form]="pickerForm" [control]="multiPickerControlWithMaxlengthAndPreselects"></novo-control>
     </div>
     <!-- Row picker with maxlength is implemented but currently turned off because it is not being used and there was no UI created for it.
@@ -26,8 +26,8 @@
     <div class="novo-form-row">
       <novo-control [form]="pickerForm" [control]="rowMultiPickerControlWithMaxlength"></novo-control>
     </div-->
-    <div class="novo-form-row">
+    <div class="novo-form-row" data-automation-id="form-picker-text-labels">
       <novo-control [form]="pickerForm" [control]="textPickerWithGetLabels"></novo-control>
     </div>
 </novo-form>
-<div class="final-value">Value: {{pickerForm.value | json}}</div>
+<div class="final-value" data-automation-id="form-picker-value">Value: {{pickerForm.value | json}}</div>

--- a/projects/novo-examples/src/form-controls/form/text-based-controls/text-based-controls-example.html
+++ b/projects/novo-examples/src/form-controls/form/text-based-controls/text-based-controls-example.html
@@ -1,38 +1,38 @@
 <!--Check out the FormDemo.js for more information!-->
-<button theme="secondary" (click)="form.showAllFields()">Show All Fields</button>
-<button theme="secondary" (click)="form.showOnlyRequired(false)">Show Required Fields</button>
+<button theme="secondary" (click)="form.showAllFields()" data-automation-id="form-text-show-all">Show All Fields</button>
+<button theme="secondary" (click)="form.showOnlyRequired(false)" data-automation-id="form-text-show-required">Show Required Fields</button>
 <br/>
 <br/>
-<novo-form [form]="textForm" #form>
-    <div class="novo-form-row">
+<novo-form [form]="textForm" #form data-automation-id="form-text">
+    <div class="novo-form-row" data-automation-id="form-text-input">
         <novo-control [form]="textForm" [control]="textControl"></novo-control>
     </div>
-    <div class="novo-form-row">
+    <div class="novo-form-row" data-automation-id="form-text-mask">
         <novo-control [form]="textForm" [control]="textMaskControl"></novo-control>
     </div>
-    <div class="novo-form-row">
+    <div class="novo-form-row" data-automation-id="form-text-email">
         <novo-control [autoFocus]="true" [form]="textForm" [control]="emailControl"></novo-control>
     </div>
-    <div class="novo-form-row">
+    <div class="novo-form-row" data-automation-id="form-text-number">
         <novo-control [form]="textForm" [control]="numberControl"></novo-control>
     </div>
-    <div class="novo-form-row">
+    <div class="novo-form-row" data-automation-id="form-text-currency">
         <novo-control [form]="textForm" [control]="currencyControl"></novo-control>
     </div>
-    <div class="novo-form-row">
+    <div class="novo-form-row" data-automation-id="form-text-float">
         <novo-control [form]="textForm" [control]="floatControl"></novo-control>
     </div>
-    <div class="novo-form-row">
+    <div class="novo-form-row" data-automation-id="form-text-percentage">
         <novo-control [form]="textForm" [control]="percentageControl"></novo-control>
     </div>
-    <div class="novo-form-row">
+    <div class="novo-form-row" data-automation-id="form-text-textarea">
         <novo-control [form]="textForm" [control]="textAreaControl"></novo-control>
     </div>
-    <div class="novo-form-row">
+    <div class="novo-form-row" data-automation-id="form-text-quicknote">
         <novo-control [form]="textForm" [control]="quickNoteControl"></novo-control>
     </div>
-    <div class="novo-form-row">
+    <div class="novo-form-row" data-automation-id="form-text-editor">
         <novo-control [form]="textForm" [control]="aceEditorControl"></novo-control>
     </div>
 </novo-form>
-<div class="final-value">Value: {{textForm.value | json}}</div>
+<div class="final-value" data-automation-id="form-text-value">Value: {{textForm.value | json}}</div>

--- a/projects/novo-examples/src/form-controls/multi-picker/basic-multi-picker/basic-multi-picker-example.html
+++ b/projects/novo-examples/src/form-controls/multi-picker/basic-multi-picker/basic-multi-picker-example.html
@@ -1,9 +1,10 @@
-<div class="selected-value">Selected States: <span *ngFor="let item of value.states">{{item}} </span>
-    Selected Collaborators: <span *ngFor="let item of value.collaborators">{{item}} </span></div>
+<div class="selected-value" data-automation-id="multi-picker-basic-value">Selected States: <span *ngFor="let item of value.states; let i = index" [attr.data-automation-id]="'multi-picker-basic-state-' + i">{{item}} </span>
+    Selected Collaborators: <span *ngFor="let item of value.collaborators; let i = index" [attr.data-automation-id]="'multi-picker-basic-collaborator-' + i">{{item}} </span></div>
 <multi-picker
     [source]="staticDemo"
     [placeholder]="placeholder"
     [types]="types"
     [(ngModel)]="value"
-    (changed)="onChanged($event)">
+    (changed)="onChanged($event)"
+    data-automation-id="multi-picker-basic">
 </multi-picker>

--- a/projects/novo-examples/src/form-controls/multi-picker/nested-multi-picker/nested-multi-picker-example.html
+++ b/projects/novo-examples/src/form-controls/multi-picker/nested-multi-picker/nested-multi-picker-example.html
@@ -1,9 +1,10 @@
-<div class="selected-value">Selected Departments: <span *ngFor="let item of parentChildValue.departments">{{item}} </span>
-    Selected Users: <span *ngFor="let item of parentChildValue.users">{{item}} </span></div>
+<div class="selected-value" data-automation-id="multi-picker-nested-value">Selected Departments: <span *ngFor="let item of parentChildValue.departments; let i = index" [attr.data-automation-id]="'multi-picker-nested-dept-' + i">{{item}} </span>
+    Selected Users: <span *ngFor="let item of parentChildValue.users; let i = index" [attr.data-automation-id]="'multi-picker-nested-user-' + i">{{item}} </span></div>
 <multi-picker
     [source]="parentChild"
     [placeholder]="placeholder"
     [types]="parentChildTypes"
     [(ngModel)]="parentChildValue"
-    (changed)="onChanged($event)">
+    (changed)="onChanged($event)"
+    data-automation-id="multi-picker-nested">
 </multi-picker>

--- a/projects/novo-examples/src/form-controls/picker/async-picker/async-picker-example.html
+++ b/projects/novo-examples/src/form-controls/picker/async-picker/async-picker-example.html
@@ -1,2 +1,2 @@
-<div class="selected-value">Selected Value: {{value}}</div>
-<novo-picker [config]="async" [placeholder]="placeholder" [(ngModel)]="value"></novo-picker>
+<div class="selected-value" data-automation-id="picker-async-value">Selected Value: {{value}}</div>
+<novo-picker [config]="async" [placeholder]="placeholder" [(ngModel)]="value" data-automation-id="picker-async-input"></novo-picker>

--- a/projects/novo-examples/src/form-controls/picker/basic-picker/basic-picker-example.html
+++ b/projects/novo-examples/src/form-controls/picker/basic-picker/basic-picker-example.html
@@ -1,2 +1,2 @@
-<div class="selected-value">Selected Value: {{value}}</div>
-<novo-picker [config]="staticDemo" [placeholder]="placeholder" [(ngModel)]="value"></novo-picker>
+<div class="selected-value" data-automation-id="picker-basic-value">Selected Value: {{value}}</div>
+<novo-picker [config]="staticDemo" [placeholder]="placeholder" [(ngModel)]="value" data-automation-id="picker-basic-input"></novo-picker>

--- a/projects/novo-examples/src/form-controls/picker/custom-picker-results/custom-picker-results-example.html
+++ b/projects/novo-examples/src/form-controls/picker/custom-picker-results/custom-picker-results-example.html
@@ -1,2 +1,2 @@
-<div class="selected-value">Selected Value: {{value}}</div>
-<novo-picker [config]="custom" [placeholder]="placeholder" [(ngModel)]="value"></novo-picker>
+<div class="selected-value" data-automation-id="picker-custom-value">Selected Value: {{value}}</div>
+<novo-picker [config]="custom" [placeholder]="placeholder" [(ngModel)]="value" data-automation-id="picker-custom-input"></novo-picker>

--- a/projects/novo-examples/src/form-controls/picker/default-options-picker/default-options-picker-example.html
+++ b/projects/novo-examples/src/form-controls/picker/default-options-picker/default-options-picker-example.html
@@ -1,5 +1,5 @@
-<div class="selected-value">Selected Value: {{defaultArrayValue}}</div>
-<novo-picker [config]="defaultArrayConfig" [placeholder]="placeholder" [(ngModel)]="defaultArrayValue"></novo-picker>
+<div class="selected-value" data-automation-id="picker-default-array-value">Selected Value: {{defaultArrayValue}}</div>
+<novo-picker [config]="defaultArrayConfig" [placeholder]="placeholder" [(ngModel)]="defaultArrayValue" data-automation-id="picker-default-array-input"></novo-picker>
 <br/><br/>
-<div class="selected-value">Selected Value: {{defaultFunctionValue}}</div>
-<novo-picker [config]="defaultFunctionConfig" [placeholder]="placeholder" [(ngModel)]="defaultFunctionValue"></novo-picker>
+<div class="selected-value" data-automation-id="picker-default-function-value">Selected Value: {{defaultFunctionValue}}</div>
+<novo-picker [config]="defaultFunctionConfig" [placeholder]="placeholder" [(ngModel)]="defaultFunctionValue" data-automation-id="picker-default-function-input"></novo-picker>

--- a/projects/novo-examples/src/form-controls/picker/entity-picker/entity-picker-example.html
+++ b/projects/novo-examples/src/form-controls/picker/entity-picker/entity-picker-example.html
@@ -1,2 +1,2 @@
-<div class="selected-value">Selected Value: {{entity}}</div>
-<novo-picker [config]="entityDemo" [placeholder]="placeholder" [(ngModel)]="entity"></novo-picker>
+<div class="selected-value" data-automation-id="picker-entity-value">Selected Value: {{entity}}</div>
+<novo-picker [config]="entityDemo" [placeholder]="placeholder" [(ngModel)]="entity" data-automation-id="picker-entity-input"></novo-picker>

--- a/projects/novo-examples/src/form-controls/picker/formatted-picker/formatted-picker-example.html
+++ b/projects/novo-examples/src/form-controls/picker/formatted-picker/formatted-picker-example.html
@@ -1,2 +1,2 @@
-<div class="selected-value">Selected Value: {{value}}</div>
-<novo-picker [config]="formatted" [placeholder]="placeholder" [(ngModel)]="value"></novo-picker>
+<div class="selected-value" data-automation-id="picker-formatted-value">Selected Value: {{value}}</div>
+<novo-picker [config]="formatted" [placeholder]="placeholder" [(ngModel)]="value" data-automation-id="picker-formatted-input"></novo-picker>

--- a/projects/novo-examples/src/form-controls/picker/grouped-picker/grouped-picker-example.html
+++ b/projects/novo-examples/src/form-controls/picker/grouped-picker/grouped-picker-example.html
@@ -1,4 +1,4 @@
-<h6 data-automation-id="picker-grouped-basic-heading">Basic Static Example</h6>
+<h6>Basic Static Example</h6>
 <p>Fully static data, optional "all" category</p>
 <div class="selected-value" data-automation-id="picker-grouped-basic-value">Selected Value: {{ groupedPicker1Value | json }}</div>
 <novo-picker [config]="groupedPicker1" [placeholder]="placeholder" [(ngModel)]="groupedPicker1Value" (changed)="onChanged($event)" data-automation-id="picker-grouped-basic-input"></novo-picker>
@@ -6,7 +6,7 @@
 <br/>
 <br/>
 
-<h6 data-automation-id="picker-grouped-custom-heading">Custom Static Example</h6>
+<h6>Custom Static Example</h6>
 <p>Fully static data, all category turned off</p>
 <div class="selected-value" data-automation-id="picker-grouped-custom-value">Selected Value: {{ groupedPicker2Value | json }}</div>
 <novo-picker [config]="groupedPicker2" [placeholder]="placeholder" [(ngModel)]="groupedPicker2Value" (changed)="onChanged($event)" data-automation-id="picker-grouped-custom-input"></novo-picker>
@@ -14,14 +14,14 @@
 <br/>
 <br/>
 
-<h6 data-automation-id="picker-grouped-async-heading">Basic Async Example</h6>
+<h6>Basic Async Example</h6>
 <p>Category list is static (always has to be) with the items fetched via async call</p>
 <div class="selected-value" data-automation-id="picker-grouped-async-value">Selected Value: {{ groupedPicker3Value | json }}</div>
 <novo-picker [config]="groupedPicker3" [placeholder]="placeholder" [(ngModel)]="groupedPicker3Value" (changed)="onChanged($event)" data-automation-id="picker-grouped-async-input"></novo-picker>
 <br/>
 <br/>
 
-<h6 data-automation-id="picker-grouped-async-filter-heading">Async Example w/ Custom Filter</h6>
+<h6>Async Example w/ Custom Filter</h6>
 <p>You can also have a custom filter, limited to just a switch</p>
 <div class="selected-value" data-automation-id="picker-grouped-async-filter-value">Selected Value: {{ groupedPicker4Value | json }}</div>
 <novo-picker [config]="groupedPicker4" [placeholder]="placeholder" [(ngModel)]="groupedPicker4Value" (changed)="onChanged($event)" data-automation-id="picker-grouped-async-filter-input"></novo-picker>

--- a/projects/novo-examples/src/form-controls/picker/grouped-picker/grouped-picker-example.html
+++ b/projects/novo-examples/src/form-controls/picker/grouped-picker/grouped-picker-example.html
@@ -1,27 +1,27 @@
-<h6>Basic Static Example</h6>
+<h6 data-automation-id="picker-grouped-basic-heading">Basic Static Example</h6>
 <p>Fully static data, optional "all" category</p>
-<div class="selected-value">Selected Value: {{ groupedPicker1Value | json }}</div>
-<novo-picker [config]="groupedPicker1" [placeholder]="placeholder" [(ngModel)]="groupedPicker1Value" (changed)="onChanged($event)"></novo-picker>
+<div class="selected-value" data-automation-id="picker-grouped-basic-value">Selected Value: {{ groupedPicker1Value | json }}</div>
+<novo-picker [config]="groupedPicker1" [placeholder]="placeholder" [(ngModel)]="groupedPicker1Value" (changed)="onChanged($event)" data-automation-id="picker-grouped-basic-input"></novo-picker>
 
 <br/>
 <br/>
 
-<h6>Custom Static Example</h6>
+<h6 data-automation-id="picker-grouped-custom-heading">Custom Static Example</h6>
 <p>Fully static data, all category turned off</p>
-<div class="selected-value">Selected Value: {{ groupedPicker2Value | json }}</div>
-<novo-picker [config]="groupedPicker2" [placeholder]="placeholder" [(ngModel)]="groupedPicker2Value" (changed)="onChanged($event)"></novo-picker>
+<div class="selected-value" data-automation-id="picker-grouped-custom-value">Selected Value: {{ groupedPicker2Value | json }}</div>
+<novo-picker [config]="groupedPicker2" [placeholder]="placeholder" [(ngModel)]="groupedPicker2Value" (changed)="onChanged($event)" data-automation-id="picker-grouped-custom-input"></novo-picker>
 
 <br/>
 <br/>
 
-<h6>Basic Async Example</h6>
+<h6 data-automation-id="picker-grouped-async-heading">Basic Async Example</h6>
 <p>Category list is static (always has to be) with the items fetched via async call</p>
-<div class="selected-value">Selected Value: {{ groupedPicker3Value | json }}</div>
-<novo-picker [config]="groupedPicker3" [placeholder]="placeholder" [(ngModel)]="groupedPicker3Value" (changed)="onChanged($event)"></novo-picker>
+<div class="selected-value" data-automation-id="picker-grouped-async-value">Selected Value: {{ groupedPicker3Value | json }}</div>
+<novo-picker [config]="groupedPicker3" [placeholder]="placeholder" [(ngModel)]="groupedPicker3Value" (changed)="onChanged($event)" data-automation-id="picker-grouped-async-input"></novo-picker>
 <br/>
 <br/>
 
-<h6>Async Example w/ Custom Filter</h6>
+<h6 data-automation-id="picker-grouped-async-filter-heading">Async Example w/ Custom Filter</h6>
 <p>You can also have a custom filter, limited to just a switch</p>
-<div class="selected-value">Selected Value: {{ groupedPicker4Value | json }}</div>
-<novo-picker [config]="groupedPicker4" [placeholder]="placeholder" [(ngModel)]="groupedPicker4Value" (changed)="onChanged($event)"></novo-picker>
+<div class="selected-value" data-automation-id="picker-grouped-async-filter-value">Selected Value: {{ groupedPicker4Value | json }}</div>
+<novo-picker [config]="groupedPicker4" [placeholder]="placeholder" [(ngModel)]="groupedPicker4Value" (changed)="onChanged($event)" data-automation-id="picker-grouped-async-filter-input"></novo-picker>

--- a/projects/novo-examples/src/form-controls/picker/mixed-picker/mixed-picker-example.html
+++ b/projects/novo-examples/src/form-controls/picker/mixed-picker/mixed-picker-example.html
@@ -1,4 +1,4 @@
-<h6>Mixed Options Example</h6>
+<h6 data-automation-id="picker-mixed-heading">Mixed Options Example</h6>
 <p>Some primary options have no secondary option, some have static secondary options, and some have dynamic secondary options</p>
-<div class="selected-value">Selected Value: {{ mixedPickerValue | json }}</div>
-<novo-picker [config]="mixedPicker" [placeholder]="placeholder" [(ngModel)]="mixedPickerValue" (changed)="onChanged($event)"></novo-picker>
+<div class="selected-value" data-automation-id="picker-mixed-value">Selected Value: {{ mixedPickerValue | json }}</div>
+<novo-picker [config]="mixedPicker" [placeholder]="placeholder" [(ngModel)]="mixedPickerValue" (changed)="onChanged($event)" data-automation-id="picker-mixed-input"></novo-picker>

--- a/projects/novo-examples/src/form-controls/picker/mixed-picker/mixed-picker-example.html
+++ b/projects/novo-examples/src/form-controls/picker/mixed-picker/mixed-picker-example.html
@@ -1,4 +1,4 @@
-<h6 data-automation-id="picker-mixed-heading">Mixed Options Example</h6>
+<h6>Mixed Options Example</h6>
 <p>Some primary options have no secondary option, some have static secondary options, and some have dynamic secondary options</p>
 <div class="selected-value" data-automation-id="picker-mixed-value">Selected Value: {{ mixedPickerValue | json }}</div>
 <novo-picker [config]="mixedPicker" [placeholder]="placeholder" [(ngModel)]="mixedPickerValue" (changed)="onChanged($event)" data-automation-id="picker-mixed-input"></novo-picker>

--- a/projects/novo-examples/src/form-controls/picker/override-template/override-template-example.html
+++ b/projects/novo-examples/src/form-controls/picker/override-template/override-template-example.html
@@ -1,2 +1,2 @@
-<div class="selected-value">Selected Value: {{ overrideValue }}</div>
-<novo-picker [config]="overrideDemo" [placeholder]="placeholder" [(ngModel)]="overrideValue"></novo-picker>
+<div class="selected-value" data-automation-id="picker-override-value">Selected Value: {{ overrideValue }}</div>
+<novo-picker [config]="overrideDemo" [placeholder]="placeholder" [(ngModel)]="overrideValue" data-automation-id="picker-override-input"></novo-picker>

--- a/projects/novo-examples/src/form-controls/radio-buttons/basic-radio/basic-radio-example.html
+++ b/projects/novo-examples/src/form-controls/radio-buttons/basic-radio/basic-radio-example.html
@@ -1,5 +1,5 @@
-<novo-radio-group [(ngModel)]="model" (change)="onChange($event)">
-  <novo-radio value="one">Make me anything!</novo-radio>
-  <novo-radio value="two" [disabled]="true">I'm disabled!</novo-radio>
-  <novo-radio value="three">TEST!</novo-radio>
+<novo-radio-group [(ngModel)]="model" (change)="onChange($event)" data-automation-id="radio-basic-group">
+  <novo-radio value="one" data-automation-id="radio-basic-one">Make me anything!</novo-radio>
+  <novo-radio value="two" [disabled]="true" data-automation-id="radio-basic-two">I'm disabled!</novo-radio>
+  <novo-radio value="three" data-automation-id="radio-basic-three">TEST!</novo-radio>
 </novo-radio-group>

--- a/projects/novo-examples/src/form-controls/radio-buttons/button-radio/button-radio-example.html
+++ b/projects/novo-examples/src/form-controls/radio-buttons/button-radio/button-radio-example.html
@@ -1,12 +1,12 @@
-<novo-radio-group>
-  <novo-radio button="true" [checked]="false" name="button" value="one" (change)="onChange($event)" label="One">
+<novo-radio-group data-automation-id="radio-button-group">
+  <novo-radio button="true" [checked]="false" name="button" value="one" (change)="onChange($event)" label="One" data-automation-id="radio-button-one">
   </novo-radio>
-  <novo-radio button="true" [checked]="true" name="button" value="two" (change)="onChange($event)" label="Two">
+  <novo-radio button="true" [checked]="true" name="button" value="two" (change)="onChange($event)" label="Two" data-automation-id="radio-button-two">
   </novo-radio>
-  <novo-radio button="true" [checked]="false" name="button" value="three" (change)="onChange($event)" label="Three">
+  <novo-radio button="true" [checked]="false" name="button" value="three" (change)="onChange($event)" label="Three" data-automation-id="radio-button-three">
   </novo-radio>
-  <novo-radio button="true" [checked]="false" name="button" value="disabled" (change)="onChange($event)" label="Disabled" [disabled]="true">
+  <novo-radio button="true" [checked]="false" name="button" value="disabled" (change)="onChange($event)" label="Disabled" [disabled]="true" data-automation-id="radio-button-disabled">
   </novo-radio>
-  <novo-radio button="true" [checked]="true" name="button" value="alsoDisabled" (change)="onChange($event)" label="Also Disabled" [disabled]="true">
+  <novo-radio button="true" [checked]="true" name="button" value="alsoDisabled" (change)="onChange($event)" label="Also Disabled" [disabled]="true" data-automation-id="radio-button-also-disabled">
   </novo-radio>
 </novo-radio-group>

--- a/projects/novo-examples/src/form-controls/radio-buttons/icon-radio/icon-radio-example.html
+++ b/projects/novo-examples/src/form-controls/radio-buttons/icon-radio/icon-radio-example.html
@@ -1,12 +1,12 @@
-<novo-radio-group>
-  <novo-radio button="true" theme="icon" icon="company" name="icon" value="one" (change)="onChange($event)">
+<novo-radio-group data-automation-id="radio-icon-group">
+  <novo-radio button="true" theme="icon" icon="company" name="icon" value="one" (change)="onChange($event)" data-automation-id="radio-icon-company">
   </novo-radio>
-  <novo-radio button="true" theme="icon" icon="job" name="icon" value="two" (change)="onChange($event)">
+  <novo-radio button="true" theme="icon" icon="job" name="icon" value="two" (change)="onChange($event)" data-automation-id="radio-icon-job">
   </novo-radio>
-  <novo-radio button="true" theme="icon" icon="candidate" name="icon" value="three" (change)="onChange($event)">
+  <novo-radio button="true" theme="icon" icon="candidate" name="icon" value="three" (change)="onChange($event)" data-automation-id="radio-icon-candidate">
   </novo-radio>
-  <novo-radio button="true" theme="icon" icon="opportunity" name="icon" value="disabled" (change)="onChange($event)" [disabled]="true">
+  <novo-radio button="true" theme="icon" icon="opportunity" name="icon" value="disabled" (change)="onChange($event)" [disabled]="true" data-automation-id="radio-icon-opportunity">
   </novo-radio>
-  <novo-radio button="true" theme="icon" icon="lead" name="icon" value="alsoDisabled" (change)="onChange($event)" [checked]="true" [disabled]="true">
+  <novo-radio button="true" theme="icon" icon="lead" name="icon" value="alsoDisabled" (change)="onChange($event)" [checked]="true" [disabled]="true" data-automation-id="radio-icon-lead">
   </novo-radio>
 </novo-radio-group>

--- a/projects/novo-examples/src/form-controls/radio-buttons/vertical-radio/vertical-radio-example.html
+++ b/projects/novo-examples/src/form-controls/radio-buttons/vertical-radio/vertical-radio-example.html
@@ -1,5 +1,5 @@
-<novo-radio-group appearance="vertical">
-  <novo-radio [checked]="false" name="vertical" value="one" (change)="onChange($event)">Make me anything!</novo-radio>
-  <novo-radio [checked]="true" name="vertical" value="two" (change)="onChange($event)" [disabled]="true">I'm disabled!</novo-radio>
-  <novo-radio [checked]="false" name="vertical" value="three" (change)="onChange($event)">REALLY!</novo-radio>
+<novo-radio-group appearance="vertical" data-automation-id="radio-vertical-group">
+  <novo-radio [checked]="false" name="vertical" value="one" (change)="onChange($event)" data-automation-id="radio-vertical-one">Make me anything!</novo-radio>
+  <novo-radio [checked]="true" name="vertical" value="two" (change)="onChange($event)" [disabled]="true" data-automation-id="radio-vertical-two">I'm disabled!</novo-radio>
+  <novo-radio [checked]="false" name="vertical" value="three" (change)="onChange($event)" data-automation-id="radio-vertical-three">REALLY!</novo-radio>
 </novo-radio-group>

--- a/projects/novo-examples/src/form-controls/select/basic-select-with-search/basic-select-with-search-example.html
+++ b/projects/novo-examples/src/form-controls/select/basic-select-with-search/basic-select-with-search-example.html
@@ -1,4 +1,4 @@
-<h3 data-automation-id="select-search-heading">Single selection</h3>
+<h3>Single selection</h3>
 <p>
   <novo-field data-automation-id="select-search-field">
     <novo-label>State</novo-label>

--- a/projects/novo-examples/src/form-controls/select/basic-select-with-search/basic-select-with-search-example.html
+++ b/projects/novo-examples/src/form-controls/select/basic-select-with-search/basic-select-with-search-example.html
@@ -1,18 +1,18 @@
-<h3>Single selection</h3>
+<h3 data-automation-id="select-search-heading">Single selection</h3>
 <p>
-  <novo-field>
+  <novo-field data-automation-id="select-search-field">
     <novo-label>State</novo-label>
-    <novo-select [formControl]="stateCtrl" placeholder="Select" displayIcon="globe-o" #singleSelect>
+    <novo-select [formControl]="stateCtrl" placeholder="Select" displayIcon="globe-o" #singleSelect data-automation-id="select-search-input">
       <novo-option>
-        <novo-select-search [formControl]="stateFilterCtrl"></novo-select-search>
+        <novo-select-search [formControl]="stateFilterCtrl" data-automation-id="select-search-filter"></novo-select-search>
       </novo-option>
 
-      <novo-option *ngFor="let state of filteredStates | async" [value]="state">
+      <novo-option *ngFor="let state of filteredStates | async; let i = index" [value]="state" [attr.data-automation-id]="'select-search-option-' + i">
         {{state.name}}
       </novo-option>
     </novo-select>
   </novo-field>
 </p>
-<p>
+<p data-automation-id="select-search-result">
   Selected Bank: {{stateCtrl.value?.name}}
 </p>

--- a/projects/novo-examples/src/form-controls/select/basic-select/basic-select-example.html
+++ b/projects/novo-examples/src/form-controls/select/basic-select/basic-select-example.html
@@ -1,5 +1,5 @@
 <novo-field data-automation-id="select-basic-field-1">
-  <novo-label>
+  <novo-label data-automation-id="select-basic-value-1">
     <span class="caption">Selected Value:</span> {{value}}
   </novo-label>
   <novo-select [placeholder]="placeholder" [(ngModel)]="value" data-automation-id="select-basic-options">
@@ -9,7 +9,7 @@
   </novo-select>
 </novo-field>
 <novo-field data-automation-id="select-basic-field-2">
-  <novo-label>
+  <novo-label data-automation-id="select-basic-value-2">
     <span class="caption">Selected Value:</span> {{withNumbersValue.label}}
   </novo-label>
   <novo-select [options]="withNumbers" [(ngModel)]="withNumbersValue" data-automation-id="select-basic-numbers"></novo-select>

--- a/projects/novo-examples/src/form-controls/select/basic-select/basic-select-example.html
+++ b/projects/novo-examples/src/form-controls/select/basic-select/basic-select-example.html
@@ -1,28 +1,28 @@
-<novo-field>
+<novo-field data-automation-id="select-basic-field-1">
   <novo-label>
     <span class="caption">Selected Value:</span> {{value}}
   </novo-label>
-  <novo-select [placeholder]="placeholder" [(ngModel)]="value">
-    <novo-option *ngFor="let option of options" [value]="option">
+  <novo-select [placeholder]="placeholder" [(ngModel)]="value" data-automation-id="select-basic-options">
+    <novo-option *ngFor="let option of options; let i = index" [value]="option" [attr.data-automation-id]="'select-basic-option-' + i">
       {{option}}
     </novo-option>
   </novo-select>
 </novo-field>
-<novo-field>
+<novo-field data-automation-id="select-basic-field-2">
   <novo-label>
     <span class="caption">Selected Value:</span> {{withNumbersValue.label}}
   </novo-label>
-  <novo-select [options]="withNumbers" [(ngModel)]="withNumbersValue"></novo-select>
+  <novo-select [options]="withNumbers" [(ngModel)]="withNumbersValue" data-automation-id="select-basic-numbers"></novo-select>
 </novo-field>
-<novo-field>
+<novo-field data-automation-id="select-basic-field-3">
   <novo-label>
     <span class="caption">Disabled State</span>
   </novo-label>
-  <novo-select [options]="options" [placeholder]="placeholder" [(ngModel)]="value" disabled></novo-select>
+  <novo-select [options]="options" [placeholder]="placeholder" [(ngModel)]="value" disabled data-automation-id="select-basic-disabled"></novo-select>
 </novo-field>
-<novo-field>
+<novo-field data-automation-id="select-basic-field-4">
   <novo-label>
     <span class="caption">No Model With Header</span>
   </novo-label>
-  <novo-select [options]="options" [placeholder]="placeholder" [headerConfig]="headerConfig"></novo-select>
+  <novo-select [options]="options" [placeholder]="placeholder" [headerConfig]="headerConfig" data-automation-id="select-basic-header"></novo-select>
 </novo-field>

--- a/projects/novo-examples/src/form-controls/select/legacy-select-option/legacy-select-option-example.html
+++ b/projects/novo-examples/src/form-controls/select/legacy-select-option/legacy-select-option-example.html
@@ -1,5 +1,5 @@
 <novo-field data-automation-id="select-legacy-field">
-  <novo-label>
+  <novo-label data-automation-id="select-legacy-value">
     <span class="caption">Selected Value:</span> {{value}}
   </novo-label>
   <novo-select [placeholder]="placeholder" [(ngModel)]="value" data-automation-id="select-legacy-input">

--- a/projects/novo-examples/src/form-controls/select/legacy-select-option/legacy-select-option-example.html
+++ b/projects/novo-examples/src/form-controls/select/legacy-select-option/legacy-select-option-example.html
@@ -1,9 +1,9 @@
-<novo-field>
+<novo-field data-automation-id="select-legacy-field">
   <novo-label>
     <span class="caption">Selected Value:</span> {{value}}
   </novo-label>
-  <novo-select [placeholder]="placeholder" [(ngModel)]="value">
-    <novo-option *ngFor="let option of options" [value]="option">
+  <novo-select [placeholder]="placeholder" [(ngModel)]="value" data-automation-id="select-legacy-input">
+    <novo-option *ngFor="let option of options; let i = index" [value]="option" [attr.data-automation-id]="'select-legacy-option-' + i">
       {{option}}
     </novo-option>
   </novo-select>

--- a/projects/novo-examples/src/form-controls/select/long-select/long-select-example.html
+++ b/projects/novo-examples/src/form-controls/select/long-select/long-select-example.html
@@ -1,4 +1,4 @@
-<novo-field>
+<novo-field data-automation-id="select-long-field">
   <novo-label><span class="caption">Selected Value:</span>{{state}}</novo-label>
-  <novo-select [options]="states" [placeholder]="placeholder" [(ngModel)]="state"></novo-select>
+  <novo-select [options]="states" [placeholder]="placeholder" [(ngModel)]="state" data-automation-id="select-long-input"></novo-select>
 </novo-field>

--- a/projects/novo-examples/src/form-controls/select/long-select/long-select-example.html
+++ b/projects/novo-examples/src/form-controls/select/long-select/long-select-example.html
@@ -1,4 +1,4 @@
 <novo-field data-automation-id="select-long-field">
-  <novo-label><span class="caption">Selected Value:</span>{{state}}</novo-label>
+  <novo-label data-automation-id="select-long-value"><span class="caption">Selected Value:</span>{{state}}</novo-label>
   <novo-select [options]="states" [placeholder]="placeholder" [(ngModel)]="state" data-automation-id="select-long-input"></novo-select>
 </novo-field>

--- a/projects/novo-examples/src/form-controls/select/multiple-select-with-search/multiple-select-with-search-example.html
+++ b/projects/novo-examples/src/form-controls/select/multiple-select-with-search/multiple-select-with-search-example.html
@@ -1,19 +1,19 @@
-<h3>Multiple selection</h3>
+<h3 data-automation-id="select-multi-search-heading">Multiple selection</h3>
 <p>
-  <novo-field>
-    <novo-select [formControl]="stateMultiCtrl" placeholder="States" [multiple]="true" #multiSelect>
+  <novo-field data-automation-id="select-multi-search-field">
+    <novo-select [formControl]="stateMultiCtrl" placeholder="States" [multiple]="true" #multiSelect data-automation-id="select-multi-search-input">
       <novo-option>
-        <novo-select-search [formControl]="stateMultiFilterCtrl"></novo-select-search>
+        <novo-select-search [formControl]="stateMultiFilterCtrl" data-automation-id="select-multi-search-filter"></novo-select-search>
       </novo-option>
-      <novo-option *ngFor="let state of filteredStatesMulti | async" [value]="state">
+      <novo-option *ngFor="let state of filteredStatesMulti | async; let i = index" [value]="state" [attr.data-automation-id]="'select-multi-search-option-' + i">
         {{state.name}}
       </novo-option>
     </novo-select>
   </novo-field>
 </p>
-<p>
+<p data-automation-id="select-multi-search-results-heading">
   Selected States:
 </p>
-<ul *ngFor="let state of stateMultiCtrl?.value">
-  <li>{{state.name}}</li>
+<ul>
+  <li *ngFor="let state of stateMultiCtrl?.value; let i = index" [attr.data-automation-id]="'select-multi-search-result-' + i">{{state.name}}</li>
 </ul>

--- a/projects/novo-examples/src/form-controls/select/multiple-select-with-search/multiple-select-with-search-example.html
+++ b/projects/novo-examples/src/form-controls/select/multiple-select-with-search/multiple-select-with-search-example.html
@@ -1,4 +1,4 @@
-<h3 data-automation-id="select-multi-search-heading">Multiple selection</h3>
+<h3>Multiple selection</h3>
 <p>
   <novo-field data-automation-id="select-multi-search-field">
     <novo-select [formControl]="stateMultiCtrl" placeholder="States" [multiple]="true" #multiSelect data-automation-id="select-multi-search-input">

--- a/projects/novo-examples/src/form-controls/select/multiple-select/multiple-select-example.html
+++ b/projects/novo-examples/src/form-controls/select/multiple-select/multiple-select-example.html
@@ -1,5 +1,5 @@
 <novo-field data-automation-id="select-multiple-field">
-  <novo-label>Selected Value: <span class="caption">{{selected}}</span></novo-label>
+  <novo-label data-automation-id="select-multiple-value">Selected Value: <span class="caption">{{selected}}</span></novo-label>
   <novo-select [placeholder]="placeholder" [(ngModel)]="selected" multiple data-automation-id="select-multiple-input">
     <novo-option *ngFor="let state of states; let i = index" [value]="state" [attr.data-automation-id]="'select-multiple-option-' + i">{{state}}</novo-option>
   </novo-select>

--- a/projects/novo-examples/src/form-controls/select/multiple-select/multiple-select-example.html
+++ b/projects/novo-examples/src/form-controls/select/multiple-select/multiple-select-example.html
@@ -1,6 +1,6 @@
-<novo-field>
+<novo-field data-automation-id="select-multiple-field">
   <novo-label>Selected Value: <span class="caption">{{selected}}</span></novo-label>
-  <novo-select [placeholder]="placeholder" [(ngModel)]="selected" multiple>
-    <novo-option *ngFor="let state of states" [value]="state">{{state}}</novo-option>
+  <novo-select [placeholder]="placeholder" [(ngModel)]="selected" multiple data-automation-id="select-multiple-input">
+    <novo-option *ngFor="let state of states; let i = index" [value]="state" [attr.data-automation-id]="'select-multiple-option-' + i">{{state}}</novo-option>
   </novo-select>
 </novo-field>

--- a/projects/novo-examples/src/form-controls/tiles/tiles-usage/tiles-usage-example.html
+++ b/projects/novo-examples/src/form-controls/tiles/tiles-usage/tiles-usage-example.html
@@ -3,29 +3,33 @@ Default:
 <novo-tiles
   [options]="demoTilesDefault"
   (onChange)="select('Default', $event)"
-  [(ngModel)]="valueDefault" />
+  [(ngModel)]="valueDefault"
+  data-automation-id="tiles-default" />
 <hr />
 Icons:
 <br />
 <novo-tiles
   [options]="demoTilesIcons"
   (onChange)="select('Icons', $event)"
-  [(ngModel)]="valueIcons" />
+  [(ngModel)]="valueIcons"
+  data-automation-id="tiles-icons" />
 <hr />
 Disabled:
 <br />
 <novo-tiles disabled
   [options]="demoTilesDisabled"
   (onChange)="select('Disabled', $event)"
-  [(ngModel)]="valueDisabled" />
+  [(ngModel)]="valueDisabled"
+  data-automation-id="tiles-disabled" />
 <hr />
 Custom Colors:
 <br />
 <novo-tiles
   [options]="demoTilesColor"
   (onChange)="select('Color', $event)"
-  [(ngModel)]="valueColor" />
-<novo-row gap="md" justify="end">
-    <button theme="primary" type="button" name="addButton" (click)="addTile()">Add Tile</button>
-    <button theme="secondary" type="button" name="resetButton" (click)="resetTiles()">Reset</button>
+  [(ngModel)]="valueColor"
+  data-automation-id="tiles-colors" />
+<novo-row gap="md" justify="end" data-automation-id="tiles-buttons">
+    <button theme="primary" type="button" name="addButton" (click)="addTile()" data-automation-id="tiles-add">Add Tile</button>
+    <button theme="secondary" type="button" name="resetButton" (click)="resetTiles()" data-automation-id="tiles-reset">Reset</button>
 </novo-row>

--- a/projects/novo-examples/src/form-controls/time-picker/time-picker/time-picker-example.html
+++ b/projects/novo-examples/src/form-controls/time-picker/time-picker/time-picker-example.html
@@ -1,62 +1,63 @@
-<novo-row gap="3rem" align="space-between">
-  <div flex>
+<novo-row gap="3rem" align="space-between" data-automation-id="time-picker-inputs">
+  <div flex data-automation-id="time-picker-input-1">
     <novo-time-picker-input
       [military]="display.value"
       [disabled]="disabled.value"
       [analog]="appearance.value"
       [hasButtons]="hasButtons.value"
-      [(ngModel)]="time1"></novo-time-picker-input>
-    <novo-hint>value: {{time1}}</novo-hint>
+      [(ngModel)]="time1"
+      data-automation-id="time-picker-input-1-control"></novo-time-picker-input>
+    <novo-hint data-automation-id="time-picker-input-1-hint">value: {{time1}}</novo-hint>
   </div>
 
   <novo-divider vertical></novo-divider>
 
-  <novo-field flex>
+  <novo-field flex data-automation-id="time-picker-input-2">
     <novo-label>Set an Alarm</novo-label>
-    <input novoInput [(ngModel)]="time2" [timeFormat]="format.value" [picker]="timepicker" />
+    <input novoInput [(ngModel)]="time2" [timeFormat]="format.value" [picker]="timepicker" data-automation-id="time-picker-input-2-control" />
     <novo-picker-toggle novoSuffix icon="clock">
-      <novo-time-picker #timepicker></novo-time-picker>
+      <novo-time-picker #timepicker data-automation-id="time-picker-input-2-picker"></novo-time-picker>
     </novo-picker-toggle>
-    <novo-hint>value: {{time2}}</novo-hint>
+    <novo-hint data-automation-id="time-picker-input-2-hint">value: {{time2}}</novo-hint>
     <novo-hint>The <code>timeFormat</code> attribute controls model.</novo-hint>
   </novo-field>
 
 </novo-row>
-<novo-row class="bgc-bright" align="flex-start" gap="xl" padding="md">
-  <novo-field>
+<novo-row class="bgc-bright" align="flex-start" gap="xl" padding="md" data-automation-id="time-picker-options">
+  <novo-field data-automation-id="time-picker-display-field">
     <novo-label>Display Format?</novo-label>
-    <novo-radio-group #display appearance="vertical" [value]="true">
-      <novo-radio name="display" [value]="true">HH:mm</novo-radio>
-      <novo-radio name="display" [value]="false">hh:mm A</novo-radio>
+    <novo-radio-group #display appearance="vertical" [value]="true" data-automation-id="time-picker-display-group">
+      <novo-radio name="display" [value]="true" data-automation-id="time-picker-display-24">HH:mm</novo-radio>
+      <novo-radio name="display" [value]="false" data-automation-id="time-picker-display-12">hh:mm A</novo-radio>
     </novo-radio-group>
   </novo-field>
-  <novo-field>
+  <novo-field data-automation-id="time-picker-format-field">
     <novo-label>Value Format?</novo-label>
-    <novo-radio-group #format appearance="vertical" value="iso8601">
-      <novo-radio name="format" value="date">date</novo-radio>
-      <novo-radio name="format" value="iso8601">iso8601</novo-radio>
-      <novo-radio name="format" value="string">string</novo-radio>
+    <novo-radio-group #format appearance="vertical" value="iso8601" data-automation-id="time-picker-format-group">
+      <novo-radio name="format" value="date" data-automation-id="time-picker-format-date">date</novo-radio>
+      <novo-radio name="format" value="iso8601" data-automation-id="time-picker-format-iso">iso8601</novo-radio>
+      <novo-radio name="format" value="string" data-automation-id="time-picker-format-string">string</novo-radio>
     </novo-radio-group>
   </novo-field>
-  <novo-field>
+  <novo-field data-automation-id="time-picker-appearance-field">
     <novo-label>Appearance</novo-label>
-    <novo-radio-group #appearance appearance="vertical" [value]="false">
-      <novo-radio name="appearance" [value]="false">Default</novo-radio>
-      <novo-radio name="appearance" [value]="true">Analog (deprecated)</novo-radio>
+    <novo-radio-group #appearance appearance="vertical" [value]="false" data-automation-id="time-picker-appearance-group">
+      <novo-radio name="appearance" [value]="false" data-automation-id="time-picker-appearance-default">Default</novo-radio>
+      <novo-radio name="appearance" [value]="true" data-automation-id="time-picker-appearance-analog">Analog (deprecated)</novo-radio>
     </novo-radio-group>
   </novo-field>
-  <novo-field>
+  <novo-field data-automation-id="time-picker-disabled-field">
     <novo-label>Disabled?</novo-label>
-    <novo-radio-group #disabled appearance="vertical" [value]="false">
-      <novo-radio name="disabled" [value]="false">Enabled</novo-radio>
-      <novo-radio name="disabled" [value]="true">Disabled</novo-radio>
+    <novo-radio-group #disabled appearance="vertical" [value]="false" data-automation-id="time-picker-disabled-group">
+      <novo-radio name="disabled" [value]="false" data-automation-id="time-picker-disabled-enabled">Enabled</novo-radio>
+      <novo-radio name="disabled" [value]="true" data-automation-id="time-picker-disabled-disabled">Disabled</novo-radio>
     </novo-radio-group>
   </novo-field>
-  <novo-field>
+  <novo-field data-automation-id="time-picker-buttons-field">
     <novo-label>Save/Cancel Buttons?</novo-label>
-    <novo-radio-group #hasButtons appearance="vertical" [value]="false">
-      <novo-radio name="disabled" [value]="true">Enabled</novo-radio>
-      <novo-radio name="disabled" [value]="false">Disabled</novo-radio>
+    <novo-radio-group #hasButtons appearance="vertical" [value]="false" data-automation-id="time-picker-buttons-group">
+      <novo-radio name="disabled" [value]="true" data-automation-id="time-picker-buttons-enabled">Enabled</novo-radio>
+      <novo-radio name="disabled" [value]="false" data-automation-id="time-picker-buttons-disabled">Disabled</novo-radio>
     </novo-radio-group>
   </novo-field>
 </novo-row>

--- a/projects/novo-examples/src/form-controls/timezone/timezone/basic-timezone-example.html
+++ b/projects/novo-examples/src/form-controls/timezone/timezone/basic-timezone-example.html
@@ -1,8 +1,9 @@
-<div *ngFor="let item of items">
+<div *ngFor="let item of items; let i = index" data-automation-id="timezone-items">
   <novo-checkbox
     [label]="item.name"
     [(ngModel)]="item.isChecked"
     [disabled]="item.disabled"
     [indeterminate]="item.indeterminate"
-    (onSelect)="onChange($event, item)"></novo-checkbox>
+    (onSelect)="onChange($event, item)"
+    [attr.data-automation-id]="'timezone-item-' + i"></novo-checkbox>
 </div>

--- a/projects/novo-examples/src/form-controls/value/address-value/address-value-example.html
+++ b/projects/novo-examples/src/form-controls/value/address-value/address-value-example.html
@@ -1,1 +1,1 @@
-<novo-value [data]="data" [meta]="meta" [theme]="theme"></novo-value>
+<novo-value [data]="data" [meta]="meta" [theme]="theme" data-automation-id="value-address"></novo-value>

--- a/projects/novo-examples/src/form-controls/value/associated-value/associated-value-example.html
+++ b/projects/novo-examples/src/form-controls/value/associated-value/associated-value-example.html
@@ -1,1 +1,1 @@
-<novo-value [data]="data" [meta]="meta" [theme]="theme"></novo-value>
+<novo-value [data]="data" [meta]="meta" [theme]="theme" data-automation-id="value-associated"></novo-value>

--- a/projects/novo-examples/src/form-controls/value/basic-value/basic-value-example.html
+++ b/projects/novo-examples/src/form-controls/value/basic-value/basic-value-example.html
@@ -1,1 +1,1 @@
-<novo-value [data]="data" [meta]="meta" [theme]="theme"></novo-value>
+<novo-value [data]="data" [meta]="meta" [theme]="theme" data-automation-id="value-basic"></novo-value>

--- a/projects/novo-examples/src/form-controls/value/category-value/category-value-example.html
+++ b/projects/novo-examples/src/form-controls/value/category-value/category-value-example.html
@@ -1,1 +1,1 @@
-<novo-value [data]="data" [meta]="meta" [theme]="theme"></novo-value>
+<novo-value [data]="data" [meta]="meta" [theme]="theme" data-automation-id="value-category"></novo-value>

--- a/projects/novo-examples/src/form-controls/value/corporate-user-value/corporate-user-value-example.html
+++ b/projects/novo-examples/src/form-controls/value/corporate-user-value/corporate-user-value-example.html
@@ -1,1 +1,1 @@
-<novo-value [data]="data" [meta]="meta" [theme]="theme"></novo-value>
+<novo-value [data]="data" [meta]="meta" [theme]="theme" data-automation-id="value-corporate-user"></novo-value>

--- a/projects/novo-examples/src/form-controls/value/date-time-value/date-time-value-example.html
+++ b/projects/novo-examples/src/form-controls/value/date-time-value/date-time-value-example.html
@@ -1,1 +1,1 @@
-<novo-value [data]="data" [meta]="meta" [theme]="theme"></novo-value>
+<novo-value [data]="data" [meta]="meta" [theme]="theme" data-automation-id="value-date-time"></novo-value>

--- a/projects/novo-examples/src/form-controls/value/entity-list-value/entity-list-value-example.html
+++ b/projects/novo-examples/src/form-controls/value/entity-list-value/entity-list-value-example.html
@@ -1,1 +1,1 @@
-<novo-value [data]="data" [meta]="meta" [theme]="theme"></novo-value>
+<novo-value [data]="data" [meta]="meta" [theme]="theme" data-automation-id="value-entity-list"></novo-value>

--- a/projects/novo-examples/src/form-controls/value/external-link-value/external-link-value-example.html
+++ b/projects/novo-examples/src/form-controls/value/external-link-value/external-link-value-example.html
@@ -1,1 +1,1 @@
-<novo-value [data]="data" [meta]="meta" [theme]="theme"></novo-value>
+<novo-value [data]="data" [meta]="meta" [theme]="theme" data-automation-id="value-external-link"></novo-value>

--- a/projects/novo-examples/src/form-controls/value/formatter-value/formatter-value-example.html
+++ b/projects/novo-examples/src/form-controls/value/formatter-value/formatter-value-example.html
@@ -1,1 +1,1 @@
-<novo-value [data]="data" [meta]="meta" [theme]="theme"></novo-value>
+<novo-value [data]="data" [meta]="meta" [theme]="theme" data-automation-id="value-formatter"></novo-value>

--- a/projects/novo-examples/src/form-controls/value/icon-value/icon-value-example.html
+++ b/projects/novo-examples/src/form-controls/value/icon-value/icon-value-example.html
@@ -1,1 +1,1 @@
-<novo-value [data]="data" [meta]="meta" [theme]="theme"></novo-value>
+<novo-value [data]="data" [meta]="meta" [theme]="theme" data-automation-id="value-icon"></novo-value>

--- a/projects/novo-examples/src/form-controls/value/multi-option-value/multi-option-value-example.html
+++ b/projects/novo-examples/src/form-controls/value/multi-option-value/multi-option-value-example.html
@@ -1,1 +1,1 @@
-<novo-value [data]="data" [meta]="meta" [theme]="theme"></novo-value>
+<novo-value [data]="data" [meta]="meta" [theme]="theme" data-automation-id="value-multi-option"></novo-value>

--- a/projects/novo-examples/src/layouts/cards/basic-card/basic-card-example.html
+++ b/projects/novo-examples/src/layouts/cards/basic-card/basic-card-example.html
@@ -47,9 +47,9 @@
     <novo-caption>Target $50k</novo-caption>
   </novo-row>
   <novo-progress appearance="radial" total="60" mx="2xl" data-automation-id="card-sales-progress">
-    <novo-progress-bar value="50" color="success"></novo-progress-bar>
-    <novo-progress-bar value="40" color="negative"></novo-progress-bar>
-    <novo-progress-bar value="30" color="warning"></novo-progress-bar>
+    <novo-progress-bar value="50" color="success" data-automation-id="card-sales-progress-success"></novo-progress-bar>
+    <novo-progress-bar value="40" color="negative" data-automation-id="card-sales-progress-negative"></novo-progress-bar>
+    <novo-progress-bar value="30" color="warning" data-automation-id="card-sales-progress-warning"></novo-progress-bar>
   </novo-progress>
   <novo-row justify="space-between">
     <novo-text><strong>$7,700</strong> ahead</novo-text>

--- a/projects/novo-examples/src/layouts/cards/basic-card/basic-card-example.html
+++ b/projects/novo-examples/src/layouts/cards/basic-card/basic-card-example.html
@@ -8,27 +8,28 @@
   [close]="close"
   (onRefresh)="onRefresh()"
   (onClose)="onClose()"
-  [padding]="padding">
+  [padding]="padding"
+  data-automation-id="card-all-attributes">
   This is the ALL attribute card content!
 </novo-card>
 
 
-<novo-row gap="lg">
-  <novo-card inline padding="lg">
+<novo-row gap="lg" data-automation-id="card-inline-group">
+  <novo-card inline padding="lg" data-automation-id="card-inline-interviews">
     <novo-stack align="center">
       <novo-title larger>500</novo-title>
       <novo-caption>Interviews</novo-caption>
     </novo-stack>
   </novo-card>
 
-  <novo-card inline padding="lg">
+  <novo-card inline padding="lg" data-automation-id="card-inline-ratio">
     <novo-stack align="center">
       <novo-caption>1st Interviews to Placements</novo-caption>
       <novo-title larger>10 : 1</novo-title>
     </novo-stack>
   </novo-card>
 
-  <novo-card inline padding="lg">
+  <novo-card inline padding="lg" data-automation-id="card-inline-cvs">
     <novo-stack align="center">
       <novo-caption>CVs Sent to 1st Interviews</novo-caption>
       <novo-title larger>83%</novo-title>
@@ -37,7 +38,7 @@
 
 </novo-row>
 
-<novo-card inline inset="large">
+<novo-card inline inset="large" data-automation-id="card-sales">
   <novo-row justify="space-between">
     <novo-text bold>Total Sales</novo-text>
     <novo-text bold>$10k</novo-text>
@@ -45,7 +46,7 @@
   <novo-row align="center">
     <novo-caption>Target $50k</novo-caption>
   </novo-row>
-  <novo-progress appearance="radial" total="60" mx="2xl">
+  <novo-progress appearance="radial" total="60" mx="2xl" data-automation-id="card-sales-progress">
     <novo-progress-bar value="50" color="success"></novo-progress-bar>
     <novo-progress-bar value="40" color="negative"></novo-progress-bar>
     <novo-progress-bar value="30" color="warning"></novo-progress-bar>

--- a/projects/novo-examples/src/layouts/cards/card-config/card-config-example.html
+++ b/projects/novo-examples/src/layouts/cards/card-config/card-config-example.html
@@ -1,6 +1,6 @@
-<novo-card [config]="fullConfig">
-  <novo-card-actions>
-      <button theme="icon" icon="info" (click)="singleAction()"></button>
+<novo-card [config]="fullConfig" data-automation-id="card-config">
+  <novo-card-actions data-automation-id="card-config-actions">
+      <button theme="icon" icon="info" (click)="singleAction()" data-automation-id="card-config-info"></button>
   </novo-card-actions>
   DEMO :)
 </novo-card>

--- a/projects/novo-examples/src/layouts/cards/card-with-image/card-with-image-example.html
+++ b/projects/novo-examples/src/layouts/cards/card-with-image/card-with-image-example.html
@@ -1,15 +1,16 @@
-<novo-card class="example-card">
-  <novo-card-header>
+<novo-card class="example-card" data-automation-id="card-image">
+  <novo-card-header data-automation-id="card-image-header">
     <novo-avatar tooltip="Ferdinand del Toro"
-      [source]="{profileImage: 'https://www.eaglebrae.co.uk/wp-content/uploads/close-up-highland-cow.jpg'}">
+      [source]="{profileImage: 'https://www.eaglebrae.co.uk/wp-content/uploads/close-up-highland-cow.jpg'}"
+      data-automation-id="card-image-avatar">
     </novo-avatar>
     <novo-title>Highland Cattle</novo-title>
     <novo-caption>Breed of Rustic Cattle</novo-caption>
-    <novo-action icon="times" tooltip="Close Card"></novo-action>
+    <novo-action icon="times" tooltip="Close Card" data-automation-id="card-image-close"></novo-action>
   </novo-card-header>
   <img novo-card-image src="https://upload.wikimedia.org/wikipedia/commons/7/78/Highland_Cattle_4.jpg"
-    alt="Photo of a Highland Calf" />
-  <novo-card-content>
+    alt="Photo of a Highland Calf" data-automation-id="card-image-img" />
+  <novo-card-content data-automation-id="card-image-content">
     <novo-text>
       The Highland (Scottish Gaelic: Bò Ghàidhealach; Scots: Hielan coo) is a Scottish breed of rustic cattle. It
       originated in the <novo-link>Scottish Highlands</novo-link> and the Outer Hebrides islands of Scotland and has
@@ -19,11 +20,11 @@
       been exported to several other countries.<sup>[1]</sup>
     </novo-text>
   </novo-card-content>
-  <novo-card-footer>
-    <novo-button>
+  <novo-card-footer data-automation-id="card-image-footer">
+    <novo-button data-automation-id="card-image-pin">
       PIN <novo-icon>pin</novo-icon>
     </novo-button>
-    <novo-button>
+    <novo-button data-automation-id="card-image-share">
       SHARE <novo-icon>share</novo-icon>
     </novo-button>
   </novo-card-footer>

--- a/projects/novo-examples/src/layouts/expansion/accordion/accordion-example.html
+++ b/projects/novo-examples/src/layouts/expansion/accordion/accordion-example.html
@@ -1,22 +1,24 @@
 <novo-accordion
   [displayMode]="isFlat ? 'flat' : 'default'"
-  [multi]="isMulti">
-  <novo-expansion-panel>
-    <novo-expansion-panel-header>
+  [multi]="isMulti"
+  data-automation-id="accordion">
+  <novo-expansion-panel data-automation-id="accordion-panel-1">
+    <novo-expansion-panel-header data-automation-id="accordion-panel-1-header">
       This is the expansion 1 title
     </novo-expansion-panel-header>
-    <section>
+    <section data-automation-id="accordion-panel-1-nested">
       <novo-accordion
         [displayMode]="isFlat ? 'flat' : 'default'"
-        [multi]="isMulti">
-        <novo-expansion-panel>
-          <novo-expansion-panel-header>
+        [multi]="isMulti"
+        data-automation-id="accordion-nested">
+        <novo-expansion-panel data-automation-id="accordion-nested-1">
+          <novo-expansion-panel-header data-automation-id="accordion-nested-1-header">
             This is the expansion 1 title
           </novo-expansion-panel-header>
           <p>This the expansion 1 content</p>
         </novo-expansion-panel>
-        <novo-expansion-panel>
-          <novo-expansion-panel-header>
+        <novo-expansion-panel data-automation-id="accordion-nested-2">
+          <novo-expansion-panel-header data-automation-id="accordion-nested-2-header">
             This is the expansion 2 title
           </novo-expansion-panel-header>
           <p>This the expansion 2 content</p>
@@ -30,17 +32,17 @@
     </section>
   </novo-expansion-panel>
 
-  <novo-expansion-panel>
-    <novo-expansion-panel-header>
+  <novo-expansion-panel data-automation-id="accordion-panel-2">
+    <novo-expansion-panel-header data-automation-id="accordion-panel-2-header">
       This is the expansion 2 title
     </novo-expansion-panel-header>
     <p>This the expansion 2 content</p>
   </novo-expansion-panel>
 </novo-accordion>
-<div>
+<div data-automation-id="accordion-options">
   <br />
   <span>Flat Expansion</span>
-  <novo-switch theme="grapefruit" [(ngModel)]="isFlat"></novo-switch>
+  <novo-switch theme="grapefruit" [(ngModel)]="isFlat" data-automation-id="accordion-flat-toggle"></novo-switch>
   <span>Multiple Expansion</span>
-  <novo-switch theme="grapefruit" [(ngModel)]="isMulti"></novo-switch>
+  <novo-switch theme="grapefruit" [(ngModel)]="isMulti" data-automation-id="accordion-multi-toggle"></novo-switch>
 </div>

--- a/projects/novo-examples/src/layouts/expansion/basic-expansion/basic-expansion-example.html
+++ b/projects/novo-examples/src/layouts/expansion/basic-expansion/basic-expansion-example.html
@@ -1,5 +1,5 @@
-<novo-expansion-panel [disabled]="isDisabled">
-  <novo-expansion-panel-header>
+<novo-expansion-panel [disabled]="isDisabled" data-automation-id="expansion-basic">
+  <novo-expansion-panel-header data-automation-id="expansion-basic-header">
     <novo-panel-title>
       This is the expansion title
     </novo-panel-title>
@@ -7,10 +7,10 @@
       This is a summary of the content
     </novo-panel-description>
   </novo-expansion-panel-header>
-  <p>This is the primary content of the panel.</p>
+  <p data-automation-id="expansion-basic-content">This is the primary content of the panel.</p>
 </novo-expansion-panel>
-<div>
+<div data-automation-id="expansion-basic-options">
   <br/>
   <span>Is Disabled?</span>
-  <novo-switch theme="grapefruit" [(ngModel)]="isDisabled"></novo-switch>
+  <novo-switch theme="grapefruit" [(ngModel)]="isDisabled" data-automation-id="expansion-basic-toggle"></novo-switch>
 </div>

--- a/projects/novo-examples/src/layouts/expansion/lazy-expansion/lazy-expansion-example.html
+++ b/projects/novo-examples/src/layouts/expansion/lazy-expansion/lazy-expansion-example.html
@@ -1,9 +1,9 @@
-<novo-expansion-panel>
-    <novo-expansion-panel-header>
+<novo-expansion-panel data-automation-id="expansion-lazy">
+    <novo-expansion-panel-header data-automation-id="expansion-lazy-header">
       This is the expansion title
     </novo-expansion-panel-header>
 
-    <ng-template matExpansionPanelContent>
+    <ng-template matExpansionPanelContent data-automation-id="expansion-lazy-content">
       Some deferred content
     </ng-template>
 </novo-expansion-panel>

--- a/projects/novo-examples/src/layouts/header/basic-header/basic-header-example.html
+++ b/projects/novo-examples/src/layouts/header/basic-header/basic-header-example.html
@@ -1,23 +1,23 @@
-<header [accent]="theme">
-  <novo-action icon="convert" tooltip="Change Theme" (click)="changeTheme()"></novo-action>
-  <novo-action icon="refresh" tooltip="Show Popup" (click)="catchEv('refresh', $event)"></novo-action>
-  <novo-action icon="times" tooltip="Show Popup" (click)="catchEv('close', $event)"></novo-action>
+<header [accent]="theme" data-automation-id="header-basic">
+  <novo-action icon="convert" tooltip="Change Theme" (click)="changeTheme()" data-automation-id="header-basic-theme"></novo-action>
+  <novo-action icon="refresh" tooltip="Show Popup" (click)="catchEv('refresh', $event)" data-automation-id="header-basic-refresh"></novo-action>
+  <novo-action icon="times" tooltip="Show Popup" (click)="catchEv('close', $event)" data-automation-id="header-basic-close"></novo-action>
 
-  <novo-title larger>
+  <novo-title larger data-automation-id="header-basic-title">
     <novo-icon>{{icon}}</novo-icon>
     <span>Ferdinand del Toro</span>
   </novo-title>
-  <section>
+  <section data-automation-id="header-basic-info">
     Extra Info
   </section>
-  <novo-nav direction="horizontal">
-    <novo-tab>
+  <novo-nav direction="horizontal" data-automation-id="header-basic-nav">
+    <novo-tab data-automation-id="header-basic-overview">
       <span>Overview</span>
     </novo-tab>
-    <novo-tab>
+    <novo-tab data-automation-id="header-basic-activity">
       <span>Activity</span>
     </novo-tab>
-    <novo-tab>
+    <novo-tab data-automation-id="header-basic-email">
       <span>Email</span>
     </novo-tab>
   </novo-nav>

--- a/projects/novo-examples/src/layouts/header/condensed-header/condensed-header-example.html
+++ b/projects/novo-examples/src/layouts/header/condensed-header/condensed-header-example.html
@@ -1,28 +1,28 @@
-<header [theme]="theme" condensed>
-  <novo-action icon="convert" tooltip="Change Theme" (click)="changeTheme()"></novo-action>
-  <novo-action icon="refresh" tooltip="Show Popup" (click)="catchEv('refresh', $event)"></novo-action>
-  <novo-action icon="times" tooltip="Show Popup" (click)="catchEv('close', $event)"></novo-action>
+<header [theme]="theme" condensed data-automation-id="header-condensed">
+  <novo-action icon="convert" tooltip="Change Theme" (click)="changeTheme()" data-automation-id="header-condensed-theme"></novo-action>
+  <novo-action icon="refresh" tooltip="Show Popup" (click)="catchEv('refresh', $event)" data-automation-id="header-condensed-refresh"></novo-action>
+  <novo-action icon="times" tooltip="Show Popup" (click)="catchEv('close', $event)" data-automation-id="header-condensed-close"></novo-action>
 
-  <novo-icon color="white" [name]="icon">{{icon}}</novo-icon>
-  <novo-title>
+  <novo-icon color="white" [name]="icon" data-automation-id="header-condensed-icon">{{icon}}</novo-icon>
+  <novo-title data-automation-id="header-condensed-title">
     <span class="id">123456</span>
     <novo-divider vertical></novo-divider>
     <span class="name">Steve Jobs</span>
   </novo-title>
-  <section class="links">
-    <button theme="icon" color="white" [icon]="'google'"></button>
-    <button theme="icon" color="white" [icon]="'linkedin-f'"></button>
-    <button theme="icon" color="white" [icon]="'location'"></button>
+  <section class="links" data-automation-id="header-condensed-links">
+    <button theme="icon" color="white" [icon]="'google'" data-automation-id="header-condensed-google"></button>
+    <button theme="icon" color="white" [icon]="'linkedin-f'" data-automation-id="header-condensed-linkedin"></button>
+    <button theme="icon" color="white" [icon]="'location'" data-automation-id="header-condensed-location"></button>
   </section>
 </header>
-<novo-nav theme="white" direction="horizontal">
-  <novo-tab>
+<novo-nav theme="white" direction="horizontal" data-automation-id="header-condensed-nav">
+  <novo-tab data-automation-id="header-condensed-overview">
     <span>Overview</span>
   </novo-tab>
-  <novo-tab>
+  <novo-tab data-automation-id="header-condensed-activity">
     <span>Activity</span>
   </novo-tab>
-  <novo-tab>
+  <novo-tab data-automation-id="header-condensed-email">
     <span>Email</span>
   </novo-tab>
 </novo-nav>

--- a/projects/novo-examples/src/layouts/header/header-searchbar/header-searchbar-example.html
+++ b/projects/novo-examples/src/layouts/header/header-searchbar/header-searchbar-example.html
@@ -1,14 +1,14 @@
-<header [theme]="theme">
-  <novo-icon size="2xl">{{icon}}</novo-icon>
-  <novo-title size="2xl">Header</novo-title>
-  <section class="header-content">
-    <novo-search [theme]="theme"></novo-search>
+<header [theme]="theme" data-automation-id="header-search">
+  <novo-icon size="2xl" data-automation-id="header-search-icon">{{icon}}</novo-icon>
+  <novo-title size="2xl" data-automation-id="header-search-title">Header</novo-title>
+  <section class="header-content" data-automation-id="header-search-content">
+    <novo-search [theme]="theme" data-automation-id="header-search-input"></novo-search>
   </section>
 
-  <novo-action icon="convert" tooltip="Change Theme" (click)="changeTheme()"></novo-action>
-  <novo-action icon="refresh" tooltip="Show Popup" (click)="catchEv('refresh', $event)"></novo-action>
-  <novo-action icon="times" tooltip="Show Popup" (click)="catchEv('close', $event)"></novo-action>
+  <novo-action icon="convert" tooltip="Change Theme" (click)="changeTheme()" data-automation-id="header-search-theme"></novo-action>
+  <novo-action icon="refresh" tooltip="Show Popup" (click)="catchEv('refresh', $event)" data-automation-id="header-search-refresh"></novo-action>
+  <novo-action icon="times" tooltip="Show Popup" (click)="catchEv('close', $event)" data-automation-id="header-search-close"></novo-action>
 
 </header>
 <br />
-<novo-checkbox label="Always Open?" [(ngModel)]="isChecked"></novo-checkbox>
+<novo-checkbox label="Always Open?" [(ngModel)]="isChecked" data-automation-id="header-search-always-open"></novo-checkbox>

--- a/projects/novo-examples/src/layouts/header/header-subtitle/header-subtitle-example.html
+++ b/projects/novo-examples/src/layouts/header/header-subtitle/header-subtitle-example.html
@@ -1,9 +1,9 @@
-<novo-header [theme]="theme">
-  <novo-action icon="convert" tooltip="Change Theme" (click)="changeTheme()"></novo-action>
-  <novo-action icon="refresh" tooltip="Show Popup" (click)="catchEv('refresh', $event)"></novo-action>
-  <novo-action icon="times" tooltip="Show Popup" (click)="catchEv('close', $event)"></novo-action>
+<novo-header [theme]="theme" data-automation-id="header-subtitle">
+  <novo-action icon="convert" tooltip="Change Theme" (click)="changeTheme()" data-automation-id="header-subtitle-theme"></novo-action>
+  <novo-action icon="refresh" tooltip="Show Popup" (click)="catchEv('refresh', $event)" data-automation-id="header-subtitle-refresh"></novo-action>
+  <novo-action icon="times" tooltip="Show Popup" (click)="catchEv('close', $event)" data-automation-id="header-subtitle-close"></novo-action>
 
-  <novo-icon>{{icon}}</novo-icon>
-  <novo-title>Header</novo-title>
-  <novo-title size="sm">with subtitle</novo-title>
+  <novo-icon data-automation-id="header-subtitle-icon">{{icon}}</novo-icon>
+  <novo-title data-automation-id="header-subtitle-title">Header</novo-title>
+  <novo-title size="sm" data-automation-id="header-subtitle-text">with subtitle</novo-title>
 </novo-header>

--- a/projects/novo-examples/src/layouts/list/basic-list/basic-list-example.html
+++ b/projects/novo-examples/src/layouts/list/basic-list/basic-list-example.html
@@ -1,17 +1,17 @@
-<header>
-    <novo-list direction="vertical">
-        <novo-list-item *ngFor="let item of pulseItems">
-            <item-header>
-                <item-avatar [icon]="item.type"></item-avatar>
-                <item-title>{{item.name}}</item-title>
-                <item-header-end>
+<header data-automation-id="list-basic-header">
+    <novo-list direction="vertical" data-automation-id="list-basic">
+        <novo-list-item *ngFor="let item of pulseItems; let i = index" [attr.data-automation-id]="'list-basic-item-' + i">
+            <item-header data-automation-id="list-basic-item-header">
+                <item-avatar [icon]="item.type" data-automation-id="list-basic-item-avatar"></item-avatar>
+                <item-title data-automation-id="list-basic-item-title">{{item.name}}</item-title>
+                <item-header-end data-automation-id="list-basic-item-time">
                     <span>
                         <i class="bhi-clock"></i>
                         {{item.timeAgo | date: 'shortTime'}}
                     </span>
                 </item-header-end>
             </item-header>
-            <item-content direction="vertical">
+            <item-content direction="vertical" data-automation-id="list-basic-item-content">
                 <p>
                     <i *ngIf="item.icon.name" class="{{item.icon.name}} {{item.icon.sentiment}}"></i>
                     {{item.comment}}

--- a/projects/novo-examples/src/layouts/list/themed-list/themed-list-example.html
+++ b/projects/novo-examples/src/layouts/list/themed-list/themed-list-example.html
@@ -1,6 +1,6 @@
-<header>
-    <novo-list theme="navigation" direction="vertical">
-        <novo-list-item *ngFor="let item of pulseItems">
+<header data-automation-id="list-themed-header">
+    <novo-list theme="navigation" direction="vertical" data-automation-id="list-themed">
+        <novo-list-item *ngFor="let item of pulseItems; let i = index" [attr.data-automation-id]="'list-themed-item-' + i">
             <item-header>
                 <item-avatar [icon]="item.type"></item-avatar>
                 <item-title>{{item.name}}</item-title>

--- a/projects/novo-examples/src/layouts/sidenav/basic-sidenav/basic-sidenav-example.html
+++ b/projects/novo-examples/src/layouts/sidenav/basic-sidenav/basic-sidenav-example.html
@@ -1,6 +1,6 @@
-<div class="sidenav-example">
-  <novo-toolbar color="navigation">
-    <novo-action icon="menu" (click)="sidenav.toggle()"></novo-action>
+<div class="sidenav-example" data-automation-id="sidenav-example">
+  <novo-toolbar color="navigation" data-automation-id="sidenav-toolbar">
+    <novo-action icon="menu" (click)="sidenav.toggle()" data-automation-id="sidenav-menu"></novo-action>
     <novo-divider vertical></novo-divider>
     <img class="logo" src="assets/images/bullhorn-logo.svg" width="120" height="32" />
 
@@ -40,22 +40,23 @@
       [mode]="isMobile ? 'over' : 'side'"
       [opened]="!isMobile"
       [disableClose]="!isMobile"
-      theme="navigation">
-      <novo-header theme="navigation" [condensed]="true">
-        <div novo-title>Application Menu</div>
+      theme="navigation"
+      data-automation-id="sidenav">
+      <novo-header theme="navigation" [condensed]="true" data-automation-id="sidenav-header">
+        <div novo-title data-automation-id="sidenav-title">Application Menu</div>
       </novo-header>
-      <novo-list theme="navigation" direction="vertical">
+      <novo-list theme="navigation" direction="vertical" data-automation-id="sidenav-list">
         <novo-divider></novo-divider>
-        <novo-list-item><a>Job Orders</a></novo-list-item>
-        <button list-item>Companies</button>
-        <novo-list-item>Placements</novo-list-item>
-        <novo-list-item>Contacts</novo-list-item>
-        <novo-list-item>Candidates</novo-list-item>
+        <novo-list-item data-automation-id="sidenav-orders"><a>Job Orders</a></novo-list-item>
+        <button list-item data-automation-id="sidenav-companies">Companies</button>
+        <novo-list-item data-automation-id="sidenav-placements">Placements</novo-list-item>
+        <novo-list-item data-automation-id="sidenav-contacts">Contacts</novo-list-item>
+        <novo-list-item data-automation-id="sidenav-candidates">Candidates</novo-list-item>
         <novo-divider></novo-divider>
-        <novo-list-item>Reports</novo-list-item>
-        <novo-list-item>Settings</novo-list-item>
-        <novo-list-item>About</novo-list-item>
-        <a list-item>Users</a>
+        <novo-list-item data-automation-id="sidenav-reports">Reports</novo-list-item>
+        <novo-list-item data-automation-id="sidenav-settings">Settings</novo-list-item>
+        <novo-list-item data-automation-id="sidenav-about">About</novo-list-item>
+        <a list-item data-automation-id="sidenav-users">Users</a>
 
       </novo-list>
 

--- a/projects/novo-examples/src/layouts/stepper/stepper-horizontal/stepper-horizontal-example.html
+++ b/projects/novo-examples/src/layouts/stepper/stepper-horizontal/stepper-horizontal-example.html
@@ -1,29 +1,29 @@
-<novo-horizontal-stepper [linear]="isLinear" #stepper>
-  <novo-step [stepControl]="firstFormGroup" label="Fill out your name" theme="candidate" icon="candidate" #step1>
-    <form [formGroup]="firstFormGroup">
-      <input placeholder="Last name, First name" formControlName="firstCtrl" required />
-      <div>Form Valid? {{firstFormGroup?.valid}}</div>
+<novo-horizontal-stepper [linear]="isLinear" #stepper data-automation-id="stepper-horizontal">
+  <novo-step [stepControl]="firstFormGroup" label="Fill out your name" theme="candidate" icon="candidate" #step1 data-automation-id="stepper-step-1">
+    <form [formGroup]="firstFormGroup" data-automation-id="stepper-form-1">
+      <input placeholder="Last name, First name" formControlName="firstCtrl" required data-automation-id="stepper-input-1" />
+      <div data-automation-id="stepper-valid-1">Form Valid? {{firstFormGroup?.valid}}</div>
       <div>
-        <button (click)="next(stepper, step1)">Next</button>
+        <button (click)="next(stepper, step1)" data-automation-id="stepper-next-1">Next</button>
       </div>
     </form>
   </novo-step>
-  <novo-step [stepControl]="secondFormGroup" theme="contact">
-    <form [formGroup]="secondFormGroup">
+  <novo-step [stepControl]="secondFormGroup" theme="contact" data-automation-id="stepper-step-2">
+    <form [formGroup]="secondFormGroup" data-automation-id="stepper-form-2">
       <ng-template novoStepLabel>Fill out your address</ng-template>
-      <input placeholder="Address" formControlName="secondCtrl" required />
+      <input placeholder="Address" formControlName="secondCtrl" required data-automation-id="stepper-input-2" />
       <div>
-        <button (click)="stepper.previous()">Back</button>
-        <button (click)="stepper.next()">Next</button>
+        <button (click)="stepper.previous()" data-automation-id="stepper-back-2">Back</button>
+        <button (click)="stepper.next()" data-automation-id="stepper-next-2">Next</button>
       </div>
     </form>
   </novo-step>
-  <novo-step>
+  <novo-step data-automation-id="stepper-step-3">
     <ng-template novoStepLabel>Done</ng-template>
     You are now done.
     <div>
-      <button novo-button (click)="stepper.previous()">Back</button>
-      <button novo-button (click)="stepper.complete()">Done</button>
+      <button novo-button (click)="stepper.previous()" data-automation-id="stepper-back-3">Back</button>
+      <button novo-button (click)="stepper.complete()" data-automation-id="stepper-complete">Done</button>
     </div>
   </novo-step>
 </novo-horizontal-stepper>

--- a/projects/novo-examples/src/layouts/stepper/stepper-vertical/stepper-vertical-example.html
+++ b/projects/novo-examples/src/layouts/stepper/stepper-vertical/stepper-vertical-example.html
@@ -1,28 +1,28 @@
-<novo-vertical-stepper [linear]="isLinear" #stepper>
-  <novo-step [stepControl]="firstFormGroup" theme="candidate" icon="candidate" #step1>
-    <form [formGroup]="firstFormGroup">
+<novo-vertical-stepper [linear]="isLinear" #stepper data-automation-id="stepper-vertical">
+  <novo-step [stepControl]="firstFormGroup" theme="candidate" icon="candidate" #step1 data-automation-id="stepper-vertical-1">
+    <form [formGroup]="firstFormGroup" data-automation-id="stepper-vertical-form-1">
       <ng-template novoStepLabel>Fill out your name</ng-template>
-      <input placeholder="Last name, First name" formControlName="firstCtrl" required />
+      <input placeholder="Last name, First name" formControlName="firstCtrl" required data-automation-id="stepper-vertical-input-1" />
       <div>
-        <button (click)="next(stepper, step1)" [disabled]="!firstFormGroup?.valid">Next</button>
+        <button (click)="next(stepper, step1)" [disabled]="!firstFormGroup?.valid" data-automation-id="stepper-vertical-next-1">Next</button>
       </div>
     </form>
   </novo-step>
-  <novo-step [stepControl]="secondFormGroup" theme="contact" icon="person">
-    <form [formGroup]="secondFormGroup">
+  <novo-step [stepControl]="secondFormGroup" theme="contact" icon="person" data-automation-id="stepper-vertical-2">
+    <form [formGroup]="secondFormGroup" data-automation-id="stepper-vertical-form-2">
       <ng-template novoStepLabel>Fill out your address</ng-template>
-      <input placeholder="Address" formControlName="secondCtrl" required />
+      <input placeholder="Address" formControlName="secondCtrl" required data-automation-id="stepper-vertical-input-2" />
       <div>
-        <button (click)="stepper.previous()">Back</button>
-        <button (click)="stepper.next()">Next</button>
+        <button (click)="stepper.previous()" data-automation-id="stepper-vertical-back-2">Back</button>
+        <button (click)="stepper.next()" data-automation-id="stepper-vertical-next-2">Next</button>
       </div>
     </form>
   </novo-step>
-  <novo-step>
+  <novo-step data-automation-id="stepper-vertical-3">
     <ng-template novoStepLabel>Done</ng-template>
     You are now done.
     <div>
-      <button novo-button (click)="stepper.reset()">Reset</button>
+      <button novo-button (click)="stepper.reset()" data-automation-id="stepper-vertical-reset">Reset</button>
     </div>
   </novo-step>
 </novo-vertical-stepper>

--- a/projects/novo-examples/src/layouts/tabs/tabs-basic/tabs-basic-example.html
+++ b/projects/novo-examples/src/layouts/tabs/tabs-basic/tabs-basic-example.html
@@ -1,7 +1,7 @@
-<novo-nav theme="white" mx="xl">
-  <novo-tab>Overview</novo-tab>
-  <novo-tab>Edit</novo-tab>
-  <novo-tab>Activity</novo-tab>
-  <novo-tab>Notes</novo-tab>
-  <novo-tab disabled>Disabled</novo-tab>
+<novo-nav theme="white" mx="xl" data-automation-id="tabs-basic">
+  <novo-tab data-automation-id="tabs-basic-overview">Overview</novo-tab>
+  <novo-tab data-automation-id="tabs-basic-edit">Edit</novo-tab>
+  <novo-tab data-automation-id="tabs-basic-activity">Activity</novo-tab>
+  <novo-tab data-automation-id="tabs-basic-notes">Notes</novo-tab>
+  <novo-tab disabled data-automation-id="tabs-basic-disabled">Disabled</novo-tab>
 </novo-nav>

--- a/projects/novo-examples/src/layouts/tabs/tabs-color/tabs-color-example.html
+++ b/projects/novo-examples/src/layouts/tabs/tabs-color/tabs-color-example.html
@@ -10,15 +10,15 @@
 
   <novo-toolbar-row>
     <novo-nav [outlet]="outlet" direction="horizontal" [(selectedIndex)]="selected" data-automation-id="tabs-color-group">
-      <novo-tab>
+      <novo-tab data-automation-id="tabs-color-tab-1">
         <novo-icon>person</novo-icon>
         <novo-label>Tab 1</novo-label>
       </novo-tab>
-      <novo-tab>
+      <novo-tab data-automation-id="tabs-color-tab-2">
         <novo-icon>person</novo-icon>
         <novo-label>Tab 2</novo-label>
       </novo-tab>
-      <novo-tab disabled>
+      <novo-tab disabled data-automation-id="tabs-color-tab-3">
         <novo-icon>person</novo-icon>
         <novo-label>Tab 3</novo-label>
       </novo-tab>
@@ -28,13 +28,13 @@
 
 
 <novo-nav-outlet #outlet>
-  <novo-nav-content>
+  <novo-nav-content data-automation-id="tabs-color-content-1">
     <h1>Tab 1 Content</h1>
   </novo-nav-content>
-  <novo-nav-content>
+  <novo-nav-content data-automation-id="tabs-color-content-2">
     <h1>Tab 2 Content</h1>
   </novo-nav-content>
-  <novo-nav-content>
+  <novo-nav-content data-automation-id="tabs-color-content-3">
     <h1>Tab 3 Content</h1>
   </novo-nav-content>
 </novo-nav-outlet>

--- a/projects/novo-examples/src/layouts/tabs/tabs-color/tabs-color-example.html
+++ b/projects/novo-examples/src/layouts/tabs/tabs-color/tabs-color-example.html
@@ -1,5 +1,5 @@
-<novo-toolbar>
-  <novo-toolbar-row accent="orange" gap="md">
+<novo-toolbar data-automation-id="tabs-color-toolbar">
+  <novo-toolbar-row accent="orange" gap="md" data-automation-id="tabs-color-header">
     <novo-icon>bull</novo-icon>
     <novo-title>Tab Example</novo-title>
     <span class="example-spacer"></span>
@@ -9,7 +9,7 @@
   </novo-toolbar-row>
 
   <novo-toolbar-row>
-    <novo-nav [outlet]="outlet" direction="horizontal" [(selectedIndex)]="selected">
+    <novo-nav [outlet]="outlet" direction="horizontal" [(selectedIndex)]="selected" data-automation-id="tabs-color-group">
       <novo-tab>
         <novo-icon>person</novo-icon>
         <novo-label>Tab 1</novo-label>

--- a/projects/novo-examples/src/layouts/tabs/tabs-condensed/tabs-condensed-example.html
+++ b/projects/novo-examples/src/layouts/tabs/tabs-condensed/tabs-condensed-example.html
@@ -1,21 +1,21 @@
 <novo-nav theme="white" [outlet]="condensed" condensed="true" data-automation-id="tabs-condensed">
-  <novo-tab>
+  <novo-tab data-automation-id="tabs-condensed-tab-1">
       <span><i class="bhi-person"></i>Tab 1</span>
   </novo-tab>
-  <novo-tab>
+  <novo-tab data-automation-id="tabs-condensed-tab-2">
       <span><i class="bhi-person"></i>Tab 2</span>
   </novo-tab>
-  <novo-tab [disabled]="true">
+  <novo-tab [disabled]="true" data-automation-id="tabs-condensed-tab-3">
       <span><i class="bhi-person"></i>Tab 3</span>
   </novo-tab>
 </novo-nav>
 
 
 <novo-nav-outlet #condensed>
-  <novo-nav-content>
+  <novo-nav-content data-automation-id="tabs-condensed-content-1">
       <h1>Tab 1 Content</h1>
   </novo-nav-content>
-  <novo-nav-content>
+  <novo-nav-content data-automation-id="tabs-condensed-content-2">
       <h1>Tab 2 Content</h1>
   </novo-nav-content>
 </novo-nav-outlet>

--- a/projects/novo-examples/src/layouts/tabs/tabs-condensed/tabs-condensed-example.html
+++ b/projects/novo-examples/src/layouts/tabs/tabs-condensed/tabs-condensed-example.html
@@ -1,4 +1,4 @@
-<novo-nav theme="white" [outlet]="condensed" condensed="true">
+<novo-nav theme="white" [outlet]="condensed" condensed="true" data-automation-id="tabs-condensed">
   <novo-tab>
       <span><i class="bhi-person"></i>Tab 1</span>
   </novo-tab>

--- a/projects/novo-examples/src/layouts/tabs/tabs-router/tabs-router-example.html
+++ b/projects/novo-examples/src/layouts/tabs/tabs-router/tabs-router-example.html
@@ -1,14 +1,14 @@
-<header>
-  <novo-nav theme="white" router>
-      <novo-tab-link>
+<header data-automation-id="tabs-router-header">
+  <novo-nav theme="white" router data-automation-id="tabs-router">
+      <novo-tab-link data-automation-id="tabs-router-1">
           <span>
               <i class="bhi-person"></i>Tab 1</span>
       </novo-tab-link>
-      <novo-tab-link>
+      <novo-tab-link data-automation-id="tabs-router-2">
           <span>
               <i class="bhi-person"></i>Tab 2</span>
       </novo-tab-link>
-       <novo-tab-link [disabled]="true">
+       <novo-tab-link [disabled]="true" data-automation-id="tabs-router-3">
           <span>
               <i class="bhi-person"></i>Tab 3</span>
       </novo-tab-link>

--- a/projects/novo-examples/src/layouts/tabs/tabs-vertical/tabs-vertical-example.html
+++ b/projects/novo-examples/src/layouts/tabs/tabs-vertical/tabs-vertical-example.html
@@ -1,4 +1,4 @@
-<novo-nav theme="white" [outlet]="colorVert" direction="vertical">
+<novo-nav theme="white" [outlet]="colorVert" direction="vertical" data-automation-id="tabs-vertical">
   <novo-tab>
       <span>
           <i class="bhi-person"></i>Tab 1</span>

--- a/projects/novo-examples/src/layouts/tabs/tabs-vertical/tabs-vertical-example.html
+++ b/projects/novo-examples/src/layouts/tabs/tabs-vertical/tabs-vertical-example.html
@@ -1,20 +1,20 @@
 <novo-nav theme="white" [outlet]="colorVert" direction="vertical" data-automation-id="tabs-vertical">
-  <novo-tab>
+  <novo-tab data-automation-id="tabs-vertical-tab-1">
       <span>
           <i class="bhi-person"></i>Tab 1</span>
   </novo-tab>
-  <novo-tab>
+  <novo-tab data-automation-id="tabs-vertical-tab-2">
       <span>
           <i class="bhi-person"></i>Tab 2</span>
   </novo-tab>
-  <novo-tab [disabled]="true">
+  <novo-tab [disabled]="true" data-automation-id="tabs-vertical-tab-3">
       <span>
           <i class="bhi-person"></i>Tab 3</span>
   </novo-tab>
 </novo-nav>
 
 <novo-nav-outlet #colorVert>
-  <novo-nav-content>
+  <novo-nav-content data-automation-id="tabs-vertical-content-1">
       <h1>Tab 1 Content</h1>
 
       <p>
@@ -33,7 +33,7 @@
           scenester small batch.
       </p>
   </novo-nav-content>
-  <novo-nav-content>
+  <novo-nav-content data-automation-id="tabs-vertical-content-2">
       <h1>Tab 2 Content</h1>
 
       <p>

--- a/projects/novo-examples/src/utils/code-editor/basic-code/basic-code-example.html
+++ b/projects/novo-examples/src/utils/code-editor/basic-code/basic-code-example.html
@@ -1,1 +1,1 @@
-<novo-code-editor [(ngModel)]="value"></novo-code-editor>
+<novo-code-editor [(ngModel)]="value" data-automation-id="code-editor-basic"></novo-code-editor>

--- a/projects/novo-examples/src/utils/drag-drop/drag-drop/drag-drop-example.html
+++ b/projects/novo-examples/src/utils/drag-drop/drag-drop/drag-drop-example.html
@@ -1,6 +1,6 @@
 
-<p>Click and drag these buttons to place them in a new position. When rearranged, they emit an event to demonstrate the new order.</p>
-<div [novoDragDrop]="objects" (novoDragDropFinish)="dragFinished($event)" class="drag-box">
+<p data-automation-id="drag-drop-intro">Click and drag these buttons to place them in a new position. When rearranged, they emit an event to demonstrate the new order.</p>
+<div [novoDragDrop]="objects" data-automation-id="drag-drop-1" (novoDragDropFinish)="dragFinished($event)" class="drag-box">
     <novo-card *ngFor="let item of objects"
         class="demo-drag-item">
         <novo-card-header class="novo-drag-target {{item.bgClass}}">
@@ -18,7 +18,7 @@
 
 <h2>Dynamic list</h2>
 <novo-button (click)="addObject2()">Add another object to list</novo-button>
-<div [novoDragDrop]="objects2" (novoDragDropFinish)="dragFinished2($event)" class="drag-box">
+<div [novoDragDrop]="objects2" data-automation-id="drag-drop-2" (novoDragDropFinish)="dragFinished2($event)" class="drag-box">
     <novo-card *ngFor="let item of objects2"
         class="demo-drag-item">
         <novo-card-header class="novo-drag-target {{item.bgClass}}">
@@ -33,7 +33,7 @@
 
 <h2>Draggable items in a scrolling list</h2>
 <div class="scroll-container">
-    <div [novoDragDrop]="objects3" (novoDragDropFinish)="dragFinished3($event)" class="drag-box wider">
+    <div [novoDragDrop]="objects3" data-automation-id="drag-drop-3" (novoDragDropFinish)="dragFinished3($event)" class="drag-box wider">
         <novo-card *ngFor="let item of objects3"
             class="demo-drag-item">
             <novo-card-header class="novo-drag-target {{item.bgClass}}">

--- a/projects/novo-examples/src/utils/drag-drop/drag-drop/drag-drop-example.html
+++ b/projects/novo-examples/src/utils/drag-drop/drag-drop/drag-drop-example.html
@@ -1,9 +1,11 @@
 
 <p data-automation-id="drag-drop-intro">Click and drag these buttons to place them in a new position. When rearranged, they emit an event to demonstrate the new order.</p>
 <div [novoDragDrop]="objects" data-automation-id="drag-drop-1" (novoDragDropFinish)="dragFinished($event)" class="drag-box">
-    <novo-card *ngFor="let item of objects"
-        class="demo-drag-item">
-        <novo-card-header class="novo-drag-target {{item.bgClass}}">
+    <novo-card *ngFor="let item of objects; let i = index"
+        class="demo-drag-item"
+        [attr.data-automation-id]="'drag-drop-1-card-' + i">
+        <novo-card-header class="novo-drag-target {{item.bgClass}}"
+            [attr.data-automation-id]="'drag-drop-1-header-' + i">
             <novo-title>{{item.headerText}}</novo-title>
             <novo-action (click)="removeObject(item)" icon="close" tooltip="Close Item"></novo-action>
         </novo-card-header>
@@ -13,15 +15,17 @@
     </novo-card>
 </div>
 
-<p *ngIf="objectMoved">{{objectMoved.name}} moved.</p>
-<p>Current object order is: {{objectsAsString}}</p>
+<p *ngIf="objectMoved" data-automation-id="drag-drop-moved">{{objectMoved.name}} moved.</p>
+<p data-automation-id="drag-drop-order">Current object order is: {{objectsAsString}}</p>
 
 <h2>Dynamic list</h2>
-<novo-button (click)="addObject2()">Add another object to list</novo-button>
+<novo-button (click)="addObject2()" data-automation-id="drag-drop-add-button">Add another object to list</novo-button>
 <div [novoDragDrop]="objects2" data-automation-id="drag-drop-2" (novoDragDropFinish)="dragFinished2($event)" class="drag-box">
-    <novo-card *ngFor="let item of objects2"
-        class="demo-drag-item">
-        <novo-card-header class="novo-drag-target {{item.bgClass}}">
+    <novo-card *ngFor="let item of objects2; let i = index"
+        class="demo-drag-item"
+        [attr.data-automation-id]="'drag-drop-2-card-' + i">
+        <novo-card-header class="novo-drag-target {{item.bgClass}}"
+            [attr.data-automation-id]="'drag-drop-2-header-' + i">
             <novo-title>{{item.headerText}}</novo-title>
             <novo-action (click)="removeObject2(item)" icon="close" tooltip="Close Item"></novo-action>
         </novo-card-header>
@@ -34,9 +38,11 @@
 <h2>Draggable items in a scrolling list</h2>
 <div class="scroll-container">
     <div [novoDragDrop]="objects3" data-automation-id="drag-drop-3" (novoDragDropFinish)="dragFinished3($event)" class="drag-box wider">
-        <novo-card *ngFor="let item of objects3"
-            class="demo-drag-item">
-            <novo-card-header class="novo-drag-target {{item.bgClass}}">
+        <novo-card *ngFor="let item of objects3; let i = index"
+            class="demo-drag-item"
+            [attr.data-automation-id]="'drag-drop-3-card-' + i">
+            <novo-card-header class="novo-drag-target {{item.bgClass}}"
+                [attr.data-automation-id]="'drag-drop-3-header-' + i">
                 <novo-title>{{item.headerText}}</novo-title>
             </novo-card-header>
             <novo-card-content>

--- a/projects/novo-examples/src/utils/field-interactions/fi-adding-removing/fi-adding-removing-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-adding-removing/fi-adding-removing-example.html
@@ -1,4 +1,4 @@
 <novo-dynamic-form [fieldsets]="controls" [(form)]="form" layout="vertical" data-automation-id="fi-adding-removing-form"></novo-dynamic-form>
-<div class="final-value">Form Value - {{ form.value | json }}</div>
-<div class="final-value">Form Dirty - {{ form.dirty | json }}</div>
-<div class="final-value">Is Form Valid? - {{ form.valid | json }}</div>
+<div class="final-value" data-automation-id="fi-adding-removing-form-value">Form Value - {{ form.value | json }}</div>
+<div class="final-value" data-automation-id="fi-adding-removing-form-dirty">Form Dirty - {{ form.dirty | json }}</div>
+<div class="final-value" data-automation-id="fi-adding-removing-form-valid">Is Form Valid? - {{ form.valid | json }}</div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-adding-removing/fi-adding-removing-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-adding-removing/fi-adding-removing-example.html
@@ -1,4 +1,4 @@
-<novo-dynamic-form [fieldsets]="controls" [(form)]="form" layout="vertical"></novo-dynamic-form>
+<novo-dynamic-form [fieldsets]="controls" [(form)]="form" layout="vertical" data-automation-id="fi-adding-removing-form"></novo-dynamic-form>
 <div class="final-value">Form Value - {{ form.value | json }}</div>
 <div class="final-value">Form Dirty - {{ form.dirty | json }}</div>
 <div class="final-value">Is Form Valid? - {{ form.valid | json }}</div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-async/fi-async-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-async/fi-async-example.html
@@ -1,4 +1,4 @@
-<novo-form [form]="form" layout="vertical">
+<novo-form [form]="form" layout="vertical" data-automation-id="fi-async-form">
     <div class="novo-form-row">
         <novo-control [form]="form" [control]="controls.async1Control"></novo-control>
     </div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-async/fi-async-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-async/fi-async-example.html
@@ -6,6 +6,6 @@
         <novo-control [form]="form" [control]="controls.async2Control"></novo-control>
     </div>
 </novo-form>
-<div class="final-value">Form Value - {{ form.value | json }}</div>
-<div class="final-value">Form Dirty - {{ form.dirty | json }}</div>
-<div class="final-value">Is Form Valid? - {{ form.valid | json }}</div>
+<div class="final-value" data-automation-id="fi-async-form-value">Form Value - {{ form.value | json }}</div>
+<div class="final-value" data-automation-id="fi-async-form-dirty">Form Dirty - {{ form.dirty | json }}</div>
+<div class="final-value" data-automation-id="fi-async-form-valid">Is Form Valid? - {{ form.valid | json }}</div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-calculation/fi-calculation-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-calculation/fi-calculation-example.html
@@ -1,4 +1,4 @@
-<novo-form [form]="form" layout="vertical">
+<novo-form [form]="form" layout="vertical" data-automation-id="fi-calculation-form">
     <div class="novo-form-row">
         <novo-control [form]="form" [control]="controls.aControl"></novo-control>
     </div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-calculation/fi-calculation-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-calculation/fi-calculation-example.html
@@ -12,7 +12,7 @@
         <novo-control [form]="form" [control]="controls.dateModifiedControl"></novo-control>
     </div>
 </novo-form>
-<div class="final-value">Form Value - {{ form.value | json }}</div>
-<div class="final-value">
+<div class="final-value" data-automation-id="fi-calculation-form-value">Form Value - {{ form.value | json }}</div>
+<div class="final-value" data-automation-id="fi-calculation-form-dirty">
     Form Dirty - {{ form.dirty | json }}</div>
-<div class="final-value">Is Form Valid? - {{ form.valid | json }}</div>
+<div class="final-value" data-automation-id="fi-calculation-form-valid">Is Form Valid? - {{ form.valid | json }}</div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-confirm/fi-confirm-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-confirm/fi-confirm-example.html
@@ -6,6 +6,6 @@
         <novo-control [form]="form" [control]="controls.confirm2Control"></novo-control>
     </div>
 </novo-form>
-<div class="final-value">Form Value - {{ form.value | json }}</div>
-<div class="final-value">Form Dirty - {{ form.dirty | json }}</div>
-<div class="final-value">Is Form Valid? - {{ form.valid | json }}</div>
+<div class="final-value" data-automation-id="fi-confirm-form-value">Form Value - {{ form.value | json }}</div>
+<div class="final-value" data-automation-id="fi-confirm-form-dirty">Form Dirty - {{ form.dirty | json }}</div>
+<div class="final-value" data-automation-id="fi-confirm-form-valid">Is Form Valid? - {{ form.valid | json }}</div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-confirm/fi-confirm-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-confirm/fi-confirm-example.html
@@ -1,4 +1,4 @@
-<novo-form [form]="form" layout="vertical">
+<novo-form [form]="form" layout="vertical" data-automation-id="fi-confirm-form">
     <div class="novo-form-row">
         <novo-control [form]="form" [control]="controls.confirm1Control"></novo-control>
     </div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-description/fi-description-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-description/fi-description-example.html
@@ -1,4 +1,4 @@
-<novo-form [form]="form" layout="vertical">
+<novo-form [form]="form" layout="vertical" data-automation-id="fi-description-form">
     <div class="novo-form-row">
         <novo-control [form]="form" [control]="controls.descriptionControl"></novo-control>
     </div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-description/fi-description-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-description/fi-description-example.html
@@ -6,6 +6,6 @@
         <novo-control [form]="form" [control]="controls.toggleControl"></novo-control>
     </div>
 </novo-form>
-<div class="final-value">Form Value - {{ form.value | json }}</div>
-<div class="final-value">Form Dirty - {{ form.dirty | json }}</div>
-<div class="final-value">Is Form Valid? - {{ form.valid | json }}</div>
+<div class="final-value" data-automation-id="fi-description-form-value">Form Value - {{ form.value | json }}</div>
+<div class="final-value" data-automation-id="fi-description-form-dirty">Form Dirty - {{ form.dirty | json }}</div>
+<div class="final-value" data-automation-id="fi-description-form-valid">Is Form Valid? - {{ form.valid | json }}</div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-enable-disable/fi-enable-disable-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-enable-disable/fi-enable-disable-example.html
@@ -1,4 +1,4 @@
-<novo-form [form]="form" layout="vertical">
+<novo-form [form]="form" layout="vertical" data-automation-id="fi-enable-disable-form">
     <div class="novo-form-row">
         <novo-control [form]="form" [control]="controls.textControl"></novo-control>
     </div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-enable-disable/fi-enable-disable-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-enable-disable/fi-enable-disable-example.html
@@ -6,6 +6,6 @@
         <novo-control [form]="form" [control]="controls.toggleControl"></novo-control>
     </div>
 </novo-form>
-<div class="final-value">Form Value - {{ form.value | json }}</div>
-<div class="final-value">Form Dirty - {{ form.dirty | json }}</div>
-<div class="final-value">Is Form Valid? - {{ form.valid | json }}</div>
+<div class="final-value" data-automation-id="fi-enable-disable-form-value">Form Value - {{ form.value | json }}</div>
+<div class="final-value" data-automation-id="fi-enable-disable-form-dirty">Form Dirty - {{ form.dirty | json }}</div>
+<div class="final-value" data-automation-id="fi-enable-disable-form-valid">Is Form Valid? - {{ form.valid | json }}</div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-globals/fi-globals-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-globals/fi-globals-example.html
@@ -1,4 +1,4 @@
-<novo-form [form]="form" layout="vertical">
+<novo-form [form]="form" layout="vertical" data-automation-id="fi-globals-form">
     <div class="novo-form-row">
         <novo-control [form]="form" [control]="controls.globalControl"></novo-control>
     </div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-globals/fi-globals-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-globals/fi-globals-example.html
@@ -3,6 +3,6 @@
         <novo-control [form]="form" [control]="controls.globalControl"></novo-control>
     </div>
 </novo-form>
-<div class="final-value">Form Value - {{ form.value | json }}</div>
-<div class="final-value">Form Dirty - {{ form.dirty | json }}</div>
-<div class="final-value">Is Form Valid? - {{ form.valid | json }}</div>
+<div class="final-value" data-automation-id="fi-globals-form-value">Form Value - {{ form.value | json }}</div>
+<div class="final-value" data-automation-id="fi-globals-form-dirty">Form Dirty - {{ form.dirty | json }}</div>
+<div class="final-value" data-automation-id="fi-globals-form-valid">Is Form Valid? - {{ form.valid | json }}</div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-hide-show/fi-hide-show-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-hide-show/fi-hide-show-example.html
@@ -1,4 +1,4 @@
-<novo-form [form]="form" layout="vertical">
+<novo-form [form]="form" layout="vertical" data-automation-id="fi-hide-show-form">
     <div class="novo-form-row">
         <novo-control [form]="form" [control]="controls.textControl"></novo-control>
     </div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-hide-show/fi-hide-show-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-hide-show/fi-hide-show-example.html
@@ -9,6 +9,6 @@
         <novo-control [form]="form" [control]="controls.toggleControl"></novo-control>
     </div>
 </novo-form>
-<div class="final-value">Form Value - {{ form.value | json }}</div>
-<div class="final-value">Form Dirty - {{ form.dirty | json }}</div>
-<div class="final-value">Is Form Valid? - {{ form.valid | json }}</div>
+<div class="final-value" data-automation-id="fi-hide-show-form-value">Form Value - {{ form.value | json }}</div>
+<div class="final-value" data-automation-id="fi-hide-show-form-dirty">Form Dirty - {{ form.dirty | json }}</div>
+<div class="final-value" data-automation-id="fi-hide-show-form-valid">Is Form Valid? - {{ form.valid | json }}</div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-messaging/fi-messaging-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-messaging/fi-messaging-example.html
@@ -12,6 +12,6 @@
         <novo-control [form]="form" [control]="controls.promptControl"></novo-control>
     </div>
 </novo-form>
-<div class="final-value">Form Value - {{ form.value | json }}</div>
-<div class="final-value">Form Dirty - {{ form.dirty | json }}</div>
-<div class="final-value">Is Form Valid? - {{ form.valid | json }}</div>
+<div class="final-value" data-automation-id="fi-messaging-form-value">Form Value - {{ form.value | json }}</div>
+<div class="final-value" data-automation-id="fi-messaging-form-dirty">Form Dirty - {{ form.dirty | json }}</div>
+<div class="final-value" data-automation-id="fi-messaging-form-valid">Is Form Valid? - {{ form.valid | json }}</div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-messaging/fi-messaging-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-messaging/fi-messaging-example.html
@@ -1,4 +1,4 @@
-<novo-form [form]="form" layout="vertical">
+<novo-form [form]="form" layout="vertical" data-automation-id="fi-messaging-form">
     <div class="novo-form-row">
         <novo-control [form]="form" [control]="controls.tipControl"></novo-control>
     </div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-modify-added-picker/fi-modify-added-picker-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-modify-added-picker/fi-modify-added-picker-example.html
@@ -1,4 +1,4 @@
-<novo-form [form]="form" layout="vertical">
+<novo-form [form]="form" layout="vertical" data-automation-id="fi-modify-added-picker-form">
   <div class="novo-form-row">
     <novo-control [form]="form" [control]="controls.pickerControl"></novo-control>
   </div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-modify-options/fi-modify-options-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-modify-options/fi-modify-options-example.html
@@ -1,4 +1,4 @@
-<novo-form [form]="form" layout="vertical">
+<novo-form [form]="form" layout="vertical" data-automation-id="fi-modify-options-form">
     <div class="novo-form-row">
         <novo-control [form]="form" [control]="controls.selectControl"></novo-control>
     </div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-modify-options/fi-modify-options-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-modify-options/fi-modify-options-example.html
@@ -12,6 +12,6 @@
         <novo-control [form]="form" [control]="controls.makePickerAsyncControl"></novo-control>
     </div>
 </novo-form>
-<div class="final-value">Form Value - {{ form.value | json }}</div>
-<div class="final-value">Form Dirty - {{ form.dirty | json }}</div>
-<div class="final-value">Is Form Valid? - {{ form.valid | json }}</div>
+<div class="final-value" data-automation-id="fi-modify-options-form-value">Form Value - {{ form.value | json }}</div>
+<div class="final-value" data-automation-id="fi-modify-options-form-dirty">Form Dirty - {{ form.dirty | json }}</div>
+<div class="final-value" data-automation-id="fi-modify-options-form-valid">Is Form Valid? - {{ form.valid | json }}</div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-nested/fi-nested-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-nested/fi-nested-example.html
@@ -1,4 +1,4 @@
-<novo-form [form]="form">
+<novo-form [form]="form" data-automation-id="fi-nested-form">
   <div class="novo-form-row">
     <novo-control [form]="form" [control]="minPayRateControl"></novo-control>
   </div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-nested/fi-nested-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-nested/fi-nested-example.html
@@ -13,6 +13,6 @@
                       key="rows"></novo-control-group>
 </novo-form>
 
-<div class="final-value">Form Value - <pre>{{ form.value | json }}</pre></div>
-<div class="final-value">Form Dirty - {{ form.dirty }}</div>
-<div class="final-value">Is Form Valid? - {{ form.valid }}</div>
+<div class="final-value" data-automation-id="fi-nested-form-value">Form Value - <pre>{{ form.value | json }}</pre></div>
+<div class="final-value" data-automation-id="fi-nested-form-dirty">Form Dirty - {{ form.dirty }}</div>
+<div class="final-value" data-automation-id="fi-nested-form-valid">Is Form Valid? - {{ form.valid }}</div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-popover/fi-popover-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-popover/fi-popover-example.html
@@ -15,6 +15,6 @@
       <novo-control [form]="form" [control]="controls.popoverPlacementControl"></novo-control>
   </div>
 </novo-form>
-<div class="final-value">Form Value - {{ form.value | json }}</div>
-<div class="final-value">Form Dirty - {{ form.dirty | json }}</div>
-<div class="final-value">Is Form Valid? - {{ form.valid | json }}</div>
+<div class="final-value" data-automation-id="fi-popover-form-value">Form Value - {{ form.value | json }}</div>
+<div class="final-value" data-automation-id="fi-popover-form-dirty">Form Dirty - {{ form.dirty | json }}</div>
+<div class="final-value" data-automation-id="fi-popover-form-valid">Is Form Valid? - {{ form.valid | json }}</div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-popover/fi-popover-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-popover/fi-popover-example.html
@@ -1,4 +1,4 @@
-<novo-form [form]="form" layout="vertical">
+<novo-form [form]="form" layout="vertical" data-automation-id="fi-popover-form">
   <div class="novo-form-row">
       <novo-control [form]="form" [control]="controls.popoverTitleControl"></novo-control>
   </div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-required/fi-required-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-required/fi-required-example.html
@@ -6,6 +6,6 @@
         <novo-control [form]="form" [control]="controls.toggleControl"></novo-control>
     </div>
 </novo-form>
-<div class="final-value">Form Value - {{ form.value | json }}</div>
-<div class="final-value">Form Dirty - {{ form.dirty | json }}</div>
-<div class="final-value">Is Form Valid? - {{ form.valid | json }}</div>
+<div class="final-value" data-automation-id="fi-required-form-value">Form Value - {{ form.value | json }}</div>
+<div class="final-value" data-automation-id="fi-required-form-dirty">Form Dirty - {{ form.dirty | json }}</div>
+<div class="final-value" data-automation-id="fi-required-form-valid">Is Form Valid? - {{ form.valid | json }}</div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-required/fi-required-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-required/fi-required-example.html
@@ -1,4 +1,4 @@
-<novo-form [form]="form" layout="vertical">
+<novo-form [form]="form" layout="vertical" data-automation-id="fi-required-form">
     <div class="novo-form-row">
         <novo-control [form]="form" [control]="controls.requiredControl"></novo-control>
     </div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-tooltip/fi-tooltip-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-tooltip/fi-tooltip-example.html
@@ -9,6 +9,6 @@
       <novo-control [form]="form" [control]="controls.tooltipPrelineControl"></novo-control>
   </div>
 </novo-form>
-<div class="final-value">Form Value - {{ form.value | json }}</div>
-<div class="final-value">Form Dirty - {{ form.dirty | json }}</div>
-<div class="final-value">Is Form Valid? - {{ form.valid | json }}</div>
+<div class="final-value" data-automation-id="fi-tooltip-form-value">Form Value - {{ form.value | json }}</div>
+<div class="final-value" data-automation-id="fi-tooltip-form-dirty">Form Dirty - {{ form.dirty | json }}</div>
+<div class="final-value" data-automation-id="fi-tooltip-form-valid">Is Form Valid? - {{ form.valid | json }}</div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-tooltip/fi-tooltip-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-tooltip/fi-tooltip-example.html
@@ -1,4 +1,4 @@
-<novo-form [form]="form" layout="vertical">
+<novo-form [form]="form" layout="vertical" data-automation-id="fi-tooltip-form">
   <div class="novo-form-row">
       <novo-control [form]="form" [control]="controls.tooltipControl"></novo-control>
   </div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-validation/fi-validation-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-validation/fi-validation-example.html
@@ -3,7 +3,7 @@
         <novo-control [form]="form" [control]="controls.validationControl"></novo-control>
     </div>
 </novo-form>
-<div class="final-value">Form Value - {{ form.value | json }}</div>
-<div class="final-value">Form Dirty - {{ form.dirty | json }}</div>
-<div class="final-value">Is Form Valid? - {{ form.valid | json }}</div>
-<div class="final-value">Is User Modified? - {{ isUserModified }}</div>
+<div class="final-value" data-automation-id="fi-validation-form-value">Form Value - {{ form.value | json }}</div>
+<div class="final-value" data-automation-id="fi-validation-form-dirty">Form Dirty - {{ form.dirty | json }}</div>
+<div class="final-value" data-automation-id="fi-validation-form-valid">Is Form Valid? - {{ form.valid | json }}</div>
+<div class="final-value" data-automation-id="fi-validation-user-modified">Is User Modified? - {{ isUserModified }}</div>

--- a/projects/novo-examples/src/utils/field-interactions/fi-validation/fi-validation-example.html
+++ b/projects/novo-examples/src/utils/field-interactions/fi-validation/fi-validation-example.html
@@ -1,4 +1,4 @@
-<novo-form [form]="form" layout="vertical">
+<novo-form [form]="form" layout="vertical" data-automation-id="fi-validation-form">
     <div class="novo-form-row">
         <novo-control [form]="form" [control]="controls.validationControl"></novo-control>
     </div>

--- a/projects/novo-examples/src/utils/pipes/pluralize/pluralize-example.html
+++ b/projects/novo-examples/src/utils/pipes/pluralize/pluralize-example.html
@@ -1,2 +1,2 @@
-<p>{{'Kitty' | plural}}</p>
-<p>{{'Cat' | plural}}</p>
+<p data-automation-id="pluralize-kitty">{{'Kitty' | plural}}</p>
+<p data-automation-id="pluralize-cat">{{'Cat' | plural}}</p>

--- a/projects/novo-examples/src/utils/quick-note/basic-quick-note/basic-quick-note-example.html
+++ b/projects/novo-examples/src/utils/quick-note/basic-quick-note/basic-quick-note-example.html
@@ -1,4 +1,4 @@
-<novo-quick-note [(ngModel)]="note" [placeholder]="placeholder" [config]="basic"></novo-quick-note>
+<novo-quick-note [(ngModel)]="note" [placeholder]="placeholder" [config]="basic" data-automation-id="quick-note-basic"></novo-quick-note>
 <div class="data">
     <p>Note: {{note | json}}</p>
 </div>

--- a/projects/novo-examples/src/utils/quick-note/basic-quick-note/basic-quick-note-example.html
+++ b/projects/novo-examples/src/utils/quick-note/basic-quick-note/basic-quick-note-example.html
@@ -1,4 +1,4 @@
 <novo-quick-note [(ngModel)]="note" [placeholder]="placeholder" [config]="basic" data-automation-id="quick-note-basic"></novo-quick-note>
-<div class="data">
+<div class="data" data-automation-id="quick-note-basic-output">
     <p>Note: {{note | json}}</p>
 </div>

--- a/projects/novo-examples/src/utils/quick-note/custom-quick-note-results/custom-quick-note-results-example.html
+++ b/projects/novo-examples/src/utils/quick-note/custom-quick-note-results/custom-quick-note-results-example.html
@@ -1,4 +1,4 @@
-<novo-quick-note [(ngModel)]="note" [placeholder]="placeholder" [config]="customResults"></novo-quick-note>
+<novo-quick-note [(ngModel)]="note" [placeholder]="placeholder" [config]="customResults" data-automation-id="quick-note-custom-results"></novo-quick-note>
 <div class="data">
     <p>Note: {{note | json}}</p>
 </div>

--- a/projects/novo-examples/src/utils/quick-note/custom-quick-note-results/custom-quick-note-results-example.html
+++ b/projects/novo-examples/src/utils/quick-note/custom-quick-note-results/custom-quick-note-results-example.html
@@ -1,4 +1,4 @@
 <novo-quick-note [(ngModel)]="note" [placeholder]="placeholder" [config]="customResults" data-automation-id="quick-note-custom-results"></novo-quick-note>
-<div class="data">
+<div class="data" data-automation-id="quick-note-custom-results-output">
     <p>Note: {{note | json}}</p>
 </div>

--- a/projects/novo-examples/src/utils/quick-note/custom-quick-note/custom-quick-note-example.html
+++ b/projects/novo-examples/src/utils/quick-note/custom-quick-note/custom-quick-note-example.html
@@ -1,4 +1,4 @@
-<novo-quick-note [(ngModel)]="note" [placeholder]="placeholder" [config]="custom"></novo-quick-note>
+<novo-quick-note [(ngModel)]="note" [placeholder]="placeholder" [config]="custom" data-automation-id="quick-note-custom"></novo-quick-note>
 <div class="data">
     <p>Note: {{note | json}}</p>
 </div>

--- a/projects/novo-examples/src/utils/quick-note/custom-quick-note/custom-quick-note-example.html
+++ b/projects/novo-examples/src/utils/quick-note/custom-quick-note/custom-quick-note-example.html
@@ -1,4 +1,4 @@
 <novo-quick-note [(ngModel)]="note" [placeholder]="placeholder" [config]="custom" data-automation-id="quick-note-custom"></novo-quick-note>
-<div class="data">
+<div class="data" data-automation-id="quick-note-custom-output">
     <p>Note: {{note | json}}</p>
 </div>

--- a/projects/novo-examples/src/utils/security/security/security-example.html
+++ b/projects/novo-examples/src/utils/security/security/security-example.html
@@ -1,11 +1,11 @@
 <div data-automation-id="security-permissions">
-    <p *bhUnless="'A'">Shown if has permission <strong>A</strong></p>
-    <p *bhUnless="'B'">Shown if has permission <strong>B</strong></p>
-    <p *bhUnless="'C'">Shown if has permission <strong>C</strong></p>
-    <p *bhUnless="'A && B'">Shown if has permissions <strong>A && B</strong></p>
-    <p *bhUnless="'A && C'">Shown if has permissions <strong>A && C</strong></p>
-    <p *bhUnless="'A && B && C'">Shown if has permissions <strong>A && B && C</strong></p>
-    <p *bhUnless="'A || B'">Shown if has permissions <strong>A || B</strong></p>
-    <p> Permissions are : <strong>{{ perms | json }}</strong></p>
+    <p *bhUnless="'A'" data-automation-id="security-perm-a">Shown if has permission <strong>A</strong></p>
+    <p *bhUnless="'B'" data-automation-id="security-perm-b">Shown if has permission <strong>B</strong></p>
+    <p *bhUnless="'C'" data-automation-id="security-perm-c">Shown if has permission <strong>C</strong></p>
+    <p *bhUnless="'A && B'" data-automation-id="security-perm-a-and-b">Shown if has permissions <strong>A && B</strong></p>
+    <p *bhUnless="'A && C'" data-automation-id="security-perm-a-and-c">Shown if has permissions <strong>A && C</strong></p>
+    <p *bhUnless="'A && B && C'" data-automation-id="security-perm-a-and-b-and-c">Shown if has permissions <strong>A && B && C</strong></p>
+    <p *bhUnless="'A || B'" data-automation-id="security-perm-a-or-b">Shown if has permissions <strong>A || B</strong></p>
+    <p data-automation-id="security-current-perms"> Permissions are : <strong>{{ perms | json }}</strong></p>
     <button (click)="shufflePermissions()" data-automation-id="security-shuffle">Shuffle</button>
 </div>

--- a/projects/novo-examples/src/utils/security/security/security-example.html
+++ b/projects/novo-examples/src/utils/security/security/security-example.html
@@ -1,4 +1,4 @@
-<div>
+<div data-automation-id="security-permissions">
     <p *bhUnless="'A'">Shown if has permission <strong>A</strong></p>
     <p *bhUnless="'B'">Shown if has permission <strong>B</strong></p>
     <p *bhUnless="'C'">Shown if has permission <strong>C</strong></p>
@@ -7,5 +7,5 @@
     <p *bhUnless="'A && B && C'">Shown if has permissions <strong>A && B && C</strong></p>
     <p *bhUnless="'A || B'">Shown if has permissions <strong>A || B</strong></p>
     <p> Permissions are : <strong>{{ perms | json }}</strong></p>
-    <button (click)="shufflePermissions()">Shuffle</button>
+    <button (click)="shufflePermissions()" data-automation-id="security-shuffle">Shuffle</button>
 </div>


### PR DESCRIPTION
## **Description**

- Add data-automation-ids for the form controls and utils sections

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**