### PR TITLE
style(Theming): Overhauling styles to better support theming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17375,7 +17375,7 @@
     },
     "node_modules/novo-design-tokens": {
       "version": "0.1.4",
-      "resolved": "git+ssh://git@github.com/bullhorn/novo-design-tokens.git#0151a3111477cbc535c9cffca5a0b6d1e3fb0ab2",
+      "resolved": "git+ssh://git@github.com/bullhorn/novo-design-tokens.git#99330d4761bb8297b59a32ad17a0b73ae82a1c62",
       "license": "MIT"
     },
     "node_modules/npm": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "codemirror": "6.0.2",
         "date-fns": "4.1.0",
         "imask": "^7.6.1",
-        "novo-design-tokens": "^0.1.4",
+        "novo-design-tokens": "github:bullhorn/novo-design-tokens#f/cssvar-theming",
         "post-robot": "9.0.36",
         "rxjs": "~7.8.2",
         "timezone-support": "^3.1.0",
@@ -17375,8 +17375,7 @@
     },
     "node_modules/novo-design-tokens": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/novo-design-tokens/-/novo-design-tokens-0.1.4.tgz",
-      "integrity": "sha512-nBgdsnA3fhsYZebPSMxLX5DzX2JHklBpBX+htaZxq5P/cdR6H9Rw3LwBgABINHR0E0DZBCjv9DDtrCYOHa1DtA==",
+      "resolved": "git+ssh://git@github.com/bullhorn/novo-design-tokens.git#0151a3111477cbc535c9cffca5a0b6d1e3fb0ab2",
       "license": "MIT"
     },
     "node_modules/npm": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "codemirror": "6.0.2",
     "date-fns": "4.1.0",
     "imask": "^7.6.1",
-    "novo-design-tokens": "^0.1.4",
+    "novo-design-tokens": "github:bullhorn/novo-design-tokens#f/cssvar-theming",
     "post-robot": "9.0.36",
     "rxjs": "~7.8.2",
     "timezone-support": "^3.1.0",

