### PR TITLE
ci(Workflow): Add GitHub Actions workflow for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,58 @@
+name: Publish Novo Elements
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        type: boolean
+        description: Dry Run
+
+jobs:
+  build_and_release:
+    name: Build & Publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup NodeJS
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.22.0
+          registry-url: 'https://registry.npmjs.org'
+      - name: Update npm
+        run: npm install -g npm@10.9.7
+      - name: Verify tag matches package.json version
+        if: github.event_name == 'push'
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="${{ github.ref_name }}"
+          echo "Tag: $TAG"
+          echo "package.json version: $VERSION"
+          if [ "$TAG" != "$VERSION" ]; then
+            echo "::error::Tag '$TAG' does not match package.json version '$VERSION'"
+            exit 1
+          fi
+      - name: Install Dependencies
+        run: |
+          npm ci
+      - name: Building Projects
+        run: |
+          npm run build:ci
+      - name: Sync dist version with root package.json
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Setting dist/novo-elements version to $VERSION"
+          (cd dist/novo-elements && npm version "$VERSION" --no-git-tag-version --allow-same-version)
+      - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm publish dist/novo-elements${{ github.event.inputs.dry-run == 'true' && ' --dry-run' || '' }}


### PR DESCRIPTION
## **Description**
A new workflow is added that is triggered when a tag is created. This new workflow will publish the package to the npm registry.


#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**