### PR TITLE
feat(Address): Add auto suggestions to address block (BH-101288)

### DIFF
--- a/projects/demo/app/app.module.ts
+++ b/projects/demo/app/app.module.ts
@@ -46,7 +46,7 @@ export function provideAppBridgeService(http) {
         ScrollingModule,
         // Vendor
         NovoElementsModule,
-        NovoElementProviders.forRoot(),
+        NovoElementProviders.forRoot({ address: {} }),
         // APP
         NovoExamplesRoutesModule], providers: [
         // NovoTemplateService,

--- a/projects/novo-elements/src/elements/form/ControlTemplates.ts
+++ b/projects/novo-elements/src/elements/form/ControlTemplates.ts
@@ -1,9 +1,10 @@
 import { AfterViewInit, Component, QueryList, ViewChildren } from '@angular/core';
 import { NovoTemplate } from 'novo-elements/elements/common';
 import { NovoTemplateService } from 'novo-elements/services';
+
 @Component({
-    selector: 'novo-control-templates',
-    template: `
+  selector: 'novo-control-templates',
+  template: `
     <!---Readonly--->
     <ng-template novoTemplate="read-only" let-form="form" let-control>
       <div>{{ form.getRawValue()[control.key] }}</div>
@@ -693,7 +694,7 @@ import { NovoTemplateService } from 'novo-elements/services';
       </div>
     </ng-template>
   `,
-    standalone: false,
+  standalone: false,
 })
 export class NovoControlTemplates implements AfterViewInit {
   @ViewChildren(NovoTemplate)

--- a/projects/novo-elements/src/elements/form/extras/FormExtras.module.ts
+++ b/projects/novo-elements/src/elements/form/extras/FormExtras.module.ts
@@ -5,16 +5,18 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { NovoButtonModule } from 'novo-elements/elements/button';
 import { NovoCheckboxModule } from 'novo-elements/elements/checkbox';
+import { NovoOverlayModule } from 'novo-elements/elements/common';
+import { NovoFieldModule } from 'novo-elements/elements/field';
+import { NovoFlexModule } from 'novo-elements/elements/flex';
 import { NovoLoadingModule } from 'novo-elements/elements/loading';
 import { NovoPickerModule } from 'novo-elements/elements/picker';
+import { GooglePlacesModule } from 'novo-elements/elements/places';
 import { NovoSelectModule } from 'novo-elements/elements/select';
 import { NovoTooltipModule } from 'novo-elements/elements/tooltip';
 import { NovoPipesModule } from 'novo-elements/pipes';
 import { NovoAddressElement } from './address/Address';
 import { NovoFileInputElement } from './file/FileInput';
 import { NumberRangeComponent } from './number-range/number-range.component';
-import { NovoFlexModule } from 'novo-elements/elements/flex';
-import { NovoFieldModule } from 'novo-elements/elements/field';
 
 @NgModule({
   imports: [
@@ -31,9 +33,10 @@ import { NovoFieldModule } from 'novo-elements/elements/field';
     NovoFlexModule,
     NovoFieldModule,
     ReactiveFormsModule,
+    GooglePlacesModule,
+    NovoOverlayModule,
   ],
   declarations: [NovoAddressElement, NovoFileInputElement, NumberRangeComponent],
   exports: [NovoAddressElement, NovoFileInputElement, NumberRangeComponent],
 })
 export class NovoFormExtrasModule {}
-

--- a/projects/novo-elements/src/elements/form/extras/address/Address.spec.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.spec.ts
@@ -1,10 +1,12 @@
 import { TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
+import { NovoOverlayModule } from 'novo-elements/elements/common';
 import { NovoPickerModule } from 'novo-elements/elements/picker';
+import { GooglePlacesModule } from 'novo-elements/elements/places';
 import { NovoSelectModule } from 'novo-elements/elements/select';
 import { NovoTooltipModule } from 'novo-elements/elements/tooltip';
 import { NovoLabelService } from 'novo-elements/services';
-import { Helpers } from 'novo-elements/utils';
+import { Helpers, Key } from 'novo-elements/utils';
 import { tick } from 'novo-testing';
 import { vi } from 'vitest';
 import { NovoAddressElement } from './Address';
@@ -16,7 +18,7 @@ describe('Elements: NovoAddressElement', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [NovoAddressElement],
-      imports: [FormsModule, NovoSelectModule, NovoPickerModule, NovoTooltipModule],
+      imports: [FormsModule, NovoSelectModule, NovoPickerModule, NovoTooltipModule, GooglePlacesModule, NovoOverlayModule],
       providers: [{ provide: NovoLabelService, useClass: NovoLabelService }],
     }).compileComponents();
     fixture = TestBed.createComponent(NovoAddressElement);
@@ -598,6 +600,154 @@ describe('Elements: NovoAddressElement', () => {
       component.ngDoCheck();
       expect(component.isValid).not.toHaveBeenCalled();
       expect(component.isInvalid).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Address 1 autocomplete', () => {
+    beforeEach(() => {
+      component.config = {
+        address1: { required: false },
+        address2: { required: false },
+        city: { required: false },
+        state: { required: false },
+        zip: { required: false },
+        countryID: { required: false },
+      };
+      component.model = {};
+      component.overlay = { openPanel: vi.fn(), closePanel: vi.fn(), panelOpen: false };
+      component.placesList = { onKeyDown: vi.fn() };
+      vi.spyOn(component, 'onInput').mockImplementation(() => {});
+    });
+
+    describe('Method: onPlaceSelected()', () => {
+      beforeEach(() => {
+        vi.spyOn(component, 'updateStates').mockImplementation(() => {});
+        vi.spyOn(component, 'updateControl').mockImplementation(() => {});
+      });
+
+      it('should no-op on null/undefined', () => {
+        component.model = { address1: 'keep' };
+        component.onPlaceSelected(null);
+        component.onPlaceSelected(undefined);
+        expect(component.model.address1).toEqual('keep');
+        expect(component.updateControl).not.toHaveBeenCalled();
+      });
+
+      it('should overwrite returned fields and map countryCode to countryID/countryName', () => {
+        component.onPlaceSelected({
+          address1: '100 Summer Street',
+          city: 'Boston',
+          state: 'MA',
+          zip: '02110',
+          countryCode: 'US',
+        });
+        expect(component.model.address1).toEqual('100 Summer Street');
+        expect(component.model.city).toEqual('Boston');
+        expect(component.model.state).toEqual('MA');
+        expect(component.model.zip).toEqual('02110');
+        expect(component.model.countryID).toEqual(1);
+        expect(component.model.countryName).toEqual('United States');
+        expect(component.updateStates).toHaveBeenCalled();
+        expect(component.updateControl).toHaveBeenCalled();
+      });
+
+      it('should persist a field the API omits (address2 with no unit)', () => {
+        component.model = { address2: 'Suite 500' };
+        component.onPlaceSelected({ address1: '100 Summer Street', city: 'Boston' });
+        expect(component.model.address2).toEqual('Suite 500');
+        expect(component.model.address1).toEqual('100 Summer Street');
+      });
+
+      it('should clear a field when the API returns an empty string', () => {
+        component.model = { address2: 'Suite 500' };
+        component.onPlaceSelected({ address1: '100 Summer Street', address2: '' });
+        expect(component.model.address2).toEqual('');
+      });
+
+      it('should close the overlay and clear the debounced term', () => {
+        component.debouncedSearch = '100 Sum';
+        component.onPlaceSelected({ address1: '100 Summer Street' });
+        expect(component.debouncedSearch).toEqual('');
+        expect(component.overlay.closePanel).toHaveBeenCalled();
+      });
+    });
+
+    describe('Method: onMatchesUpdated()', () => {
+      it('should open the overlay when there are matches', () => {
+        component.onMatchesUpdated([{ placeId: '1' }]);
+        expect(component.overlay.openPanel).toHaveBeenCalled();
+        expect(component.overlay.closePanel).not.toHaveBeenCalled();
+      });
+
+      it('should close the overlay when there are no matches', () => {
+        component.onMatchesUpdated([]);
+        expect(component.overlay.closePanel).toHaveBeenCalled();
+        expect(component.overlay.openPanel).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('Method: onAddress1Input()', () => {
+      const inputEvent = (value: string) => ({ target: { value } }) as unknown as Event;
+
+      it('should read the live input value (not the possibly-stale model), open the panel, and debounce it', async () => {
+        component.ngOnInit();
+        // model.address1 is intentionally different to prove we read the event value.
+        component.model.address1 = 'stale';
+        const event = inputEvent('100 Summer');
+        component.onAddress1Input(event);
+        expect(component.onInput).toHaveBeenCalledWith(event, 'address1');
+        expect(component.overlay.openPanel).toHaveBeenCalled();
+        await tick(350);
+        expect(component.debouncedSearch).toEqual('100 Summer');
+      });
+
+      it('should clear the term and close the overlay when the field is empty', () => {
+        component.onAddress1Input(inputEvent(''));
+        expect(component.debouncedSearch).toEqual('');
+        expect(component.overlay.closePanel).toHaveBeenCalled();
+      });
+
+      it('should re-fire the same term after a selection reset debouncedSearch (no distinctUntilChanged swallow)', async () => {
+        component.ngOnInit();
+        component.onAddress1Input(inputEvent('100 Summer'));
+        await tick(350);
+        expect(component.debouncedSearch).toEqual('100 Summer');
+        // Simulate a selection clearing the debounced term, then searching the same text again.
+        component.debouncedSearch = '';
+        component.onAddress1Input(inputEvent('100 Summer'));
+        await tick(350);
+        expect(component.debouncedSearch).toEqual('100 Summer');
+      });
+    });
+
+    describe('Method: onAddress1Keydown()', () => {
+      it('should do nothing when the panel is closed', () => {
+        component.overlay.panelOpen = false;
+        component.onAddress1Keydown({ key: Key.ArrowDown } as KeyboardEvent);
+        expect(component.placesList.onKeyDown).not.toHaveBeenCalled();
+      });
+
+      it('should close the overlay on Escape', () => {
+        component.overlay.panelOpen = true;
+        component.onAddress1Keydown({ key: Key.Escape } as KeyboardEvent);
+        expect(component.overlay.closePanel).toHaveBeenCalled();
+      });
+
+      it('should forward arrow keys to the places list', () => {
+        component.overlay.panelOpen = true;
+        const event = { key: Key.ArrowDown } as KeyboardEvent;
+        component.onAddress1Keydown(event);
+        expect(component.placesList.onKeyDown).toHaveBeenCalledWith(event);
+      });
+
+      it('should prevent default and forward on Enter', () => {
+        component.overlay.panelOpen = true;
+        const preventDefault = vi.fn();
+        const event = { key: Key.Enter, preventDefault } as unknown as KeyboardEvent;
+        component.onAddress1Keydown(event);
+        expect(preventDefault).toHaveBeenCalled();
+        expect(component.placesList.onKeyDown).toHaveBeenCalledWith(event);
+      });
     });
   });
 });

--- a/projects/novo-elements/src/elements/form/extras/address/Address.spec.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.spec.ts
@@ -706,18 +706,6 @@ describe('Elements: NovoAddressElement', () => {
         expect(component.debouncedSearch).toEqual('');
         expect(component.overlay.closePanel).toHaveBeenCalled();
       });
-
-      it('should re-fire the same term after a selection reset debouncedSearch (no distinctUntilChanged swallow)', async () => {
-        component.ngOnInit();
-        component.onAddress1Input(inputEvent('100 Summer'));
-        await tick(350);
-        expect(component.debouncedSearch).toEqual('100 Summer');
-        // Simulate a selection clearing the debounced term, then searching the same text again.
-        component.debouncedSearch = '';
-        component.onAddress1Input(inputEvent('100 Summer'));
-        await tick(350);
-        expect(component.debouncedSearch).toEqual('100 Summer');
-      });
     });
 
     describe('Method: onAddress1Keydown()', () => {

--- a/projects/novo-elements/src/elements/form/extras/address/Address.spec.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.spec.ts
@@ -672,6 +672,75 @@ describe('Elements: NovoAddressElement', () => {
       });
     });
 
+    describe('Method: onPlaceSelected() — Google Places raw format', () => {
+      // The raw shape emitted by google-places-list when using the Google API directly.
+      const usPlace = {
+        address_components: [
+          { long_name: '100', short_name: '100', types: ['street_number'] },
+          { long_name: 'Summer Street', short_name: 'Summer St', types: ['route'] },
+          { long_name: 'Boston', short_name: 'Boston', types: ['locality', 'political'] },
+          { long_name: 'Massachusetts', short_name: 'MA', types: ['administrative_area_level_1', 'political'] },
+          { long_name: '02110', short_name: '02110', types: ['postal_code'] },
+          { long_name: 'United States', short_name: 'US', types: ['country', 'political'] },
+        ],
+        formatted_address: '100 Summer St, Boston, MA 02110, USA',
+        place_id: 'ChIJexample',
+      };
+
+      beforeEach(() => {
+        vi.spyOn(component, 'updateStates').mockImplementation(() => {});
+        vi.spyOn(component, 'updateControl').mockImplementation(() => {});
+      });
+
+      it('should map raw address_components into the flat model fields', () => {
+        component.onPlaceSelected(usPlace as any);
+        expect(component.model.address1).toEqual('100 Summer Street'); // street_number + route
+        expect(component.model.city).toEqual('Boston'); // locality
+        expect(component.model.state).toEqual('Massachusetts'); // admin_area_level_1 long_name, not 'MA'
+        expect(component.model.zip).toEqual('02110'); // postal_code
+        expect(component.model.countryID).toEqual(1); // country short_name 'US' -> COUNTRIES.code
+        expect(component.model.countryName).toEqual('United States');
+        expect(component.updateStates).toHaveBeenCalled();
+        expect(component.updateControl).toHaveBeenCalled();
+      });
+
+      it('should map subpremise into address2', () => {
+        const place = {
+          address_components: [...usPlace.address_components, { long_name: 'Suite 500', short_name: 'Suite 500', types: ['subpremise'] }],
+        };
+        component.onPlaceSelected(place as any);
+        expect(component.model.address2).toEqual('Suite 500');
+      });
+
+      it('should leave an existing address2 untouched when the result has no subpremise', () => {
+        component.model = { address2: 'Suite 500' };
+        component.onPlaceSelected(usPlace as any);
+        expect(component.model.address2).toEqual('Suite 500');
+      });
+
+      it('should fall back to postal_town for city when locality is absent', () => {
+        const ukPlace = {
+          address_components: [
+            { long_name: '10', short_name: '10', types: ['street_number'] },
+            { long_name: 'Downing Street', short_name: 'Downing St', types: ['route'] },
+            { long_name: 'London', short_name: 'London', types: ['postal_town'] },
+            { long_name: 'SW1A 2AA', short_name: 'SW1A 2AA', types: ['postal_code'] },
+            { long_name: 'United Kingdom', short_name: 'GB', types: ['country', 'political'] },
+          ],
+        };
+        component.onPlaceSelected(ukPlace as any);
+        expect(component.model.city).toEqual('London');
+      });
+
+      it('should pass through formattedAddress, placeId, and the country code/name', () => {
+        const result = component.parseGooglePlaceDetail(usPlace);
+        expect(result.formattedAddress).toEqual('100 Summer St, Boston, MA 02110, USA');
+        expect(result.placeId).toEqual('ChIJexample');
+        expect(result.countryCode).toEqual('US'); // short_name
+        expect(result.countryName).toEqual('United States'); // long_name
+      });
+    });
+
     describe('Method: onMatchesUpdated()', () => {
       it('should open the overlay when there are matches', () => {
         component.onMatchesUpdated([{ placeId: '1' }]);

--- a/projects/novo-elements/src/elements/form/extras/address/Address.spec.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.spec.ts
@@ -712,10 +712,29 @@ describe('Elements: NovoAddressElement', () => {
         expect(component.model.address2).toEqual('Suite 500');
       });
 
-      it('should leave an existing address2 untouched when the result has no subpremise', () => {
+      it('should blank an existing address2 when the selected place has no subpremise', () => {
         component.model = { address2: 'Suite 500' };
         component.onPlaceSelected(usPlace as any);
-        expect(component.model.address2).toEqual('Suite 500');
+        expect(component.model.address2).toEqual('');
+      });
+
+      it('should clear the finer fields when a partial place (state/country only) is selected', () => {
+        component.model = { address1: '100 Summer Street', address2: 'Suite 500', city: 'Boston', state: 'Massachusetts', zip: '02110' };
+        const statePlace = {
+          address_components: [
+            { long_name: 'Texas', short_name: 'TX', types: ['administrative_area_level_1', 'political'] },
+            { long_name: 'United States', short_name: 'US', types: ['country', 'political'] },
+          ],
+          formatted_address: 'Texas, USA',
+        };
+        component.onPlaceSelected(statePlace as any);
+        expect(component.model.address1).toEqual('');
+        expect(component.model.address2).toEqual('');
+        expect(component.model.city).toEqual('');
+        expect(component.model.zip).toEqual('');
+        expect(component.model.state).toEqual('Texas');
+        expect(component.model.countryID).toEqual(1);
+        expect(component.model.countryName).toEqual('United States');
       });
 
       it('should fall back to postal_town for city when locality is absent', () => {

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -533,8 +533,10 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit, DoCheck
     // backend. Normalize the Google shape into flat fields before applying.
     const result: AddressLookupResult = placeDetail.address_components ? this.parseGooglePlaceDetail(placeDetail) : placeDetail;
 
-    // Overwrite each field the API returns (including an explicit empty string);
-    // fields the API omits (undefined) persist — e.g. address2 when no unit/suite.
+    // Overwrite each field the result defines, including an explicit empty string — the
+    // Google parser resolves omitted components to '' so a partial selection (e.g. a
+    // state/country only) clears the finer fields. A REST result may instead leave a field
+    // undefined to mean "unspecified", in which case the existing model value persists.
     if (result.address1 !== undefined) {
       this.model.address1 = result.address1;
     }
@@ -566,15 +568,16 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit, DoCheck
     this.overlay?.closePanel();
   }
 
-  // Map a raw Google Places detail into the flat AddressLookupResult shape. Returns
-  // undefined for components the result omits so existing model fields persist; the
+  // Map a raw Google Places detail into the flat AddressLookupResult shape. A selected
+  // place is the complete address, so components it omits resolve to '' (an explicit clear)
+  // rather than undefined — selecting e.g. "Texas, USA" blanks address1/city/zip. The
   // country/state names use long_name to match COUNTRIES.code and getStates() labels.
   private parseGooglePlaceDetail(place: { address_components?: any[]; formatted_address?: string; place_id?: string }): AddressLookupResult {
     const components: Array<{ long_name: string; short_name: string; types: string[] }> = place.address_components || [];
-    const find = (type: string, useShort = false): string | undefined => {
+    const find = (type: string, useShort = false): string => {
       const match = components.find((component) => component.types.includes(type));
       if (!match) {
-        return undefined;
+        return '';
       }
       return useShort ? match.short_name : match.long_name;
     };

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -16,14 +16,6 @@ const ADDRESS_VALUE_ACCESSOR = {
   multi: true,
 };
 
-export interface AddressLookupPrediction {
-  placeId?: string;
-  displayAddress?: string;
-  primaryText?: string;
-  secondaryText?: string;
-  types?: string[];
-}
-
 export interface AddressLookupResult {
   address1?: string;
   address2?: string;

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -531,31 +531,36 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit, DoCheck
     }
   }
 
-  onPlaceSelected(placeDetail: AddressLookupResult): void {
+  onPlaceSelected(placeDetail: AddressLookupResult & { address_components?: any[]; formatted_address?: string }): void {
     if (!placeDetail) {
       return;
     }
 
+    // google-places-list emits the raw Google Places detail (snake_case address_components)
+    // when using the Google API directly, or a pre-parsed AddressLookupResult from a REST
+    // backend. Normalize the Google shape into flat fields before applying.
+    const result: AddressLookupResult = placeDetail.address_components ? this.parseGooglePlaceDetail(placeDetail) : placeDetail;
+
     // Overwrite each field the API returns (including an explicit empty string);
     // fields the API omits (undefined) persist — e.g. address2 when no unit/suite.
-    if (placeDetail.address1 !== undefined) {
-      this.model.address1 = placeDetail.address1;
+    if (result.address1 !== undefined) {
+      this.model.address1 = result.address1;
     }
-    if (placeDetail.address2 !== undefined) {
-      this.model.address2 = placeDetail.address2;
+    if (result.address2 !== undefined) {
+      this.model.address2 = result.address2;
     }
-    if (placeDetail.city !== undefined) {
-      this.model.city = placeDetail.city;
+    if (result.city !== undefined) {
+      this.model.city = result.city;
     }
-    if (placeDetail.state !== undefined) {
-      this.model.state = placeDetail.state;
+    if (result.state !== undefined) {
+      this.model.state = result.state;
     }
-    if (placeDetail.zip !== undefined) {
-      this.model.zip = placeDetail.zip;
+    if (result.zip !== undefined) {
+      this.model.zip = result.zip;
     }
 
-    if (placeDetail.countryCode) {
-      const country = COUNTRIES.find((c) => c.code === placeDetail.countryCode);
+    if (result.countryCode) {
+      const country = COUNTRIES.find((c) => c.code === result.countryCode);
       if (country) {
         this.model.countryID = country.id;
         this.model.countryName = country.name;
@@ -567,6 +572,32 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit, DoCheck
     this.fieldList.forEach((field) => this.onInput(null, field));
     this.debouncedSearch = '';
     this.overlay?.closePanel();
+  }
+
+  // Map a raw Google Places detail into the flat AddressLookupResult shape. Returns
+  // undefined for components the result omits so existing model fields persist; the
+  // country/state names use long_name to match COUNTRIES.code and getStates() labels.
+  private parseGooglePlaceDetail(place: { address_components?: any[]; formatted_address?: string; place_id?: string }): AddressLookupResult {
+    const components: Array<{ long_name: string; short_name: string; types: string[] }> = place.address_components || [];
+    const find = (type: string, useShort = false): string | undefined => {
+      const match = components.find((component) => component.types.includes(type));
+      if (!match) {
+        return undefined;
+      }
+      return useShort ? match.short_name : match.long_name;
+    };
+    const street = [find('street_number'), find('route')].filter(Boolean).join(' ');
+    return {
+      address1: street,
+      address2: find('subpremise'),
+      city: find('locality') || find('postal_town') || find('sublocality') || find('sublocality_level_1'),
+      state: find('administrative_area_level_1'),
+      zip: find('postal_code'),
+      countryName: find('country'),
+      countryCode: find('country', true),
+      formattedAddress: place.formatted_address,
+      placeId: place.place_id,
+    };
   }
 
   setStateLabel(model: any) {

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -528,15 +528,10 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit, DoCheck
       return;
     }
 
-    // google-places-list emits the raw Google Places detail (snake_case address_components)
-    // when using the Google API directly, or a pre-parsed AddressLookupResult from a REST
-    // backend. Normalize the Google shape into flat fields before applying.
+    // Normalize the raw Google detail into flat fields; REST results arrive pre-parsed.
     const result: AddressLookupResult = placeDetail.address_components ? this.parseGooglePlaceDetail(placeDetail) : placeDetail;
 
-    // Overwrite each field the result defines, including an explicit empty string — the
-    // Google parser resolves omitted components to '' so a partial selection (e.g. a
-    // state/country only) clears the finer fields. A REST result may instead leave a field
-    // undefined to mean "unspecified", in which case the existing model value persists.
+    // Set fields the result defines (including '' to clear); undefined leaves the model value.
     if (result.address1 !== undefined) {
       this.model.address1 = result.address1;
     }
@@ -568,10 +563,7 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit, DoCheck
     this.overlay?.closePanel();
   }
 
-  // Map a raw Google Places detail into the flat AddressLookupResult shape. A selected
-  // place is the complete address, so components it omits resolve to '' (an explicit clear)
-  // rather than undefined — selecting e.g. "Texas, USA" blanks address1/city/zip. The
-  // country/state names use long_name to match COUNTRIES.code and getStates() labels.
+  // Map a raw Google detail to flat fields; omitted components resolve to '' so partial selections clear finer fields.
   private parseGooglePlaceDetail(place: { address_components?: any[]; formatted_address?: string; place_id?: string }): AddressLookupResult {
     const components: Array<{ long_name: string; short_name: string; types: string[] }> = place.address_components || [];
     const find = (type: string, useShort = false): string => {

--- a/projects/novo-elements/src/elements/form/extras/address/Address.ts
+++ b/projects/novo-elements/src/elements/form/extras/address/Address.ts
@@ -1,9 +1,13 @@
 // NG2
-import { Component, DoCheck, EventEmitter, forwardRef, Input, OnInit, Output } from '@angular/core';
+import { Component, DoCheck, ElementRef, EventEmitter, forwardRef, Inject, Input, OnDestroy, OnInit, Optional, Output, ViewChild } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { Subject, Subscription } from 'rxjs';
+import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 // APP
+import { NovoOverlayTemplateComponent } from 'novo-elements/elements/common';
+import { NOVO_ADDRESS_CONFIG, PlacesListComponent, PlacesSettings } from 'novo-elements/elements/places';
 import { NovoLabelService } from 'novo-elements/services';
-import { COUNTRIES, findByCountryId, getStates, Helpers } from 'novo-elements/utils';
+import { COUNTRIES, findByCountryId, getStates, Helpers, Key } from 'novo-elements/utils';
 
 // Value accessor for the component (supports ngModel)
 const ADDRESS_VALUE_ACCESSOR = {
@@ -11,6 +15,31 @@ const ADDRESS_VALUE_ACCESSOR = {
   useExisting: forwardRef(() => NovoAddressElement),
   multi: true,
 };
+
+export interface AddressLookupPrediction {
+  placeId?: string;
+  displayAddress?: string;
+  primaryText?: string;
+  secondaryText?: string;
+  types?: string[];
+}
+
+export interface AddressLookupResult {
+  address1?: string;
+  address2?: string;
+  city?: string;
+  state?: string;
+  zip?: string;
+  countryName?: string;
+  countryCode?: string;
+  formattedAddress?: string;
+  location?: { latitude: number; longitude: number };
+  viewport?: {
+    northeast: { latitude: number; longitude: number };
+    southwest: { latitude: number; longitude: number };
+  };
+  placeId?: string;
+}
 
 export interface NovoAddressSubfieldConfig {
   label: string;
@@ -34,9 +63,9 @@ export interface NovoAddressConfig {
 }
 
 @Component({
-    selector: 'novo-address',
-    providers: [ADDRESS_VALUE_ACCESSOR],
-    template: `
+  selector: 'novo-address',
+  providers: [ADDRESS_VALUE_ACCESSOR],
+  template: `
     <span
       *ngIf="!config?.address1?.hidden"
       class="street-address"
@@ -51,6 +80,7 @@ export interface NovoAddressConfig {
       >
       </i>
       <input
+        #address1El
         [class.maxlength-error]="invalidMaxlength.address1"
         type="text"
         id="address1"
@@ -62,10 +92,20 @@ export interface NovoAddressConfig {
         (ngModelChange)="updateControl()"
         (focus)="isFocused($event, 'address1')"
         (blur)="isBlurred($event, 'address1')"
-        (input)="onInput($event, 'address1')"
+        (input)="onAddress1Input($event)"
+        (keydown)="onAddress1Keydown($event)"
         [disabled]="disabled.address1"
       />
     </span>
+    <novo-overlay-template *ngIf="addressConfig" [parent]="address1ElRef" position="above-below">
+      <google-places-list
+        [term]="debouncedSearch"
+        [userSettings]="addressConfig"
+        (select)="onPlaceSelected($event)"
+        (matchesUpdated)="onMatchesUpdated($event)"
+      >
+      </google-places-list>
+    </novo-overlay-template>
     <span
       *ngIf="!config?.address2?.hidden"
       class="apt suite"
@@ -184,32 +224,24 @@ export interface NovoAddressConfig {
       ></novo-picker>
     </span>
   `,
-    styleUrls: ['./Address.scss'],
-    standalone: false,
+  styleUrls: ['./Address.scss'],
+  standalone: false,
 })
-export class NovoAddressElement implements ControlValueAccessor, OnInit, DoCheck {
+export class NovoAddressElement implements ControlValueAccessor, OnInit, DoCheck, OnDestroy {
   @Input()
   config: NovoAddressConfig;
-  private _readOnly = false;
-  @Input()
-  set readOnly(readOnly: boolean) {
-    this._readOnly = readOnly;
-    this.fieldList.forEach((field: string) => {
-      this.disabled[field] = this._readOnly;
-    });
-    if (this.model) {
-      this.updateStates();
-    }
-  }
-  get readOnly(): boolean {
-    return this._readOnly;
-  }
-  private previousRequiredState: Record<string, boolean> = {};
+  @ViewChild('address1El', { read: ElementRef })
+  address1ElRef: ElementRef;
+  @ViewChild(NovoOverlayTemplateComponent)
+  overlay: NovoOverlayTemplateComponent;
+  @ViewChild(PlacesListComponent)
+  placesList: PlacesListComponent;
+  debouncedSearch: string = '';
+  private searchTerms$ = new Subject<string>();
+  private searchSubscription: Subscription;
   states: Array<any> = [];
   fieldList: Array<string> = ['address1', 'address2', 'city', 'state', 'zip', 'countryID'];
   model: any;
-  onModelChange: Function = () => {};
-  onModelTouched: Function = () => {};
   focused: any = {};
   invalid: any = {};
   disabled: any = {};
@@ -226,8 +258,33 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit, DoCheck
   blur: EventEmitter<any> = new EventEmitter();
   @Output()
   validityChange: EventEmitter<any> = new EventEmitter();
+  private previousRequiredState: Record<string, boolean> = {};
 
-  constructor(public labels: NovoLabelService) {}
+  constructor(
+    public labels: NovoLabelService,
+    @Optional() @Inject(NOVO_ADDRESS_CONFIG) public addressConfig: PlacesSettings,
+  ) {}
+
+  private _readOnly = false;
+
+  get readOnly(): boolean {
+    return this._readOnly;
+  }
+
+  @Input()
+  set readOnly(readOnly: boolean) {
+    this._readOnly = readOnly;
+    this.fieldList.forEach((field: string) => {
+      this.disabled[field] = this._readOnly;
+    });
+    if (this.model) {
+      this.updateStates();
+    }
+  }
+
+  onModelChange: Function = () => {};
+
+  onModelTouched: Function = () => {};
 
   ngOnInit() {
     if (!this.config) {
@@ -242,6 +299,18 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit, DoCheck
     }
     if (Helpers.isBlank(this.model.countryID)) {
       this.updateStates();
+    }
+    this.searchSubscription = this.searchTerms$.pipe(
+      debounceTime(300),
+      distinctUntilChanged(),
+    ).subscribe(term => {
+      this.debouncedSearch = term;
+    });
+  }
+
+  ngOnDestroy() {
+    if (this.searchSubscription) {
+      this.searchSubscription.unsubscribe();
     }
   }
 
@@ -420,6 +489,84 @@ export class NovoAddressElement implements ControlValueAccessor, OnInit, DoCheck
     this.model.state = state;
     this.updateControl();
     this.onInput(null, 'state');
+  }
+
+  onAddress1Input(event: Event): void {
+    this.onInput(event, 'address1');
+    // Read the live DOM value; model.address1 can lag a keystroke.
+    const term = (event?.target as HTMLInputElement)?.value ?? '';
+    if (!term) {
+      this.debouncedSearch = '';
+      this.overlay?.closePanel();
+      return;
+    }
+    // Open on type so the projected picker is attached to fetch/show results.
+    this.overlay?.openPanel();
+    this.searchTerms$.next(term);
+  }
+
+  onMatchesUpdated(matches: any[]): void {
+    // Close when a query returns no results, otherwise keep the panel open.
+    if (matches?.length) {
+      this.overlay?.openPanel();
+    } else {
+      this.overlay?.closePanel();
+    }
+  }
+
+  onAddress1Keydown(event: KeyboardEvent): void {
+    if (!this.overlay?.panelOpen) {
+      return;
+    }
+    if (event.key === Key.Escape) {
+      this.overlay.closePanel();
+      return;
+    }
+    if (event.key === Key.ArrowUp || event.key === Key.ArrowDown || event.key === Key.Enter) {
+      if (event.key === Key.Enter) {
+        // Prevent submitting the surrounding form when selecting a prediction.
+        event.preventDefault();
+      }
+      this.placesList?.onKeyDown(event);
+    }
+  }
+
+  onPlaceSelected(placeDetail: AddressLookupResult): void {
+    if (!placeDetail) {
+      return;
+    }
+
+    // Overwrite each field the API returns (including an explicit empty string);
+    // fields the API omits (undefined) persist — e.g. address2 when no unit/suite.
+    if (placeDetail.address1 !== undefined) {
+      this.model.address1 = placeDetail.address1;
+    }
+    if (placeDetail.address2 !== undefined) {
+      this.model.address2 = placeDetail.address2;
+    }
+    if (placeDetail.city !== undefined) {
+      this.model.city = placeDetail.city;
+    }
+    if (placeDetail.state !== undefined) {
+      this.model.state = placeDetail.state;
+    }
+    if (placeDetail.zip !== undefined) {
+      this.model.zip = placeDetail.zip;
+    }
+
+    if (placeDetail.countryCode) {
+      const country = COUNTRIES.find((c) => c.code === placeDetail.countryCode);
+      if (country) {
+        this.model.countryID = country.id;
+        this.model.countryName = country.name;
+      }
+    }
+
+    this.updateStates();
+    this.updateControl();
+    this.fieldList.forEach((field) => this.onInput(null, field));
+    this.debouncedSearch = '';
+    this.overlay?.closePanel();
   }
 
   setStateLabel(model: any) {

--- a/projects/novo-elements/src/elements/places/index.ts
+++ b/projects/novo-elements/src/elements/places/index.ts
@@ -1,3 +1,4 @@
 export * from './places.component';
 export * from './places.module';
 export * from './places.service';
+export * from './places.tokens';

--- a/projects/novo-elements/src/elements/places/places.component.spec.ts
+++ b/projects/novo-elements/src/elements/places/places.component.spec.ts
@@ -1,0 +1,61 @@
+import { Key } from 'novo-elements/utils';
+import { vi } from 'vitest';
+import { PlacesListComponent } from './places.component';
+
+describe('Elements: PlacesListComponent', () => {
+  let component: PlacesListComponent;
+
+  beforeEach(() => {
+    const elmRef: any = { nativeElement: document.createElement('div') };
+    const cdr: any = { detectChanges: () => {} };
+    component = new PlacesListComponent('browser', elmRef, {} as any, {} as any, cdr);
+  });
+
+  describe('Output: matchesUpdated', () => {
+    it('should emit the matches when the prediction list updates', () => {
+      let emitted: any[];
+      component.matchesUpdated.subscribe((matches) => (emitted = matches));
+      const predictions = [{ placeId: '1' }, { placeId: '2' }];
+
+      component['updateListItem'](predictions);
+
+      expect(component.matches).toEqual(predictions);
+      expect(component.dropdownOpen).toBe(true);
+      expect(emitted).toEqual(predictions);
+    });
+
+    it('should emit an empty array when there are no predictions', () => {
+      let emitted: any[];
+      component.matchesUpdated.subscribe((matches) => (emitted = matches));
+
+      component['updateListItem'](null);
+
+      expect(component.matches).toEqual([]);
+      expect(emitted).toEqual([]);
+    });
+
+    it('should reset the active match when the list refreshes', () => {
+      component.activeMatch = { placeId: 'stale' };
+      component['updateListItem']([{ placeId: '1' }]);
+      expect(component.activeMatch).toBeUndefined();
+    });
+  });
+
+  describe('Method: onKeyDown()', () => {
+    it('should NOT select on Enter when no prediction is highlighted', () => {
+      const selectSpy = vi.spyOn(component, 'selectMatch');
+      component.dropdownOpen = true;
+      component.activeMatch = undefined;
+      expect(() => component.onKeyDown({ key: Key.Enter } as KeyboardEvent)).not.toThrow();
+      expect(selectSpy).not.toHaveBeenCalled();
+    });
+
+    it('should select on Enter when a prediction is highlighted', () => {
+      const selectSpy = vi.spyOn(component, 'selectMatch').mockImplementation(() => {});
+      component.dropdownOpen = true;
+      component.activeMatch = { placeId: '1' };
+      component.onKeyDown({ key: Key.Enter } as KeyboardEvent);
+      expect(selectSpy).toHaveBeenCalledWith({ placeId: '1' });
+    });
+  });
+});

--- a/projects/novo-elements/src/elements/places/places.component.spec.ts
+++ b/projects/novo-elements/src/elements/places/places.component.spec.ts
@@ -58,4 +58,71 @@ describe('Elements: PlacesListComponent', () => {
       expect(selectSpy).toHaveBeenCalledWith({ placeId: '1' });
     });
   });
+
+  describe('Method: getPrimaryText()', () => {
+    it('should use the REST primaryText when present', () => {
+      expect(component.getPrimaryText({ primaryText: 'Acme HQ' })).toEqual('Acme HQ');
+    });
+
+    it('should use the Google structured_formatting.main_text', () => {
+      expect(component.getPrimaryText({ structured_formatting: { main_text: '100 Summer St' } })).toEqual('100 Summer St');
+    });
+
+    it('should fall back to displayAddress, then description', () => {
+      expect(component.getPrimaryText({ displayAddress: '100 Summer St, Boston' })).toEqual('100 Summer St, Boston');
+      expect(component.getPrimaryText({ description: '100 Summer St, Boston, MA' })).toEqual('100 Summer St, Boston, MA');
+    });
+
+    it('should prefer the REST primaryText over the Google format', () => {
+      expect(component.getPrimaryText({ primaryText: 'REST', structured_formatting: { main_text: 'Google' } })).toEqual('REST');
+    });
+
+    it('should return an empty string when nothing matches', () => {
+      expect(component.getPrimaryText({})).toEqual('');
+    });
+  });
+
+  describe('Method: getSecondaryText()', () => {
+    it('should use the REST secondaryText when present', () => {
+      expect(component.getSecondaryText({ secondaryText: 'Boston, MA' })).toEqual('Boston, MA');
+    });
+
+    it('should use the Google structured_formatting.secondary_text', () => {
+      expect(component.getSecondaryText({ structured_formatting: { secondary_text: 'Boston, MA, USA' } })).toEqual('Boston, MA, USA');
+    });
+
+    it('should prefer the REST secondaryText over the Google format', () => {
+      expect(component.getSecondaryText({ secondaryText: 'REST', structured_formatting: { secondary_text: 'Google' } })).toEqual('REST');
+    });
+
+    it('should return an empty string when nothing matches', () => {
+      expect(component.getSecondaryText({})).toEqual('');
+    });
+  });
+
+  describe('Method: getPlaceLocationInfo()', () => {
+    it('should resolve Google details using the camelCase placeId', () => {
+      const getGeoPlaceDetail = vi.fn().mockResolvedValue(null);
+      component['_googlePlacesService'] = { getGeoPlaceDetail } as any;
+      component.settings = { useGoogleGeoApi: true } as any;
+      component['getPlaceLocationInfo']({ placeId: 'abc' });
+      expect(getGeoPlaceDetail).toHaveBeenCalledWith('abc');
+    });
+
+    it('should fall back to the snake_case place_id', () => {
+      const getGeoPlaceDetail = vi.fn().mockResolvedValue(null);
+      component['_googlePlacesService'] = { getGeoPlaceDetail } as any;
+      component.settings = { useGoogleGeoApi: true } as any;
+      component['getPlaceLocationInfo']({ place_id: 'xyz' });
+      expect(getGeoPlaceDetail).toHaveBeenCalledWith('xyz');
+    });
+
+    it('should use the REST endpoint with the placeId when useGoogleGeoApi is false', () => {
+      const getPlaceDetails = vi.fn().mockResolvedValue(null);
+      component['_googlePlacesService'] = { getPlaceDetails } as any;
+      component.settings = { useGoogleGeoApi: false, geoLocDetailServerUrl: 'https://api/detail' } as any;
+      component['getPlaceLocationInfo']({ placeId: 'abc' });
+      expect(getPlaceDetails).toHaveBeenCalledWith('https://api/detail', 'abc');
+    });
+  });
 });