--- a/projects/demo/assets/styles/main.scss
+++ b/projects/demo/assets/styles/main.scss
@@ -66,21 +66,21 @@ starting at line 82. >>
   }
   section {
     &.design {
-      background: $white;
+      background: var(--color-white);
     }
     > aside {
-      background: $background;
+      background: var(--color-background);
       padding: 10px 20px;
       border-radius: 3px;
       display: inline-block;
-      border: 2px solid darken($background, 2%);
+      border: 2px solid darkenLive('--theme-background-main', 2);
       h6 {
-        color: $mint;
+        color: var(--color-mint);
         margin-bottom: 5px;
       }
       &.design-principle {
         h6 {
-          border-bottom: 1px solid darken($background, 5%);
+          border-bottom: 1px solid darkenLive('--theme-background-main', 5);
           padding-bottom: 8px;
           span {
             font-weight: 300;
@@ -88,13 +88,13 @@ starting at line 82. >>
         }
         .hint {
           display: block;
-          color: darken($background, 50%);
+          color: darkenLive('--theme-background-main', 50);
           margin: 5px 0;
           padding: 10px;
           font-size: 0.9em;
           border-radius: 3px;
-          background: darken($background, 5%);
-          border: 1px solid darken($background, 10%);
+          background: darkenLive('--theme-background-main', 5);
+          border: 1px solid darkenLive('--theme-background-main', 10);
           i {
             margin-right: 10px;
           }
@@ -119,10 +119,10 @@ starting at line 82. >>
     margin-top: 15px;
   }
   .not-accepted {
-    color: $negative;
+    color: var(--color-negative);
   }
   .accepted {
-    color: $success;
+    color: var(--color-success);
   } // Custom page element initial display reset
   color,
   home,
@@ -131,7 +131,7 @@ starting at line 82. >>
   typography {
     display: block;
     & > header {
-      background: $off-white;
+      background: var(--color-off)-white;
     }
     & > section.design.container {
       article {

--- a/projects/demo/assets/styles/sidenav.scss
+++ b/projects/demo/assets/styles/sidenav.scss
@@ -5,7 +5,7 @@
   left: 0;
   width: 300px;
   height: 100vh;
-  color: $white;
+  color: var(--color-white);
   background-color: #1b2127;
   overflow-y: scroll;
   z-index: 20;
@@ -65,11 +65,11 @@
     display: block;
 
     .center-dot {
-      fill: $white;
+      fill: var(--color-white);
     }
 
     .outer-ring {
-      fill: $bittersweet;
+      fill: var(--color-bittersweet);
       transform-origin: 50% 50%;
       animation-duration: 20000ms;
       animation-iteration-count: infinite;
@@ -78,7 +78,7 @@
     }
 
     .inner-ring {
-      fill: $bittersweet;
+      fill: var(--color-bittersweet);
       transform-origin: 50% 50%;
       animation-duration: 20000ms;
       animation-iteration-count: infinite;
@@ -108,7 +108,7 @@
     display: flex;
     flex-flow: row nowrap;
     align-items: center;
-    gap: $spacing-md;
+    gap: var(--spacing-md);
     margin: 0;
     margin-right: 20px;
     height: 2.5rem;
@@ -135,12 +135,12 @@
   a.menu-item-header:focus,
   a.menu-item-header:hover {
     outline: none;
-    color: #fff;
+    color: inherit;
   }
 
   .router-link-active.menu-link,
   .router-link-active.menu-item-header {
-    color: #fff;
+    color: inherit;
     transition: color 0.5s;
   }
 
@@ -148,10 +148,10 @@
     display: flex;
     flex-flow: row nowrap;
     align-items: center;
-    gap: $spacing-md;
+    gap: var(--spacing-md);
 
     .menu-item-header {
-      color: $sand;
+      color: var(--color-sand);
       height: 2.5rem;
       line-height: 2.5rem;
       display: block;
@@ -170,7 +170,7 @@
     height: 2.5rem;
     width: 4px;
     pointer-events: none;
-    background: $bittersweet;
+    background: var(--color-bittersweet);
     transition: transform 0.5s;
     transition-timing-function: cubic-bezier(1, 0.01, 0, 1.22);
   }

--- a/projects/novo-elements/src/elements/agenda/common/AgendaDateChange.scss
+++ b/projects/novo-elements/src/elements/agenda/common/AgendaDateChange.scss
@@ -6,14 +6,14 @@
   .cal-date-change {
     border-radius: 3px;
     border: 1px solid #e1e1e1;
-    background-color: $white;
+    background-color: var(--background-body);
     position: relative;
     padding: 10px 15px;
     text-align: center;
 
     > span {
       padding: 5px;
-      color: $black;
+      color: var(--form-text);
     }
 
     > i {

--- a/projects/novo-elements/src/elements/agenda/common/AgendaDateChange.scss
+++ b/projects/novo-elements/src/elements/agenda/common/AgendaDateChange.scss
@@ -4,6 +4,8 @@
   display: inline-block;
 
   .cal-date-change {
+    // TODO: semantic role TBD - could be border-radius-small
+    // TODO: semantic role TBD - could be border-radius or border-radius-small
     border-radius: 3px;
     border: 1px solid #e1e1e1;
     background-color: var(--background-body);

--- a/projects/novo-elements/src/elements/agenda/common/AgendaHoursLayout.scss
+++ b/projects/novo-elements/src/elements/agenda/common/AgendaHoursLayout.scss
@@ -11,10 +11,10 @@
     }
 
     .cal-hour:nth-child(even) {
-      background-color: $off-white;
+      background-color: var(--background-main);
     }
     .cal-hour:nth-child(odd) {
-      background-color: $white;
+      background-color: var(--background-body);
     }
 
     .cal-hour-segment {

--- a/projects/novo-elements/src/elements/agenda/common/AgendaHoursLayout.scss
+++ b/projects/novo-elements/src/elements/agenda/common/AgendaHoursLayout.scss
@@ -35,6 +35,7 @@
       padding-top: 5px;
       width: 70px;
       text-align: center;
+      // TODO: semantic role TBD - rec disabled
       color: $grey;
     }
 
@@ -46,6 +47,7 @@
 
     .cal-hour-segment:hover,
     .cal-drag-over .cal-hour-segment {
+      // TODO: semantic role TBD - rec background-bright
       background-color: #ededed;
     }
   }

--- a/projects/novo-elements/src/elements/agenda/day/AgendaDayView.scss
+++ b/projects/novo-elements/src/elements/agenda/day/AgendaDayView.scss
@@ -17,7 +17,7 @@
         min-height: 30px;
         display: flex;
         flex-flow: row nowrap;
-        background-color: $off-white;
+        background-color: var(--background-main);
 
         .cal-event-ribbon {
           width: 4px;

--- a/projects/novo-elements/src/elements/agenda/day/AgendaDayView.scss
+++ b/projects/novo-elements/src/elements/agenda/day/AgendaDayView.scss
@@ -11,7 +11,7 @@
 
       .cal-event {
         height: inherit;
-        font-size: 12px;
+        font-size: var(--font-size-sm);
         margin-left: 2px;
         margin-right: 2px;
         min-height: 30px;
@@ -34,7 +34,7 @@
           line-height: 26px;
         }
         .cal-event-description {
-          font-size: 10px;
+          font-size: var(--font-size-xs);
           line-height: 13px;
         }
       }

--- a/projects/novo-elements/src/elements/agenda/month/AgendaMonthView.scss
+++ b/projects/novo-elements/src/elements/agenda/month/AgendaMonthView.scss
@@ -2,14 +2,14 @@
 
 :host {
   ::ng-deep .agenda-month-view {
-    background-color: $white;
+    background-color: var(--background-body);
 
     .agenda-header {
       display: flex;
       flex-flow: column;
       text-align: center;
       font-weight: bolder;
-      border-bottom: 2px solid #e1e1e1;
+      border-bottom: 2px solid var(--border);
       .agenda-header-top {
         display: flex;
         flex-flow: row nowrap;
@@ -46,10 +46,12 @@
 
     .agenda-cell-row .agenda-cell:hover,
     .agenda-cell.agenda-has-events.agenda-open {
+      // TODO: semantic role TBD - rec theme-background-dark
       background-color: #ededed;
     }
 
     .agenda-days {
+      // TODO: semantic role TBD - rec border, same across file
       border: 1px solid #e1e1e1;
       border-bottom: 0;
     }
@@ -119,7 +121,7 @@
       text-align: center;
       line-height: 22px;
       font-size: 12px;
-      color: $white;
+      color: var(--text-bg-contrast);
     }
 
     .agenda-day-cell.agenda-in-month.agenda-has-events {
@@ -132,6 +134,7 @@
     }
 
     .agenda-day-cell.agenda-weekend .agenda-day-number {
+      // TODO: semantic role TBD - Should likely be darkened off negative, but may need contrast attention
       color: darkred;
     }
 
@@ -140,16 +143,19 @@
     }
 
     .agenda-day-cell.agenda-today .agenda-day-number {
+      // TODO: semantic role TBD - Should likely be text-main
       color: $dark;
     }
 
     .agenda-day-cell.agenda-drag-over {
+      // TODO: semantic role TBD - Should likely be theme-background-muted
       background-color: darken(#ededed, 5%) !important;
     }
 
     .agenda-open-day-events {
       padding: 15px;
       color: white;
+      // TODO: semantic role TBD - close to steel or neutral
       background-color: #555;
       box-shadow: inset 0 0 15px 0 rgba(0, 0, 0, 0.5);
     }

--- a/projects/novo-elements/src/elements/agenda/month/AgendaMonthView.scss
+++ b/projects/novo-elements/src/elements/agenda/month/AgendaMonthView.scss
@@ -94,7 +94,7 @@
       display: inline-block;
       min-width: 10px;
       padding: 3px 7px;
-      font-size: 12px;
+      font-size: var(--font-size-sm);
       font-weight: 700;
       line-height: 1;
       color: white;
@@ -121,7 +121,7 @@
       vertical-align: middle;
       text-align: center;
       line-height: 22px;
-      font-size: 12px;
+      font-size: var(--font-size-sm);
       color: var(--text-bg-contrast);
     }
 
@@ -145,7 +145,7 @@
 
     .agenda-day-cell.agenda-today .agenda-day-number {
       // TODO: semantic role TBD - Should likely be text-main
-      color: $dark;
+      color: var(--font-color-base);
     }
 
     .agenda-day-cell.agenda-drag-over {

--- a/projects/novo-elements/src/elements/agenda/month/AgendaMonthView.scss
+++ b/projects/novo-elements/src/elements/agenda/month/AgendaMonthView.scss
@@ -114,6 +114,7 @@
     .agenda-event {
       width: 22px;
       height: 22px;
+      // TODO: semantic role TBD - could be border-radius or border-radius-small
       border-radius: 4px;
       display: inline-block;
       margin: 2px;

--- a/projects/novo-elements/src/elements/agenda/week/AgendaWeekView.scss
+++ b/projects/novo-elements/src/elements/agenda/week/AgendaWeekView.scss
@@ -13,7 +13,7 @@
       flex: 1;
       text-align: center;
       padding: 5px;
-      background-color: $off-white;
+      background-color: var(--background-main);
     }
 
     .cal-day-headers .cal-header:not(:last-child) {
@@ -46,7 +46,7 @@
           min-height: 30px;
           display: flex;
           flex-flow: column;
-          background-color: $off-white;
+          background-color: var(--background-main);
 
           .cal-event-ribbon {
             min-height: 4px;

--- a/projects/novo-elements/src/elements/agenda/week/AgendaWeekView.scss
+++ b/projects/novo-elements/src/elements/agenda/week/AgendaWeekView.scss
@@ -42,7 +42,7 @@
 
         .cal-event {
           height: inherit;
-          font-size: 12px;
+          font-size: var(--font-size-sm);
           min-height: 30px;
           display: flex;
           flex-flow: column;
@@ -59,7 +59,7 @@
             text-overflow: ellipsis;
           }
           .cal-event-description {
-            font-size: 10px;
+            font-size: var(--font-size-xs);
             line-height: 13px;
             padding: 0px 0px 0px 10px;
             overflow: hidden;

--- a/projects/novo-elements/src/elements/avatar/Avatar.scss
+++ b/projects/novo-elements/src/elements/avatar/Avatar.scss
@@ -25,10 +25,11 @@
     height: 40px;
   }
   &.avatar-shape-round {
+    // TODO: semantic role TBD
     border-radius: 2em;
   }
   &.avatar-shape-square {
-    border-radius: 0.4em;
+    border-radius: var(--border-radius-round);
   }
 
   @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {

--- a/projects/novo-elements/src/elements/avatar/Avatar.scss
+++ b/projects/novo-elements/src/elements/avatar/Avatar.scss
@@ -34,7 +34,7 @@
   @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {
     &.avatar-color-#{$name} {
       color: getContrastColor($name);
-      background-color: $color;
+      background-color: var(--color-#{$name});
     }
   }
 }

--- a/projects/novo-elements/src/elements/breadcrumbs/breadcrumb-item/BreadcrumbItem.scss
+++ b/projects/novo-elements/src/elements/breadcrumbs/breadcrumb-item/BreadcrumbItem.scss
@@ -77,7 +77,7 @@
 
     li {
       padding: 0 15px;
-      font-size: 12px;
+      font-size: var(--font-size-sm);
       line-height: 36px;
       width: 200px;
       overflow: hidden;
@@ -86,7 +86,7 @@
       cursor: pointer;
 
       a {
-        color: $dark;
+        color: var(--font-color-base);
         line-height: 36px;
         width: 170px;
         display: inline-block;

--- a/projects/novo-elements/src/elements/breadcrumbs/breadcrumb-item/BreadcrumbItem.scss
+++ b/projects/novo-elements/src/elements/breadcrumbs/breadcrumb-item/BreadcrumbItem.scss
@@ -23,7 +23,7 @@
 
     ::ng-deep a {
       @extend .novo-breadcrumb-font-style;
-      color: $ocean;
+      color: var(--links);
       cursor: pointer;
       &:focus {
         text-decoration: none;

--- a/projects/novo-elements/src/elements/button/styles/button-dialogue.scss
+++ b/projects/novo-elements/src/elements/button/styles/button-dialogue.scss
@@ -15,7 +15,7 @@
     &:hover,
     &:focus,
     &:active {
-      background: var(--background-faded);
+      background: var(--background-muted);
     }
     &[inverse] {
       &:hover,

--- a/projects/novo-elements/src/elements/button/styles/button-dialogue.scss
+++ b/projects/novo-elements/src/elements/button/styles/button-dialogue.scss
@@ -5,16 +5,17 @@
   &[theme="dialogue"] {
     @include theme-text-colors("color");
     background: transparent;
-    color: $positive;
+    color: var(--color-positive);
     i {
       line-height: 1.2;
     }
-    &:hover,
-    &:focus {
-      background: lighten($light, 7%);
+    &[color=text] {
+      color: inherit;
     }
+    &:hover,
+    &:focus,
     &:active {
-      background: lighten($light, 2%);
+      background: var(--background-faded);
     }
     &[inverse] {
       &:hover,

--- a/projects/novo-elements/src/elements/button/styles/button-fab.scss
+++ b/projects/novo-elements/src/elements/button/styles/button-fab.scss
@@ -6,7 +6,7 @@
     @include theme-backgrounds("color", false);
     border-radius: 50% !important;
     padding: 0;
-    font-size: 1.2rem;
+    font-size: var(--font-size-sm);
     width: 3.2rem;
     height: 3.2rem;
     display: inline-flex;

--- a/projects/novo-elements/src/elements/button/styles/button-icon.scss
+++ b/projects/novo-elements/src/elements/button/styles/button-icon.scss
@@ -8,7 +8,7 @@
     font-size: 1.4rem;
     height: 2.4rem;
     &[inverse] {
-      color: #fff;
+      color: var(--color-contrast-text);
     }
     i {
       display: contents;
@@ -26,7 +26,7 @@
     }
     &[size="small"] {
       padding: var(--spacing-sm);
-      font-size: 1.2rem;
+      font-size: var(--font-size-sm);
       height: 2rem;
     }
     &[size="medium"] {

--- a/projects/novo-elements/src/elements/button/styles/button-icon.scss
+++ b/projects/novo-elements/src/elements/button/styles/button-icon.scss
@@ -4,7 +4,7 @@
   // Icon Themed Button
   &[theme="icon"] {
     @include theme-text-colors("color");
-    padding: $spacing-sm;
+    padding: var(--spacing-sm);
     font-size: 1.4rem;
     height: 2.4rem;
     &[inverse] {
@@ -25,7 +25,7 @@
       display: contents;
     }
     &[size="small"] {
-      padding: $spacing-sm;
+      padding: var(--spacing-sm);
       font-size: 1.2rem;
       height: 2rem;
     }
@@ -35,7 +35,7 @@
     &[size="large"] {
       font-size: 2rem;
       height: 2.8rem;
-      padding: $spacing-md;
+      padding: var(--spacing-md);
     }
   }
 }

--- a/projects/novo-elements/src/elements/button/styles/button-other.scss
+++ b/projects/novo-elements/src/elements/button/styles/button-other.scss
@@ -4,13 +4,13 @@
   // Field Themed Button
   &[theme="field"] {
     background: transparent;
-    color: $dark;
+    color: var(--font-color-base);
     border: none;
     border-radius: 0;
     border-bottom: 1px solid var(--border);
     margin-bottom: 4px;
     padding: var(--spacing-xs) var(--spacing-sm);
-    font-size: 1.2rem;
+    font-size: var(--font-size-sm);
     height: 1.8rem;
     text-align: left;
     &:hover,
@@ -39,7 +39,7 @@
     width: 100%;
     z-index: z("default");
     text-transform: none;
-    font-size: 1.2rem;
+    font-size: var(--font-size-sm);
     height: 1.8rem;
 
     &.empty {

--- a/projects/novo-elements/src/elements/button/styles/button-other.scss
+++ b/projects/novo-elements/src/elements/button/styles/button-other.scss
@@ -9,7 +9,7 @@
     border-radius: 0;
     border-bottom: 1px solid var(--border);
     margin-bottom: 4px;
-    padding: $spacing-xs $spacing-sm;
+    padding: var(--spacing-xs) var(--spacing-sm);
     font-size: 1.2rem;
     height: 1.8rem;
     text-align: left;
@@ -50,7 +50,8 @@
       outline: none;
     }
     &:hover {
-      border-bottom: 1px solid lighten($dark, 15%);
+      // TODO: semantic role TBD - rec border
+      border-bottom: 1px solid brightenLive('--color-dark', 15);
       i {
         opacity: 0.75;
       }

--- a/projects/novo-elements/src/elements/button/styles/button-primary.scss
+++ b/projects/novo-elements/src/elements/button/styles/button-primary.scss
@@ -5,7 +5,7 @@
   &[theme="primary"] {
     @include theme-backgrounds-live();
     background: var(--color-positive);
-    color: #fff;
+    color: var(--color-contrast-positive);
     text-align: left;
 
     &:hover,

--- a/projects/novo-elements/src/elements/button/styles/button-primary.scss
+++ b/projects/novo-elements/src/elements/button/styles/button-primary.scss
@@ -3,30 +3,32 @@
 :host {
   // Primary theme
   &[theme="primary"] {
-    @include theme-backgrounds("color");
-    background: $positive;
+    @include theme-backgrounds-live();
+    background: var(--color-positive);
     color: #fff;
     text-align: left;
 
     &:hover,
     &:focus {
-      box-shadow: $shadow-2, $shadow-1;
+
       filter: brightness(1.15);
+      box-shadow: var(--shadow-2), var(--shadow-1);
     }
     &:active {
       filter: brightness(0.85);
-      box-shadow: $shadow-1;
+      box-shadow: var(--shadow-1);
     }
 
     &[color="white"] {
-      background: $white;
-      color: $ocean;
+      background: var(--background-main);
+      color: var(--color-positive);
       &:hover,
       &:focus {
-        background: $background;
+        background: var(--background-main);
       }
       &:active {
-        background: darken($background, 5%);
+        background: darkenLive('--theme-background-main', 5);
+        //background: var(--background-muted);
       }
       i {
         background: rgba(0, 0, 0, 0.05);

--- a/projects/novo-elements/src/elements/button/styles/button-secondary.scss
+++ b/projects/novo-elements/src/elements/button/styles/button-secondary.scss
@@ -8,31 +8,32 @@
 
     text-align: left;
     align-items: center;
-    background: $white;
-    color: $positive;
-    border: 1px solid $positive;
-    padding: 0 calc(#{$spacing-md} - 1px);
+    // TODO: semantic role TBD - should likely be transparent, rather than background?
+    background: var(--color-white);
+    color: var(--color-positive);
+    border: 1px solid var(--color-positive);
+    padding: 0 calc(#{var(--spacing-md)} - 1px);
 
     i.loading {
       margin-left: 0.8rem;
       svg {
         .spinner {
-          fill: $positive;
+          fill: var(--color-positive);
         }
       }
     }
     &:hover,
     &:focus {
-      box-shadow: $shadow-2, $shadow-1;
+      box-shadow: var(--shadow-2), var(--shadow-1);
       background: $white;
     }
     &:active {
-      box-shadow: $shadow-1;
+      box-shadow: var(--shadow-1);
     }
     &[inverse] {
       background: rgba(0, 0, 0, 0.25);
-      color: #fff;
-      border: 1px solid #fff;
+      color: var(--color-contrast-positive);
+      border: 1px solid var(--color-contrast-positive);
       &:hover,
       &:focus {
         background: rgba(0, 0, 0, 0.35);

--- a/projects/novo-elements/src/elements/button/styles/button-standard.scss
+++ b/projects/novo-elements/src/elements/button/styles/button-standard.scss
@@ -8,10 +8,10 @@
     background: var(--button-background);
     &:hover,
     &:focus {
-      box-shadow: $shadow-2, $shadow-1;
+      box-shadow: var(--shadow-2), var(--shadow-1);
     }
     &:active {
-      box-shadow: $shadow-1;
+      box-shadow: var(--shadow-1);
     }
   }
 }

--- a/projects/novo-elements/src/elements/button/styles/button.scss
+++ b/projects/novo-elements/src/elements/button/styles/button.scss
@@ -5,7 +5,7 @@
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  padding: 0 $spacing-md;
+  padding: 0 var(--spacing-md);
   font-size: var(--font-size-button);
   height: 3rem;
   border: none;
@@ -14,7 +14,7 @@
   border-radius: 3px;
   text-transform: uppercase;
   transition: all 200ms ease-in-out;
-  gap: $spacing-md;
+  gap: var(--spacing-md);
   cursor: pointer;
   user-select: none;
   text-overflow: clip;
@@ -41,9 +41,9 @@
   &[size="small"],
   &[size="sm"] {
     font-size: 1rem;
-    padding: 0 $spacing-md;
+    padding: 0 var(--spacing-md);
     height: 2.4rem;
-    gap: $spacing-sm;
+    gap: var(--spacing-sm);
     .button-contents,
     i {
       height: 1rem;
@@ -53,9 +53,9 @@
   &[size="large"],
   &[size="lg"] {
     font-size: 1.6rem;
-    padding: 0 $spacing-lg;
+    padding: 0 var(--spacing-lg);
     height: 3.6rem;
-    gap: $spacing-lg;
+    gap: var(--spacing-lg);
     .button-contents,
     i {
       height: 1.6rem;

--- a/projects/novo-elements/src/elements/button/styles/button.scss
+++ b/projects/novo-elements/src/elements/button/styles/button.scss
@@ -41,7 +41,7 @@
 
   &[size="small"],
   &[size="sm"] {
-    font-size: 1rem;
+    font-size: var(--font-size-xs);
     padding: 0 var(--spacing-md);
     height: 2.4rem;
     gap: var(--spacing-sm);

--- a/projects/novo-elements/src/elements/button/styles/button.scss
+++ b/projects/novo-elements/src/elements/button/styles/button.scss
@@ -11,6 +11,7 @@
   border: none;
   color: var(--text-main, $dark);
   background: transparent;
+  // TODO: semantic role TBD - could be border-radius or border-radius-small
   border-radius: 3px;
   text-transform: uppercase;
   transition: all 200ms ease-in-out;

--- a/projects/novo-elements/src/elements/calendar/calendar.component.scss
+++ b/projects/novo-elements/src/elements/calendar/calendar.component.scss
@@ -1,7 +1,7 @@
 @import "../../styles/variables.scss";
 
 :host(.layout-horizontal) {
-  font-size: 1.2rem;
+  font-size: var(--font-size-sm);
 
   .calendar-content {
     flex-flow: row nowrap;
@@ -9,9 +9,9 @@
 
   .month-view + .month-view {
     border-collapse: unset;
-    border-left: 1px solid $light;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
+    border-left: 1px solid var(--color-border);
+    margin-left: var(--spacing-sm);
+    padding-left: var(--spacing-sm);
   }
 }
 :host(.layout-vertical) {

--- a/projects/novo-elements/src/elements/calendar/calendar.component.scss
+++ b/projects/novo-elements/src/elements/calendar/calendar.component.scss
@@ -82,6 +82,7 @@
       color: var(--color-positive);
       font-weight: 600;
       .month {
+        // TODO: semantic role TBD - could be border-radius or border-radius-small
         border-radius: 2px;
         padding: 3px 8px;
         &:hover {
@@ -91,6 +92,7 @@
         }
       }
       .year {
+        // TODO: semantic role TBD - could be border-radius or border-radius-small
         border-radius: 2px;
         padding: 3px 8px;
         &:hover {

--- a/projects/novo-elements/src/elements/calendar/calendar.component.scss
+++ b/projects/novo-elements/src/elements/calendar/calendar.component.scss
@@ -71,7 +71,7 @@
         width: 0;
       }
       &:hover:after {
-        border-right: 4px solid $positive;
+        border-right: 4px solid var(--color-positive);
         cursor: pointer;
       }
     }
@@ -79,14 +79,14 @@
       flex: 1;
       display: inline-block;
       vertical-align: middle;
-      color: $positive;
+      color: var(--color-positive);
       font-weight: 600;
       .month {
         border-radius: 2px;
         padding: 3px 8px;
         &:hover {
-          background: $positive;
-          color: #fff;
+          background: var(--color-positive);
+          color: var(--color-contrast-positive);
           cursor: pointer;
         }
       }
@@ -94,8 +94,8 @@
         border-radius: 2px;
         padding: 3px 8px;
         &:hover {
-          background: $positive;
-          color: #fff;
+          background: var(--color-positive);
+          color: var(--color-contrast-positive);
           cursor: pointer;
         }
       }
@@ -117,7 +117,7 @@
       }
       &:hover:before {
         opacity: 1;
-        border-left: 4px solid $positive;
+        border-left: 4px solid var(--color-positive);
         cursor: pointer;
       }
     }

--- a/projects/novo-elements/src/elements/calendar/month-select/month-select.component.scss
+++ b/projects/novo-elements/src/elements/calendar/month-select/month-select.component.scss
@@ -9,11 +9,11 @@
     cursor: pointer;
     border-radius: 0.4rem;
     &.selected {
-      background-color: $positive;
+      background-color: var(--color-positive);
       color: #fff;
     }
     &:hover {
-      background-color: $positive;
+      background-color: var(--color-positive);
       color: #fff;
     }
   }

--- a/projects/novo-elements/src/elements/calendar/month-select/month-select.component.scss
+++ b/projects/novo-elements/src/elements/calendar/month-select/month-select.component.scss
@@ -7,7 +7,7 @@
   .month {
     padding: 1rem;
     cursor: pointer;
-    border-radius: 0.4rem;
+    border-radius: var(--border-radius-round);
     &.selected {
       background-color: var(--color-positive);
       color: #fff;

--- a/projects/novo-elements/src/elements/calendar/month-view/month-view.component.scss
+++ b/projects/novo-elements/src/elements/calendar/month-view/month-view.component.scss
@@ -46,7 +46,7 @@
       height: 3.2rem;
       width: 3.2rem;
       line-height: 1;
-      font-size: 1.2rem;
+      font-size: var(--font-size-sm);
       padding: 1px;
       border: none;
       background-color: transparent;
@@ -152,7 +152,7 @@
           height: 100%;
           max-width: 3.2rem;
           margin: 0 auto;
-          box-shadow: inset 0 0 0 2px $light;
+          box-shadow: inset 0 0 0 2px var(--color-border);
         }
         &.inRange,
         &.selected {

--- a/projects/novo-elements/src/elements/calendar/month-view/month-view.component.scss
+++ b/projects/novo-elements/src/elements/calendar/month-view/month-view.component.scss
@@ -30,6 +30,7 @@
       text-overflow: ellipsis;
       margin: 5px;
       font-weight: normal;
+      // TODO: semantic role TBD - could be border-radius or border-radius-small
       border-radius: 3px;
       &.selected {
         background-color: var(--selection);

--- a/projects/novo-elements/src/elements/calendar/month-view/month-view.component.scss
+++ b/projects/novo-elements/src/elements/calendar/month-view/month-view.component.scss
@@ -163,8 +163,8 @@
 
       &.inPreview .day {
         border-radius: 0;
-        border-top: 1px dashed $positive;
-        border-bottom: 1px dashed $positive;
+        border-top: 1px dashed var(--color-positive);
+        border-bottom: 1px dashed var(--color-positive);
       }
 
       &.previewStart .day {
@@ -172,14 +172,14 @@
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
         box-shadow: none !important;
-        border-left: 1px dashed $positive;
+        border-left: 1px dashed var(--color-positive);
       }
       &.previewEnd .day {
         border-radius: 50%;
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
         box-shadow: none !important;
-        border-right: 1px dashed $positive;
+        border-right: 1px dashed var(--color-positive);
       }
     }
   }

--- a/projects/novo-elements/src/elements/calendar/year-select/year-select.component.scss
+++ b/projects/novo-elements/src/elements/calendar/year-select/year-select.component.scss
@@ -11,11 +11,11 @@
     cursor: pointer;
     border-radius: 0.4rem;
     &.selected {
-      background-color: $positive;
+      background-color: var(--color-positive);
       color: #fff;
     }
     &:hover {
-      background-color: $positive;
+      background-color: var(--color-positive);
       color: #fff;
     }
   }

--- a/projects/novo-elements/src/elements/calendar/year-select/year-select.component.scss
+++ b/projects/novo-elements/src/elements/calendar/year-select/year-select.component.scss
@@ -9,7 +9,7 @@
   .year {
     padding: 1rem;
     cursor: pointer;
-    border-radius: 0.4rem;
+    border-radius: var(--border-radius-round);
     &.selected {
       background-color: var(--color-positive);
       color: #fff;

--- a/projects/novo-elements/src/elements/card/Card.scss
+++ b/projects/novo-elements/src/elements/card/Card.scss
@@ -5,7 +5,7 @@
   flex-flow: column;
   background-color: var(--background-bright, $color-white);
   box-shadow: $shadow-card;
-  border-radius: 0.4em;
+  border-radius: var(--border-radius-round);
   position: relative;
   overflow-x: hidden;
 
@@ -19,7 +19,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    border-radius: 0.4em;
+    border-radius: var(--border-radius-round);
     background-color: var(--background-bright, $color-white);
     display: flex;
     flex-direction: column;

--- a/projects/novo-elements/src/elements/card/Card.scss
+++ b/projects/novo-elements/src/elements/card/Card.scss
@@ -64,7 +64,8 @@
       }
     }
     .actions {
-      color: lighten($dark, 15%);
+      // TODO: semantic role TBD - rec text-main
+      color: brightenLive('--color-dark', 15);
       white-space: nowrap;
     }
   }
@@ -74,12 +75,13 @@
     max-width: inherit;
     text-align: center;
     line-height: 25px;
-    color: lighten($grey, 10%);
+    // TODO: semantic role TBD - rec new "text-secondary"
+    color: brightenLive('--color-grey', 10);
     i {
       display: block;
       font-size: 24px;
       margin: 0 0 0.5em;
-      color: lighten($grey, 20%);
+      color: brightenLive('--color-grey', 20);
     }
   }
 
@@ -97,22 +99,22 @@
     padding: 0;
   }
   &.novo-card-inset-small {
-    padding: $spacing-sm;
+    padding: var(--spacing-sm);
   }
   &.novo-card-inset-medium {
-    padding: $spacing-md;
+    padding: var(--spacing-md);
   }
   &.novo-card-inset-large {
-    padding: $spacing-lg;
+    padding: var(--spacing-lg);
   }
 
   ::ng-deep .novo-card-header + .novo-card-content.condensed,
   ::ng-deep .novo-card-header + :not(.novo-card-content) {
-    margin-top: $spacing-sm;
+    margin-top: var(--spacing-sm);
   }
 
   ::ng-deep [novo-card-image] {
     width: calc(100%);
-    margin: $spacing-md 0;
+    margin: var(--spacing-md) 0;
   }
 }

--- a/projects/novo-elements/src/elements/card/Card.scss
+++ b/projects/novo-elements/src/elements/card/Card.scss
@@ -39,14 +39,15 @@
       min-width: 0;
       flex: 1;
       ::ng-deep i.bhi-move {
-        color: $light;
+        // TODO: semantic role TBD 
+        color: var(--font-color-secondary);
         margin-right: 0.3em;
         cursor: pointer;
       }
       h1,
       h2,
       h3 {
-        font-size: $font-size-lg;
+        font-size: var(--font-size-lg);
         font-weight: 500;
         line-height: 1.5;
         color: var(--text-main, #3d464d);

--- a/projects/novo-elements/src/elements/card/CardContent.scss
+++ b/projects/novo-elements/src/elements/card/CardContent.scss
@@ -3,6 +3,6 @@
 :host {
   display: block;
   &:not(.condensed) {
-    padding: $spacing-md $spacing-md;
+    padding: var(--spacing-md);
   }
 }

--- a/projects/novo-elements/src/elements/card/CardFooter.scss
+++ b/projects/novo-elements/src/elements/card/CardFooter.scss
@@ -2,9 +2,9 @@
 
 :host {
   @include theme-backgrounds();
-  padding: 0 $spacing-md $spacing-md $spacing-md;
+  padding: 0 var(--spacing-md) var(--spacing-md) var(--spacing-md);
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: $spacing-md;
+  gap: var(--spacing-md);
 }

--- a/projects/novo-elements/src/elements/card/CardHeader.scss
+++ b/projects/novo-elements/src/elements/card/CardHeader.scss
@@ -2,11 +2,11 @@
 
 :host {
   @include theme-backgrounds();
-  padding: $spacing-md $spacing-md 0 $spacing-md;
+  padding: var(--spacing-md) var(--spacing-md) 0 var(--spacing-md);
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: $spacing-md;
+  gap: var(--spacing-md);
 
   .novo-card-header-text {
     flex: 1 1 0px;

--- a/projects/novo-elements/src/elements/category-dropdown/CategoryDropdown.scss
+++ b/projects/novo-elements/src/elements/category-dropdown/CategoryDropdown.scss
@@ -42,7 +42,8 @@
         font-size: 1em;
         background: transparent !important;
         border: none;
-        border-bottom: 1px solid lighten($dark, 45%);
+        // TODO: semantic role TBD - rec border, more in the same file
+        border-bottom: 1px solid brightenLive('--color-dark', 45);
         border-radius: 0;
         outline: none;
         height: 2rem;
@@ -55,10 +56,10 @@
         color: #26282b;
         margin-left: 10px;
         &:hover {
-          border-bottom: 1px solid lighten($dark, 15%);
+          border-bottom: 1px solid brightenLive('--color-dark', 15);
         }
         &:focus {
-          border-bottom: 1px solid $positive;
+          border-bottom: 1px solid var(--color-positive);
         }
         &::placeholder {
           color: var(--form-placeholder);
@@ -99,6 +100,7 @@
     novo-nav {
       max-height: 140px;
       overflow: auto;
+      // TODO: semantic role TBD - rec border
       border-bottom: 1px solid #ccc;
       > novo-tab {
         height: 30px;
@@ -124,15 +126,15 @@
       font-size: 0.9em;
       &:focus,
       &:hover {
-        background: lighten($light, 10%);
-        color: darken($light, 55%);
+        background: brightenLive('--color-light', 10);
+        color: darkenLive('--color-light', 55);
         .novo-category-dropdown-hover {
           display: block;
         }
       }
       .novo-category-dropdown-hover {
         display: none;
-        color: $positive;
+        color: var(--color-positive);
         font-size: 0.9em;
         > i {
           font-size: 0.9em;

--- a/projects/novo-elements/src/elements/category-dropdown/CategoryDropdown.scss
+++ b/projects/novo-elements/src/elements/category-dropdown/CategoryDropdown.scss
@@ -15,6 +15,7 @@
       min-width: 400px;
       display: block;
       z-index: z("max");
+      // TODO: semantic role TBD - could be border-radius or border-radius-small
       border-radius: 2px;
       top: 100%;
       margin-top: 5px;

--- a/projects/novo-elements/src/elements/category-dropdown/CategoryDropdown.scss
+++ b/projects/novo-elements/src/elements/category-dropdown/CategoryDropdown.scss
@@ -72,12 +72,12 @@
         bottom: 15px;
         right: 5px;
         color: #aaaaaa;
-        font-size: 1.2rem;
+        font-size: var(--font-size-sm);
         margin-right: 10px;
       }
       i.bhi-times {
         cursor: pointer;
-        font-size: 1.2rem;
+        font-size: var(--font-size-sm);
       }
     }
     footer {

--- a/projects/novo-elements/src/elements/checkbox/CheckList.scss
+++ b/projects/novo-elements/src/elements/checkbox/CheckList.scss
@@ -18,7 +18,7 @@
           i {
             &.bhi-checkbox-empty,
             &.bhi-radio-empty {
-              color: $color-positive;
+              color: var(--color-positive);
             }
           }
         }
@@ -48,12 +48,13 @@
         i {
           &.bhi-checkbox-empty,
           &.bhi-checkbox-filled {
-            color: $color-positive;
+            color: var(--color-positive);
           }
         }
       }
     }
     label {
+      // TODO: semantic role TBD - rec text-muted
       color: darken(#d2d2d2, 30%);
       margin-left: 0;
       cursor: pointer;
@@ -79,7 +80,7 @@
         }
         &.bhi-checkbox-filled,
         &.bhi-radio-filled {
-          color: $color-positive;
+          color: var(--color-positive);
         }
       }
       span {

--- a/projects/novo-elements/src/elements/checkbox/Checkbox.scss
+++ b/projects/novo-elements/src/elements/checkbox/Checkbox.scss
@@ -21,7 +21,7 @@
           i {
             &.bhi-checkbox-empty,
             &.bhi-radio-empty {
-              color: $color-positive;
+              color: var(--color-positive);
             }
           }
         }
@@ -29,6 +29,7 @@
     }
     &.checked {
       label {
+        // TODO(theme): #d2d2d2 has no design token yet; register it, then migrate to darkenLive('--color-...', 60)
         color: darken(#d2d2d2, 60%);
         i {
           animation: iconEnter 160ms ease-in-out;
@@ -51,12 +52,13 @@
         i {
           &.bhi-checkbox-empty,
           &.bhi-checkbox-filled {
-            color: $color-positive;
+            color: var(--color-positive);
           }
         }
       }
     }
     label {
+      // TODO(theme): #d2d2d2 has no design token yet; register it, then migrate to darkenLive('--color-...', 30)
       color: darken(#d2d2d2, 30%);
       margin-left: 0;
       cursor: pointer;
@@ -82,7 +84,7 @@
         }
         &.bhi-checkbox-filled,
         &.bhi-radio-filled {
-          color: $color-positive;
+          color: var(--color-positive);
         }
       }
       span {

--- a/projects/novo-elements/src/elements/chips/Chip.scss
+++ b/projects/novo-elements/src/elements/chips/Chip.scss
@@ -175,15 +175,15 @@ $chip-spacing: (
   @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {
     &.novo-color-#{$name} {
       color: getContrastColor($name);
-      background: $color;
+      background: getCssVarname($name);
       & > * {
         color: inherit;
       }
     }
 
     &.novo-accent-#{$name} {
-      border: 1px solid $color;
-      color: $color;
+      border: 1px solid getCssVarname($name);
+      color: getCssVarname($name);
     }
   }
 }

--- a/projects/novo-elements/src/elements/chips/Chip.scss
+++ b/projects/novo-elements/src/elements/chips/Chip.scss
@@ -155,7 +155,7 @@ $chip-spacing: (
     $height: map-get($chip-height, $size);
     &.novo-size-#{$size} {
       font-size: map-get($chip-fontsize, $size);
-      border-radius: 0.4rem;
+      border-radius: var(--border-radius-round);
       padding: var(--spacing-none) $spacing;
       min-height: $height;
       gap: $spacing;

--- a/projects/novo-elements/src/elements/chips/Chip.scss
+++ b/projects/novo-elements/src/elements/chips/Chip.scss
@@ -29,11 +29,11 @@ $chip-height: (
   "xl": 3.6rem,
 );
 $chip-spacing: (
-  "xs": $spacing-xs,
-  "sm": $spacing-sm,
-  "md": $spacing-md,
-  "lg": $spacing-lg,
-  "xl": $spacing-xl,
+  "xs": var(--spacing-xs),
+  "sm": var(--spacing-sm),
+  "md": var(--spacing-md),
+  "lg": var(--spacing-lg),
+  "xl": var(--spacing-xl),
 );
 
 .novo-chip {
@@ -50,9 +50,9 @@ $chip-spacing: (
   display: inline-flex;
   align-items: center;
   cursor: default;
-  gap: 1rem;
-  border-radius: 0.4rem;
-  padding: $spacing-none $spacing-md;
+  gap: var(--spacing-md);
+  border-radius: var(--size-border-radius-round);
+  padding: var(--spacing-none) var(--spacing-md);
   min-height: 2.4rem;
   height: 1px;
   max-width: 100%;
@@ -76,7 +76,7 @@ $chip-spacing: (
 
     &:focus {
       outline: none;
-      border: 1px solid var(--selection);
+      border: var(--border-width-thin) solid var(--selection);
 
       &::after {
         opacity: 0.16;
@@ -84,7 +84,7 @@ $chip-spacing: (
     }
 
     &:hover {
-      border: 1px solid var(--selection);
+      border: var(--border-width-thin) solid var(--selection);
     }
   }
 
@@ -139,11 +139,13 @@ $chip-spacing: (
   }
 
   .novo-chip-remove {
-    color: $light;
+    // TODO: semantic role TBD - rec font-color-base
+    color: var(--color-light);
   }
   &:not(.novo-chip-disabled) {
     .novo-chip-remove:hover {
-      color: darken($light, 30%);
+      // TODO: semantic role TBD - rec disabled or a shade
+      color: darkenLive('--color-light', 30);
     }
   }
 
@@ -154,7 +156,7 @@ $chip-spacing: (
     &.novo-size-#{$size} {
       font-size: map-get($chip-fontsize, $size);
       border-radius: 0.4rem;
-      padding: $spacing-none $spacing;
+      padding: var(--spacing-none) $spacing;
       min-height: $height;
       gap: $spacing;
 

--- a/projects/novo-elements/src/elements/chips/Chips.scss
+++ b/projects/novo-elements/src/elements/chips/Chips.scss
@@ -43,7 +43,7 @@
   }
   .chip-input-container {
     flex: 1 15rem;
-    padding-left: 1rem;
+    padding-left: var(--spacing-md);
     input {
       padding-top: 0;
       border: none;
@@ -80,7 +80,7 @@
     bottom: 8px;
     right: 0;
     font-size: 1.1em;
-    color: $dark;
+    color: var(--font-color-base);
   }
 
   & + i {

--- a/projects/novo-elements/src/elements/chips/Chips.scss
+++ b/projects/novo-elements/src/elements/chips/Chips.scss
@@ -6,7 +6,7 @@
   align-items: center;
   flex-wrap: wrap;
   justify-content: flex-start;
-  border-bottom: 1px solid lighten($dark, 45%);
+  border-bottom: 1px solid brightenLive('--color-dark', 45);
   transition: all 200ms ease-in-out;
   position: relative;
   padding: 2px 0;
@@ -21,13 +21,14 @@
     margin-bottom: 20px;
   }
   &:hover {
-    border-bottom: 1px solid lighten($dark, 15%);
+    // TODO: semantic role TBD - rec border, same elsewhere in this file
+    border-bottom: 1px solid brightenLive('--color-dark', 15);
   }
   &.selected,
   &.selected:hover {
-    border-bottom: 1px solid $positive;
+    border-bottom: 1px solid var(--color-positive);
     & + i {
-      color: $positive;
+      color: var(--color-positive);
     }
   }
   &.disabled {
@@ -64,7 +65,7 @@
     right: 0;
     bottom: -20px;
     font-size: 0.9rem;
-    color: $negative;
+    color: var(--color-negative);
     cursor: pointer;
     display: flex;
     align-items: center;
@@ -122,10 +123,10 @@
           width: 100%;
         }
         &.active {
-          background-color: lighten($positive, 35%);
+          background-color: brightenLive('--color-positive', 35);
         }
         &:hover {
-          background-color: lighten($positive, 35%);
+          background-color: brightenLive('--color-positive', 35);
         }
         item-content {
           flex-flow: row wrap;

--- a/projects/novo-elements/src/elements/chips/RowChips.scss
+++ b/projects/novo-elements/src/elements/chips/RowChips.scss
@@ -24,7 +24,8 @@
       align-items: center;
       background: transparent !important;
       border: none;
-      border-bottom: 1px dashed lighten($dark, 30%);
+      // TODO: semantic role TBD - rec border-solid?
+      border-bottom: 1px dashed brightenLive('--color-dark', 30);
       border-radius: 0;
       outline: none;
       height: 2em;
@@ -62,7 +63,7 @@
       }
     }
     i.bhi-delete-o {
-      color: $negative;
+      color: var(--color-negative);
     }
   }
   .novo-chip.novo-row-chip {

--- a/projects/novo-elements/src/elements/chips/RowChips.scss
+++ b/projects/novo-elements/src/elements/chips/RowChips.scss
@@ -71,6 +71,7 @@
   }
   .novo-row-chips-empty-message {
     font-style: italic;
+    // TODO: semantic role TBD - rec font-secondary
     color: $grey;
   }
   i {

--- a/projects/novo-elements/src/elements/color-picker/color-picker.component.scss
+++ b/projects/novo-elements/src/elements/color-picker/color-picker.component.scss
@@ -9,7 +9,7 @@
   box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
   transform: translateY(0%);
   transition: all 0.15s cubic-bezier(0.35, 0, 0.25, 1);
-  border-radius: 0.4rem;
+  border-radius: var(--border-radius-round);
   width: 18rem;
 
   .novo-color-preview {

--- a/projects/novo-elements/src/elements/color-picker/color-swatch.component.ts
+++ b/projects/novo-elements/src/elements/color-picker/color-swatch.component.ts
@@ -20,7 +20,7 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output
     styles: [
         `
       .swatch {
-        border-radius: 0.4rem;
+        border-radius: var(--border-radius-round);
       }
     `,
     ],

--- a/projects/novo-elements/src/elements/common/option/optgroup.component.scss
+++ b/projects/novo-elements/src/elements/common/option/optgroup.component.scss
@@ -3,6 +3,7 @@
 
 .novo-optgroup-label {
   @include novo-label-text();
+  // TODO: semantic role TBD - rec font-secondary
   color: $grey;
   cursor: default;
   flex: 1;

--- a/projects/novo-elements/src/elements/common/option/option.component.scss
+++ b/projects/novo-elements/src/elements/common/option/option.component.scss
@@ -1,7 +1,8 @@
 @import "../../../styles/variables.scss";
 @import "../typography/text.mixins.scss";
-
-$novo-menu-side-padding: 0.5rem;
+:root {
+  --novo-menu-side-padding: var(--spacing-sm);
+}
 
 .novo-option {
   @include novo-body-text();
@@ -20,43 +21,43 @@ $novo-menu-side-padding: 0.5rem;
   -webkit-tap-highlight-color: transparent;
 
   &:hover:not(.novo-option-inert) {
-    background: var(--background-main, rgba($ocean, 0.1));
+    background: var(--background-main, rgb(from var(--color-positive) r g b / 0.1));
   }
 
   &:active:not(.novo-option-inert),
   &.novo-active:not(.novo-option-inert) {
-    background: rgba($ocean, 0.3);
+    background: rgb(from var(--color-positive) r g b / 0.3);
   }
 
   &.novo-selected, .add-icon {
-    color: $positive;
+    color: var(--color-positive);
   }
 
   &.disabled,
   &[aria-disabled="true"] {
     cursor: not-allowed;
-    color: $disabled;
+    color: var(--color-disabled);
     &:hover {
-      background: rgba($negative, 10%);
+      background: rgba(var(--color-negative), 10%);
     }
   }
 
   .novo-optgroup &:not(.novo-option-multiple) {
-    padding-left: $novo-menu-side-padding * 2;
+    padding-left: calc(var(--novo-menu-side-padding) * 2);
 
     [dir="rtl"] & {
-      padding-left: $novo-menu-side-padding;
-      padding-right: $novo-menu-side-padding * 2;
+      padding-left: var(--novo-menu-side-padding);
+      padding-right: calc(var(--novo-menu-side-padding) * 2);
     }
   }
 
   @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {
     &.novo-accent-#{$name} {
-      border-left: 4px solid $color;
+      border-left: 4px solid getCssVarname($name);
     }
     &.novo-fill-#{$name}:not(.novo-option-inert) {
       color: getContrastColor($name);
-      background: $color;
+      background-color: getCssVarname($name);
       &:hover,
       &:focus {
         background: getTintColor($name);
@@ -80,11 +81,5 @@ $novo-menu-side-padding: 0.5rem;
 }
 
 .novo-option-pseudo-checkbox {
-  $margin: calc($novo-menu-side-padding / 2);
-  margin-right: $margin;
-
-  [dir="rtl"] & {
-    margin-left: $margin;
-    margin-right: 0;
-  }
+  margin-inline-end: calc(var(--novo-menu-side-padding) / 2);
 }

--- a/projects/novo-elements/src/elements/common/selection/pseudo-checkbox/pseudo-checkbox.component.scss
+++ b/projects/novo-elements/src/elements/common/selection/pseudo-checkbox/pseudo-checkbox.component.scss
@@ -28,7 +28,7 @@ $_novo-pseudo-checkmark-size: $novo-checkbox-size - (2 * $_novo-pseudo-checkbox-
   }
 
   i {
-    font-size: 1.4rem;
+    font-size: var(--font-size-novo-default);
     line-height: 1rem;
   }
 }

--- a/projects/novo-elements/src/elements/common/selection/pseudo-checkbox/pseudo-checkbox.component.scss
+++ b/projects/novo-elements/src/elements/common/selection/pseudo-checkbox/pseudo-checkbox.component.scss
@@ -23,7 +23,7 @@ $_novo-pseudo-checkmark-size: $novo-checkbox-size - (2 * $_novo-pseudo-checkbox-
 
   &.novo-pseudo-checkbox-checked,
   &.novo-pseudo-checkbox-indeterminate {
-    color: $ocean;
+    color: var(--color-positive);
     animation: iconEnter 160ms ease-in-out;
   }
 

--- a/projects/novo-elements/src/elements/common/typography/text.mixins.scss
+++ b/projects/novo-elements/src/elements/common/typography/text.mixins.scss
@@ -120,7 +120,7 @@
 @mixin text-colors() {
   @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {
     &.text-color-#{$name} {
-      color: $color;
+      color: getCssVarname($name)
     }
   }
 }

--- a/projects/novo-elements/src/elements/common/typography/text.mixins.scss
+++ b/projects/novo-elements/src/elements/common/typography/text.mixins.scss
@@ -2,7 +2,7 @@
 
 @mixin text-disabled($property) {
   pointer-events: none;
-  color: $disabled;
+  color: var(--color-disabled);
 }
 
 @mixin base-text-rules() {
@@ -37,28 +37,28 @@
     font-size: inherit;
   }
   &.text-size-body {
-    font-size: $font-size-body;
+    font-size: var(--font-size-body);
   }
   &.text-size-xs {
-    font-size: $font-size-xs;
+    font-size: var(--font-size-xs);
   }
   &.text-size-sm {
-    font-size: $font-size-sm;
+    font-size: var(--font-size-sm);
   }
   &.text-size-md {
-    font-size: $font-size-md;
+    font-size: var(--font-size-md);
   }
   &.text-size-lg {
-    font-size: $font-size-lg;
+    font-size: var(--font-size-lg);
   }
   &.text-size-xl {
-    font-size: $font-size-xl;
+    font-size: var(--font-size-xl);
   }
   &.text-size-2xl {
-    font-size: $font-size-2xl;
+    font-size: var(--font-size-2xl);
   }
   &.text-size-3xl {
-    font-size: $font-size-3xl;
+    font-size: var(--font-size-3xl);
   }
   &.text-size-smaller {
     font-size: 0.8em;
@@ -71,31 +71,31 @@
 @mixin text-weights() {
   // Font Weight Utils
   &.text-weight-hairline {
-    font-weight: 100;
+    font-weight: var(--font-weight-hairline);
   }
   &.text-weight-thin {
-    font-weight: 200;
+    font-weight: var(--font-weight-thin);
   }
   &.text-weight-light {
-    font-weight: 300;
+    font-weight: var(--font-weight-light);
   }
   &.text-weight-normal {
-    font-weight: 400;
+    font-weight: var(--font-weight-normal);
   }
   &.text-weight-medium {
-    font-weight: 500;
+    font-weight: var(--font-weight-medium);
   }
   &.text-weight-semibold {
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
   }
   &.text-weight-bold {
-    font-weight: 700;
+    font-weight: var(--font-weight-bold);
   }
   &.text-weight-extrabold {
-    font-weight: 800;
+    font-weight: var(--font-weight-extrabold);
   }
   &.text-weight-heavy {
-    font-weight: 900;
+    font-weight: var(--font-weight-heavy);
   }
   &.text-weight-lighter {
     font-weight: lighter;

--- a/projects/novo-elements/src/elements/data-table/data-table.component.scss
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.scss
@@ -238,6 +238,7 @@ cdk-table {
     cursor: pointer;
     font-size: 1.2em;
     padding: 0.5em;
+    // TODO: semantic role TBD - could be border-radius or border-radius-small
     border-radius: 3px;
     &.disabled {
       pointer-events: none;

--- a/projects/novo-elements/src/elements/data-table/data-table.component.scss
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.scss
@@ -1,7 +1,7 @@
 @import "../../styles/variables.scss";
 @import "../../styles/reset";
 
-$table-bg-accent: var(--background-bright, $off-white);
+$table-bg-accent: var(--background-bright, $color-off-white);
 $novo-row-horizontal-padding: 20px;
 $table-header-font-weight: 400;
 $breakpoint: 1000px;
@@ -31,10 +31,10 @@ cdk-table {
       .novo-data-table-dropdown-cell,
       .novo-data-table-expand-cell,
       .novo-data-table-checkbox-cell {
-        background-color: rgba($ocean, 0.15);
+        background-color: rgb(from var(--color-positive) r g b / 0.15);
       }
       + .novo-data-table-detail-row {
-        background-color: rgba($ocean, 0.15);
+        background-color: rgb(from var(--color-positive) r g b / 0.15);
       }
     }
     + .novo-data-table-detail-row {
@@ -55,10 +55,10 @@ cdk-table {
       .novo-data-table-dropdown-cell,
       .novo-data-table-expand-cell,
       .novo-data-table-checkbox-cell {
-        background-color: rgba($ocean, 0.15);
+        background-color: rgb(from var(--color-positive) r g b / 0.15);
       }
       + .novo-data-table-detail-row {
-        background-color: rgba($ocean, 0.15);
+        background-color: rgb(from var(--color-positive) r g b / 0.15);
       }
     }
     + .novo-data-table-detail-row {
@@ -111,14 +111,14 @@ cdk-table {
   &.resizable {
     padding-right: 0;
     &:hover {
-      background-color: var(--background-muted, $neutral);
+      background-color: var(--background-muted, --color-neutral);
     }
     .data-table-header-resizable {
       height: 100%;
 
       span {
         cursor: ew-resize;
-        background-color: var(--border, $neutral);
+        background-color: var(--border, --color-neutral);
         width: 1px;
         margin: 0 4px;
         display: block;
@@ -182,17 +182,17 @@ cdk-table {
 
   button.active {
     color: $white;
-    background: $positive;
+    background: var(--color-positive);
     &:hover,
     &:active,
     &:focus,
     &:visited {
-      background: $positive !important;
+      background: var(--color-positive) !important;
     }
   }
   &.clickable {
     cursor: pointer;
-    color: $company;
+    color: var(--color-company);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -333,7 +333,7 @@ cdk-table {
       }
       &.bhi-box-yes,
       &.bhi-checkbox-filled {
-        color: $positive;
+        color: var(--color-positive);
       }
     }
   }
@@ -358,7 +358,7 @@ novo-data-table {
     display: flex;
     align-items: center;
     flex-shrink: 0;
-    border-bottom: 1px solid var(--border, $off-white);
+    border-bottom: 1px solid var(--border, $color-off-white);
     &.pagination-footer {
       justify-content: space-between;
     }
@@ -465,7 +465,7 @@ novo-data-table {
     display: flex;
     flex: 1;
     .novo-data-table-custom-filter {
-      border-right: 1px solid var(--border, $off-white);
+      border-right: 1px solid var(--border, $color-off-white);
       novo-date-picker {
         .calendar {
           box-shadow: none;
@@ -515,7 +515,7 @@ novo-data-table {
     align-items: center;
     > div,
     div.novo-data-table-footer-cell {
-      border-top: 1px solid var(--border, $off-white);
+      border-top: 1px solid var(--border, $color-off-white);
       flex: 1;
       min-width: 200px;
       display: flex;
@@ -553,7 +553,7 @@ novo-data-table {
     overflow-x: hidden;
   }
   .footer {
-    border-top: 1px solid var(--border, $off-white);
+    border-top: 1px solid var(--border, $color-off-white);
     padding: 5px 10px;
     display: flex;
     justify-content: flex-end;
@@ -581,10 +581,10 @@ novo-data-table {
     height: 100%;
     min-height: 200px;
     width: 100%;
-    background: #fff;
+    background: var(--background-bright);
     padding: 0 !important;
     .back-link {
-      color: $positive;
+      color: var(--color-positive);
       line-height: 3em;
       font-size: 0.9em;
       padding-left: 5px;
@@ -603,16 +603,17 @@ novo-data-table {
     }
   }
   span.error-text {
-    color: $negative;
+    color: var(--color-negative);
     position: relative;
     left: 10px;
     top: -17px;
     font-size: x-small;
   }
   .filter-null-results {
-    background-color: $white;
+    background-color: var(--background-body);
     text-align: center;
-    color: darken($light, 15%);
+    // TODO: semantic role TBD - rec color-disabled
+    color: darkenLive('--color-light', 15);
     background: transparent;
     font-weight: 500;
   }

--- a/projects/novo-elements/src/elements/data-table/data-table.component.scss
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.scss
@@ -169,7 +169,7 @@ cdk-table {
     color: var(--text-muted);
     background: transparent;
     pointer-events: all;
-    margin-left: 0.5rem;
+    margin-left: var(--spacing-sm);
     line-height: 1em;
     outline: none;
     &:hover {
@@ -181,7 +181,7 @@ cdk-table {
   }
 
   button.active {
-    color: $white;
+    color: var(--color-contrast-positive);
     background: var(--color-positive);
     &:hover,
     &:active,
@@ -459,6 +459,7 @@ novo-data-table {
     display: flex;
     align-items: center;
     justify-content: center;
+    // TODO: semantic role TBD - rec font-secondary
     color: $grey;
     z-index: 5;
   }

--- a/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.scss
+++ b/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.scss
@@ -108,21 +108,22 @@ $breakpoint: 1000px;
         border-radius: 2px;
         list-style-type: none;
         cursor: pointer;
-        color: $company;
+        color: var(--color-company);
         &.disabled {
           opacity: 0.3;
           pointer-events: none;
         }
       }
       .page.active {
-        color: $company;
+        color: var(--color-company);
         background-color: rgba($black, 0.1);
         opacity: 1;
       }
     }
     .novo-data-table-of-total-amount {
-      color: $slate;
-      font-size: 12px;
+      // TODO: semantic role TBD - rec color-disabled
+      color: var(--color-slate);
+      font-size: var(--font-size-sm);
     }
   }
 }

--- a/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.scss
+++ b/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.scss
@@ -67,7 +67,7 @@ $breakpoint: 1000px;
     }
     h5.rows {
       padding: 0;
-      font-size: 12px;
+      font-size: var(--font-size-sm);
       opacity: 0.75;
       letter-spacing: 0.1px;
     }

--- a/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.scss
+++ b/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.scss
@@ -105,6 +105,7 @@ $breakpoint: 1000px;
         width: 2.4rem;
         height: 2.4rem;
         font-size: var(--font-size-text);
+        // TODO: semantic role TBD - could be border-radius or border-radius-small
         border-radius: 2px;
         list-style-type: none;
         cursor: pointer;

--- a/projects/novo-elements/src/elements/date-picker/DatePicker.scss
+++ b/projects/novo-elements/src/elements/date-picker/DatePicker.scss
@@ -18,8 +18,8 @@
     .month-view + .month-view {
       border-collapse: unset;
       border-left: 1px solid var(--border);
-      margin-left: 0.5rem;
-      padding-left: 0.5rem;
+      margin-left: var(--spacing-sm);
+      padding-left: var(--spacing-sm);
     }
 
     .calendar-top {

--- a/projects/novo-elements/src/elements/date-picker/DatePicker.scss
+++ b/projects/novo-elements/src/elements/date-picker/DatePicker.scss
@@ -15,7 +15,7 @@
 
     .month-view + .month-view {
       border-collapse: unset;
-      border-left: 1px solid $light;
+      border-left: 1px solid var(--border);
       margin-left: 0.5rem;
       padding-left: 0.5rem;
     }
@@ -23,15 +23,15 @@
     .calendar-top {
       display: flex;
       flex-flow: column;
-      background: $positive;
-      color: #fff;
+      background: var(--color-positive);
+      color: var(--color-contrast-positive);
       font-size: 14px;
       border-top-right-radius: 4px;
       border-top-left-radius: 4px;
       h1 {
         font-weight: 600;
         font-size: 4.2em;
-        color: #fff;
+        color: var(--color-contrast-positive);
         margin: 0;
         padding: 0;
       }
@@ -55,7 +55,7 @@
       }
     }
     .date-range-tabs {
-      border-bottom: 1px solid $off-white;
+      border-bottom: 1px solid var(--border-2);
       display: flex;
       align-items: center;
       justify-content: space-between;
@@ -64,6 +64,7 @@
       &.week-select-mode {
         & > span {
           cursor: default;
+          // TODO: Do we need this color var? Should be text-main
           color: $font-color-base;
           pointer-events: none;
           opacity: 1 !important;
@@ -73,7 +74,7 @@
         }
       }
       & > span {
-        color: $positive;
+        color: var(--color-positive);
         text-align: center;
         flex: 1;
         cursor: pointer;
@@ -90,7 +91,7 @@
         height: 2px;
         bottom: 0;
         left: 0;
-        background: $positive;
+        background: var(--color-positive);
         transition: transform 200ms ease-in-out;
       }
     }
@@ -103,7 +104,7 @@
       -webkit-user-select: none;
       justify-content: space-between;
       cursor: default;
-      border-bottom: 1px solid $off-white;
+      border-bottom: 1px solid var(--border-2);
       .previous {
         width: 30px;
         height: 15px;
@@ -120,7 +121,7 @@
           width: 0;
         }
         &:hover:after {
-          border-right: 4px solid $positive;
+          border-right: 4px solid var(--color-positive);
           cursor: pointer;
         }
       }
@@ -128,13 +129,13 @@
         flex: 1;
         display: inline-block;
         vertical-align: middle;
-        color: $positive;
+        color: var(--color-positive);
         font-weight: 600;
         .month {
           border-radius: 2px;
           padding: 3px 8px;
           &:hover {
-            background: $positive;
+            background: var(--color-positive);
             color: #fff;
             cursor: pointer;
           }
@@ -143,7 +144,7 @@
           border-radius: 2px;
           padding: 3px 8px;
           &:hover {
-            background: $positive;
+            background: var(--color-positive);
             color: #fff;
             cursor: pointer;
           }
@@ -166,7 +167,7 @@
         }
         &:hover:before {
           opacity: 1;
-          border-left: 4px solid $positive;
+          border-left: 4px solid var(--color-positive);
           cursor: pointer;
         }
       }

--- a/projects/novo-elements/src/elements/date-picker/DatePicker.scss
+++ b/projects/novo-elements/src/elements/date-picker/DatePicker.scss
@@ -3,6 +3,8 @@
 :host {
   display: block;
   .date-picker-container {
+    // TODO: semantic role TBD
+    // TODO: semantic role TBD - could be border-radius or border-radius-small
     border-radius: 4px;
     width: min-content;
     text-align: center;
@@ -132,6 +134,7 @@
         color: var(--color-positive);
         font-weight: 600;
         .month {
+          // TODO: semantic role TBD - could be border-radius or border-radius-small
           border-radius: 2px;
           padding: 3px 8px;
           &:hover {
@@ -141,6 +144,7 @@
           }
         }
         .year {
+          // TODO: semantic role TBD - could be border-radius or border-radius-small
           border-radius: 2px;
           padding: 3px 8px;
           &:hover {

--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.scss
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.scss
@@ -24,11 +24,11 @@
     transition: all 300ms;
     color: $dark;
     &:focus {
-      border-bottom: 1px solid $ocean;
+      border-bottom: 1px solid var(--color-positive);
     }
   }
   span.error-text {
-    color: $negative;
+    color: var(--color-negative);
     padding-top: 10px;
     flex: 1;
     display: flex;

--- a/projects/novo-elements/src/elements/date-picker/DatePickerInput.scss
+++ b/projects/novo-elements/src/elements/date-picker/DatePickerInput.scss
@@ -11,7 +11,7 @@
   input {
     font-size: 1em;
     border: none;
-    border-bottom: 1px solid $light;
+    border-bottom: 1px solid var(--color-border);
     background: transparent !important;
     border-radius: 0;
     outline: none;
@@ -22,7 +22,7 @@
     box-shadow: none;
     box-sizing: content-box;
     transition: all 300ms;
-    color: $dark;
+    color: var(--font-color-base);
     &:focus {
       border-bottom: 1px solid var(--color-positive);
     }
@@ -40,7 +40,7 @@
     position: absolute;
     right: 0;
     top: 0px;
-    font-size: 1.2rem;
+    font-size: var(--font-size-sm);
     cursor: pointer;
   }
 }

--- a/projects/novo-elements/src/elements/date-picker/DateRangeInput.scss
+++ b/projects/novo-elements/src/elements/date-picker/DateRangeInput.scss
@@ -38,7 +38,7 @@
     transition: all 300ms;
     color: var(--text-main);
     &:focus {
-      border-bottom: 1px solid $ocean;
+      border-bottom: 1px solid var(--color-positive);
     }
   }
   novo-icon {

--- a/projects/novo-elements/src/elements/date-picker/MultiDateInput.scss
+++ b/projects/novo-elements/src/elements/date-picker/MultiDateInput.scss
@@ -14,6 +14,7 @@
       margin: 0px;
     }
     &.selected {
+      // TODO: semantic role TBD - rec background-main
       background: $light;
       border-radius: 50%;
     }

--- a/projects/novo-elements/src/elements/date-picker/MultiDateInput.scss
+++ b/projects/novo-elements/src/elements/date-picker/MultiDateInput.scss
@@ -22,6 +22,7 @@
   ul.summary {
     display: inline;
     list-style: none;
+    // TODO: semantic role TBD - rec font-color-secondary
     color: darken(#d2d2d2, 30%);
     padding: 0 10px 0;
 

--- a/projects/novo-elements/src/elements/date-time-picker/_DateTimePicker.scss
+++ b/projects/novo-elements/src/elements/date-time-picker/_DateTimePicker.scss
@@ -6,6 +6,7 @@ $time-select-height: 45px;
   display: block;
   width: min-content;
   overflow: hidden;
+  // TODO: semantic role TBD - could be border-radius or border-radius-small
   border-radius: 4px;
   background-color: var(--background-bright);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15), 0 2px 7px rgba(0, 0, 0, 0.1);

--- a/projects/novo-elements/src/elements/date-time-picker/_DateTimePicker.scss
+++ b/projects/novo-elements/src/elements/date-time-picker/_DateTimePicker.scss
@@ -7,7 +7,7 @@ $time-select-height: 45px;
   width: min-content;
   overflow: hidden;
   border-radius: 4px;
-  background-color: #fff;
+  background-color: var(--background-bright);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15), 0 2px 7px rgba(0, 0, 0, 0.1);
   z-index: z(max);
   .date-time-container {
@@ -19,7 +19,7 @@ $time-select-height: 45px;
       position: absolute;
       height: 100%;
       width: 100%;
-      background: #fff;
+      background: var(--background-bright);
       transform: translateX(100%);
       transition: transform 200ms ease-in-out;
       z-index: z(above);
@@ -43,7 +43,7 @@ $time-select-height: 45px;
       position: relative;
       height: 45px;
       & > span {
-        color: $positive;
+        color: var(--color-positive);
         text-align: center;
         flex: 1;
         cursor: pointer;
@@ -62,7 +62,7 @@ $time-select-height: 45px;
         height: 2px;
         bottom: 0;
         left: 0;
-        background: $positive;
+        background: var(--color-positive);
         transition: transform 200ms ease-in-out;
       }
     }

--- a/projects/novo-elements/src/elements/divider/divider.component.scss
+++ b/projects/novo-elements/src/elements/divider/divider.component.scss
@@ -6,7 +6,7 @@ $novo-divider-inset-margin: 80px;
 .novo-divider {
   display: block;
   margin: 0;
-  border-top-width: $novo-divider-width;
+  border-top-width: var(--border-width-thin);
   border-top-style: solid;
   border-top-color: var(--border);
 
@@ -16,8 +16,8 @@ $novo-divider-inset-margin: 80px;
     border-right-width: $novo-divider-width;
     border-right-style: solid;
     border-right-color: var(--border);
-    margin-left: $spacing-md;
-    margin-right: $spacing-md;
+    margin-left: var(--spacing-md);
+    margin-right: var(--spacing-md);
   }
 
   &.novo-divider-inset {

--- a/projects/novo-elements/src/elements/dropdown/Dropdown.scss
+++ b/projects/novo-elements/src/elements/dropdown/Dropdown.scss
@@ -27,9 +27,9 @@
   margin: 0;
   padding: 0;
   min-width: 180px;
-  margin-top: $spacing-sm;
-  margin-bottom: $spacing-sm;
-  box-shadow: $shadow-3;
+  margin-top: var(--spacing-sm);
+  margin-bottom: var(--spacing-sm);
+  box-shadow: var(--shadow-3);
   &.has-height {
     overflow: auto;
   }
@@ -40,7 +40,7 @@
       flex: 1;
       font-weight: 500;
       text-transform: uppercase;
-      padding: $spacing-sm $spacing-md;
+      padding: var(--spacing-sm) var(--spacing-md);
       display: block;
     }
     hr {

--- a/projects/novo-elements/src/elements/dropdown/Dropdown.scss
+++ b/projects/novo-elements/src/elements/dropdown/Dropdown.scss
@@ -46,6 +46,7 @@
     hr {
       border: none;
       height: 1px;
+      // TODO: semantic role TBD - rec background-main
       background: $light;
     }
   }

--- a/projects/novo-elements/src/elements/expansion/_expansion-theme.scss
+++ b/projects/novo-elements/src/elements/expansion/_expansion-theme.scss
@@ -31,6 +31,7 @@
   }
 
   .novo-expansion-panel-header[aria-disabled="true"] {
+    // TODO: semantic role TBD - rec color-shade-disabled
     color: $grey;
     pointer-events: none;
 

--- a/projects/novo-elements/src/elements/expansion/_expansion-theme.scss
+++ b/projects/novo-elements/src/elements/expansion/_expansion-theme.scss
@@ -44,7 +44,7 @@
   .novo-expansion-panel.novo-expanded {
     @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {
       &[theme="#{$name}"] {
-        border-top: 3px solid $color;
+        border-top: 3px solid getCssVarname($name);
       }
     }
   }

--- a/projects/novo-elements/src/elements/field/error/error.scss
+++ b/projects/novo-elements/src/elements/field/error/error.scss
@@ -5,5 +5,5 @@
   padding-bottom: 5px;
   flex: 1;
   font-size: 0.8em;
-  color: $negative;
+  color: var(--color-negative);
 }

--- a/projects/novo-elements/src/elements/field/field-fill.scss
+++ b/projects/novo-elements/src/elements/field/field-fill.scss
@@ -45,6 +45,7 @@
       }
       &.novo-field-disabled {
         .novo-field-input {
+          // TODO: semantic role TBD - rec color-shade-disabled
           color: $grey !important;
           // TODO: // TODO: semantic role TBD - rec define a new border color
           border-bottom: 1px dashed $grey !important;

--- a/projects/novo-elements/src/elements/field/field-fill.scss
+++ b/projects/novo-elements/src/elements/field/field-fill.scss
@@ -23,7 +23,7 @@
 
     &.novo-field-appearance-underlined {
       .novo-field-input {
-        border-bottom: 1px solid lighten($dark, 45%) !important;
+        border-bottom: 1px solid brightenLive('--border-hard', 45) !important;
       }
       &:not(.novo-focused):hover {
         .novo-field-input {
@@ -32,20 +32,21 @@
       }
       &.novo-focused {
         .novo-field-label {
-          color: $positive !important;
+          color: var(--color-positive) !important;
         }
         .novo-field-input {
-          border-bottom: 1px solid $positive !important;
+          border-bottom: 1px solid var(--color-positive) !important;
         }
       }
       &.novo-field-invalid {
         .novo-field-input {
-          border-bottom: 1px solid $negative !important;
+          border-bottom: 1px solid var(--color-negative) !important;
         }
       }
       &.novo-field-disabled {
         .novo-field-input {
           color: $grey !important;
+          // TODO: // TODO: semantic role TBD - rec define a new border color
           border-bottom: 1px dashed $grey !important;
         }
         &:not(.novo-focused):hover {

--- a/projects/novo-elements/src/elements/field/field-list.scss
+++ b/projects/novo-elements/src/elements/field/field-list.scss
@@ -4,7 +4,7 @@
 :host {
   &.novo-field-appearance-list {
     &.novo-field-layout-horizontal {
-      border-bottom: 1px solid $off-white !important;
+      border-bottom: 1px solid var(--border-2) !important;
       padding: 0.5rem 1.2rem;
       min-height: 4.2rem;
 
@@ -20,17 +20,17 @@
       &.novo-field-appearance-underlined {
         &:not(.novo-focused):hover {
           .novo-field-input {
-            background: rgba($positive, 0.15);
+            background: rgb(from var(--color-positive) r g b / 0.15);
           }
         }
         &.novo-focused {
           .novo-field-label {
-            color: $positive !important;
+            color: var(--color-positive) !important;
           }
         }
         &.novo-field-invalid {
           .novo-field-label {
-            color: $negative !important;
+            color: var(--color-negative) !important;
           }
         }
       }

--- a/projects/novo-elements/src/elements/field/field-outline.scss
+++ b/projects/novo-elements/src/elements/field/field-outline.scss
@@ -3,7 +3,7 @@
 
 :host {
   &.novo-field-appearance-outline {
-    border: 1px solid lighten($dark, 45%) !important;
+    border: 1px solid brightenLive('--color-dark', 45) !important;
     border-radius: 0.4rem;
     padding: 0.5rem;
 
@@ -21,10 +21,10 @@
       border: 1px solid $dark !important;
     }
     &.novo-focused {
-      border: 1px solid $positive !important;
+      border: 1px solid var(--color-positive) !important;
     }
     &.novo-field-invalid {
-      border: 1px solid $negative !important;
+      border: 1px solid var(--color-negative) !important;
     }
   }
 }

--- a/projects/novo-elements/src/elements/field/field-outline.scss
+++ b/projects/novo-elements/src/elements/field/field-outline.scss
@@ -10,8 +10,8 @@
     &.novo-field-layout-vertical {
       .novo-field-label {
         background: white;
-        margin-top: -1.5rem;
-        margin-left: 0.5rem;
+        margin-top: calc(-1 * var(--spacing-xl));
+        margin-left: var(--spacing-sm);
         width: max-content;
         padding: 0.5rem;
       }

--- a/projects/novo-elements/src/elements/field/field-outline.scss
+++ b/projects/novo-elements/src/elements/field/field-outline.scss
@@ -4,7 +4,7 @@
 :host {
   &.novo-field-appearance-outline {
     border: 1px solid brightenLive('--color-dark', 45) !important;
-    border-radius: 0.4rem;
+    border-radius: var(--border-radius-round);
     padding: 0.5rem;
 
     &.novo-field-layout-vertical {

--- a/projects/novo-elements/src/elements/field/field-standard.scss
+++ b/projects/novo-elements/src/elements/field/field-standard.scss
@@ -5,7 +5,7 @@
   &.novo-field-appearance-standard {
     &.novo-field-appearance-underlined {
       .novo-field-input {
-        border-bottom: 1px solid lighten($dark, 45%) !important;
+        border-bottom: 1px solid brightenLive('--color-dark', 45) !important;
       }
       &:not(.novo-focused):hover {
         .novo-field-input {
@@ -14,12 +14,12 @@
       }
       &.novo-focused {
         .novo-field-input {
-          border-bottom: 1px solid $positive !important;
+          border-bottom: 1px solid var(--color-positive) !important;
         }
       }
       &.novo-field-invalid {
         .novo-field-input {
-          border-bottom: 1px solid $negative !important;
+          border-bottom: 1px solid var(--color-negative) !important;
         }
       }
       &.novo-field-disabled {

--- a/projects/novo-elements/src/elements/field/field.scss
+++ b/projects/novo-elements/src/elements/field/field.scss
@@ -39,7 +39,7 @@
 
   &.ng-invalid.ng-dirty.ng-touched {
     .novo-field-input {
-      border-bottom: 1px solid $negative !important;
+      border-bottom: 1px solid var(--color-negative) !important;
     }
   }
 

--- a/projects/novo-elements/src/elements/form/ControlGroup.scss
+++ b/projects/novo-elements/src/elements/form/ControlGroup.scss
@@ -100,7 +100,7 @@ novo-control-group {
       .novo-control-group-row {
         display: flex;
         align-items: center;
-        border-bottom: 1px solid lighten($dark, 45%);
+        border-bottom: 1px solid brightenLive('--color-dark', 45);
         padding: 0.4em;
         &:last-of-type {
           border-bottom: none;
@@ -170,7 +170,7 @@ novo-control-group {
         min-width: 3rem;
         margin-left: 1rem;
         i.bhi-delete-o {
-          color: $negative;
+          color: var(--color-negative);
           font-size: 1.2em;
         }
       }

--- a/projects/novo-elements/src/elements/form/ControlGroup.scss
+++ b/projects/novo-elements/src/elements/form/ControlGroup.scss
@@ -6,7 +6,7 @@ novo-control-group {
   background: var(--background-bright, $color-white);
 
   &.novo-control-group-appearance-card {
-    border-radius: 0.4rem;
+    border-radius: var(--border-radius-round);
     box-shadow: rgba(0, 0, 0, 0.09) 0px 1px 7px 0px, rgba(0, 0, 0, 0.2) 0px 1px 3px 0px;
   }
 
@@ -20,7 +20,7 @@ novo-control-group {
     align-items: center;
     justify-content: space-between;
     font-weight: 600;
-    border-radius: 0.4rem 0.4rem 0 0;
+    border-radius: var(--border-radius-round) 0.4rem 0 0;
 
     button {
       padding: 3px 15px;

--- a/projects/novo-elements/src/elements/form/ControlGroup.scss
+++ b/projects/novo-elements/src/elements/form/ControlGroup.scss
@@ -30,7 +30,7 @@ novo-control-group {
       align-items: center;
     }
     label.novo-control-group-description {
-      font-size: 1rem;
+      font-size: var(--font-size-xs);
       font-weight: 500;
       padding-right: 10px;
     }
@@ -118,7 +118,7 @@ novo-control-group {
         flex: 1;
         > span {
           color: var(--text-muted);
-          font-size: 1rem;
+          font-size: var(--font-size-xs);
           font-weight: 500;
           text-transform: uppercase;
           overflow: hidden;
@@ -168,7 +168,7 @@ novo-control-group {
         width: 3rem;
         min-height: 3rem;
         min-width: 3rem;
-        margin-left: 1rem;
+        margin-left: var(--spacing-md);
         i.bhi-delete-o {
           color: var(--color-negative);
           font-size: 1.2em;

--- a/projects/novo-elements/src/elements/form/Form.scss
+++ b/projects/novo-elements/src/elements/form/Form.scss
@@ -36,7 +36,7 @@ novo-dynamic-form {
           height: auto;
           opacity: 1;
           input.ng-touched.ng-invalid:not(.ng-pristine):not(.novo-control-container) {
-            border-bottom: 1px solid $negative !important;
+            border-bottom: 1px solid var(--color-negative) !important;
             &.valid-number {
               border-bottom: none !important;
             }
@@ -47,7 +47,7 @@ novo-dynamic-form {
           novo-picker.ng-touched.ng-invalid:not(.ng-pristine) input,
           textarea.ng-touched.ng-invalid:not(.ng-pristine):not(.ng-valid),
           chips.ng-touched.ng-invalid:not(.ng-pristine) {
-            border-bottom: 1px solid $negative !important;
+            border-bottom: 1px solid var(--color-negative) !important;
           }
           &.checklist,
           &.file,
@@ -65,14 +65,14 @@ novo-dynamic-form {
             .ng-touched.ng-invalid:not(.ng-pristine):not(.novo-control-container) {
               border-bottom: none !important;
               > input {
-                border-bottom: 1px solid $negative !important;
+                border-bottom: 1px solid var(--color-negative) !important;
               }
             }
           }
           novo-date-time-picker-input.ng-touched.ng-invalid:not(.ng-pristine):not(.novo-control-container) {
             border-bottom: none !important;
             input {
-              border-bottom: 1px solid $negative !important;
+              border-bottom: 1px solid var(--color-negative) !important;
             }
           }
           &.hidden {
@@ -90,7 +90,8 @@ novo-dynamic-form {
             }
             input:not(.picker-input):not(.tiles-input) {
               &::placeholder {
-                color: lighten($dark, 30%) !important;
+                // TODO: semantic role TBD - rec text-disabled or text-muted
+                color: brightenLive('--color-dark', 30) !important;
               }
               border-bottom-style: dashed !important;
             }
@@ -105,7 +106,7 @@ novo-dynamic-form {
               border-bottom-style: dashed !important;
               i.bhi-collapse {
                 top: auto;
-                color: lighten($dark, 30%) !important;
+                color: brightenLive('--color-dark', 30) !important;
               }
             }
             label {
@@ -114,7 +115,7 @@ novo-dynamic-form {
               }
             }
             chips {
-              border-bottom: 1px dashed lighten($dark, 30%) !important;
+              border-bottom: 1px dashed brightenLive('--color-dark', 30) !important;
               input {
                 border: none !important;
               }
@@ -178,7 +179,7 @@ novo-dynamic-form {
               font-size: 12px;
               color: $grey;
               &.error {
-                color: $negative;
+                color: var(--color-negative);
               }
             }
             .record-count {
@@ -195,7 +196,7 @@ novo-dynamic-form {
             .messages {
               flex: 1;
               span.error-text {
-                color: $negative;
+                color: var(--color-negative);
                 padding-bottom: 5px;
                 padding-right: 5px;
                 flex: 1;
@@ -208,12 +209,12 @@ novo-dynamic-form {
                 flex: 1;
               }
               .warning-text {
-                color: $warning;
+                color: var(--color-warning);
               }
             }
           }
           .error-message {
-            color: $negative;
+            color: var(--color-negative);
             font-size: var(--font-size-caption);
             padding: 5px 0;
             flex-basis: 100%;
@@ -231,7 +232,7 @@ novo-dynamic-form {
               font-size: 12px;
               color: $grey;
               &.error {
-                color: $negative;
+                color: var(--color-negative);
               }
             }
             span.error-text {
@@ -275,7 +276,7 @@ novo-dynamic-form {
                   max-width: 15px;
                   max-height: 15px;
                   .spinner {
-                    fill: $positive;
+                    fill: var(--color-positive);
                   }
                 }
               }
@@ -322,7 +323,7 @@ novo-dynamic-form {
                     input {
                       background: transparent !important;
                       border: none;
-                      border-bottom: 1px solid lighten($dark, 45%);
+                      border-bottom: 1px solid brightenLive('--color-dark', 45);
                       border-radius: 0;
                       outline: none;
                       height: 2rem;
@@ -334,29 +335,29 @@ novo-dynamic-form {
                       transition: all 300ms;
                       color: var(--text-main);
                       &:hover {
-                        border-bottom: 1px solid lighten($dark, 15%);
+                        border-bottom: 1px solid brightenLive('--color-dark', 15);
                       }
                       &:focus {
-                        border-bottom: 1px solid $positive;
+                        border-bottom: 1px solid var(--color-positive);
                       }
                       &:invalid {
                         border-bottom: 1px solid #da4453;
                       }
                       &.maxlength-error {
-                        border-bottom: 1px solid $negative !important;
+                        border-bottom: 1px solid var(--color-negative) !important;
                       }
                     }
                     &.highlighted {
                       input,
                       novo-select {
-                        background-color: lighten($ocean, 35%) !important;
+                        background-color: brightenLive('--color-ocean', 35) !important;
                       }
                     }
                     textarea {
                       height: 2rem;
                       background: transparent !important;
                       border: none;
-                      border-bottom: 1px solid lighten($dark, 45%);
+                      border-bottom: 1px solid brightenLive('--color-dark', 45);
                       border-radius: 0;
                       outline: none;
                       width: 100%;
@@ -370,17 +371,17 @@ novo-dynamic-form {
                       color: var(--text-main);
                       overflow-y: hidden;
                       &:hover {
-                        border-bottom: 1px solid lighten($dark, 15%);
+                        border-bottom: 1px solid brightenLive('--color-dark', 15);
                       }
                       &:focus {
-                        border-bottom: 1px solid $positive;
+                        border-bottom: 1px solid var(--color-positive);
                         overflow-y: auto !important;
                       }
                       &:invalid {
                         border-bottom: 1px solid #da4453;
                       }
                       &.maxlength-error {
-                        border-bottom: 1px solid $negative;
+                        border-bottom: 1px solid var(--color-negative);
                       }
                     }
                     textarea[autosize] {
@@ -439,7 +440,7 @@ novo-dynamic-form {
                         left: 0;
                         display: flex;
                         flex-direction: column;
-                        background: #fff;
+                        background: var(--background-bright);
                         z-index: z(above);
                         box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
                         border-bottom-right-radius: 3px;
@@ -489,12 +490,12 @@ novo-dynamic-form {
                     font-size: 13px;
                     margin-right: 10px;
                     &.bhi-circle {
-                      color: $grapefruit;
+                      color: var(--color-error);
                       text-align: center;
                       font-size: 7px;
                     }
                     &.bhi-check {
-                      color: $grass;
+                      color: var(--color-success);
                     }
                     &.address {
                       display: none;
@@ -515,6 +516,7 @@ novo-dynamic-form {
       }
     }
   }
+  // TODO: Better support for dark theming may mean simply changing CSS vars, rather than overrides of this fashion.
   &[dark] {
     .novo-form-container {
       form {
@@ -539,20 +541,20 @@ novo-dynamic-form {
             time-input {
               input,
               textarea {
-                color: $light;
-                border-bottom: 1px solid rgba(lighten($dark, 12%), 0.25);
+                color: var(--font-color-secondary);
+                border-bottom: 1px solid color-mix(in srgb, brightenLive('--color-dark', 12) 25%, transparent);
                 background: transparent !important;
                 &:focus {
-                  border-bottom: 1px solid $ocean;
+                  border-bottom: 1px solid var(--color-positive);
                 }
               }
             }
             novo-select {
               > div[type="button"] {
-                color: $light;
-                border-bottom: 1px solid rgba(lighten($dark, 12%), 0.25);
+                color: var(--font-color-secondary);
+                border-bottom: 1px solid color-mix(in srgb, brightenLive('--color-dark', 12) 25%, transparent);
                 &:focus {
-                  border-bottom: 1px solid $ocean;
+                  border-bottom: 1px solid var(--color-positive);
                 }
               }
             }
@@ -597,7 +599,7 @@ novo-dynamic-form {
             &.disabled {
               input:not(.picker-input):not(.tiles-input) {
                 &::placeholder {
-                  color: lighten($dark, 30%) !important;
+                  color: brightenLive('--color-dark', 30) !important;
                 }
                 border-bottom-style: dashed !important;
               }
@@ -611,7 +613,7 @@ novo-dynamic-form {
                 border-bottom-style: dashed !important;
                 i.bhi-collapse {
                   top: auto;
-                  color: lighten($dark, 30%) !important;
+                  color: brightenLive('--color-dark', 30) !important;
                 }
               }
               label {
@@ -620,7 +622,7 @@ novo-dynamic-form {
                 }
               }
               chips {
-                border-bottom: 1px dashed lighten($dark, 30%) !important;
+                border-bottom: 1px dashed brightenLive('--color-dark', 30) !important;
                 input {
                   border: none !important;
                 }

--- a/projects/novo-elements/src/elements/form/Form.scss
+++ b/projects/novo-elements/src/elements/form/Form.scss
@@ -176,14 +176,14 @@ novo-dynamic-form {
               margin-bottom: 0;
             }
             .character-count {
-              font-size: 12px;
+              font-size: var(--font-size-sm);
               color: $grey;
               &.error {
                 color: var(--color-negative);
               }
             }
             .record-count {
-              font-size: 12px;
+              font-size: var(--font-size-sm);
               color: $grey;
               margin-right: 9em;
               &.zero-count {
@@ -229,7 +229,7 @@ novo-dynamic-form {
               visibility: hidden;
             }
             .character-count {
-              font-size: 12px;
+              font-size: var(--font-size-sm);
               color: $grey;
               &.error {
                 color: var(--color-negative);
@@ -409,7 +409,7 @@ novo-dynamic-form {
                       }
                       label.input-label {
                         padding-left: 5px;
-                        color: $dark;
+                        color: var(--font-color-base);
                       }
                     }
                     > div.novo-control-input-container {
@@ -422,7 +422,7 @@ novo-dynamic-form {
                         position: absolute;
                         right: 0;
                         top: 0;
-                        font-size: 1.2rem;
+                        font-size: var(--font-size-sm);
                       }
                       > i.bhi-times {
                         cursor: pointer;
@@ -451,7 +451,7 @@ novo-dynamic-form {
                           border-top-right-radius: 0;
                           border-bottom-right-radius: 0;
                           box-shadow: none;
-                          border-right: 1px solid rgba($light, 0.5);
+                          border-right: 1px solid rgb(from var(--color-border) r g b / 0.5);
                           > .calendar {
                             box-shadow: none;
                           }

--- a/projects/novo-elements/src/elements/form/extras/address/Address.scss
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.scss
@@ -14,7 +14,7 @@
       &.invalid {
         ::ng-deep input,
         ::ng-deep novo-select div[type="button"] {
-          border-bottom: 1px solid $negative !important;
+          border-bottom: 1px solid var(--color-negative) !important;
         }
       }
     }
@@ -36,7 +36,7 @@
     justify-content: space-between;
     align-items: flex-end;
     input.invalid {
-      border-bottom: 1px solid $negative;
+      border-bottom: 1px solid var(--color-negative);
     }
   }
   .street-address {
@@ -84,7 +84,7 @@
     pointer-events: none;
     input {
       &::placeholder {
-        color: lighten($dark, 30%) !important;
+        color: brightenLive('--color-dark', 30) !important;
       }
       border-bottom-style: dashed !important;
     }
@@ -123,11 +123,11 @@
     .country-name {
       &:hover:not(.invalid) i.required-indicator.bhi-circle,
       &:hover:not(.invalid) i.required-indicator.bhi-check {
-        border-bottom: 1px solid lighten($dark, 15%);
+        border-bottom: 1px solid brightenLive('--color-dark', 15);
       }
       &.focus:not(.invalid) i.required-indicator.bhi-circle,
       &.focus:not(.invalid) i.required-indicator.bhi-check {
-        border-bottom: 1px solid $positive;
+        border-bottom: 1px solid var(--color-positive);
       }
     }
     i.required-indicator {
@@ -144,7 +144,7 @@
     }
     .invalid i.required-indicator,
     .invalid i.required-indicator {
-      border-bottom: 1px solid $negative;
+      border-bottom: 1px solid var(--color-negative);
     }
   }
 }

--- a/projects/novo-elements/src/elements/form/extras/file/FileInput.scss
+++ b/projects/novo-elements/src/elements/form/extras/file/FileInput.scss
@@ -1,7 +1,7 @@
 @import "../../../../styles/variables.scss";
 
 @mixin file-item-style() {
-  background-color: $white;
+  background-color: var(--background-body);
   box-shadow: 0 1px 4px rgba(#000, 0.15), 0 2px 10px rgba(#000, 0.09);
   padding: 4px 12px;
   display: flex;
@@ -51,7 +51,7 @@ novo-file-input {
       button:focus,
       button.active {
         background: none;
-        color: $positive;
+        color: var(--color-positive);
       }
       &.disabled {
         box-shadow: none;
@@ -79,7 +79,7 @@ novo-file-input {
     &:hover,
     &.active {
       label.boxed {
-        border: 2px dashed $positive;
+        border: 2px dashed var(--color-positive);
       }
     }
     &.disabled {
@@ -99,7 +99,7 @@ novo-file-input {
       pointer-events: none;
       /*This for FF*/
       strong {
-        color: $positive;
+        color: var(--color-positive);
       }
       small {
         margin-top: 7px;

--- a/projects/novo-elements/src/elements/form/fieldset-header.scss
+++ b/projects/novo-elements/src/elements/form/fieldset-header.scss
@@ -2,10 +2,11 @@
   background: var(--background-muted);
   box-sizing: content-box;
   padding: 1rem 1rem 1rem 0.5rem;
-  margin-bottom: 2rem;
+  margin-bottom: var(--spacing-2xl);
   display: flex;
-  margin-left: -1.5rem;
-  margin-right: -1.5rem;
+  margin-left: calc(-1 * var(--spacing-xl));
+  margin-right: calc(-1 * var(--spacing-xl));
+  // TODO: semantic role TBD - could be font-size-lg for closest cousin
   font-size: 1.8rem;
   ::ng-deep i,
   ::ng-deep novo-icon {

--- a/projects/novo-elements/src/elements/header/Header.scss
+++ b/projects/novo-elements/src/elements/header/Header.scss
@@ -96,17 +96,17 @@
       .header-titles,
       .header-title {
         ::ng-deep .novo-icon {
-          color: $color;
+          color: getCssVarname($name);
         }
       }
       & > section:first-of-type {
-        border-bottom: 2px solid $color;
+        border-bottom: 2px solid getCssVarname($name);
       }
     }
     &.novo-theme-#{$name} {
       & > section:first-of-type {
-        background: $color;
-        color: $contrast;
+        background: getCssVarname($name);
+        color: getContrastColor($name);
         border-bottom: none;
       }
       ::ng-deep .novo-title {

--- a/projects/novo-elements/src/elements/header/Header.scss
+++ b/projects/novo-elements/src/elements/header/Header.scss
@@ -29,8 +29,8 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    padding: 0 $spacing-lg;
-    gap: $spacing-sm;
+    padding: 0 var(--spacing-lg);
+    gap: var(--spacing-sm);
     box-sizing: border-box;
     // line-height: 4rem;
 
@@ -40,7 +40,7 @@
     div.header-title {
       display: flex;
       align-items: center;
-      gap: $spacing-sm;
+      gap: var(--spacing-sm);
       // making room for ellipsis
       padding-inline-end: 2em;
       // prevent pushing other flex content
@@ -83,7 +83,7 @@
       display: flex;
       align-items: center;
       justify-content: flex-start;
-      gap: $spacing-sm;
+      gap: var(--spacing-sm);
     }
 
     ::ng-deep .novo-action {

--- a/projects/novo-elements/src/elements/header/Header.scss
+++ b/projects/novo-elements/src/elements/header/Header.scss
@@ -51,7 +51,7 @@
       }
 
       ::ng-deep novo-icon {
-        margin-right: 1rem;
+        margin-right: var(--spacing-md);
       }
     }
     .header-titles {
@@ -112,7 +112,7 @@
       ::ng-deep .novo-title {
         color: inherit;
         overflow: hidden;
-        padding-right: 0.5rem;
+        padding-right: var(--spacing-sm);
       }
       ::ng-deep .novo-action {
         button,

--- a/projects/novo-elements/src/elements/icon/Icon.scss
+++ b/projects/novo-elements/src/elements/icon/Icon.scss
@@ -38,7 +38,9 @@ $icon-border-radius: 0.3em;
     &[theme="#{$name}"] {
       i {
         color: $white;
-        background: $color;
+        // Theming TODO: Should be contrast?
+        //color: getContrastColor($name);
+        background: getCssVarname($name);
         border-radius: $icon-border-radius;
         width: 1.6em;
         height: 1.6em;

--- a/projects/novo-elements/src/elements/list/list-item-content.scss
+++ b/projects/novo-elements/src/elements/list/list-item-content.scss
@@ -21,7 +21,7 @@
   &.novo-item-content ::ng-deep i {
     @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {
       &.#{$name} {
-        color: $color;
+        color: getCssVarname($name);
       }
     }
   }

--- a/projects/novo-elements/src/elements/list/list-item-header-avatar.scss
+++ b/projects/novo-elements/src/elements/list/list-item-header-avatar.scss
@@ -5,7 +5,7 @@
   ::ng-deep i {
     @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {
       &.#{$name} {
-        color: $color;
+        color: getCssVarname($name);
       }
     }
   }

--- a/projects/novo-elements/src/elements/list/list-item.scss
+++ b/projects/novo-elements/src/elements/list/list-item.scss
@@ -3,14 +3,14 @@
 @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {
   $contrast: getContrastColor($name);
   :host-context([theme="#{$name}"]) {
-    background: $color;
-    color: $contrast;
+    background: getCssVarname($name);
+    color: getContrastColor($name);
     border: unset;
     border-bottom: 1px solid rgba(#fff, 0.1);
     outline: none;
     item-title h6,
     i {
-      color: $contrast;
+      color: getContrastColor($name);
     }
     item-content {
       > * {

--- a/projects/novo-elements/src/elements/list/list-item.scss
+++ b/projects/novo-elements/src/elements/list/list-item.scss
@@ -19,7 +19,7 @@
     }
     &:hover,
     &:active {
-      background: lighten($color, 20%);
+      background: brightenLive('--color-#{$name}', 20);
     }
   }
 }
@@ -31,10 +31,10 @@
   flex-direction: row;
   outline: none;
   &:hover {
-    background: rgba($positive, 0.2);
+    background: rgb(from var(--color-positive) r g b / 0.2);
   }
   &.active {
-    background: rgba($positive, 0.3);
+    background: rgb(from var(--color-positive) r g b / 0.3);
   }
   &:last-child {
     border-bottom: none;

--- a/projects/novo-elements/src/elements/loading/NovoSpinner.scss
+++ b/projects/novo-elements/src/elements/loading/NovoSpinner.scss
@@ -62,7 +62,7 @@ $large-spinner-size: 2.1em;
   &.white,
   &[inverse] {
     .dot:before {
-      background-color: $white;
+      background-color: var(--background-body);
     }
   }
 

--- a/projects/novo-elements/src/elements/menu/menu-content.component.scss
+++ b/projects/novo-elements/src/elements/menu/menu-content.component.scss
@@ -19,11 +19,11 @@
       padding-inline-start: 0px !important;
       box-shadow: $shadow-multi;
       :hover {
-        background: rgba($ocean, 0.1);
+        background: rgb(from var(--color-positive) r g b / 0.1);
         color: $dark;
       }
       :active {
-        background: rgba($ocean, 0.4);
+        background: rgb(from var(--color-positive) r g b / 0.4);
       }
       .menu-item-container {
         display: flex;
@@ -31,7 +31,7 @@
         position: relative;
         .sub-menu-caret {
           position: absolute;
-          right: $spacing-sm;
+          right: var(--spacing-sm);
         }
       }
 
@@ -39,7 +39,7 @@
         @include novo-body-text();
         cursor: pointer;
         margin: 0;
-        padding: $spacing-md $spacing-md $spacing-md $spacing-lg;
+        padding: var(--spacing-md) var(--spacing-md) var(--spacing-md) var(--spacing-lg);
         box-sizing: border-box;
         display: flex;
         align-items: center;
@@ -49,11 +49,11 @@
       .divider {
         order: none;
         height: 1px;
-        background: $silver;
+        background: var(--background-dark);
       }
       a {
         &.disabled {
-          color: $disabled;
+          color: var(--color-disabled);
           cursor: not-allowed;
         }
       }

--- a/projects/novo-elements/src/elements/menu/menu-content.component.scss
+++ b/projects/novo-elements/src/elements/menu/menu-content.component.scss
@@ -20,7 +20,7 @@
       box-shadow: $shadow-multi;
       :hover {
         background: rgb(from var(--color-positive) r g b / 0.1);
-        color: $dark;
+        color: var(--font-color-base);
       }
       :active {
         background: rgb(from var(--color-positive) r g b / 0.4);

--- a/projects/novo-elements/src/elements/modal/modal.component.scss
+++ b/projects/novo-elements/src/elements/modal/modal.component.scss
@@ -12,8 +12,8 @@
 
   > .novo-button.modal-close {
     position: absolute;
-    right: $spacing-xl;
-    top: $spacing-xl;
+    right: var(--spacing-xl);
+    top: var(--spacing-xl);
   }
 
   > ::ng-deep header {
@@ -28,7 +28,7 @@
   }
 
   > ::ng-deep section {
-    padding: $spacing-md $spacing-xl;
+    padding: var(--spacing-md) var(--spacing-xl);
     max-height: 500px;
     overflow: auto;
   }
@@ -37,8 +37,8 @@
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    padding: $spacing-md;
-    gap: $spacing-md;
+    padding: var(--spacing-md);
+    gap: var(--spacing-md);
     ::ng-deep button {
       min-width: 10rem;
     }

--- a/projects/novo-elements/src/elements/modal/modal.component.scss
+++ b/projects/novo-elements/src/elements/modal/modal.component.scss
@@ -3,6 +3,7 @@
 :host {
   display: block;
   background-color: var(--background-bright);
+  // TODO: semantic role TBD - could be border-radius or border-radius-small
   border-radius: 4px;
   box-shadow: 0 1px 7px rgba(0, 0, 0, 0.09), 0 1px 3px rgba(0, 0, 0, 0.2);
   z-index: z(modal);

--- a/projects/novo-elements/src/elements/modal/notification.component.scss
+++ b/projects/novo-elements/src/elements/modal/notification.component.scss
@@ -29,38 +29,38 @@
     }
 
     h1 {
-      font-size: $font-size-2xl;
+      font-size: var(--font-size-2xl);
       margin: 10px auto 0;
     }
     h2 {
-      font-size: $font-size-xl;
+      font-size: var(--font-size-xl);
       color: var(--text-muted);
       margin: 0 auto;
       padding: 0;
     }
     h3 {
-      font-size: $font-size-lg;
+      font-size: var(--font-size-lg);
       margin: 0 auto;
     }
     h4 {
-      font-size: $font-size-lg;
+      font-size: var(--font-size-lg);
       color: var(--text-muted);
       margin: 0 auto;
       padding: 0;
     }
     h5 {
-      font-size: $font-size-md;
+      font-size: var(--font-size-md);
       margin: 0 auto;
     }
     h6 {
-      font-size: $font-size-md;
+      font-size: var(--font-size-md);
       margin: 0 auto;
     }
 
     i.indicator {
       color: var(--text-muted);
       border: 1px solid var(--text-muted);
-      font-size: $font-size-2xl;
+      font-size: var(--font-size-2xl);
       border-radius: 50%;
       padding: var(--spacing-md);
       margin: 2rem auto;

--- a/projects/novo-elements/src/elements/modal/notification.component.scss
+++ b/projects/novo-elements/src/elements/modal/notification.component.scss
@@ -13,15 +13,15 @@
 
   & > .novo-button.modal-close {
     position: absolute;
-    right: $spacing-xl;
-    top: $spacing-xl;
+    right: var(--spacing-xl);
+    top: var(--spacing-xl);
   }
 
   ::ng-deep .novo-notification-body {
     display: flex;
     flex-direction: column;
-    padding: 0 $spacing-xl;
-    margin: $spacing-lg 0 55px;
+    padding: 0 var(--spacing-xl);
+    margin: var(--spacing-lg) 0 55px;
 
     & > img {
       width: 100%;
@@ -61,7 +61,7 @@
       border: 1px solid var(--text-muted);
       font-size: $font-size-2xl;
       border-radius: 50%;
-      padding: $spacing-md;
+      padding: var(--spacing-md);
       margin: 2rem auto;
       align-self: center;
     }
@@ -70,8 +70,8 @@
   &[type="success"] {
     .novo-notification-body {
       i.indicator {
-        color: $success;
-        border-color: $success;
+        color: var(--color-success);
+        border-color: var(--color-success);
       }
     }
   }
@@ -79,8 +79,8 @@
   &[type="warning"] {
     .novo-notification-body {
       i.indicator {
-        color: $warning;
-        border-color: $warning;
+        color: var(--color-warning);
+        border-color: var(--color-warning);
       }
     }
   }
@@ -88,8 +88,8 @@
   &[type="error"] {
     .novo-notification-body {
       i.indicator {
-        color: $negative;
-        border-color: $negative;
+        color: var(--color-negative);
+        border-color: var(--color-negative);
       }
     }
   }
@@ -98,8 +98,8 @@
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    padding: $spacing-md;
-    gap: $spacing-md;
+    padding: var(--spacing-md);
+    gap: var(--spacing-md);
 
     button {
       min-width: 10rem;

--- a/projects/novo-elements/src/elements/modal/notification.component.scss
+++ b/projects/novo-elements/src/elements/modal/notification.component.scss
@@ -4,6 +4,7 @@
   text-align: center;
   display: block;
   background-color: var(--background-bright);
+  // TODO: semantic role TBD - could be border-radius or border-radius-small
   border-radius: 4px;
   box-shadow: 0 1px 7px rgba(0, 0, 0, 0.09), 0 1px 3px rgba(0, 0, 0, 0.2);
   z-index: z(modal);

--- a/projects/novo-elements/src/elements/multi-picker/_MultiPicker.scss
+++ b/projects/novo-elements/src/elements/multi-picker/_MultiPicker.scss
@@ -9,6 +9,7 @@
   ul.summary {
     display: inline;
     list-style: none;
+    // TODO: semantic role TBD - rec font-secondary
     color: darken(#d2d2d2, 30%);
     padding: 0 10px 0;
 
@@ -41,13 +42,14 @@
           i {
             &.bhi-checkbox-empty,
             &.bhi-checkbox-indeterminate {
-              color: $positive;
+              color: var(--color-positive);
             }
           }
         }
       }
       &.checked {
         label {
+          // TODO(theme): #d2d2d2 has no design token yet; register it, then migrate to darkenLive('--color-...', 60)
           color: darken(#d2d2d2, 60%);
         }
       }
@@ -61,7 +63,7 @@
 
       &.bhi-checkbox-filled,
       &.bhi-checkbox-indeterminate {
-        color: $positive;
+        color: var(--color-positive);
       }
     }
   }

--- a/projects/novo-elements/src/elements/picker/Picker.scss
+++ b/projects/novo-elements/src/elements/picker/Picker.scss
@@ -80,7 +80,7 @@ novo-picker {
 
     @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {
       &.#{$name} {
-        background: $color;
+        background: getCssVarname($name);
       }
     }
   }

--- a/projects/novo-elements/src/elements/picker/Picker.scss
+++ b/projects/novo-elements/src/elements/picker/Picker.scss
@@ -64,6 +64,7 @@ novo-picker {
     top: 2px;
     background: var(--background-main);
     font-size: 1em;
+    // TODO: semantic role TBD - could be border-radius or border-radius-small
     border-radius: 3px;
     padding: 3px;
   }
@@ -72,6 +73,7 @@ novo-picker {
     left: 5px;
     top: 3px;
     font-size: 1em;
+    // TODO: semantic role TBD - could be border-radius or border-radius-small
     border-radius: 3px;
     padding: 3px;
     color: $white;

--- a/projects/novo-elements/src/elements/picker/Picker.scss
+++ b/projects/novo-elements/src/elements/picker/Picker.scss
@@ -12,7 +12,7 @@ novo-picker {
   &.selected,
   &.selected:hover {
     & + i {
-      color: $positive;
+      color: var(--color-positive);
     }
   }
   padding-bottom: 0;
@@ -27,7 +27,7 @@ novo-picker {
     font-size: 1em;
     background: transparent !important;
     border: none;
-    border-bottom: 1px solid lighten($dark, 45%);
+    border-bottom: 1px solid brightenLive('--color-dark', 45);
     border-radius: 0;
     outline: none;
     height: 2rem;
@@ -39,10 +39,10 @@ novo-picker {
     transition: all 300ms;
     color: #26282b;
     &:hover {
-      border-bottom: 1px solid lighten($dark, 15%);
+      border-bottom: 1px solid brightenLive('--color-dark', 15);
     }
     &:focus {
-      border-bottom: 1px solid $positive;
+      border-bottom: 1px solid var(--color-positive);
     }
     &:invalid {
       border-bottom: 1px solid #da4453;
@@ -52,17 +52,17 @@ novo-picker {
     }
     &.entity-selected {
       padding-left: 2.5em;
-      background: $off-white !important;
+      background: var(--background-main) !important;
     }
     &:disabled {
-      border-bottom: 1px dashed lighten($dark, 45%) !important;
+      border-bottom: 1px dashed brightenLive('--color-dark', 45) !important;
     }
   }
   i.bhi-more {
     position: absolute;
     left: 0;
     top: 2px;
-    background: $off-white;
+    background: var(--background-main);
     font-size: 1em;
     border-radius: 3px;
     padding: 3px;

--- a/projects/novo-elements/src/elements/picker/Picker.scss
+++ b/projects/novo-elements/src/elements/picker/Picker.scss
@@ -88,18 +88,18 @@ novo-picker {
   i.bhi-times {
     position: absolute;
     right: 0;
-    color: $dark;
+    color: var(--font-color-base);
     &.entity-selected {
       right: 5px;
     }
   }
   i.bhi-search {
     top: 0px;
-    font-size: 1.2rem;
+    font-size: var(--font-size-sm);
   }
   i.bhi-times {
     top: 0px;
     cursor: pointer;
-    font-size: 1.2rem;
+    font-size: var(--font-size-sm);
   }
 }

--- a/projects/novo-elements/src/elements/picker/extras/grouped-multi-picker-results/GroupedMultiPickerResults.scss
+++ b/projects/novo-elements/src/elements/picker/extras/grouped-multi-picker-results/GroupedMultiPickerResults.scss
@@ -109,7 +109,7 @@
         position: absolute;
         right: 10px;
         top: 12px;
-        font-size: 1.2rem;
+        font-size: var(--font-size-sm);
         &.disabled {
           pointer-events: none;
           opacity: 0.4;

--- a/projects/novo-elements/src/elements/picker/extras/grouped-multi-picker-results/GroupedMultiPickerResults.scss
+++ b/projects/novo-elements/src/elements/picker/extras/grouped-multi-picker-results/GroupedMultiPickerResults.scss
@@ -1,12 +1,12 @@
 @import "../../../../styles/variables.scss";
 
 :host {
-  background-color: $white;
+  background-color: var(--background-body);
   max-height: 300px;
   padding: 0;
   margin: 0;
   box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
-  border: 1px solid $positive;
+  border: 1px solid var(--color-positive);
   transform: translateY(0%);
   transition: all 0.15s cubic-bezier(0.35, 0, 0.25, 1);
   display: flex;
@@ -36,7 +36,7 @@
       height: 50px;
       display: flex;
       align-items: center;
-      border-top: 1px solid $off-white;
+      border-top: 1px solid var(--border-2);
       label {
         font-weight: 500;
       }
@@ -56,14 +56,14 @@
         color: #999999;
       }
       &.active {
-        color: $positive;
-        border-left-color: $positive;
+        color: var(--color-positive);
+        border-left-color: var(--color-positive);
         background-color: #e9e9e9;
         item-end {
-          color: $positive;
+          color: var(--color-positive);
         }
         ::ng-deep .list-item > item-content > * {
-          color: $positive !important;
+          color: var(--color-positive) !important;
         }
       }
     }
@@ -82,8 +82,8 @@
         padding: 0.95em;
         background: transparent !important;
         border: none;
-        border-bottom: 1px solid $off-white;
-        border-left: 1px solid $off-white;
+        border-bottom: 1px solid var(--border-2);
+        border-left: 1px solid var(--border-2);
         border-radius: 0;
         border-radius: 0;
         outline: none;
@@ -93,11 +93,11 @@
         transition: all 300ms;
         color: #26282b;
         &:hover {
-          border-bottom: 1px solid $off-white;
+          border-bottom: 1px solid var(--border-2);
         }
         &:focus {
-          border-bottom: 1px solid $positive;
-          border-left: 1px solid $positive;
+          border-bottom: 1px solid var(--color-positive);
+          border-left: 1px solid var(--color-positive);
         }
         &[disabled] {
           pointer-events: none;
@@ -120,7 +120,7 @@
       }
     }
     .grouped-multi-picker-list-container {
-      border-left: 1px solid $off-white;
+      border-left: 1px solid var(--border-2);
       flex: 1;
       display: flex;
       flex-direction: column;

--- a/projects/novo-elements/src/elements/picker/extras/mixed-multi-picker-results/MixedMultiPickerResults.scss
+++ b/projects/novo-elements/src/elements/picker/extras/mixed-multi-picker-results/MixedMultiPickerResults.scss
@@ -1,12 +1,12 @@
 @import "../../../../styles/variables.scss";
 
 :host {
-  background-color: $white;
+  background-color: var(--background-body);
   max-height: 300px;
   padding: 0;
   margin: 0;
   box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
-  border: 1px solid $positive;
+  border: 1px solid var(--color-positive);
   transform: translateY(0%);
   transition: all 0.15s cubic-bezier(0.35, 0, 0.25, 1);
   display: flex;
@@ -34,7 +34,7 @@
         width: 100%;
       }
       &:hover {
-        background-color: lighten($positive, 39%);
+        background-color: brightenLive('--color-positive', 39);
       }
       .list-item {
         justify-content: center;
@@ -43,14 +43,14 @@
         color: #999999;
       }
       &.active {
-        color: $positive;
-        border-left-color: $positive;
-        background-color: lighten($positive, 35%);
+        color: var(--color-positive);
+        border-left-color: var(--color-positive);
+        background-color: brightenLive('--color-positive', 35);
         item-end {
-          color: $positive;
+          color: var(--color-positive);
         }
         .list-item > item-content > * {
-          color: $positive !important;
+          color: var(--color-positive) !important;
         }
       }
       item-content {
@@ -76,10 +76,10 @@
           width: 100%;
         }
         &.active {
-          background-color: lighten($positive, 35%);
+          background-color: brightenLive('--color-positive', 35);
         }
         &:hover {
-          background-color: lighten($positive, 39%);
+          background-color: brightenLive('--color-positive', 39);
         }
         item-content {
           flex-flow: row wrap;
@@ -97,8 +97,8 @@
         padding: 0.95em;
         background: transparent !important;
         border: none;
-        border-bottom: 1px solid $off-white;
-        border-left: 1px solid $off-white;
+        border-bottom: 1px solid var(--border-2);
+        border-left: 1px solid var(--border-2);
         border-radius: 0;
         border-radius: 0;
         outline: none;
@@ -108,11 +108,11 @@
         transition: all 300ms;
         color: #26282b;
         &:hover {
-          border-bottom: 1px solid $off-white;
+          border-bottom: 1px solid var(--border-2);
         }
         &:focus {
-          border-bottom: 1px solid $positive;
-          border-left: 1px solid $positive;
+          border-bottom: 1px solid var(--color-positive);
+          border-left: 1px solid var(--color-positive);
         }
         &[disabled] {
           pointer-events: none;
@@ -135,7 +135,7 @@
       }
     }
     .mixed-multi-picker-list-container {
-      border-left: 1px solid $off-white;
+      border-left: 1px solid var(--border-2);
       flex: 1;
       display: flex;
       flex-direction: column;

--- a/projects/novo-elements/src/elements/picker/extras/mixed-multi-picker-results/MixedMultiPickerResults.scss
+++ b/projects/novo-elements/src/elements/picker/extras/mixed-multi-picker-results/MixedMultiPickerResults.scss
@@ -124,7 +124,7 @@
         position: absolute;
         right: 10px;
         top: 12px;
-        font-size: 1.2rem;
+        font-size: var(--font-size-sm);
         &.disabled {
           pointer-events: none;
           opacity: 0.4;

--- a/projects/novo-elements/src/elements/picker/extras/picker-results/PickerResult.scss
+++ b/projects/novo-elements/src/elements/picker/extras/picker-results/PickerResult.scss
@@ -7,6 +7,6 @@
 
 :host(.active) {
   > novo-list-item {
-    background-color: lighten($positive, 35%);
+    background-color: brightenLive('--color-positive', 35);
   }
 }

--- a/projects/novo-elements/src/elements/picker/extras/picker-results/PickerResults.scss
+++ b/projects/novo-elements/src/elements/picker/extras/picker-results/PickerResults.scss
@@ -18,10 +18,10 @@ entity-picker-results {
         width: 100%;
       }
       &.active {
-        background-color: lighten($positive, 35%);
+        background-color: brightenLive('--color-positive', 35);
       }
       &:hover {
-        background-color: lighten($positive, 39%);
+        background-color: brightenLive('--color-positive', 39);
       }
       .novo-item-content {
         flex-flow: row wrap;
@@ -49,14 +49,14 @@ entity-picker-results {
   .picker-loader,
   .picker-null-recent-results,
   .picker-null-results {
-    background-color: $white;
+    background-color: var(--background-body);
     text-align: center;
-    color: darken($light, 15%);
+    color: darkenLive('--color-light', 15);
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
-    border: 1px solid $positive;
+    border: 1px solid var(--color-positive);
     transform: translateY(0%);
     transition: all 0.15s cubic-bezier(0.35, 0, 0.25, 1);
-    padding: $spacing-sm;
+    padding: var(--spacing-sm);
   }
 
   p.picker-error,
@@ -69,12 +69,12 @@ entity-picker-results {
 
   picker-loader,
   .picker-loader {
-    background-color: $white;
+    background-color: var(--background-body);
     display: flex;
     align-items: center;
     flex-direction: column;
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
-    border: 1px solid $positive;
+    border: 1px solid var(--color-positive);
     transform: translateY(0%);
     transition: all 0.15s cubic-bezier(0.35, 0, 0.25, 1);
   }
@@ -92,21 +92,21 @@ picker-results,
 .picker-results,
 quick-note-results,
 .quick-note-results {
-  background-color: $white;
+  background-color: var(--background-body);
   cursor: default;
   line-height: 26px;
   width: 100%;
   display: block;
   novo-list,
   ul {
-    background-color: $white;
+    background-color: var(--background-body);
     max-height: 200px;
     overflow: auto;
     list-style: none;
     padding: 0;
     margin: 0;
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
-    border: 1px solid $positive;
+    border: 1px solid var(--color-positive);
     transform: translateY(0%);
     transition: all 0.15s cubic-bezier(0.35, 0, 0.25, 1);
     display: block;
@@ -122,7 +122,7 @@ quick-note-results,
       h6 {
         padding-top: 0;
         font-weight: 400;
-        color: lighten($dark, 35%);
+        color: brightenLive('--color-dark', 35);
         strong {
           font-weight: 400;
           color: $dark;
@@ -131,7 +131,7 @@ quick-note-results,
       &.active,
       &:focus,
       &:hover {
-        background-color: lighten($positive, 35%);
+        background-color: brightenLive('--color-positive', 35);
       }
       &.disabled {
         opacity: 0.5;
@@ -170,7 +170,7 @@ entity-picker-results {
     max-height: 49vh;
     overflow: auto;
     .novo-item-content {
-      margin-top: $spacing-sm;
+      margin-top: var(--spacing-sm);
       margin-left: 1.8rem;
       row-gap: 1rem;
       .novo-text {
@@ -197,7 +197,7 @@ distribution-list-picker-results {
   background: $white;
   padding: 1px;
   &.active {
-    border: 1px solid $positive;
+    border: 1px solid var(--color-positive);
   }
   .novo-list {
     min-height: 100%;
@@ -208,7 +208,7 @@ distribution-list-picker-results {
     .novo-list-item {
       display: block;
       transition: background-color 250ms;
-      border-bottom: 1px solid $background-dark;
+      border-bottom: 1px solid var(--background-dark);
       cursor: pointer;
       &.disabled {
         opacity: 0.5;
@@ -231,10 +231,10 @@ distribution-list-picker-results {
         margin-left: 15px;
       }
       &.active {
-        background-color: lighten($positive, 35%);
+        background-color: brightenLive('--color-positive', 35);
       }
       &:hover {
-        background-color: lighten($positive, 35%);
+        background-color: brightenLive('--color-positive', 35);
       }
       item-content {
         flex-flow: row nowrap;
@@ -292,7 +292,7 @@ distribution-list-picker-results {
     z-index: 9;
     position: absolute;
     width: 100%;
-    background-color: white;
+    background-color: var(--background-bright);
     color: black;
   }
 }

--- a/projects/novo-elements/src/elements/picker/extras/picker-results/PickerResults.scss
+++ b/projects/novo-elements/src/elements/picker/extras/picker-results/PickerResults.scss
@@ -125,7 +125,7 @@ quick-note-results,
         color: brightenLive('--color-dark', 35);
         strong {
           font-weight: 400;
-          color: $dark;
+          color: var(--font-color-base);
         }
       }
       &.active,

--- a/projects/novo-elements/src/elements/picker/extras/skills-picker-results/SkillsSpecialtyPickerResults.scss
+++ b/projects/novo-elements/src/elements/picker/extras/skills-picker-results/SkillsSpecialtyPickerResults.scss
@@ -8,7 +8,7 @@
   z-index: 99;
   background: $white;
   &.active {
-    border: 1px solid $positive;
+    border: 1px solid var(--color-positive);
   }
   novo-list {
     list-style: none;
@@ -39,7 +39,7 @@
       &.active,
       &:focus,
       &:hover {
-        background-color: lighten($positive, 35%);
+        background-color: brightenLive('--color-positive', 35);
       }
       &.disabled {
         opacity: 0.5;
@@ -62,6 +62,6 @@
   .picker-loading,
   .picker-null {
     text-align: center;
-    color: darken($light, 15%);
+    color: darkenLive('--color-light', 15);
   }
 }

--- a/projects/novo-elements/src/elements/places/places.component.scss
+++ b/projects/novo-elements/src/elements/places/places.component.scss
@@ -4,7 +4,7 @@
   display: grid;
   novo-list {
     border: 1px solid #4a89dc;
-    background-color: $white;
+    background-color: var(--background-body);
     novo-list-item {
       cursor: pointer;
       flex: 0 0;
@@ -13,10 +13,10 @@
         width: 100%;
       }
       &.active {
-        background-color: lighten($positive, 35%);
+        background-color: brightenLive('--color-positive', 35);
       }
       &:hover {
-        background-color: lighten($positive, 39%);
+        background-color: brightenLive('--color-positive', 39);
       }
       item-content {
         flex-flow: row wrap;

--- a/projects/novo-elements/src/elements/popover/PopOver.scss
+++ b/projects/novo-elements/src/elements/popover/PopOver.scss
@@ -21,7 +21,7 @@
       }
     }
     &.right {
-      margin-left: 1rem;
+      margin-left: var(--spacing-md);
       &.virtual-area {
         left: -1.1rem;
       }

--- a/projects/novo-elements/src/elements/progress/Progress.scss
+++ b/projects/novo-elements/src/elements/progress/Progress.scss
@@ -22,8 +22,8 @@
   &.linear {
     width: 200px;
     height: 1.2em;
-    background-color: $background;
-    border: 1px solid $empty;
+    background-color: var(--background-main);
+    border: 1px solid var(--color-empty);
     overflow: hidden;
   }
 

--- a/projects/novo-elements/src/elements/progress/ProgressBar.scss
+++ b/projects/novo-elements/src/elements/progress/ProgressBar.scss
@@ -51,7 +51,7 @@
     @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {
       &[color="#{$name}"] {
         svg circle {
-          stroke: $color;
+          stroke: getCssVarname($name);
         }
       }
     }

--- a/projects/novo-elements/src/elements/progress/ProgressBar.scss
+++ b/projects/novo-elements/src/elements/progress/ProgressBar.scss
@@ -7,7 +7,7 @@
 
   &.linear {
     @include theme-backgrounds("color");
-    background-color: $positive;
+    background-color: var(--color-positive);
 
     &:first-child {
       border-radius: 0.2em 0 0 0.2em;
@@ -59,7 +59,7 @@
 
     svg {
       circle {
-        stroke: $positive;
+        stroke: var(--color-positive);
         transform-origin: 50% 50%;
         transform: rotate(-90deg);
         transition: 0.35s stroke-dashoffset;

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.scss
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.scss
@@ -74,7 +74,7 @@
 
   .and-or-filter-button {
     box-sizing: border-box;
-    background: #fff;
+    background: var(--background-bright);
     border: 1px solid #ddd;
     color: #5691f5;
     display: inline-block;

--- a/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.scss
+++ b/projects/novo-elements/src/elements/query-builder/condition-builder/condition-builder.component.scss
@@ -39,7 +39,7 @@
           width: 100px;
           min-width: 100px;
           max-width: 100px;
-          margin-right: 1rem;
+          margin-right: var(--spacing-md);
           novo-select {
             min-width: 70px;
           }
@@ -70,24 +70,5 @@
         padding: 0 !important;
       }
     }
-  }
-
-  .and-or-filter-button {
-    box-sizing: border-box;
-    background: var(--background-bright);
-    border: 1px solid #ddd;
-    color: #5691f5;
-    display: inline-block;
-    position: relative;
-    cursor: pointer;
-    margin: 0.4rem auto;
-    align-items: center;
-    text-align: center;
-    user-select: none;
-    outline: none;
-    white-space: nowrap;
-    text-transform: uppercase;
-    overflow: hidden;
-    transition: box-shadow 0.4s cubic-bezier(0.25, 0.8, 0.25, 1), background-color 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
   }
 }

--- a/projects/novo-elements/src/elements/radio/Radio.scss
+++ b/projects/novo-elements/src/elements/radio/Radio.scss
@@ -10,7 +10,7 @@
     }
     &[theme="icon"] {
       margin-right: 0;
-      border: 1px solid $positive;
+      border: 1px solid var(--color-positive);
     }
   }
   &:first-child {
@@ -57,7 +57,7 @@
       i {
         &.bhi-radio-empty,
         &.bhi-radio-filled {
-          color: $positive;
+          color: var(--color-positive);
         }
       }
     }
@@ -77,7 +77,7 @@
       }
       &.bhi-checkbox-filled,
       &.bhi-radio-filled {
-        color: $positive;
+        color: var(--color-positive);
       }
     }
     &.disabled {
@@ -91,12 +91,12 @@
   }
   novo-button[theme].has-icon {
     transition: all 100ms ease-in-out;
-    color: $positive;
+    color: var(--color-positive);
     background: $white;
     opacity: 1;
     &.checked {
       color: $white;
-      background: $positive;
+      background: var(--color-positive);
     }
 
     @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {

--- a/projects/novo-elements/src/elements/radio/Radio.scss
+++ b/projects/novo-elements/src/elements/radio/Radio.scss
@@ -101,8 +101,9 @@
 
     @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {
       &.checked[color="#{$name}"] {
+        // Theming TODO: Use contrast color?
         color: $white;
-        background: $color;
+        background: getCssVarname($name);
       }
     }
   }

--- a/projects/novo-elements/src/elements/radio/Radio.scss
+++ b/projects/novo-elements/src/elements/radio/Radio.scss
@@ -38,7 +38,7 @@
 :host-context(novo-radio-group.novo-radio-group-appearance-horizontal) {
   :host:not(:last-child) {
     .novo-radio-button-label {
-      margin-right: 1rem;
+      margin-right: var(--spacing-md);
     }
   }
 }

--- a/projects/novo-elements/src/elements/radio/radio-group.scss
+++ b/projects/novo-elements/src/elements/radio/radio-group.scss
@@ -6,7 +6,7 @@
   &.novo-radio-group-appearance-horizontal {
     novo-radio:not(:last-child) {
       .novo-radio-button-label {
-        margin-right: 1rem;
+        margin-right: var(--spacing-md);
       }
     }
   }

--- a/projects/novo-elements/src/elements/radio/radio-group.scss
+++ b/projects/novo-elements/src/elements/radio/radio-group.scss
@@ -26,7 +26,7 @@
       }
       &[theme="icon"] {
         margin-right: 0;
-        border: 1px solid $positive;
+        border: 1px solid var(--color-positive);
       }
     }
     &:first-child {

--- a/projects/novo-elements/src/elements/search/SearchBox.scss
+++ b/projects/novo-elements/src/elements/search/SearchBox.scss
@@ -7,16 +7,15 @@
   grid-template-rows: 1fr;
   align-items: center;
   height: 3.2rem;
-  background: $white;
-  font-size: 1.4rem;
-  border: 1px solid $light;
+  background: var(--background-bright);
+  border: 1px solid var(--color-border);
   border-radius: 0.2rem;
   max-width: 400px;
   min-width: 100px;
   transition: all 250ms ease-in-out;
 
   &[size="small"] {
-    font-size: 1rem;
+    font-size: var(--font-size-xs);
     height: 2.4rem;
     grid-template-columns: 2.4rem 1fr;
   }

--- a/projects/novo-elements/src/elements/search/SearchBox.scss
+++ b/projects/novo-elements/src/elements/search/SearchBox.scss
@@ -75,14 +75,14 @@ header {
   novo-search.always-open:not(.focused) {
     button {
       background: rgba($white, 0.25) !important;
-      color: rgba($positive, 0.25) !important;
+      color: rgb(from var(--color-positive) r g b / 0.25) !important;
     }
     input {
       background-color: rgba($white, 0.25) !important;
       border-color: rgba($white, 0.25) !important;
-      color: rgba($positive, 0.25) !important;
+      color: rgb(from var(--color-positive) r g b / 0.25) !important;
       &::placeholder {
-        color: $empty !important;
+        color: var(--color-empty) !important;
       }
     }
   }

--- a/projects/novo-elements/src/elements/search/SearchBox.scss
+++ b/projects/novo-elements/src/elements/search/SearchBox.scss
@@ -63,7 +63,7 @@
     @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {
       &[color="#{$name}"] {
         > novo-icon {
-          color: $color !important;
+          color: getCssVarname($name) !important;
         }
       }
     }

--- a/projects/novo-elements/src/elements/select/Select.scss
+++ b/projects/novo-elements/src/elements/select/Select.scss
@@ -53,7 +53,7 @@
 
     i {
       font-size: 0.8em;
-      color: $dark;
+      color: var(--font-color-base);
       position: absolute;
       right: 0px;
     }
@@ -98,7 +98,7 @@
   padding: 0;
   width: 100%;
   box-shadow: 0 -1px 3px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
-  font-size: 1rem;
+  font-size: var(--font-size-xs);
   z-index: z(below);
   opacity: 0;
 
@@ -123,7 +123,7 @@
       display: block;
       align-items: center;
       justify-content: space-between;
-      font-size: 1rem;
+      font-size: var(--font-size-xs);
       &:focus,
       &:hover {
         // TODO: semantic role TBD - rec font-color-secondary or shade
@@ -181,7 +181,7 @@
       cursor: pointer;
       text-transform: none;
       padding-top: 10px;
-      font-size: 1rem;
+      font-size: var(--font-size-xs);
       &.empty {
         color: #a9a9a9;
       }

--- a/projects/novo-elements/src/elements/select/Select.scss
+++ b/projects/novo-elements/src/elements/select/Select.scss
@@ -10,7 +10,7 @@
   cursor: pointer;
 
   &:focus .novo-select-trigger {
-    border-bottom: 1px solid $positive;
+    border-bottom: 1px solid var(--color-positive);
     i {
       color: rgba(0, 0, 0, 0.73);
     }
@@ -27,7 +27,7 @@
     align-items: center;
     background-color: transparent;
     border: none;
-    border-bottom: 1px solid lighten($dark, 45%);
+    border-bottom: 1px solid brightenLive('--color-dark', 45);
     color: var(--text-main, $dark);
     height: 2.05rem;
     position: relative;
@@ -36,7 +36,7 @@
     z-index: z(default);
     cursor: pointer;
     text-transform: none;
-    padding: 0 $spacing-md 0 $spacing-sm;
+    padding: 0 var(--spacing-md) 0 var(--spacing-sm);
     margin-bottom: -1px;
     -webkit-appearance: none;
 
@@ -44,7 +44,7 @@
       color: #a9a9a9;
     }
     &:hover {
-      border-bottom: 1px solid lighten($dark, 15%);
+      border-bottom: 1px solid brightenLive('--color-dark', 15);
     }
 
     .novo-select-placeholder {
@@ -111,7 +111,7 @@
   button {
     text-transform: uppercase;
     &.header {
-      color: $positive;
+      color: var(--color-positive);
       position: relative;
       text-align: left;
       cursor: pointer;
@@ -126,10 +126,11 @@
       font-size: 1rem;
       &:focus,
       &:hover {
-        color: darken($light, 55%);
+        // TODO: semantic role TBD - rec font-color-secondary or shade
+        color: darkenLive('--color-light', 55);
       }
       i {
-        color: $positive;
+        color: var(--color-positive);
         padding-right: 10px;
       }
       span {
@@ -153,13 +154,14 @@
       font-size: 0.8rem;
       color: #acacac;
       &:hover {
+        // TODO: semantic role TBD - rec font-color-secondary or dark shade
         color: darken(#acacac, 15%);
       }
     }
     button.primary {
-      color: $positive;
+      color: var(--color-positive);
       &:hover {
-        color: darken($positive, 15%);
+        color: darkenLive('--color-positive', 15);
       }
     }
     input {
@@ -187,7 +189,7 @@
         outline: none;
       }
       &:hover {
-        border-bottom: 1px solid $positive;
+        border-bottom: 1px solid var(--color-positive);
       }
       &.invalid {
         border-bottom: 1px solid #da4453;

--- a/projects/novo-elements/src/elements/simple-table/PaginationOld.scss
+++ b/projects/novo-elements/src/elements/simple-table/PaginationOld.scss
@@ -9,7 +9,7 @@ novo-pagination {
   }
   h5.rows {
     padding: 0;
-    font-size: 1rem;
+    font-size: var(--font-size-xs);
     opacity: 0.75;
     letter-spacing: 0.1px;
   }

--- a/projects/novo-elements/src/elements/simple-table/PaginationOld.scss
+++ b/projects/novo-elements/src/elements/simple-table/PaginationOld.scss
@@ -43,6 +43,7 @@ novo-pagination {
       padding: 0 10px;
       line-height: 2.4rem;
       font-size: var(--font-size-text);
+      // TODO: semantic role TBD - could be border-radius or border-radius-small
       border-radius: 2px;
       text-align: center;
       list-style-type: none;

--- a/projects/novo-elements/src/elements/simple-table/PaginationOld.scss
+++ b/projects/novo-elements/src/elements/simple-table/PaginationOld.scss
@@ -47,7 +47,7 @@ novo-pagination {
       text-align: center;
       list-style-type: none;
       cursor: pointer;
-      color: $company;
+      color: var(--color-company);
       &:last-child {
         padding-right: 0;
       }
@@ -57,8 +57,8 @@ novo-pagination {
       }
     }
     .page.active {
-      color: $company;
-      background-color: $off-white;
+      color: var(--color-company);
+      background-color: var(--background-main);
       opacity: 1;
     }
   }

--- a/projects/novo-elements/src/elements/simple-table/table.scss
+++ b/projects/novo-elements/src/elements/simple-table/table.scss
@@ -1,7 +1,6 @@
 @import "../../styles/variables.scss";
 @import "../../styles/reset";
 
-$table-bg-accent: #f4f4f4;
 $novo-row-horizontal-padding: 20px;
 $breakpoint: 1000px;
 
@@ -19,14 +18,14 @@ novo-simple-table {
   .novo-simple-button-cell,
   .novo-simple-dropdown-cell,
   .novo-simple-checkbox-cell {
-      background-color: $table-bg-accent;
+      background-color: var(--background-muted);
     }
     &.active {
       .novo-simple-cell,
       .novo-simple-button-cell,
       .novo-simple-dropdown-cell,
       .novo-simple-checkbox-cell {
-        background-color: rgba($ocean, 0.15);
+        background-color: rgb(from var(--color-positive) r g b / 0.15);
       }
     }
   }
@@ -35,14 +34,14 @@ novo-simple-table {
   .novo-simple-button-cell,
   .novo-simple-dropdown-cell,
   .novo-simple-checkbox-cell {
-      background-color: $white;
+      background-color: var(--background-body);
     }
     &.active {
       .novo-simple-cell,
       .novo-simple-button-cell,
       .novo-simple-dropdown-cell,
       .novo-simple-checkbox-cell {
-        background-color: rgba($ocean, 0.15);
+        background-color: rgb(from var(--color-positive) r g b / 0.15);
       }
     }
   }
@@ -56,7 +55,7 @@ novo-simple-table {
   .novo-simple-header-cell,
   novo-simple-empty-header-cell,
   .novo-simple-checkbox-header-cell {
-    border-bottom: 1px solid $off-white;
+    border-bottom: 1px solid var(--border-2);
   }
 }
 
@@ -76,7 +75,7 @@ novo-simple-table {
     display: inline-block;
   }
   button.active {
-    color: $positive;
+    color: var(--color-positive);
   }
   &.clickable {
     cursor: pointer;
@@ -92,7 +91,7 @@ novo-simple-table {
 }
 
 .novo-simple-header-cell {
-  border-left: 1px solid $off-white;
+  border-left: 1px solid var(--border-2);
   white-space: nowrap;
   display: flex;
   align-items: center;
@@ -172,7 +171,7 @@ novo-activity-table {
     display: flex;
     align-items: center;
     flex-shrink: 0;
-    border-bottom: 1px solid $off-white;
+    border-bottom: 1px solid var(--border-2);
     > [novo-activity-table-custom-header] {
       flex: 1;
     }
@@ -249,7 +248,7 @@ novo-activity-table {
     display: flex;
     flex: 1;
     .novo-activity-table-custom-filter {
-      border-right: 1px solid $off-white;
+      border-right: 1px solid var(--border-2);
       novo-date-picker {
         .calendar {
           box-shadow: none;

--- a/projects/novo-elements/src/elements/stepper/step-header.component.scss
+++ b/projects/novo-elements/src/elements/stepper/step-header.component.scss
@@ -42,13 +42,13 @@ $novo-step-header-icon-size: 1em !default;
 
   .novo-step-icon {
     .novo-step-number {
-      background: $positive;
+      background: var(--color-positive);
       color: $white;
     }
   }
   .novo-step-icon-not-touched {
     .novo-step-number {
-      background: $submission;
+      background: var(--color-submission);
       color: $white;
     }
   }
@@ -131,15 +131,15 @@ $novo-step-header-icon-size: 1em !default;
         }
         &.edit {
           &:before {
-            border-bottom: 1px solid $positive;
+            border-bottom: 1px solid var(--color-positive);
           }
         }
         &.done {
           &:before {
-            border-bottom: 1px solid $positive;
+            border-bottom: 1px solid var(--color-positive);
           }
           &:after {
-            border-top: 1px solid $positive;
+            border-top: 1px solid var(--color-positive);
           }
         }
       }

--- a/projects/novo-elements/src/elements/stepper/step-header.component.scss
+++ b/projects/novo-elements/src/elements/stepper/step-header.component.scss
@@ -36,6 +36,7 @@ $novo-step-header-icon-size: 1em !default;
       display: flex;
       align-items: center;
       justify-content: center;
+      // TODO: semantic role TBD - could be border-radius or border-radius-small
       border-radius: 4px;
     }
   }

--- a/projects/novo-elements/src/elements/stepper/step-header.component.scss
+++ b/projects/novo-elements/src/elements/stepper/step-header.component.scss
@@ -6,7 +6,7 @@ $novo-stepper-label-min-width: 50px !default;
 $novo-stepper-side-gap: 24px !default;
 $novo-vertical-stepper-content-margin: 36px !default;
 $novo-stepper-line-gap: 8px !default;
-$novo-step-optional-font-size: 12px;
+$novo-step-optional-font-size: var(--font-size-sm);
 $novo-step-header-icon-size: 1em !default;
 
 :host {
@@ -120,7 +120,7 @@ $novo-step-header-icon-size: 1em !default;
           display: block;
           width: calc(50% - 8px);
           margin-right: 8px;
-          border-bottom: 1px solid $light;
+          border-bottom: 1px solid var(--color-border);
         }
         &:after {
           content: "";
@@ -128,7 +128,7 @@ $novo-step-header-icon-size: 1em !default;
           width: calc(50% - 8px);
           margin-left: calc(50% + 8px);
           margin-top: -1px;
-          border-top: 1px solid $light;
+          border-top: 1px solid var(--color-border);
         }
         &.edit {
           &:before {

--- a/projects/novo-elements/src/elements/stepper/stepper.component.scss
+++ b/projects/novo-elements/src/elements/stepper/stepper.component.scss
@@ -19,14 +19,14 @@ $novo-stepper-line-gap: 8px !default;
     align-items: center;
     justify-content: center;
     margin-bottom: 1em;
-    background: $background;
+    background: var(--background-main);
     .novo-stepper-horizontal-line {
       border-bottom: $novo-stepper-line-width solid $light;
       flex: auto;
       min-width: 0px;
       height: $novo-horizontal-stepper-header-height;
       &.complete {
-        border-bottom: $novo-stepper-line-width solid $positive;
+        border-bottom: $novo-stepper-line-width solid var(--color-positive);
       }
     }
   }
@@ -75,15 +75,15 @@ $novo-stepper-line-gap: 8px !default;
     }
     &.edit {
       &:before {
-        border-left-color: 1px solid $positive;
+        border-left-color: 1px solid var(--color-positive);
       }
     }
     &.done {
       &:before {
-        border-left-color: 1px solid $positive;
+        border-left-color: 1px solid var(--color-positive);
       }
       &:after {
-        border-left-color: 1px solid $positive;
+        border-left-color: 1px solid var(--color-positive);
       }
     }
   }

--- a/projects/novo-elements/src/elements/stepper/stepper.component.scss
+++ b/projects/novo-elements/src/elements/stepper/stepper.component.scss
@@ -21,7 +21,7 @@ $novo-stepper-line-gap: 8px !default;
     margin-bottom: 1em;
     background: var(--background-main);
     .novo-stepper-horizontal-line {
-      border-bottom: $novo-stepper-line-width solid $light;
+      border-bottom: $novo-stepper-line-width solid var(--color-border);
       flex: auto;
       min-width: 0px;
       height: $novo-horizontal-stepper-header-height;
@@ -66,7 +66,7 @@ $novo-stepper-line-gap: 8px !default;
       z-index: z(below);
       border-left-width: $novo-stepper-line-width;
       border-left-style: solid;
-      border-left-color: $light;
+      border-left-color: var(--color-border);
 
       [dir="rtl"] & {
         left: auto;

--- a/projects/novo-elements/src/elements/switch/Switch.scss
+++ b/projects/novo-elements/src/elements/switch/Switch.scss
@@ -53,6 +53,7 @@ $switch-thumb-size: 20px !default;
     width: $switch-width - 2px;
     top: calc($switch-height / 2) - calc($switch-bar-height / 2);
     height: $switch-bar-height;
+    // TODO: semantic role TBD - could be border-radius or border-radius-small
     border-radius: 8px;
     position: absolute;
   }

--- a/projects/novo-elements/src/elements/switch/Switch.scss
+++ b/projects/novo-elements/src/elements/switch/Switch.scss
@@ -79,7 +79,7 @@ $switch-thumb-size: 20px !default;
     height: $switch-thumb-size;
     width: $switch-thumb-size;
     border-radius: 50%;
-    box-shadow: $shadow-1; // todo
+    box-shadow: var(--shadow-1); // todo
     color: getContrastColor("light");
 
     .novo-icon {
@@ -112,7 +112,7 @@ $switch-thumb-size: 20px !default;
   // Loop through analytics colors and make a switch color class for each
   @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {
     &.#{$name} {
-      @include novo-switch-style($color, lighten($color, 18%));
+      @include novo-switch-style($color, brightenLive('--color-#{$name}', 18));
       &[aria-checked="true"] {
         .novo-switch-thumb {
           color: getContrastColor($name);
@@ -122,17 +122,17 @@ $switch-thumb-size: 20px !default;
   }
 
   &.dark {
-    @include novo-switch-style($dark, darken($dark, 5%));
+    @include novo-switch-style($dark, darkenLive('--color-dark', 5));
   }
   &.light {
-    @include novo-switch-style(darken($light, 3%), $light);
+    @include novo-switch-style(darkenLive('--color-light', 3), $light);
   }
 
   .novo-switch-thumb {
     background-color: $light;
   }
   .novo-switch-bar {
-    background-color: lighten($light, 10%);
+    background-color: brightenLive('--color-light', 10);
   }
 
   &:focus {

--- a/projects/novo-elements/src/elements/switch/Switch.scss
+++ b/projects/novo-elements/src/elements/switch/Switch.scss
@@ -130,6 +130,7 @@ $switch-thumb-size: 20px !default;
   }
 
   .novo-switch-thumb {
+    // TODO: semantic role TBD - rec background-bright
     background-color: $light;
   }
   .novo-switch-bar {
@@ -138,7 +139,7 @@ $switch-thumb-size: 20px !default;
 
   &:focus {
     .novo-switch-label:not(:empty) {
-      border: 1px dotted $light;
+      border: 1px dotted var(--color-border);
     }
   }
 }

--- a/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.scss
+++ b/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.scss
@@ -94,7 +94,7 @@
               &:hover {
                 .novo-tab-link {
                   font-weight: 400;
-                  color: $positive;
+                  color: var(--color-positive);
                 }
               }
             }
@@ -119,14 +119,14 @@
 
           .quick-select-label {
             padding: 0.7em 1.9em 0 1.9em;
-            background: lighten($light, 10%);
+            background: brightenLive('--color-light', 10);
             text-transform: uppercase;
             font-size: 0.8em;
           }
 
           .quick-select-list {
             .quick-select-item {
-              background: lighten($light, 10%);
+              background: brightenLive('--color-light', 10);
               padding: 0.5em 0.8em;
               border-bottom: none;
             }
@@ -143,7 +143,7 @@
 
           novo-option {
             &:hover.novo-option-inert {
-              background: var(--background-main, rgba($ocean, 0.1));
+              background: var(--background-main, rgb(from var(--color-ocean) r g b / 0.1));
             }
           }
         }

--- a/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.scss
+++ b/projects/novo-elements/src/elements/tabbed-group-picker/TabbedGroupPicker.scss
@@ -29,7 +29,7 @@
       box-shadow: none;
       box-sizing: content-box;
       transition: all 300ms;
-      color: $dark;
+      color: var(--font-color-base);
       &::placeholder {
         color: var(--form-placeholder);
       }
@@ -40,7 +40,7 @@
       bottom: 1em;
       right: 0.5em;
       color: $grey;
-      font-size: 1.2rem;
+      font-size: var(--font-size-sm);
       margin-right: 1em;
     }
     i.bhi-times {
@@ -67,7 +67,7 @@
       align-items: center;
 
       &.left {
-        border-right: 1px solid $light;
+        border-right: 1px solid var(--color-border);
         justify-content: space-between;
 
         .clear-all-button {
@@ -163,7 +163,7 @@
           }
           .empty-item-main-message {
             font-weight: 500;
-            color: $dark;
+            color: var(--font-color-base);
           }
           .empty-item-sub-message {
             font-size: 0.9em;

--- a/projects/novo-elements/src/elements/tabs/tab-button.scss
+++ b/projects/novo-elements/src/elements/tabs/tab-button.scss
@@ -18,6 +18,8 @@
 :host-context(novo-nav[theme="color"]) {
   color: rgba(255, 255, 255, 0.75);
   &.active {
+    // TODO: This is difficult theming-wise. These themes only darken the parent region a little bit, but we don't know what base background we're working with
+    // in order to contrast it. "inherit" is a possible value - issuing font color decisions to the element applying the background
     color: #fff;
     background: rgba(0, 0, 0, 0.2);
   }

--- a/projects/novo-elements/src/elements/tabs/tab-nav.scss
+++ b/projects/novo-elements/src/elements/tabs/tab-nav.scss
@@ -10,6 +10,7 @@
 
   &[type="button-bar"] {
     display: inline-flex;
+    // TODO: semantic role TBD - could be border-radius or border-radius-small
     border-radius: 3px;
     border: 2px solid #fff;
   }

--- a/projects/novo-elements/src/elements/tabs/tab-nav.scss
+++ b/projects/novo-elements/src/elements/tabs/tab-nav.scss
@@ -23,7 +23,7 @@
   }
 
   &[theme="white"] {
-    background-color: $white;
+    background-color: var(--background-body);
     &[direction="vertical"] {
       background: transparent;
     }

--- a/projects/novo-elements/src/elements/tabs/tab-nav.scss
+++ b/projects/novo-elements/src/elements/tabs/tab-nav.scss
@@ -29,7 +29,7 @@
       background: transparent;
     }
     &[type="button-bar"] {
-      border: 2px solid $light;
+      border: 2px solid var(--color-border);
     }
   }
 

--- a/projects/novo-elements/src/elements/tabs/tab.scss
+++ b/projects/novo-elements/src/elements/tabs/tab.scss
@@ -22,10 +22,10 @@
   .novo-tab-link {
     @include novo-label-text();
     font-size: var(--font-size-tab);
-    padding: $spacing-md;
+    padding: var(--spacing-md);
     display: flex;
     align-items: center;
-    gap: $spacing-xs;
+    gap: var(--spacing-xs);
     cursor: pointer;
     text-transform: uppercase;
     &:focus {
@@ -76,7 +76,7 @@
     width: 100%;
     display: flex;
     flex-flow: row nowrap;
-    gap: $spacing-xs;
+    gap: var(--spacing-xs);
     max-width: 90%;
     white-space: nowrap;
     overflow: hidden;
@@ -185,6 +185,6 @@
 :host-context(novo-nav.condensed) {
   font-size: 1rem;
   .novo-tab-link {
-    padding: $spacing-sm;
+    padding: var(--spacing-sm);
   }
 }

--- a/projects/novo-elements/src/elements/tabs/tab.scss
+++ b/projects/novo-elements/src/elements/tabs/tab.scss
@@ -161,6 +161,8 @@
 :host-context(novo-nav[theme="color"]),
 :host-context(novo-nav[theme="neutral"]) {
   .novo-tab-link {
+    // TODO: This is difficult theming-wise. These themes only darken the parent region a little bit, but we don't know what base background we're working with
+    // in order to contrast it. "inherit" is a possible value - issuing font color decisions to the element applying the background
     color: #fff;
   }
   &.active,
@@ -183,7 +185,7 @@
 }
 
 :host-context(novo-nav.condensed) {
-  font-size: 1rem;
+  font-size: var(--font-size-xs);
   .novo-tab-link {
     padding: var(--spacing-sm);
   }

--- a/projects/novo-elements/src/elements/tiles/Tiles.scss
+++ b/projects/novo-elements/src/elements/tiles/Tiles.scss
@@ -12,6 +12,7 @@
     background: var(--background-bright);
     display: flex;
     border: solid thin var(--color-slate);
+    // TODO: semantic role TBD - could be border-radius or border-radius-small
     border-radius: 3px;
     .tile {
       margin: 2px;

--- a/projects/novo-elements/src/elements/tiles/Tiles.scss
+++ b/projects/novo-elements/src/elements/tiles/Tiles.scss
@@ -9,9 +9,9 @@
     position: absolute;
   }
   & > .tile-container {
-    background: $white;
+    background: var(--background-bright);
     display: flex;
-    border: solid thin $slate;
+    border: solid thin var(--color-slate);
     border-radius: 3px;
     .tile {
       margin: 2px;
@@ -20,7 +20,7 @@
         margin-right: 3px;
       }
       &.defaultColor.active {
-          background: darken($ocean, 20%);
+          background: darkenLive('--color-ocean', 20);
       }
       &.disabled {
         cursor: not-allowed;
@@ -34,7 +34,7 @@
       }
     }
     &.disabled {
-      border-color: lighten($grey, 20%);
+      border-color: brightenLive('--color-grey', 20);
       opacity: 0.4;
       pointer-events: auto;
       cursor: not-allowed;

--- a/projects/novo-elements/src/elements/tiles/Tiles.ts
+++ b/projects/novo-elements/src/elements/tiles/Tiles.ts
@@ -32,7 +32,7 @@ const TILES_VALUE_ACCESSOR = {
         *ngFor="let option of _options; let i = index"
         [ngClass]="{ defaultColor: !option.color, active: option.checked, disabled: option.disabled }"
         [theme]="option.checked ? 'primary' : 'dialogue'"
-        [color]="option.checked ? option.color || 'darken($ocean, 20%)' : 'dark'"
+        [color]="option.checked ? option.color || 'darken($ocean, 20%)' : 'text'"
         [icon]="option.icon"
         [side]="option.iconSide || 'left'"
         (click)="select($event, option)"

--- a/projects/novo-elements/src/elements/time-picker/TimePicker.scss
+++ b/projects/novo-elements/src/elements/time-picker/TimePicker.scss
@@ -277,7 +277,7 @@
     margin-left: 1px;
     display: block;
     position: absolute;
-    background-color: $background;
+    background-color: var(--background-main);
   }
   .analog--hour,
   .analog--minute {

--- a/projects/novo-elements/src/elements/time-picker/TimePicker.scss
+++ b/projects/novo-elements/src/elements/time-picker/TimePicker.scss
@@ -48,6 +48,7 @@
     justify-content: center;
   }
   .digital--clock {
+    // TODO: semantic role TBD. Background?
     color: #fff;
     font-size: 1.8em;
     font-weight: 500;
@@ -166,7 +167,7 @@
       display: block;
       right: 3.2rem;
       top: 50%;
-      margin-top: -1.5rem;
+      margin-top: calc(-1 * var(--spacing-xl));
       border-radius: 50%;
       position: absolute;
       border: 3px solid var(--selection);
@@ -300,7 +301,7 @@
     }
   }
   .analog--minute {
-    font-size: 1rem;
+    font-size: var(--font-size-xs);
     margin-left: -20px;
     margin-top: -16px;
   }

--- a/projects/novo-elements/src/elements/time-picker/TimePicker.scss
+++ b/projects/novo-elements/src/elements/time-picker/TimePicker.scss
@@ -4,6 +4,7 @@
   display: block;
   width: min-content;
   overflow: hidden;
+  // TODO: semantic role TBD - could be border-radius or border-radius-small
   border-radius: 4px;
   background-color: var(--background-bright);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15), 0 2px 7px rgba(0, 0, 0, 0.1);

--- a/projects/novo-elements/src/elements/time-picker/TimePickerInput.scss
+++ b/projects/novo-elements/src/elements/time-picker/TimePickerInput.scss
@@ -36,7 +36,7 @@
     position: absolute;
     right: 0;
     top: 0px;
-    font-size: 1.2rem;
+    font-size: var(--font-size-sm);
   }
   > i.bhi-times {
     cursor: pointer;

--- a/projects/novo-elements/src/elements/tip-well/TipWell.scss
+++ b/projects/novo-elements/src/elements/tip-well/TipWell.scss
@@ -20,6 +20,7 @@
         text-align: center;
         margin-top: 0.3rem;
         margin-right: var(--spacing-md);
+        // TODO: semantic role TBD
         color: #aaaaaa;
       }
       > p {

--- a/projects/novo-elements/src/elements/tip-well/TipWell.scss
+++ b/projects/novo-elements/src/elements/tip-well/TipWell.scss
@@ -4,14 +4,14 @@
 :host {
   &.active {
     display: inline-block;
-    margin-bottom: $spacing-md;
+    margin-bottom: var(--spacing-md);
   }
   > div {
     display: inline-block;
     border-radius: 0.25rem;
-    background-color: var(--background-main, $off-white);
+    background-color: var(--background-main, $color-off-white);
     color: var(--text-main, $dark);
-    padding: $spacing-lg;
+    padding: var(--spacing-lg);
     text-align: right;
     > div {
       display: flex;
@@ -19,7 +19,7 @@
         flex-shrink: 0;
         text-align: center;
         margin-top: 0.3rem;
-        margin-right: $spacing-md;
+        margin-right: var(--spacing-md);
         color: #aaaaaa;
       }
       > p {

--- a/projects/novo-elements/src/elements/toast/Toast.scss
+++ b/projects/novo-elements/src/elements/toast/Toast.scss
@@ -8,10 +8,10 @@
   align-content: center;
   align-items: center;
   position: relative;
-  background: $navy;
-  color: $white;
-  padding: $spacing-md;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+  background: var(--color-toast);
+  color: var(--text-bg-contrast);
+  padding: var(--spacing-md);
+  box-shadow: var(--shadow-1);
 
   &.show {
     display: grid !important;
@@ -60,7 +60,7 @@
         input {
           background: transparent !important;
           border: none;
-          border-bottom: 1px solid lighten($dark, 45%);
+          border-bottom: 1px solid brightenLive('--color-dark', 45);
           border-radius: 0;
           outline: none;
           height: 2rem;
@@ -73,10 +73,10 @@
           color: $white;
           text-overflow: ellipsis;
           &:focus {
-            background-color: $positive;
+            background-color: var(--color-positive);
           }
           &:hover {
-            border-bottom: 1px solid lighten($dark, 15%);
+            border-bottom: 1px solid brightenLive('--color-dark', 15);
           }
         }
       }
@@ -104,19 +104,19 @@
   }
 
   &.text {
-    background: $dark;
+    background: var(--color-dark);
   }
   &.neutral {
-    background: $neutral;
+    background: var(--color-neutral);
   }
   &.background {
-    background: $off-white;
+    background: var(--background-main);
     .toast-content > h5 {
-      color: $dark !important;
+      color: var(--text-main) !important;
     }
     i,
     p {
-      color: $dark;
+      color: var(--text-main);
     }
   }
 

--- a/projects/novo-elements/src/elements/toast/Toast.scss
+++ b/projects/novo-elements/src/elements/toast/Toast.scss
@@ -31,6 +31,7 @@
     width: 32px;
     height: 32px;
     background: rgba(0, 0, 0, 0.15);
+    // TODO: semantic role TBD - could be border-radius or border-radius-small
     border-radius: 3px;
   }
 
@@ -173,6 +174,7 @@
   }
 
   &[class*="growl"] {
+    // TODO: semantic role TBD - could be border-radius or border-radius-small
     border-radius: 3px;
     max-width: 350px;
   }

--- a/projects/novo-elements/src/elements/toast/Toast.scss
+++ b/projects/novo-elements/src/elements/toast/Toast.scss
@@ -49,7 +49,7 @@
   .close-icon i {
     display: flex;
     position: relative;
-    font-size: 1.2rem;
+    font-size: var(--font-size-sm);
     line-height: 1.2;
   }
 
@@ -262,7 +262,7 @@
     &.novo-accent-#{$name} {
       border: 1px solid $color;
       background: getPaleColor($name);
-      color: $dark;
+      color: var(--font-color-base);
     }
   }
 }

--- a/projects/novo-elements/src/elements/toast/Toast.scss
+++ b/projects/novo-elements/src/elements/toast/Toast.scss
@@ -257,10 +257,10 @@
   @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {
     &.#{$name} {
       color: getContrastColor($name);
-      background: $color;
+      background: getCssVarname($name);
     }
     &.novo-accent-#{$name} {
-      border: 1px solid $color;
+      border: 1px solid getCssVarname($name);
       background: getPaleColor($name);
       color: var(--font-color-base);
     }

--- a/projects/novo-elements/src/elements/toolbar/toolbar.component.scss
+++ b/projects/novo-elements/src/elements/toolbar/toolbar.component.scss
@@ -7,7 +7,7 @@
     box-sizing: border-box;
     background-color: var(--background-bright);
     color: var(--text-main);
-    padding: 0 $spacing-md;
+    padding: 0 var(--spacing-md);
     width: 100%;
     // Flexbox Vertical Alignment
     flex-direction: row;

--- a/projects/novo-elements/src/elements/toolbar/toolbar.component.scss
+++ b/projects/novo-elements/src/elements/toolbar/toolbar.component.scss
@@ -27,8 +27,8 @@
     @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {
       &.novo-color-#{$name},
       &.novo-theme-#{$name} {
-        color: $contrast;
-        background: $color;
+        color: getContrastColor($name);
+        background: getCssVarname($name);
         & > novo-text,
         & > novo-label,
         & > novo-icon,
@@ -43,12 +43,12 @@
           }
         }
         .novo-divider.novo-divider-vertical {
-          border-right-color: $tint;
+          border-right-color: getTintColor($name);
         }
       }
 
       &.novo-accent-#{$name} {
-        border-bottom: 2px solid $color;
+        border-bottom: 2px solid getCssVarname($name);
       }
     }
   }

--- a/projects/novo-elements/src/elements/tooltip/Tooltip.scss
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.scss
@@ -29,7 +29,7 @@ $tooltip-success-color: var(--color-shade-success, #458746);
     color: var(--color-white, #fff);
     border-radius: var(--tooltip-border-radius, 4px);
     padding: 8px 10px;
-    font-size: 12px;
+    font-size: var(--font-size-sm);
     line-height: 12px;
     white-space: nowrap;
     box-shadow: var(--shadow-2);

--- a/projects/novo-elements/src/elements/value/Value.scss
+++ b/projects/novo-elements/src/elements/value/Value.scss
@@ -32,17 +32,19 @@
   .actions {
     i {
       cursor: default;
+      // TODO: semantic role TBD - rec text shade
       color: #9e9e9e;
       margin-left: 15px;
       margin-top: 7px;
       &.clickable {
         cursor: pointer;
-        color: $ocean;
+        // possible we term this color separately from positive?
+        color: var(--color-positive);
       }
     }
     &.clickable {
       cursor: pointer;
-      color: $ocean;
+      color: var(--color-positive);
     }
   }
   ::ng-deep novo-entity-list {

--- a/projects/novo-elements/src/elements/value/Value.scss
+++ b/projects/novo-elements/src/elements/value/Value.scss
@@ -10,7 +10,7 @@
   padding: 8px;
   @include entity-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {
     i.#{$name} {
-      color: $color;
+      color: getCssVarname($name);
     }
   }
   &.horizontal {
@@ -51,7 +51,7 @@
     display: block;
     @include entity-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {
       i.#{$name} {
-        color: $color;
+        color: getCssVarname($name);
       }
     }
     .entity {

--- a/projects/novo-elements/src/novo-elements.scss
+++ b/projects/novo-elements/src/novo-elements.scss
@@ -67,25 +67,25 @@
 
   @if index($excluded, $name) == null {
     .novo-background-#{$name} {
-      background: $color;
-      color: $contrast;
+      background: getCssVarname($name);
+      color: getContrastColor($name);
     }
     .novo-text-#{$name} {
-      color: $color;
+      color: getCssVarname($name);
     }
 
     .bgc-#{$name} {
-      background: $color;
+      background: getCssVarname($name);
       color: $contrast;
     }
 
     .bgc-#{$name}-striped {
       & > *:nth-child(odd) {
-        background: $color;
+        background: getCssVarname($name);
       }
     }
     .txc-#{$name} {
-      color: $color;
+      color: getCssVarname($name);
     }
   }
 }

--- a/projects/novo-elements/src/styles/content/code.scss
+++ b/projects/novo-elements/src/styles/content/code.scss
@@ -4,6 +4,7 @@ samp {
   background: var(--background-main);
   color: var(--code);
   border: 1px solid var(--border);
+  // TODO: semantic role TBD - could be border-radius or border-radius-small
   border-radius: 4px;
   padding: 0 0.5ch;
   margin: 0 0.5ch;
@@ -34,6 +35,7 @@ kbd {
   font-family: var(--font-family-mono);
   background: var(--background-main);
   border: 1px solid var(--border);
+  // TODO: semantic role TBD - could be border-radius or border-radius-small
   border-radius: 2px;
   color: var(--text-main);
   padding: 2px 4px 2px 4px;

--- a/projects/novo-elements/src/styles/content/forms.scss
+++ b/projects/novo-elements/src/styles/content/forms.scss
@@ -85,6 +85,7 @@ input[type="button"] {
   padding: 0.5em 1em;
   outline: none;
   border: none;
+  // TODO: semantic role TBD - could be border-radius or border-radius-small
   border-radius: 4px;
 }
 
@@ -112,6 +113,7 @@ button:disabled {
 
 fieldset {
   border: 1px var(--focus) solid;
+  // TODO: semantic role TBD - could be border-radius or border-radius-small
   border-radius: 6px;
   margin: 0;
   margin-bottom: 12px;

--- a/projects/novo-elements/src/styles/content/misc.scss
+++ b/projects/novo-elements/src/styles/content/misc.scss
@@ -58,6 +58,7 @@ tbody tr:nth-child(even) button:hover {
 }
 
 ::-webkit-scrollbar-thumb {
+  // TODO: semantic role TBD - could be border-radius or border-radius-small
   border-radius: 6px;
   border: 2px solid var(--background-main);
 }
@@ -82,6 +83,7 @@ details {
   background-color: var(--background-bright);
   padding: 10px 10px 0;
   margin: 1em 0;
+  // TODO: semantic role TBD - could be border-radius or border-radius-small
   border-radius: 6px;
   overflow: hidden;
 }
@@ -124,6 +126,7 @@ dialog {
   background-color: var(--background-bright);
   color: var(--text-main);
   border: none;
+  // TODO: semantic role TBD - could be border-radius or border-radius-small
   border-radius: 6px;
   border-color: var(--border);
   padding: 10px 30px;

--- a/projects/novo-elements/src/styles/content/range.scss
+++ b/projects/novo-elements/src/styles/content/range.scss
@@ -5,6 +5,7 @@ $range-slider-shadow: 0 1px 1px #000, 0 0 1px #0d0d0d;
   height: 9.5px;
   transition: 0.2s;
   background: var(--background-main);
+  // TODO: semantic role TBD - could be border-radius or border-radius-small
   border-radius: 3px;
 }
 @mixin range-thumb() {
@@ -76,12 +77,14 @@ input[type="range"]::-ms-track {
 input[type="range"]::-ms-fill-lower {
   background: var(--background-main);
   border: 0.2px solid #010101;
+  // TODO: semantic role TBD - could be border-radius or border-radius-small
   border-radius: 3px;
   box-shadow: 1px 1px 1px #000, 0 0 1px #0d0d0d;
 }
 input[type="range"]::-ms-fill-upper {
   background: var(--background-main);
   border: 0.2px solid #010101;
+  // TODO: semantic role TBD - could be border-radius or border-radius-small
   border-radius: 3px;
   box-shadow: 1px 1px 1px #000, 0 0 1px #0d0d0d;
 }

--- a/projects/novo-elements/src/styles/content/root.scss
+++ b/projects/novo-elements/src/styles/content/root.scss
@@ -5,6 +5,7 @@ html {
   scrollbar-width: none;
   font-family: var(--font-family-base);
   font-size: var(--font-size-base, 10px);
+  // TODO: Can we remove this? Doesn't appear to be used
   color: var(--font-color-base, #333);
 }
 

--- a/projects/novo-elements/src/styles/iconography.scss
+++ b/projects/novo-elements/src/styles/iconography.scss
@@ -18,10 +18,11 @@ i {
         vertical-align: baseline;
         line-height: 1.8;
       }
+      // Theming TODO: Use contrast colors?
       @each $entity, $color in $entity-colors {
         &.#{$entity} {
           color: $white;
-          background: $color;
+          background: getCssVarname($entity);
         }
       }
       @each $key, $color in $analytics-colors {
@@ -37,7 +38,7 @@ i {
     &[theme="entity"] {
       @each $entity, $color in $entity-colors {
         &.#{$entity} {
-          color: $color;
+          color: getCssVarname($entity);
           background: transparent;
         }
       }

--- a/projects/novo-elements/src/styles/iconography.scss
+++ b/projects/novo-elements/src/styles/iconography.scss
@@ -31,7 +31,7 @@ i {
         }
       }
       &.large {
-        font-size: 1.2rem;
+        font-size: var(--font-size-sm);
       }
     }
     &[theme="entity"] {

--- a/projects/novo-elements/src/styles/themes/dark.scss
+++ b/projects/novo-elements/src/styles/themes/dark.scss
@@ -9,7 +9,6 @@
   --theme-background-bright: #{$color-moonlight}; //#1a242f
   --theme-background-dark: #{$color-onyx}; //e2e2e2
   --theme-background-muted: #{$color-neutral};
-  --theme-background-faded: #{$color-steel};
   --selection: #{$color-ocean}; // #1c76c5;
   --text-selection: #{$color-white};
   --text-main: #{$color-light};

--- a/projects/novo-elements/src/styles/themes/dark.scss
+++ b/projects/novo-elements/src/styles/themes/dark.scss
@@ -4,6 +4,12 @@
   --background-bright: #{$color-moonlight}; //#1a242f
   --background-dark: #{$color-onyx}; //e2e2e2
   --background-muted: #{$color-neutral};
+  --theme-background-body: #{$color-midnight}; //#202b38;
+  --theme-background-main: #{$color-darkness}; //#161f27;
+  --theme-background-bright: #{$color-moonlight}; //#1a242f
+  --theme-background-dark: #{$color-onyx}; //e2e2e2
+  --theme-background-muted: #{$color-neutral};
+  --theme-background-faded: #{$color-steel};
   --selection: #{$color-ocean}; // #1c76c5;
   --text-selection: #{$color-white};
   --text-main: #{$color-light};
@@ -25,7 +31,7 @@
   --highlight: #efdb43;
 }
 
-.theme-dark {
+:root.theme-dark {
   @include dark-variables();
 
   ::-webkit-calendar-picker-indicator {

--- a/projects/novo-elements/src/styles/themes/light.scss
+++ b/projects/novo-elements/src/styles/themes/light.scss
@@ -7,13 +7,18 @@
   --background-dark: #{$color-silver}; //e2e2e2
   --background-muted: #{$color-sand}; //f4f4f4
   --text-main: #{$color-charcoal}; //#363636;
+  --text-secondary: #{$font-color-secondary}; //#dbdbdb
   --text-muted: #{$color-neutral}; //#70777f;
   --text-disabled: #{$color-slate}; //#70777f;
   --selection: #{$color-ocean}; //#9e9e9e;
   --text-selection: #{$color-white};
+  --text-bg-contrast: #{$color-white};
   --links: #{$color-ocean};
   --focus: #{$color-ocean};
+  // TODO: semantic role work - we may want to move this to novo-design-tokens so we can get a few other shades of it.
   --border: #{$color-light}; //#dbdbdb;
+  --border-2: #{$color-off-white}; //#f7f7f7
+  --border-hard: #{$color-dark}; //#3d464d
   --code: #{$color-job};
   --animation-duration: 0.1s;
   --button-background: #{$light};

--- a/projects/novo-elements/src/styles/typography.scss
+++ b/projects/novo-elements/src/styles/typography.scss
@@ -115,8 +115,8 @@ h6.novo-section-header {
   display: flex;
   width: 100%;
   padding: 1rem 0.5rem 1rem 1.5rem;
-  margin-left: -1.5rem;
-  margin-right: -1.5rem;
+  margin-left: calc(-1 * var(--spacing-xl));
+  margin-right: calc(-1 * var(--spacing-xl));
   > i {
     display: flex;
     margin-right: 10px;

--- a/projects/novo-elements/src/styles/typography.scss
+++ b/projects/novo-elements/src/styles/typography.scss
@@ -87,6 +87,7 @@ address {
 
 mark {
   background-color: var(--highlight);
+  // TODO: semantic role TBD - could be border-radius or border-radius-small
   border-radius: 2px;
   padding: 0 2px 0 2px;
   color: #000;

--- a/projects/novo-elements/src/styles/variables.scss
+++ b/projects/novo-elements/src/styles/variables.scss
@@ -7,7 +7,7 @@
 $black: $color-black;
 $white: $color-white;
 $grey: $color-grey;
-$off-white: $color-off-white;
+// $off-white: $color-off-white;
 $light: $color-light;
 $navy: $color-navy;
 $pulse: $color-pulse;
@@ -53,27 +53,27 @@ $billableCharge: $color-billable-charge;
 $payableCharge: $color-payable-charge;
 // Color Applications
 $dark: $color-dark;
-$navigation: $color-navigation;
-$positive: $ocean;
+/*$navigation: $color-navigation;
+var(--color-positive): $ocean;
 $success: $grass;
-$negative: $grapefruit;
+var(--color-negative): $grapefruit;
 $warning: $sunflower;
 $background: $off-white;
 $background-dark: #e2e2e2;
 $neutral: $color-neutral;
 $empty: $color-empty;
-$disabled: $color-stone;
+$disabled: $color-stone;*/
 
 // Spacing
 // --------------------------------------------------
 $spacing-rules: (
   "none": $spacing-none,
-  "px": $spacing-px,
-  "xs": $spacing-xs,
-  "sm": $spacing-sm,
-  "md": $spacing-md,
-  "lg": $spacing-lg,
-  "xl": $spacing-xl,
+  "px": var(--spacing-px),
+  "xs": var(--spacing-xs),
+  "sm": var(--spacing-sm),
+  "md": var(--spacing-md),
+  "lg": var(--spacing-lg),
+  "xl": var(--spacing-xl),
 );
 
 // Sizes
@@ -123,7 +123,7 @@ $entity-colors: (
   "earnCode": $color-earn-code,
   "billableCharge": $color-billable-charge,
   "payableCharge": $color-payable-charge,
-  "complianceManager": $color-positive,
+  "complianceManager": var(--color-positive),
   "invoiceStatement": $color-invoice-statement,
 );
 // Generic Color Map

--- a/projects/novo-examples/src/_shared/figure/figure-example.scss
+++ b/projects/novo-examples/src/_shared/figure/figure-example.scss
@@ -2,7 +2,7 @@
 .figure-example {
   display: flex;
   flex-direction: column;
-  font-size: 1.2rem;
+  font-size: var(--font-size-sm);
   gap: 1rem;
 
   .figure-content {

--- a/projects/novo-examples/src/_shared/figure/figure-example.scss
+++ b/projects/novo-examples/src/_shared/figure/figure-example.scss
@@ -1,6 +1,3 @@
-$success: #8cc152;
-$negative: #da4453;
-$positive: #4a89dc;
 
 .figure-example {
   display: flex;
@@ -33,25 +30,25 @@ $positive: #4a89dc;
 
   &.figure-theme-negative {
     .figure-caption {
-      border-top: 3px solid $negative;
+      border-top: 3px solid var(--color-negative);
       novo-icon {
-        color: $negative;
+        color: var(--color-negative);
       }
     }
   }
   &.figure-theme-success {
     .figure-caption {
-      border-top: 3px solid $success;
+      border-top: 3px solid var(--color-success);
       novo-icon {
-        color: $success;
+        color: var(--color-success);
       }
     }
   }
   &.figure-theme-positive {
     .figure-caption {
-      border-top: 3px solid $positive;
+      border-top: 3px solid var(--color-positive);
       novo-icon {
-        color: $positive;
+        color: var(--color-positive);
       }
     }
   }

--- a/projects/novo-examples/src/_shared/typedef/typedef-example.scss
+++ b/projects/novo-examples/src/_shared/typedef/typedef-example.scss
@@ -2,8 +2,8 @@
   display: flex;
   flex-direction: column;
   border: 1px solid lightgray;
-  margin-bottom: 2rem;
-  font-size: 1.2rem;
+  margin-bottom: var(--spacing-2xl);
+  font-size: var(--font-size-sm);
 }
 
 .as-split-gutter {

--- a/projects/novo-examples/src/design/colors/analytics-colors/analytics-colors-example.scss
+++ b/projects/novo-examples/src/design/colors/analytics-colors/analytics-colors-example.scss
@@ -40,7 +40,7 @@
         color: rgba(255, 255, 255, 0.6);
         left: 50%;
         bottom: 40px;
-        font-size: 10px;
+        font-size: var(--font-size-xs);
         text-transform: uppercase;
         transform: translateX(-50%);
         width: 100%;

--- a/projects/novo-examples/src/design/colors/analytics-colors/analytics-colors-example.scss
+++ b/projects/novo-examples/src/design/colors/analytics-colors/analytics-colors-example.scss
@@ -24,6 +24,7 @@
       }
 
       .color-square {
+        // TODO: semantic role TBD - could be border-radius or border-radius-small
         border-radius: 4px;
         height: 150px;
         justify-content: center;

--- a/projects/novo-examples/src/design/colors/entity-colors/entity-colors-example.scss
+++ b/projects/novo-examples/src/design/colors/entity-colors/entity-colors-example.scss
@@ -40,7 +40,7 @@
         color: rgba(255, 255, 255, 0.6);
         left: 50%;
         bottom: 40px;
-        font-size: 10px;
+        font-size: var(--font-size-xs);
         text-transform: uppercase;
         transform: translateX(-50%);
         width: 100%;

--- a/projects/novo-examples/src/design/colors/entity-colors/entity-colors-example.scss
+++ b/projects/novo-examples/src/design/colors/entity-colors/entity-colors-example.scss
@@ -24,6 +24,7 @@
       }
 
       .color-square {
+        // TODO: semantic role TBD - could be border-radius or border-radius-small
         border-radius: 4px;
         height: 150px;
         justify-content: center;

--- a/projects/novo-examples/src/design/colors/primary-colors/primary-colors-example.scss
+++ b/projects/novo-examples/src/design/colors/primary-colors/primary-colors-example.scss
@@ -24,6 +24,7 @@
       }
 
       .color-square {
+        // TODO: semantic role TBD - could be border-radius or border-radius-small
         border-radius: 4px;
         height: 150px;
         justify-content: center;

--- a/projects/novo-examples/src/design/colors/primary-colors/primary-colors-example.scss
+++ b/projects/novo-examples/src/design/colors/primary-colors/primary-colors-example.scss
@@ -44,7 +44,7 @@
               color: rgba(0, 0, 0, 0.6);
               left: 50%;
               bottom: 40px;
-              font-size: 10px;
+              font-size: var(--font-size-xs);
               text-transform: uppercase;
               transform: translateX(-50%);
               width: 100%;
@@ -60,7 +60,7 @@
         color: rgba(255, 255, 255, 0.6);
         left: 50%;
         bottom: 40px;
-        font-size: 10px;
+        font-size: var(--font-size-xs);
         text-transform: uppercase;
         transform: translateX(-50%);
         width: 100%;

--- a/projects/novo-examples/src/design/iconography/iconset/iconset-example.scss
+++ b/projects/novo-examples/src/design/iconography/iconset/iconset-example.scss
@@ -40,7 +40,7 @@
             color: #333;
             left: 50%;
             top: 37px;
-            font-size: 10px;
+            font-size: var(--font-size-xs);
             text-transform: uppercase;
             transform: translateX(-50%);
             width: 100%;

--- a/projects/novo-examples/src/design/iconography/iconset/iconset-example.scss
+++ b/projects/novo-examples/src/design/iconography/iconset/iconset-example.scss
@@ -25,6 +25,7 @@
       }
 
       .icon-square {
+        // TODO: semantic role TBD - could be border-radius or border-radius-small
         border-radius: 4px;
         justify-content: center;
         align-items: center;

--- a/projects/schematics/ng-update/test-cases/v6/scss-variables_expected_output.scss
+++ b/projects/schematics/ng-update/test-cases/v6/scss-variables_expected_output.scss
@@ -5,6 +5,6 @@ html {
   font-family: $font-family-body;
   color: $font-color-base;
   line-height: $font-height-base;
-  box-shadow: $shadow-1;
+  box-shadow: var(--shadow-1);
   z-index: $zindex-1;
 }


### PR DESCRIPTION
## **Description**

Convert a large number of style parameters into CSS vars, to make them easier to override for themes

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**