### PR TITLE
fix(Popover): allow title text to wrap within popover bounds

### DIFF
--- a/projects/novo-elements/src/elements/popover/PopOver.scss
+++ b/projects/novo-elements/src/elements/popover/PopOver.scss
@@ -152,6 +152,9 @@
   .popover-title {
     @include novo-title-text();
     margin-bottom: 1rem;
+    white-space: normal;
+    overflow: hidden;
+    max-width: 100%;
   }
   .popover-content {
     @include novo-body-text();


### PR DESCRIPTION
## **Description**

- Wrap title text within popover bounds

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**