--- a/projects/novo-elements/src/elements/places/places.component.spec.ts
+++ b/projects/novo-elements/src/elements/places/places.component.spec.ts
@@ -12,16 +12,21 @@ describe('Elements: PlacesListComponent', () => {
   });
 
   describe('Output: matchesUpdated', () => {
-    it('should emit the matches when the prediction list updates', () => {
+    it('should normalize and emit the matches when the prediction list updates', () => {
       let emitted: any[];
       component.matchesUpdated.subscribe((matches) => (emitted = matches));
-      const predictions = [{ placeId: '1' }, { placeId: '2' }];
+      const predictions = [
+        { place_id: '1', structured_formatting: { main_text: 'First', secondary_text: 'City A' } },
+        { placeId: '2', primaryText: 'Second', secondaryText: 'City B' },
+      ];
 
       component['updateListItem'](predictions);
 
-      expect(component.matches).toEqual(predictions);
+      expect(component.matches.length).toBe(2);
+      expect(component.matches[0]).toMatchObject({ placeId: '1', primaryText: 'First', secondaryText: 'City A' });
+      expect(component.matches[1]).toMatchObject({ placeId: '2', primaryText: 'Second', secondaryText: 'City B' });
       expect(component.dropdownOpen).toBe(true);
-      expect(emitted).toEqual(predictions);
+      expect(emitted).toBe(component.matches);
     });
 
     it('should emit an empty array when there are no predictions', () => {
@@ -59,62 +64,93 @@ describe('Elements: PlacesListComponent', () => {
     });
   });
 
-  describe('Method: getPrimaryText()', () => {
-    it('should use the REST primaryText when present', () => {
-      expect(component.getPrimaryText({ primaryText: 'Acme HQ' })).toEqual('Acme HQ');
+  describe('Method: normalizePrediction()', () => {
+    it('should map a Google snake_case prediction into the internal shape', () => {
+      const result = component.normalizePrediction({
+        place_id: 'g1',
+        description: '100 Summer St, Boston, MA, USA',
+        structured_formatting: { main_text: '100 Summer St', secondary_text: 'Boston, MA, USA' },
+        types: ['street_address'],
+      });
+      expect(result).toMatchObject({
+        placeId: 'g1',
+        primaryText: '100 Summer St',
+        secondaryText: 'Boston, MA, USA',
+        displayAddress: '100 Summer St, Boston, MA, USA',
+        types: ['street_address'],
+      });
     });
 
-    it('should use the Google structured_formatting.main_text', () => {
-      expect(component.getPrimaryText({ structured_formatting: { main_text: '100 Summer St' } })).toEqual('100 Summer St');
+    it('should map a REST camelCase prediction into the internal shape', () => {
+      const result = component.normalizePrediction({
+        placeId: 'r1',
+        primaryText: 'Acme HQ',
+        secondaryText: 'Boston, MA',
+        displayAddress: 'Acme HQ, Boston, MA',
+      });
+      expect(result).toMatchObject({
+        placeId: 'r1',
+        primaryText: 'Acme HQ',
+        secondaryText: 'Boston, MA',
+        displayAddress: 'Acme HQ, Boston, MA',
+      });
     });
 
-    it('should fall back to displayAddress, then description', () => {
-      expect(component.getPrimaryText({ displayAddress: '100 Summer St, Boston' })).toEqual('100 Summer St, Boston');
-      expect(component.getPrimaryText({ description: '100 Summer St, Boston, MA' })).toEqual('100 Summer St, Boston, MA');
+    it('should fall back to description for primaryText (recent search shape)', () => {
+      const result = component.normalizePrediction({ place_id: 'rec1', description: '12 Main St, Albany, NY' });
+      expect(result.primaryText).toEqual('12 Main St, Albany, NY');
+      expect(result.secondaryText).toEqual('');
     });
 
-    it('should prefer the REST primaryText over the Google format', () => {
-      expect(component.getPrimaryText({ primaryText: 'REST', structured_formatting: { main_text: 'Google' } })).toEqual('REST');
+    it('should prefer the REST fields over the Google format', () => {
+      const result = component.normalizePrediction({
+        primaryText: 'REST',
+        secondaryText: 'REST 2',
+        structured_formatting: { main_text: 'Google', secondary_text: 'Google 2' },
+      });
+      expect(result.primaryText).toEqual('REST');
+      expect(result.secondaryText).toEqual('REST 2');
     });
 
-    it('should return an empty string when nothing matches', () => {
-      expect(component.getPrimaryText({})).toEqual('');
+    it('should default text to empty strings when nothing matches', () => {
+      const result = component.normalizePrediction({});
+      expect(result.primaryText).toEqual('');
+      expect(result.secondaryText).toEqual('');
+    });
+
+    it('should retain the original record on `raw` for downstream selection', () => {
+      const raw = { place_id: 'g1', description: 'X', formatted_address: 'X' };
+      const result = component.normalizePrediction(raw);
+      expect(result.raw).toBe(raw);
     });
   });
 
-  describe('Method: getSecondaryText()', () => {
-    it('should use the REST secondaryText when present', () => {
-      expect(component.getSecondaryText({ secondaryText: 'Boston, MA' })).toEqual('Boston, MA');
+  describe('Method: selectMatch()', () => {
+    it('should resolve detail via place id for a prediction', () => {
+      const spy = vi.spyOn(component as any, 'getPlaceLocationInfo').mockImplementation(() => {});
+      component.recentDropdownOpen = false;
+      const prediction = component.normalizePrediction({ place_id: 'g1' });
+      component.selectMatch(prediction);
+      expect(spy).toHaveBeenCalledWith(prediction);
     });
 
-    it('should use the Google structured_formatting.secondary_text', () => {
-      expect(component.getSecondaryText({ structured_formatting: { secondary_text: 'Boston, MA, USA' } })).toEqual('Boston, MA, USA');
-    });
-
-    it('should prefer the REST secondaryText over the Google format', () => {
-      expect(component.getSecondaryText({ secondaryText: 'REST', structured_formatting: { secondary_text: 'Google' } })).toEqual('REST');
-    });
-
-    it('should return an empty string when nothing matches', () => {
-      expect(component.getSecondaryText({})).toEqual('');
+    it('should pass the full raw detail (not the prediction) when selecting a recent search', () => {
+      const spy = vi.spyOn(component as any, 'setRecentLocation').mockImplementation(() => {});
+      component.recentDropdownOpen = true;
+      const raw = { place_id: 'rec1', formatted_address: '12 Main St', address_components: [] };
+      const prediction = component.normalizePrediction(raw);
+      component.selectMatch(prediction);
+      expect(spy).toHaveBeenCalledWith(raw);
     });
   });
 
   describe('Method: getPlaceLocationInfo()', () => {
-    it('should resolve Google details using the camelCase placeId', () => {
+    it('should resolve Google details using the normalized placeId', () => {
       const getGeoPlaceDetail = vi.fn().mockResolvedValue(null);
       component['_googlePlacesService'] = { getGeoPlaceDetail } as any;
       component.settings = { useGoogleGeoApi: true } as any;
       component['getPlaceLocationInfo']({ placeId: 'abc' });
       expect(getGeoPlaceDetail).toHaveBeenCalledWith('abc');
-    });
-
-    it('should fall back to the snake_case place_id', () => {
-      const getGeoPlaceDetail = vi.fn().mockResolvedValue(null);
-      component['_googlePlacesService'] = { getGeoPlaceDetail } as any;
-      component.settings = { useGoogleGeoApi: true } as any;
-      component['getPlaceLocationInfo']({ place_id: 'xyz' });
-      expect(getGeoPlaceDetail).toHaveBeenCalledWith('xyz');
     });
 
     it('should use the REST endpoint with the placeId when useGoogleGeoApi is false', () => {

--- a/projects/novo-elements/src/elements/places/places.component.ts
+++ b/projects/novo-elements/src/elements/places/places.component.ts
@@ -8,7 +8,7 @@ import { Key } from 'novo-elements/utils';
 import { Observable } from 'rxjs';
 import { GooglePlacesService } from './places.service';
 
-export interface Settings {
+export interface PlacesSettings {
   geoPredictionServerUrl?: string;
   geoLatLangServiceUrl?: string;
   geoLocDetailServerUrl?: string;
@@ -48,9 +48,9 @@ const PLACES_VALUE_ACCESSOR = {
       <novo-list-item *ngFor="let data of matches; let $index = index" (click)="selectedListNode($event, $index)" [ngClass]="{ active: data === activeMatch }">
         <item-header>
           <item-avatar icon="location"></item-avatar>
-          <item-title>{{ data.structured_formatting?.main_text ? data.structured_formatting.main_text : data.description }}</item-title>
+          <item-title>{{ getPrimaryText(data) }}</item-title>
         </item-header>
-        <item-content>{{ data.structured_formatting?.secondary_text }}</item-content>
+        <item-content>{{ getSecondaryText(data) }}</item-content>
       </novo-list-item>
     </novo-list>
   `,
@@ -59,11 +59,13 @@ const PLACES_VALUE_ACCESSOR = {
 })
 export class PlacesListComponent extends BasePickerResults implements OnInit, OnChanges, ControlValueAccessor {
   @Input()
-  userSettings: Settings;
+  userSettings: PlacesSettings;
   @Output()
   termChange: EventEmitter<any> = new EventEmitter<any>();
   @Output()
   select: EventEmitter<any> = new EventEmitter<any>();
+  @Output()
+  matchesUpdated: EventEmitter<any[]> = new EventEmitter<any[]>();
 
   public locationInput: string = '';
   public gettingCurrentLocationFlag: boolean = false;
@@ -71,12 +73,12 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
   public recentDropdownOpen: boolean = false;
   public isSettingsError: boolean = false;
   public settingsErrorMsg: string = '';
-  public settings: Settings = {};
+  public settings: PlacesSettings = {};
   private moduleinit: boolean = false;
   private selectedDataIndex: number = -1;
   private recentSearchData: any = [];
   private userSelectedOption: any = '';
-  private defaultSettings: Settings = {
+  private defaultSettings: PlacesSettings = {
     geoPredictionServerUrl: '',
     geoLatLangServiceUrl: '',
     geoLocDetailServerUrl: '',
@@ -276,7 +278,7 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
   }
 
   // function to set user settings if it is available.
-  private setUserSettings(): Settings {
+  private setUserSettings(): PlacesSettings {
     const _tempObj: any = {};
     if (this.userSettings && typeof this.userSettings === 'object') {
       const keys: string[] = Object.keys(this.defaultSettings);
@@ -329,8 +331,12 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
   // function to update the predicted list.
   private updateListItem(listData: any): any {
     this.matches = listData ? listData : [];
+    // Reset the highlighted match for the new result set so Enter doesn't act on a
+    // stale prediction from a previous query (nothing is selected until arrowed to).
+    this.activeMatch = undefined;
     this.dropdownOpen = true;
     this.cdr.detectChanges();
+    this.matchesUpdated.emit(this.matches);
   }
 
   // function to show the recent search result.
@@ -368,14 +374,15 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
 
   // function to retrieve the location info based on google place id.
   private getPlaceLocationInfo(selectedData: any): any {
+    const placeId = selectedData.placeId || selectedData.place_id;
     if (this.settings.useGoogleGeoApi) {
-      this._googlePlacesService.getGeoPlaceDetail(selectedData.place_id).then((data: any) => {
+      this._googlePlacesService.getGeoPlaceDetail(placeId).then((data: any) => {
         if (data) {
           this.setRecentLocation(data);
         }
       });
     } else {
-      this._googlePlacesService.getPlaceDetails(this.settings.geoLocDetailServerUrl, selectedData.place_id).then((result: any) => {
+      this._googlePlacesService.getPlaceDetails(this.settings.geoLocDetailServerUrl, placeId).then((result: any) => {
         if (result) {
           result = this.extractServerList(this.settings.serverResponseDetailHierarchy, result);
           this.setRecentLocation(result);
@@ -387,7 +394,7 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
   // function to store the selected user search in the localstorage.
   private setRecentLocation(data: any): any {
     data = JSON.parse(JSON.stringify(data));
-    data.description = data.description ? data.description : data.formatted_address;
+    data.description = data.description ? data.description : (data.formattedAddress || data.formatted_address);
     data.active = false;
     this.selectedDataIndex = -1;
     this.locationInput = data.description;
@@ -410,6 +417,38 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
     });
   }
 
+  // Handle both Google Places API format and REST backend format
+  getPrimaryText(data: any): string {
+    // REST backend format (camelCase)
+    if (data.primaryText) {
+      return data.primaryText;
+    }
+    // Google Places API format (snake_case)
+    if (data.structured_formatting?.main_text) {
+      return data.structured_formatting.main_text;
+    }
+    // Fallback to display address
+    if (data.displayAddress) {
+      return data.displayAddress;
+    }
+    if (data.description) {
+      return data.description;
+    }
+    return '';
+  }
+
+  getSecondaryText(data: any): string {
+    // REST backend format (camelCase)
+    if (data.secondaryText) {
+      return data.secondaryText;
+    }
+    // Google Places API format (snake_case)
+    if (data.structured_formatting?.secondary_text) {
+      return data.structured_formatting.secondary_text;
+    }
+    return '';
+  }
+
   onKeyDown(event: KeyboardEvent) {
     if (this.dropdownOpen) {
       if (event.key === Key.ArrowUp) {
@@ -421,7 +460,11 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
         return;
       }
       if (event.key === Key.Enter) {
-        this.selectMatch(this.activeMatch);
+        // Only select when a prediction is actually highlighted; pressing Enter
+        // with nothing active must not attempt to resolve an undefined match.
+        if (this.activeMatch) {
+          this.selectMatch(this.activeMatch);
+        }
         return;
       }
     }

--- a/projects/novo-elements/src/elements/places/places.component.ts
+++ b/projects/novo-elements/src/elements/places/places.component.ts
@@ -33,6 +33,22 @@ export interface PlacesSettings {
   locationIconUrl?: string;
 }
 
+/**
+ * Internal, normalized shape for an address prediction (an autocomplete suggestion).
+ * Raw provider records — Google's snake_case `AutocompletePrediction`, a REST backend's
+ * camelCase prediction, or a stored recent search — are mapped into this via
+ * `normalizePrediction` so the template and selection logic never branch on provider format.
+ */
+export interface AddressLookupPrediction {
+  placeId?: string;
+  primaryText?: string;
+  secondaryText?: string;
+  displayAddress?: string;
+  types?: string[];
+  /** The original provider record, retained so selecting a recent search re-emits full detail. */
+  raw?: any;
+}
+
 // Value accessor for the component (supports ngModel)
 const PLACES_VALUE_ACCESSOR = {
   provide: NG_VALUE_ACCESSOR,
@@ -48,9 +64,9 @@ const PLACES_VALUE_ACCESSOR = {
       <novo-list-item *ngFor="let data of matches; let $index = index" (click)="selectedListNode($event, $index)" [ngClass]="{ active: data === activeMatch }">
         <item-header>
           <item-avatar icon="location"></item-avatar>
-          <item-title>{{ getPrimaryText(data) }}</item-title>
+          <item-title>{{ data.primaryText }}</item-title>
         </item-header>
-        <item-content>{{ getSecondaryText(data) }}</item-content>
+        <item-content>{{ data.secondaryText }}</item-content>
       </novo-list-item>
     </novo-list>
   `,
@@ -65,7 +81,7 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
   @Output()
   select: EventEmitter<any> = new EventEmitter<any>();
   @Output()
-  matchesUpdated: EventEmitter<any[]> = new EventEmitter<any[]>();
+  matchesUpdated: EventEmitter<AddressLookupPrediction[]> = new EventEmitter<AddressLookupPrediction[]>();
 
   public locationInput: string = '';
   public gettingCurrentLocationFlag: boolean = false;
@@ -185,10 +201,12 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
   }
 
   // function to execute when user selects a match.
-  selectMatch(match: any): any {
+  selectMatch(match: AddressLookupPrediction): any {
     this.dropdownOpen = false;
     if (this.recentDropdownOpen) {
-      this.setRecentLocation(match);
+      // Recent items carry the full stored detail on `raw`; the detail (not the
+      // display-only prediction) is what downstream consumers need to map fields.
+      this.setRecentLocation(match.raw ?? match);
     } else {
       this.getPlaceLocationInfo(match);
     }
@@ -330,7 +348,7 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
 
   // function to update the predicted list.
   private updateListItem(listData: any): any {
-    this.matches = listData ? listData : [];
+    this.matches = (listData || []).map((item: any) => this.normalizePrediction(item));
     // Reset the highlighted match for the new result set so Enter doesn't act on a
     // stale prediction from a previous query (nothing is selected until arrowed to).
     this.activeMatch = undefined;
@@ -344,11 +362,7 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
     this.recentDropdownOpen = true;
     this.dropdownOpen = true;
     this._googlePlacesService.getRecentList(this.settings.recentStorageName).then((result: any) => {
-      if (result) {
-        this.matches = result;
-      } else {
-        this.matches = [];
-      }
+      this.matches = (result || []).map((item: any) => this.normalizePrediction(item));
     });
   }
 
@@ -373,8 +387,8 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
   }
 
   // function to retrieve the location info based on google place id.
-  private getPlaceLocationInfo(selectedData: any): any {
-    const placeId = selectedData.placeId || selectedData.place_id;
+  private getPlaceLocationInfo(selectedData: AddressLookupPrediction): any {
+    const placeId = selectedData.placeId;
     if (this.settings.useGoogleGeoApi) {
       this._googlePlacesService.getGeoPlaceDetail(placeId).then((data: any) => {
         if (data) {
@@ -417,36 +431,19 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
     });
   }
 
-  // Handle both Google Places API format and REST backend format
-  getPrimaryText(data: any): string {
-    // REST backend format (camelCase)
-    if (data.primaryText) {
-      return data.primaryText;
-    }
-    // Google Places API format (snake_case)
-    if (data.structured_formatting?.main_text) {
-      return data.structured_formatting.main_text;
-    }
-    // Fallback to display address
-    if (data.displayAddress) {
-      return data.displayAddress;
-    }
-    if (data.description) {
-      return data.description;
-    }
-    return '';
-  }
-
-  getSecondaryText(data: any): string {
-    // REST backend format (camelCase)
-    if (data.secondaryText) {
-      return data.secondaryText;
-    }
-    // Google Places API format (snake_case)
-    if (data.structured_formatting?.secondary_text) {
-      return data.structured_formatting.secondary_text;
-    }
-    return '';
+  // Fold a raw provider record into the internal AddressLookupPrediction shape. Handles
+  // Google's snake_case AutocompletePrediction, a REST backend's camelCase prediction, and
+  // stored recent searches (which carry a `description`). Falls through in preference order
+  // so the most specific label available is used for display.
+  normalizePrediction(raw: any): AddressLookupPrediction {
+    return {
+      placeId: raw?.placeId || raw?.place_id,
+      primaryText: raw?.primaryText || raw?.structured_formatting?.main_text || raw?.displayAddress || raw?.description || '',
+      secondaryText: raw?.secondaryText || raw?.structured_formatting?.secondary_text || '',
+      displayAddress: raw?.displayAddress || raw?.description,
+      types: raw?.types,
+      raw,
+    };
   }
 
   onKeyDown(event: KeyboardEvent) {

--- a/projects/novo-elements/src/elements/places/places.component.ts
+++ b/projects/novo-elements/src/elements/places/places.component.ts
@@ -33,19 +33,14 @@ export interface PlacesSettings {
   locationIconUrl?: string;
 }
 
-/**
- * Internal, normalized shape for an address prediction (an autocomplete suggestion).
- * Raw provider records — Google's snake_case `AutocompletePrediction`, a REST backend's
- * camelCase prediction, or a stored recent search — are mapped into this via
- * `normalizePrediction` so the template and selection logic never branch on provider format.
- */
+/** Normalized address prediction; raw provider records are mapped into this via normalizePrediction. */
 export interface AddressLookupPrediction {
   placeId?: string;
   primaryText?: string;
   secondaryText?: string;
   displayAddress?: string;
   types?: string[];
-  /** The original provider record, retained so selecting a recent search re-emits full detail. */
+  /** Original provider record, retained so recent-search selection re-emits full detail. */
   raw?: any;
 }
 
@@ -204,8 +199,7 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
   selectMatch(match: AddressLookupPrediction): any {
     this.dropdownOpen = false;
     if (this.recentDropdownOpen) {
-      // Recent items carry the full stored detail on `raw`; the detail (not the
-      // display-only prediction) is what downstream consumers need to map fields.
+      // Recent items carry full detail on `raw`, which downstream consumers need.
       this.setRecentLocation(match.raw ?? match);
     } else {
       this.getPlaceLocationInfo(match);
@@ -349,8 +343,7 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
   // function to update the predicted list.
   private updateListItem(listData: any): any {
     this.matches = (listData || []).map((item: any) => this.normalizePrediction(item));
-    // Reset the highlighted match for the new result set so Enter doesn't act on a
-    // stale prediction from a previous query (nothing is selected until arrowed to).
+    // Reset highlight so Enter can't act on a stale prediction.
     this.activeMatch = undefined;
     this.dropdownOpen = true;
     this.cdr.detectChanges();
@@ -431,10 +424,7 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
     });
   }
 
-  // Fold a raw provider record into the internal AddressLookupPrediction shape. Handles
-  // Google's snake_case AutocompletePrediction, a REST backend's camelCase prediction, and
-  // stored recent searches (which carry a `description`). Falls through in preference order
-  // so the most specific label available is used for display.
+  // Fold a raw Google/REST/recent record into the internal AddressLookupPrediction shape.
   normalizePrediction(raw: any): AddressLookupPrediction {
     return {
       placeId: raw?.placeId || raw?.place_id,
@@ -457,8 +447,7 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
         return;
       }
       if (event.key === Key.Enter) {
-        // Only select when a prediction is actually highlighted; pressing Enter
-        // with nothing active must not attempt to resolve an undefined match.
+        // Only select when a prediction is highlighted.
         if (this.activeMatch) {
           this.selectMatch(this.activeMatch);
         }

--- a/projects/novo-elements/src/elements/places/places.service.ts
+++ b/projects/novo-elements/src/elements/places/places.service.ts
@@ -14,7 +14,8 @@ export class GooglePlacesService {
 
   getPredictions(url: string, query: string): Promise<any> {
     return new Promise((resolve) => {
-      this._http.get(url + '?query=' + query).subscribe((data: any) => {
+      const separator = url.includes('?') ? '&' : '?';
+      this._http.get(url + separator + 'query=' + query).subscribe((data: any) => {
         if (data) {
           resolve(data);
         } else {
@@ -26,7 +27,8 @@ export class GooglePlacesService {
 
   getLatLngDetail(url: string, lat: number, lng: number): Promise<any> {
     return new Promise((resolve) => {
-      this._http.get(url + '?lat=' + lat + '&lng=' + lng).subscribe((data: any) => {
+      const separator = url.includes('?') ? '&' : '?';
+      this._http.get(url + separator + 'lat=' + lat + '&lng=' + lng).subscribe((data: any) => {
         if (data) {
           resolve(data);
         } else {
@@ -38,7 +40,8 @@ export class GooglePlacesService {
 
   getPlaceDetails(url: string, placeId: string): Promise<any> {
     return new Promise((resolve) => {
-      this._http.get(url + '?query=' + placeId).subscribe((data: any) => {
+      const separator = url.includes('?') ? '&' : '?';
+      this._http.get(url + separator + 'query=' + placeId).subscribe((data: any) => {
         if (data) {
           resolve(data);
         } else {

--- a/projects/novo-elements/src/elements/places/places.tokens.ts
+++ b/projects/novo-elements/src/elements/places/places.tokens.ts
@@ -1,11 +1,5 @@
 import { InjectionToken } from '@angular/core';
 import type { PlacesSettings } from './places.component';
 
-/**
- * App-wide address-lookup configuration. When provided, every `novo-address`
- * block enables Google Places autocomplete on its Address 1 input using these
- * settings. Provide it once at the application root (statically via
- * `NovoElementProviders.forRoot({ address })`, or via a `useFactory` for
- * runtime-derived endpoints).
- */
+/** App-wide address-lookup config; when provided, every novo-address enables autocomplete on Address 1. */
 export const NOVO_ADDRESS_CONFIG = new InjectionToken<PlacesSettings>('NOVO_ADDRESS_CONFIG');

--- a/projects/novo-elements/src/elements/places/places.tokens.ts
+++ b/projects/novo-elements/src/elements/places/places.tokens.ts
@@ -1,0 +1,11 @@
+import { InjectionToken } from '@angular/core';
+import type { PlacesSettings } from './places.component';
+
+/**
+ * App-wide address-lookup configuration. When provided, every `novo-address`
+ * block enables Google Places autocomplete on its Address 1 input using these
+ * settings. Provide it once at the application root (statically via
+ * `NovoElementProviders.forRoot({ address })`, or via a `useFactory` for
+ * runtime-derived endpoints).
+ */
+export const NOVO_ADDRESS_CONFIG = new InjectionToken<PlacesSettings>('NOVO_ADDRESS_CONFIG');

--- a/projects/novo-elements/src/novo-elements.providers.spec.ts
+++ b/projects/novo-elements/src/novo-elements.providers.spec.ts
@@ -1,0 +1,22 @@
+import { NOVO_ADDRESS_CONFIG } from 'novo-elements/elements/places';
+import { NovoElementProviders } from './novo-elements.providers';
+
+describe('NovoElementProviders.forRoot', () => {
+  const hasAddressProvider = (providers: any[]): boolean =>
+    providers.some((p) => p && p.provide === NOVO_ADDRESS_CONFIG);
+
+  it('registers NOVO_ADDRESS_CONFIG when an address config is supplied', () => {
+    const address = { useGoogleGeoApi: false, geoPredictionServerUrl: 'https://x/predictions' };
+    const moduleWithProviders = NovoElementProviders.forRoot({ address });
+
+    expect(hasAddressProvider(moduleWithProviders.providers as any[])).toBe(true);
+    const provider = (moduleWithProviders.providers as any[]).find((p) => p.provide === NOVO_ADDRESS_CONFIG);
+    expect(provider.useValue).toBe(address);
+  });
+
+  it('does NOT register NOVO_ADDRESS_CONFIG for a bare forRoot() (avoids shadowing root config)', () => {
+    expect(hasAddressProvider(NovoElementProviders.forRoot().providers as any[])).toBe(false);
+    expect(hasAddressProvider(NovoElementProviders.forRoot({}).providers as any[])).toBe(false);
+    expect(hasAddressProvider(NovoElementProviders.forRoot({ menu: {} }).providers as any[])).toBe(false);
+  });
+});

--- a/projects/novo-elements/src/novo-elements.providers.ts
+++ b/projects/novo-elements/src/novo-elements.providers.ts
@@ -3,9 +3,11 @@ import {
   FieldInteractionApi,
   GooglePlacesService,
   IMenuOptions, MENU_OPTIONS,
+  NOVO_ADDRESS_CONFIG,
   NovoAsideService,
   NovoModalService,
   NovoToastService,
+  PlacesSettings,
 } from 'novo-elements/elements';
 import {
   BrowserGlobalRef,
@@ -35,7 +37,7 @@ const NOVO_ELEMENTS_PROVIDERS = [
   imports: [],
 })
 export class NovoElementProviders {
-  static forRoot(options?: { menu: IMenuOptions }): ModuleWithProviders<NovoElementProviders> {
+  static forRoot(options?: { menu?: IMenuOptions; address?: PlacesSettings }): ModuleWithProviders<NovoElementProviders> {
     return {
       ngModule: NovoElementProviders,
       providers: [
@@ -44,6 +46,9 @@ export class NovoElementProviders {
           provide: MENU_OPTIONS,
           useValue: options && options.menu,
         },
+        // Only register the address config when supplied. A bare `forRoot()` in a
+        // lazy module must NOT shadow a root-level provider with `undefined`.
+        ...(options?.address ? [{ provide: NOVO_ADDRESS_CONFIG, useValue: options.address }] : []),
       ],
     };
   }

--- a/projects/novo-elements/src/novo-elements.providers.ts
+++ b/projects/novo-elements/src/novo-elements.providers.ts
@@ -46,8 +46,7 @@ export class NovoElementProviders {
           provide: MENU_OPTIONS,
           useValue: options && options.menu,
         },
-        // Only register the address config when supplied. A bare `forRoot()` in a
-        // lazy module must NOT shadow a root-level provider with `undefined`.
+        // Only register when supplied, so a bare forRoot() doesn't shadow a root provider with undefined.
         ...(options?.address ? [{ provide: NOVO_ADDRESS_CONFIG, useValue: options.address }] : []),
       ],
     };


### PR DESCRIPTION
## **Description**

Added auto-complete capability to the address block in the address1 input


https://github.com/user-attachments/assets/c5b7563d-dc99-4aa1-bec0-d1a788fe3699



#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**