### PR TITLE
feat(Address): BH-101287 - Add address search to top of address block

### DIFF
--- a/projects/novo-elements/src/elements/form/ControlTemplates.ts
+++ b/projects/novo-elements/src/elements/form/ControlTemplates.ts
@@ -1,9 +1,10 @@
 import { AfterViewInit, Component, QueryList, ViewChildren } from '@angular/core';
 import { NovoTemplate } from 'novo-elements/elements/common';
 import { NovoTemplateService } from 'novo-elements/services';
+
 @Component({
-    selector: 'novo-control-templates',
-    template: `
+  selector: 'novo-control-templates',
+  template: `
     <!---Readonly--->
     <ng-template novoTemplate="read-only" let-form="form" let-control>
       <div>{{ form.getRawValue()[control.key] }}</div>
@@ -577,6 +578,7 @@ import { NovoTemplateService } from 'novo-elements/services';
         <novo-address
           [formControlName]="control.key"
           [config]="control?.config"
+          [placesSettings]="control?.placesSettings"
           [readOnly]="control?.readOnly"
           (change)="methods.handleAddressChange($event)"
           (focus)="methods.handleFocus($event.event, $event.field)"
@@ -693,7 +695,7 @@ import { NovoTemplateService } from 'novo-elements/services';
       </div>
     </ng-template>
   `,
-    standalone: false,
+  standalone: false,
 })
 export class NovoControlTemplates implements AfterViewInit {
   @ViewChildren(NovoTemplate)

--- a/projects/novo-elements/src/elements/form/NovoFormControl.ts
+++ b/projects/novo-elements/src/elements/form/NovoFormControl.ts
@@ -4,6 +4,7 @@ import { FormControl, Validators } from '@angular/forms';
 import { notify } from 'novo-elements/utils';
 import type { IMaskOptions } from './Control';
 // APP
+import type { PlacesSettings } from 'novo-elements/elements/places';
 import { NovoControlConfig } from './FormControls';
 
 export class NovoFormControl extends FormControl {
@@ -76,6 +77,7 @@ export class NovoFormControl extends FormControl {
   warning?: string;
   highlighted?: boolean;
   disabledDateMessage?: string;
+  placesSettings?: PlacesSettings;
   private historyTimeout: any;
 
   constructor(value: any, control: NovoControlConfig) {

--- a/projects/novo-elements/src/elements/form/controls/BaseControl.ts
+++ b/projects/novo-elements/src/elements/form/controls/BaseControl.ts
@@ -25,6 +25,7 @@ class ControlConfig {
   closeOnSelect: boolean;
   config: any;
   controlType: string;
+  placesSettings?: any;
   currencyFormat: string;
   customControl?: any;
   customControlConfig?: any;
@@ -159,6 +160,7 @@ export class BaseControl extends ControlConfig {
     this.endDate = config.endDate;
     this.restrictFieldInteractions = !!config.restrictFieldInteractions;
     this.highlighted = !!config.highlighted;
+    this.placesSettings = config.placesSettings;
     if (!Helpers.isEmpty(config.warning)) {
       this.warning = config.warning;
     }

--- a/projects/novo-elements/src/elements/form/extras/FormExtras.module.ts
+++ b/projects/novo-elements/src/elements/form/extras/FormExtras.module.ts
@@ -5,16 +5,17 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { NovoButtonModule } from 'novo-elements/elements/button';
 import { NovoCheckboxModule } from 'novo-elements/elements/checkbox';
+import { NovoFieldModule } from 'novo-elements/elements/field';
+import { NovoFlexModule } from 'novo-elements/elements/flex';
 import { NovoLoadingModule } from 'novo-elements/elements/loading';
 import { NovoPickerModule } from 'novo-elements/elements/picker';
+import { GooglePlacesModule } from 'novo-elements/elements/places';
 import { NovoSelectModule } from 'novo-elements/elements/select';
 import { NovoTooltipModule } from 'novo-elements/elements/tooltip';
 import { NovoPipesModule } from 'novo-elements/pipes';
 import { NovoAddressElement } from './address/Address';
 import { NovoFileInputElement } from './file/FileInput';
 import { NumberRangeComponent } from './number-range/number-range.component';
-import { NovoFlexModule } from 'novo-elements/elements/flex';
-import { NovoFieldModule } from 'novo-elements/elements/field';
 
 @NgModule({
   imports: [
@@ -31,9 +32,9 @@ import { NovoFieldModule } from 'novo-elements/elements/field';
     NovoFlexModule,
     NovoFieldModule,
     ReactiveFormsModule,
+    GooglePlacesModule,
   ],
   declarations: [NovoAddressElement, NovoFileInputElement, NumberRangeComponent],
   exports: [NovoAddressElement, NovoFileInputElement, NumberRangeComponent],
 })
 export class NovoFormExtrasModule {}
-

--- a/projects/novo-elements/src/elements/form/extras/address/Address.scss
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.scss
@@ -4,6 +4,29 @@
   display: flex;
   flex-flow: row wrap;
   align-items: center;
+  .address-autocomplete {
+    flex: 1 1 100%;
+    position: relative;
+    padding: 0 0 10px;
+    .address-search-input {
+      width: 100%;
+      border: none;
+      border-bottom: 1px solid #afb9c0;
+      padding: 5px 0;
+      font-size: inherit;
+      &:focus {
+        outline: none;
+        border-bottom-color: $positive;
+      }
+    }
+    google-places-list {
+      position: absolute;
+      z-index: 100;
+      width: 100%;
+      background: white;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+    }
+  }
   &.ng-touched.ng-invalid:not(.ng-pristine):not(.novo-control-container) {
     .street-address,
     .apt,

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -23,11 +23,6 @@ export interface AddressLookupPrediction {
   types?: string[];
 }
 
-export interface AddressLookupPredictionResponse {
-  predictions: AddressLookupPrediction[];
-  count: number;
-}
-
 export interface AddressLookupResult {
   address1?: string;
   address2?: string;
@@ -43,10 +38,6 @@ export interface AddressLookupResult {
     southwest: { latitude: number; longitude: number };
   };
   placeId?: string;
-}
-
-export interface AddressLookupDetailResponse {
-  address: AddressLookupResult;
 }
 
 export interface NovoAddressSubfieldConfig {

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -2,6 +2,7 @@
 import { Component, DoCheck, EventEmitter, forwardRef, Input, OnInit, Output } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 // APP
+import { Settings } from 'novo-elements/elements/places';
 import { NovoLabelService } from 'novo-elements/services';
 import { COUNTRIES, findByCountryId, getStates, Helpers } from 'novo-elements/utils';
 
@@ -11,6 +12,42 @@ const ADDRESS_VALUE_ACCESSOR = {
   useExisting: forwardRef(() => NovoAddressElement),
   multi: true,
 };
+
+export interface AddressLookupPrediction {
+  referenceId?: string;
+  displayAddress?: string;
+  primaryText?: string;
+  secondaryText?: string;
+  types?: string[];
+}
+
+export interface AddressLookupPredictionResponse {
+  predictions: AddressLookupPrediction[];
+  count: number;
+}
+
+export interface AddressLookupResult {
+  address1?: string;
+  address2?: string;
+  city?: string;
+  state?: string;
+  zip?: string;
+  countryName?: string;
+  countryCode?: string;
+  formattedAddress?: string;
+  location?: { latitude: number; longitude: number };
+  viewport?: {
+    northeast: { latitude: number; longitude: number };
+    southwest: { latitude: number; longitude: number };
+  };
+  referenceId?: string;
+  types?: string[];
+  postalCodes?: string[];
+}
+
+export interface AddressLookupDetailResponse {
+  address: AddressLookupResult;
+}
 
 export interface NovoAddressSubfieldConfig {
   label: string;
@@ -34,9 +71,26 @@ export interface NovoAddressConfig {
 }
 
 @Component({
-    selector: 'novo-address',
-    providers: [ADDRESS_VALUE_ACCESSOR],
-    template: `
+  selector: 'novo-address',
+  providers: [ADDRESS_VALUE_ACCESSOR],
+  template: `
+    <span *ngIf="placesSettings" class="address-autocomplete">
+      <input
+        type="text"
+        class="address-search-input"
+        [placeholder]="'Search for an address...'"
+        [(ngModel)]="autocompleteSearch"
+        [ngModelOptions]="{ standalone: true }"
+        (ngModelChange)="onAutocompleteTermChange($event)"
+      />
+      <google-places-list
+        *ngIf="autocompleteSearch"
+        [(term)]="autocompleteSearch"
+        [userSettings]="placesSettings"
+        (select)="onPlaceSelected($event)"
+      >
+      </google-places-list>
+    </span>
     <span
       *ngIf="!config?.address1?.hidden"
       class="street-address"
@@ -184,32 +238,18 @@ export interface NovoAddressConfig {
       ></novo-picker>
     </span>
   `,
-    styleUrls: ['./Address.scss'],
-    standalone: false,
+  styleUrls: ['./Address.scss'],
+  standalone: false,
 })
 export class NovoAddressElement implements ControlValueAccessor, OnInit, DoCheck {
   @Input()
   config: NovoAddressConfig;
-  private _readOnly = false;
   @Input()
-  set readOnly(readOnly: boolean) {
-    this._readOnly = readOnly;
-    this.fieldList.forEach((field: string) => {
-      this.disabled[field] = this._readOnly;
-    });
-    if (this.model) {
-      this.updateStates();
-    }
-  }
-  get readOnly(): boolean {
-    return this._readOnly;
-  }
-  private previousRequiredState: Record<string, boolean> = {};
+  placesSettings: Settings;
+  autocompleteSearch: string = '';
   states: Array<any> = [];
   fieldList: Array<string> = ['address1', 'address2', 'city', 'state', 'zip', 'countryID'];
   model: any;
-  onModelChange: Function = () => {};
-  onModelTouched: Function = () => {};
   focused: any = {};
   invalid: any = {};
   disabled: any = {};
@@ -226,8 +266,30 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit, DoCheck
   blur: EventEmitter<any> = new EventEmitter();
   @Output()
   validityChange: EventEmitter<any> = new EventEmitter();
+  private previousRequiredState: Record<string, boolean> = {};
 
   constructor(public labels: NovoLabelService) {}
+
+  private _readOnly = false;
+
+  get readOnly(): boolean {
+    return this._readOnly;
+  }
+
+  @Input()
+  set readOnly(readOnly: boolean) {
+    this._readOnly = readOnly;
+    this.fieldList.forEach((field: string) => {
+      this.disabled[field] = this._readOnly;
+    });
+    if (this.model) {
+      this.updateStates();
+    }
+  }
+
+  onModelChange: Function = () => {};
+
+  onModelTouched: Function = () => {};
 
   ngOnInit() {
     if (!this.config) {
@@ -420,6 +482,35 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit, DoCheck
     this.model.state = state;
     this.updateControl();
     this.onInput(null, 'state');
+  }
+
+  onAutocompleteTermChange(term: string): void {
+    this.autocompleteSearch = term;
+  }
+
+  onPlaceSelected(placeDetail: AddressLookupResult): void {
+    if (!placeDetail) {
+      return;
+    }
+
+    this.model.address1 = placeDetail.address1 || '';
+    this.model.address2 = placeDetail.address2 || '';
+    this.model.city = placeDetail.city || '';
+    this.model.state = placeDetail.state || '';
+    this.model.zip = placeDetail.zip || '';
+
+    if (placeDetail.countryCode) {
+      const country = COUNTRIES.find((c) => c.code === placeDetail.countryCode);
+      if (country) {
+        this.model.countryID = country.id;
+        this.model.countryName = country.name;
+      }
+    }
+
+    this.updateStates();
+    this.updateControl();
+    this.fieldList.forEach((field) => this.onInput(null, field));
+    this.autocompleteSearch = '';
   }
 
   setStateLabel(model: any) {

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -42,9 +42,7 @@ export interface AddressLookupResult {
     northeast: { latitude: number; longitude: number };
     southwest: { latitude: number; longitude: number };
   };
-  referenceId?: string;
-  types?: string[];
-  postalCodes?: string[];
+  placeId?: string;
 }
 
 export interface AddressLookupDetailResponse {

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -1,6 +1,8 @@
 // NG2
-import { Component, DoCheck, EventEmitter, forwardRef, Input, OnInit, Output } from '@angular/core';
+import { Component, DoCheck, EventEmitter, forwardRef, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { Subject, Subscription } from 'rxjs';
+import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 // APP
 import { PlacesSettings } from 'novo-elements/elements/places';
 import { NovoLabelService } from 'novo-elements/services';
@@ -84,8 +86,8 @@ export interface NovoAddressConfig {
         (ngModelChange)="onAutocompleteTermChange($event)"
       />
       <google-places-list
-        *ngIf="autocompleteSearch"
-        [(term)]="autocompleteSearch"
+        *ngIf="debouncedSearch"
+        [term]="debouncedSearch"
         [userSettings]="placesSettings"
         (select)="onPlaceSelected($event)"
       >
@@ -241,12 +243,15 @@ export interface NovoAddressConfig {
   styleUrls: ['./Address.scss'],
   standalone: false,
 })
-export class NovoAddressElement implements ControlValueAccessor, OnInit, DoCheck {
+export class NovoAddressElement implements ControlValueAccessor, OnInit, DoCheck, OnDestroy {
   @Input()
   config: NovoAddressConfig;
   @Input()
   placesSettings: PlacesSettings;
   autocompleteSearch: string = '';
+  debouncedSearch: string = '';
+  private searchTerms$ = new Subject<string>();
+  private searchSubscription: Subscription;
   states: Array<any> = [];
   fieldList: Array<string> = ['address1', 'address2', 'city', 'state', 'zip', 'countryID'];
   model: any;
@@ -304,6 +309,18 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit, DoCheck
     }
     if (Helpers.isBlank(this.model.countryID)) {
       this.updateStates();
+    }
+    this.searchSubscription = this.searchTerms$.pipe(
+      debounceTime(300),
+      distinctUntilChanged(),
+    ).subscribe(term => {
+      this.debouncedSearch = term;
+    });
+  }
+
+  ngOnDestroy() {
+    if (this.searchSubscription) {
+      this.searchSubscription.unsubscribe();
     }
   }
 
@@ -485,7 +502,7 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit, DoCheck
   }
 
   onAutocompleteTermChange(term: string): void {
-    this.autocompleteSearch = term;
+    this.searchTerms$.next(term);
   }
 
   onPlaceSelected(placeDetail: AddressLookupResult): void {
@@ -511,6 +528,7 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit, DoCheck
     this.updateControl();
     this.fieldList.forEach((field) => this.onInput(null, field));
     this.autocompleteSearch = '';
+    this.debouncedSearch = '';
   }
 
   setStateLabel(model: any) {

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -2,7 +2,7 @@
 import { Component, DoCheck, EventEmitter, forwardRef, Input, OnInit, Output } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 // APP
-import { Settings } from 'novo-elements/elements/places';
+import { PlacesSettings } from 'novo-elements/elements/places';
 import { NovoLabelService } from 'novo-elements/services';
 import { COUNTRIES, findByCountryId, getStates, Helpers } from 'novo-elements/utils';
 
@@ -245,7 +245,7 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit, DoCheck
   @Input()
   config: NovoAddressConfig;
   @Input()
-  placesSettings: Settings;
+  placesSettings: PlacesSettings;
   autocompleteSearch: string = '';
   states: Array<any> = [];
   fieldList: Array<string> = ['address1', 'address2', 'city', 'state', 'zip', 'countryID'];

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -16,7 +16,7 @@ const ADDRESS_VALUE_ACCESSOR = {
 };
 
 export interface AddressLookupPrediction {
-  referenceId?: string;
+  placeId?: string;
   displayAddress?: string;
   primaryText?: string;
   secondaryText?: string;

--- a/projects/novo-elements/src/elements/places/places.component.ts
+++ b/projects/novo-elements/src/elements/places/places.component.ts
@@ -48,9 +48,9 @@ const PLACES_VALUE_ACCESSOR = {
       <novo-list-item *ngFor="let data of matches; let $index = index" (click)="selectedListNode($event, $index)" [ngClass]="{ active: data === activeMatch }">
         <item-header>
           <item-avatar icon="location"></item-avatar>
-          <item-title>{{ data.structured_formatting?.main_text ? data.structured_formatting.main_text : data.description }}</item-title>
+          <item-title>{{ getPrimaryText(data) }}</item-title>
         </item-header>
-        <item-content>{{ data.structured_formatting?.secondary_text }}</item-content>
+        <item-content>{{ getSecondaryText(data) }}</item-content>
       </novo-list-item>
     </novo-list>
   `,
@@ -409,6 +409,38 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
     this._googlePlacesService.getRecentList(this.settings.recentStorageName).then((data: any) => {
       this.recentSearchData = data && data.length ? data : [];
     });
+  }
+
+  // Handle both Google Places API format and REST backend format
+  getPrimaryText(data: any): string {
+    // REST backend format (camelCase)
+    if (data.primaryText) {
+      return data.primaryText;
+    }
+    // Google Places API format (snake_case)
+    if (data.structured_formatting?.main_text) {
+      return data.structured_formatting.main_text;
+    }
+    // Fallback to display address
+    if (data.displayAddress) {
+      return data.displayAddress;
+    }
+    if (data.description) {
+      return data.description;
+    }
+    return '';
+  }
+
+  getSecondaryText(data: any): string {
+    // REST backend format (camelCase)
+    if (data.secondaryText) {
+      return data.secondaryText;
+    }
+    // Google Places API format (snake_case)
+    if (data.structured_formatting?.secondary_text) {
+      return data.structured_formatting.secondary_text;
+    }
+    return '';
   }
 
   onKeyDown(event: KeyboardEvent) {

--- a/projects/novo-elements/src/elements/places/places.component.ts
+++ b/projects/novo-elements/src/elements/places/places.component.ts
@@ -8,7 +8,7 @@ import { Key } from 'novo-elements/utils';
 import { Observable } from 'rxjs';
 import { GooglePlacesService } from './places.service';
 
-export interface Settings {
+export interface PlacesSettings {
   geoPredictionServerUrl?: string;
   geoLatLangServiceUrl?: string;
   geoLocDetailServerUrl?: string;
@@ -59,7 +59,7 @@ const PLACES_VALUE_ACCESSOR = {
 })
 export class PlacesListComponent extends BasePickerResults implements OnInit, OnChanges, ControlValueAccessor {
   @Input()
-  userSettings: Settings;
+  userSettings: PlacesSettings;
   @Output()
   termChange: EventEmitter<any> = new EventEmitter<any>();
   @Output()
@@ -71,12 +71,12 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
   public recentDropdownOpen: boolean = false;
   public isSettingsError: boolean = false;
   public settingsErrorMsg: string = '';
-  public settings: Settings = {};
+  public settings: PlacesSettings = {};
   private moduleinit: boolean = false;
   private selectedDataIndex: number = -1;
   private recentSearchData: any = [];
   private userSelectedOption: any = '';
-  private defaultSettings: Settings = {
+  private defaultSettings: PlacesSettings = {
     geoPredictionServerUrl: '',
     geoLatLangServiceUrl: '',
     geoLocDetailServerUrl: '',
@@ -276,7 +276,7 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
   }
 
   // function to set user settings if it is available.
-  private setUserSettings(): Settings {
+  private setUserSettings(): PlacesSettings {
     const _tempObj: any = {};
     if (this.userSettings && typeof this.userSettings === 'object') {
       const keys: string[] = Object.keys(this.defaultSettings);

--- a/projects/novo-elements/src/elements/places/places.component.ts
+++ b/projects/novo-elements/src/elements/places/places.component.ts
@@ -368,14 +368,15 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
 
   // function to retrieve the location info based on google place id.
   private getPlaceLocationInfo(selectedData: any): any {
+    const placeId = selectedData.placeId || selectedData.place_id;
     if (this.settings.useGoogleGeoApi) {
-      this._googlePlacesService.getGeoPlaceDetail(selectedData.place_id).then((data: any) => {
+      this._googlePlacesService.getGeoPlaceDetail(placeId).then((data: any) => {
         if (data) {
           this.setRecentLocation(data);
         }
       });
     } else {
-      this._googlePlacesService.getPlaceDetails(this.settings.geoLocDetailServerUrl, selectedData.place_id).then((result: any) => {
+      this._googlePlacesService.getPlaceDetails(this.settings.geoLocDetailServerUrl, placeId).then((result: any) => {
         if (result) {
           result = this.extractServerList(this.settings.serverResponseDetailHierarchy, result);
           this.setRecentLocation(result);
@@ -387,7 +388,7 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
   // function to store the selected user search in the localstorage.
   private setRecentLocation(data: any): any {
     data = JSON.parse(JSON.stringify(data));
-    data.description = data.description ? data.description : data.formatted_address;
+    data.description = data.description ? data.description : (data.formattedAddress || data.formatted_address);
     data.active = false;
     this.selectedDataIndex = -1;
     this.locationInput = data.description;

--- a/projects/novo-elements/src/elements/places/places.service.ts
+++ b/projects/novo-elements/src/elements/places/places.service.ts
@@ -14,7 +14,8 @@ export class GooglePlacesService {
 
   getPredictions(url: string, query: string): Promise<any> {
     return new Promise((resolve) => {
-      this._http.get(url + '?query=' + query).subscribe((data: any) => {
+      const separator = url.includes('?') ? '&' : '?';
+      this._http.get(url + separator + 'query=' + query).subscribe((data: any) => {
         if (data) {
           resolve(data);
         } else {
@@ -26,7 +27,8 @@ export class GooglePlacesService {
 
   getLatLngDetail(url: string, lat: number, lng: number): Promise<any> {
     return new Promise((resolve) => {
-      this._http.get(url + '?lat=' + lat + '&lng=' + lng).subscribe((data: any) => {
+      const separator = url.includes('?') ? '&' : '?';
+      this._http.get(url + separator + 'lat=' + lat + '&lng=' + lng).subscribe((data: any) => {
         if (data) {
           resolve(data);
         } else {
@@ -38,7 +40,8 @@ export class GooglePlacesService {
 
   getPlaceDetails(url: string, placeId: string): Promise<any> {
     return new Promise((resolve) => {
-      this._http.get(url + '?query=' + placeId).subscribe((data: any) => {
+      const separator = url.includes('?') ? '&' : '?';
+      this._http.get(url + separator + 'query=' + placeId).subscribe((data: any) => {
         if (data) {
           resolve(data);
         } else {


### PR DESCRIPTION
## **Description**

Adding an address search bar that is integrated into the full address block

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**