### PR TITLE
fix(Address): harden Google Maps lazy-load and flat address shape (BH…

### DIFF
--- a/projects/demo/app/app.module.ts
+++ b/projects/demo/app/app.module.ts
@@ -46,8 +46,8 @@ export function provideAppBridgeService(http) {
         ScrollingModule,
         // Vendor
         NovoElementsModule,
-        // Supplies the key via NOVO_ADDRESS_CONFIG so the address components lazy-load the Maps
-        // SDK through GooglePlacesService — the same path real apps use — instead of a global script.
+        // To enable Google Places autocomplete, set googlePlacesKey in environment.ts.
+        // See NovoElementProviders.forRoot JSDoc for the full options shape.
         NovoElementProviders.forRoot({ address: { googleApiKey: environment.googlePlacesKey } }),
         // APP
         NovoExamplesRoutesModule], providers: [

--- a/projects/demo/app/app.module.ts
+++ b/projects/demo/app/app.module.ts
@@ -46,7 +46,9 @@ export function provideAppBridgeService(http) {
         ScrollingModule,
         // Vendor
         NovoElementsModule,
-        NovoElementProviders.forRoot({ address: {} }),
+        // Supplies the key via NOVO_ADDRESS_CONFIG so the address components lazy-load the Maps
+        // SDK through GooglePlacesService — the same path real apps use — instead of a global script.
+        NovoElementProviders.forRoot({ address: { googleApiKey: environment.googlePlacesKey } }),
         // APP
         NovoExamplesRoutesModule], providers: [
         // NovoTemplateService,

--- a/projects/demo/environments/environment.prod.ts
+++ b/projects/demo/environments/environment.prod.ts
@@ -1,6 +1,7 @@
 export const environment = {
   production: true,
-  // Google Places key for the demo. Passed to NovoElementProviders.forRoot via NOVO_ADDRESS_CONFIG
-  // so the address components lazy-load the Maps SDK. Real apps supply their own Bullhorn-managed key.
-  googlePlacesKey: 'AIzaSyA7AU3UZXB5frMpSa0koWN096kb6MMtmN8',
+  // To enable Google Places address autocomplete, set your own Google Maps API key here.
+  // See https://developers.google.com/maps/documentation/javascript/get-api-key
+  // Never commit a real key — supply it via an environment variable at build time.
+  googlePlacesKey: '',
 };

--- a/projects/demo/environments/environment.prod.ts
+++ b/projects/demo/environments/environment.prod.ts
@@ -1,3 +1,6 @@
 export const environment = {
   production: true,
+  // Google Places key for the demo. Passed to NovoElementProviders.forRoot via NOVO_ADDRESS_CONFIG
+  // so the address components lazy-load the Maps SDK. Real apps supply their own Bullhorn-managed key.
+  googlePlacesKey: 'AIzaSyA7AU3UZXB5frMpSa0koWN096kb6MMtmN8',
 };

--- a/projects/demo/environments/environment.ts
+++ b/projects/demo/environments/environment.ts
@@ -4,6 +4,9 @@
 
 export const environment = {
   production: false,
+  // Google Places key for the demo. Passed to NovoElementProviders.forRoot via NOVO_ADDRESS_CONFIG
+  // so the address components lazy-load the Maps SDK. Real apps supply their own Bullhorn-managed key.
+  googlePlacesKey: 'AIzaSyA7AU3UZXB5frMpSa0koWN096kb6MMtmN8',
 };
 
 /*

--- a/projects/demo/environments/environment.ts
+++ b/projects/demo/environments/environment.ts
@@ -4,9 +4,10 @@
 
 export const environment = {
   production: false,
-  // Google Places key for the demo. Passed to NovoElementProviders.forRoot via NOVO_ADDRESS_CONFIG
-  // so the address components lazy-load the Maps SDK. Real apps supply their own Bullhorn-managed key.
-  googlePlacesKey: 'AIzaSyA7AU3UZXB5frMpSa0koWN096kb6MMtmN8',
+  // To enable Google Places address autocomplete in the demo, set your own Google Maps API key here.
+  // See https://developers.google.com/maps/documentation/javascript/get-api-key
+  // Never commit a real key — add it locally or supply it via an environment variable at build time.
+  googlePlacesKey: '',
 };
 
 /*

--- a/projects/demo/index.html
+++ b/projects/demo/index.html
@@ -21,8 +21,6 @@
 
   <script src="//cdn.jsdelivr.net/npm/ckeditor-full@4.7.3/ckeditor.js"></script>
   <script src="//cdn.rawgit.com/krakenjs/post-robot/7da06445/dist/post-robot.js"></script>
-  <script type="text/javascript"
-    src="https://maps.google.com/maps/api/js?loading=async&key=AIzaSyA7AU3UZXB5frMpSa0koWN096kb6MMtmN8&libraries=places&language=en-US"></script>
 
 </head>
 

--- a/projects/novo-elements/src/elements/places/places.component.spec.ts
+++ b/projects/novo-elements/src/elements/places/places.component.spec.ts
@@ -156,6 +156,7 @@ describe('Elements: PlacesListComponent', () => {
         return Promise.resolve([]);
       });
       component['_googlePlacesService'] = { loadGoogleMaps, getGeoPrediction } as any;
+      component['_global'] = { nativeGlobal: { google: { maps: { places: {} } } } } as any;
       component.settings = { useGoogleGeoApi: true, geoCountryRestriction: [], geoTypes: [], geoLocation: [] } as any;
 
       component['getListQuery']('100 Sum');
@@ -196,6 +197,34 @@ describe('Elements: PlacesListComponent', () => {
       expect(getGeoPrediction).not.toHaveBeenCalled();
       expect(component['updateListItem']).toHaveBeenCalledWith([]);
       errSpy.mockRestore();
+    });
+
+    it('shows an empty list without crashing when no googleApiKey is configured (SDK not loaded)', async () => {
+      const loadGoogleMaps = vi.fn().mockResolvedValue(undefined);
+      const getGeoPrediction = vi.fn();
+      component['_googlePlacesService'] = { loadGoogleMaps, getGeoPrediction } as any;
+      component['_global'] = { nativeGlobal: {} } as any; // google.maps not present
+      component.settings = { useGoogleGeoApi: true, geoCountryRestriction: [], geoTypes: [], geoLocation: [] } as any;
+      component['updateListItem'] = vi.fn();
+
+      await component['getListQuery']('100 Sum');
+
+      expect(getGeoPrediction).not.toHaveBeenCalled();
+      expect(component['updateListItem']).toHaveBeenCalledWith([]);
+    });
+
+    it('warns once on init when useGoogleGeoApi is true but no googleApiKey is configured', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      component['_googlePlacesService'] = {
+        getRecentList: vi.fn().mockResolvedValue([]),
+      } as any;
+      // userSettings with no key; defaultSettings has useGoogleGeoApi: true
+      component.userSettings = { useGoogleGeoApi: true, googleApiKey: '' } as any;
+
+      component['moduleInit']();
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('No googleApiKey configured'));
+      warnSpy.mockRestore();
     });
 
     it('shows an empty list and logs an error when the server prediction request fails', async () => {

--- a/projects/novo-elements/src/elements/places/places.component.spec.ts
+++ b/projects/novo-elements/src/elements/places/places.component.spec.ts
@@ -197,6 +197,25 @@ describe('Elements: PlacesListComponent', () => {
       expect(component['updateListItem']).toHaveBeenCalledWith([]);
       errSpy.mockRestore();
     });
+
+    it('shows an empty list and logs an error when the server prediction request fails', async () => {
+      const getPredictions = vi.fn().mockRejectedValue(new Error('500'));
+      component['_googlePlacesService'] = { getPredictions } as any;
+      component.settings = {
+        useGoogleGeoApi: false,
+        geoPredictionServerUrl: 'https://api/pred',
+        serverResponseListHierarchy: [],
+      } as any;
+      component['updateListItem'] = vi.fn();
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      component['getListQuery']('100 Sum');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(component['updateListItem']).toHaveBeenCalledWith([]);
+      errSpy.mockRestore();
+    });
   });
 
   describe('Method: getCurrentLocationInfo()', () => {
@@ -243,6 +262,21 @@ describe('Elements: PlacesListComponent', () => {
 
       expect(getLatLngDetail).toHaveBeenCalledWith('https://api/ll', 1, 2);
       expect(component['gettingCurrentLocationFlag']).toBe(false);
+    });
+
+    it('clears the spinner when the server path request rejects', async () => {
+      const getLatLngDetail = vi.fn().mockRejectedValue(new Error('500'));
+      component['_googlePlacesService'] = { getLatLngDetail } as any;
+      component.settings = { useGoogleGeoApi: false, geoLatLangServiceUrl: 'https://api/ll' } as any;
+      component['gettingCurrentLocationFlag'] = true;
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      component['getCurrentLocationInfo']({ lat: 1, lng: 2 });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(component['gettingCurrentLocationFlag']).toBe(false);
+      errSpy.mockRestore();
     });
   });
 
@@ -326,7 +360,9 @@ describe('Elements: PlacesListComponent', () => {
       component['getListQuery']('123 Main');
       expect(component['sessionToken']).toMatch(UUID_V4);
 
-      await expect(component['getPlaceLocationInfo']({ placeId: 'abc' })).rejects.toThrow('details failed');
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      await component['getPlaceLocationInfo']({ placeId: 'abc' });
+      errSpy.mockRestore();
 
       expect(component['sessionToken']).toBe('');
     });
@@ -393,6 +429,19 @@ describe('Elements: PlacesListComponent', () => {
       await component['getPlaceLocationInfo']({ placeId: 'abc' });
 
       expect(getGeoPlaceDetail).not.toHaveBeenCalled();
+      errSpy.mockRestore();
+    });
+
+    it('logs an error and still clears the session token when server path details request fails', async () => {
+      const getPlaceDetails = vi.fn().mockRejectedValue(new Error('500'));
+      component['_googlePlacesService'] = { getPlaceDetails } as any;
+      component.settings = { useGoogleGeoApi: false, geoLocDetailServerUrl: 'https://api/detail' } as any;
+      component['sessionToken'] = 'tok-123';
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await component['getPlaceLocationInfo']({ placeId: 'abc' });
+
+      expect(component['sessionToken']).toBe('');
       errSpy.mockRestore();
     });
   });

--- a/projects/novo-elements/src/elements/places/places.component.spec.ts
+++ b/projects/novo-elements/src/elements/places/places.component.spec.ts
@@ -144,12 +144,118 @@ describe('Elements: PlacesListComponent', () => {
     });
   });
 
+  describe('Method: getListQuery()', () => {
+    it('loads the Maps SDK before requesting Google predictions', async () => {
+      const order: string[] = [];
+      const loadGoogleMaps = vi.fn().mockImplementation(() => {
+        order.push('load');
+        return Promise.resolve();
+      });
+      const getGeoPrediction = vi.fn().mockImplementation(() => {
+        order.push('predict');
+        return Promise.resolve([]);
+      });
+      component['_googlePlacesService'] = { loadGoogleMaps, getGeoPrediction } as any;
+      component.settings = { useGoogleGeoApi: true, geoCountryRestriction: [], geoTypes: [], geoLocation: [] } as any;
+
+      component['getListQuery']('100 Sum');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(loadGoogleMaps).toHaveBeenCalledWith(component.settings);
+      expect(getGeoPrediction).toHaveBeenCalled();
+      expect(order).toEqual(['load', 'predict']);
+    });
+
+    it('does NOT load the Maps SDK on the search-service path', () => {
+      const loadGoogleMaps = vi.fn();
+      const getPredictions = vi.fn().mockResolvedValue([]);
+      component['_googlePlacesService'] = { loadGoogleMaps, getPredictions } as any;
+      component.settings = {
+        useGoogleGeoApi: false,
+        geoPredictionServerUrl: 'https://api/pred',
+        serverResponseListHierarchy: [],
+      } as any;
+
+      component['getListQuery']('100 Sum');
+
+      expect(loadGoogleMaps).not.toHaveBeenCalled();
+      expect(getPredictions).toHaveBeenCalledWith('https://api/pred', '100 Sum', expect.any(String));
+    });
+
+    it('shows an empty list when the Maps SDK fails to load', async () => {
+      const loadGoogleMaps = vi.fn().mockRejectedValue(new Error('boom'));
+      const getGeoPrediction = vi.fn();
+      component['_googlePlacesService'] = { loadGoogleMaps, getGeoPrediction } as any;
+      component.settings = { useGoogleGeoApi: true, geoCountryRestriction: [], geoTypes: [], geoLocation: [] } as any;
+      component['updateListItem'] = vi.fn();
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await component['getListQuery']('100 Sum');
+
+      expect(getGeoPrediction).not.toHaveBeenCalled();
+      expect(component['updateListItem']).toHaveBeenCalledWith([]);
+      errSpy.mockRestore();
+    });
+  });
+
+  describe('Method: getCurrentLocationInfo()', () => {
+    it('loads the SDK, stores the detail, and clears the spinner on the Google path', async () => {
+      const loadGoogleMaps = vi.fn().mockResolvedValue(undefined);
+      const getGeoLatLngDetail = vi.fn().mockResolvedValue({ formattedAddress: 'x' });
+      component['_googlePlacesService'] = { loadGoogleMaps, getGeoLatLngDetail } as any;
+      component.settings = { useGoogleGeoApi: true } as any;
+      component['setRecentLocation'] = vi.fn();
+      component['gettingCurrentLocationFlag'] = true;
+
+      await component['getCurrentLocationInfo']({ lat: 1, lng: 2 });
+
+      expect(loadGoogleMaps).toHaveBeenCalledWith(component.settings);
+      expect(getGeoLatLngDetail).toHaveBeenCalledWith({ lat: 1, lng: 2 });
+      expect(component['setRecentLocation']).toHaveBeenCalledWith({ formattedAddress: 'x' });
+      expect(component['gettingCurrentLocationFlag']).toBe(false);
+    });
+
+    it('clears the spinner when the Maps SDK fails to load', async () => {
+      const loadGoogleMaps = vi.fn().mockRejectedValue(new Error('boom'));
+      const getGeoLatLngDetail = vi.fn();
+      component['_googlePlacesService'] = { loadGoogleMaps, getGeoLatLngDetail } as any;
+      component.settings = { useGoogleGeoApi: true } as any;
+      component['gettingCurrentLocationFlag'] = true;
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await component['getCurrentLocationInfo']({ lat: 1, lng: 2 });
+
+      expect(getGeoLatLngDetail).not.toHaveBeenCalled();
+      expect(component['gettingCurrentLocationFlag']).toBe(false);
+      errSpy.mockRestore();
+    });
+
+    it('uses the REST endpoint and clears the spinner on the search-service path', async () => {
+      const getLatLngDetail = vi.fn().mockResolvedValue(null);
+      component['_googlePlacesService'] = { getLatLngDetail } as any;
+      component.settings = { useGoogleGeoApi: false, geoLatLangServiceUrl: 'https://api/ll', serverResponseatLangHierarchy: [] } as any;
+      component['gettingCurrentLocationFlag'] = true;
+
+      component['getCurrentLocationInfo']({ lat: 1, lng: 2 });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(getLatLngDetail).toHaveBeenCalledWith('https://api/ll', 1, 2);
+      expect(component['gettingCurrentLocationFlag']).toBe(false);
+    });
+  });
+
   describe('Method: getPlaceLocationInfo()', () => {
-    it('should resolve Google details using the normalized placeId', () => {
+    it('should load the Maps SDK before resolving Google details using the normalized placeId', async () => {
+      const loadGoogleMaps = vi.fn().mockResolvedValue(undefined);
       const getGeoPlaceDetail = vi.fn().mockResolvedValue(null);
-      component['_googlePlacesService'] = { getGeoPlaceDetail } as any;
+      component['_googlePlacesService'] = { loadGoogleMaps, getGeoPlaceDetail } as any;
       component.settings = { useGoogleGeoApi: true } as any;
       component['getPlaceLocationInfo']({ placeId: 'abc' });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(loadGoogleMaps).toHaveBeenCalledWith(component.settings);
       expect(getGeoPlaceDetail).toHaveBeenCalledWith('abc');
     });
 
@@ -275,6 +381,19 @@ describe('Elements: PlacesListComponent', () => {
       } finally {
         (globalThis.crypto as any).randomUUID = original;
       }
+    });
+
+    it('swallows a Maps SDK load failure without calling getGeoPlaceDetail', async () => {
+      const loadGoogleMaps = vi.fn().mockRejectedValue(new Error('boom'));
+      const getGeoPlaceDetail = vi.fn();
+      component['_googlePlacesService'] = { loadGoogleMaps, getGeoPlaceDetail } as any;
+      component.settings = { useGoogleGeoApi: true } as any;
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await component['getPlaceLocationInfo']({ placeId: 'abc' });
+
+      expect(getGeoPlaceDetail).not.toHaveBeenCalled();
+      errSpy.mockRestore();
     });
   });
 });

--- a/projects/novo-elements/src/elements/places/places.component.ts
+++ b/projects/novo-elements/src/elements/places/places.component.ts
@@ -379,6 +379,9 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
       this._googlePlacesService.getPredictions(this.settings.geoPredictionServerUrl, value, this.ensureSessionToken()).then((result) => {
         result = this.extractServerList(this.settings.serverResponseListHierarchy, result);
         this.updateListItem(result);
+      }).catch((err) => {
+        console.error('Failed to load address predictions from server', err);
+        this.updateListItem([]);
       });
     }
   }
@@ -469,6 +472,9 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
           this.setRecentLocation(result);
         }
         this.gettingCurrentLocationFlag = false;
+      }).catch((err) => {
+        console.error('Failed to get current location detail from server', err);
+        this.gettingCurrentLocationFlag = false;
       });
     }
   }
@@ -494,6 +500,8 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
           result = this.extractServerList(this.settings.serverResponseDetailHierarchy, result);
           this.setRecentLocation(result);
         }
+      } catch (err) {
+        console.error('Failed to load place details from server', err);
       } finally {
         // The details call ends the Google billing session; clear the token even if the request
         // failed so the next interaction starts a fresh session.

--- a/projects/novo-elements/src/elements/places/places.component.ts
+++ b/projects/novo-elements/src/elements/places/places.component.ts
@@ -10,6 +10,7 @@ import {
   Input,
   OnChanges,
   OnInit,
+  Optional,
   Output,
   PLATFORM_ID,
 } from '@angular/core';
@@ -19,6 +20,7 @@ import { GlobalRef } from 'novo-elements/services';
 import { Key } from 'novo-elements/utils';
 import { NEVER, Observable } from 'rxjs';
 import { GooglePlacesService } from './places.service';
+import { NOVO_ADDRESS_CONFIG } from './places.tokens';
 
 export interface PlacesSettings {
   geoPredictionServerUrl?: string;
@@ -136,6 +138,8 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
     private _global: GlobalRef,
     private _googlePlacesService: GooglePlacesService,
     private cdr: ChangeDetectorRef,
+    // Fallback config from the app-wide token; used when [userSettings] does not provide a field.
+    @Optional() @Inject(NOVO_ADDRESS_CONFIG) private addressConfig: PlacesSettings = null,
   ) {
     super(_elmRef, cdr);
     this.config = {};
@@ -340,17 +344,20 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
   }
 
   // function to set user settings if it is available.
+  // Priority: [userSettings] input > NOVO_ADDRESS_CONFIG token > defaultSettings.
   private setUserSettings(): PlacesSettings {
     const _tempObj: any = {};
-    if (this.userSettings && typeof this.userSettings === 'object') {
-      const keys: string[] = Object.keys(this.defaultSettings);
-      for (const value of keys) {
-        _tempObj[value] = this.userSettings[value] !== undefined ? this.userSettings[value] : this.defaultSettings[value];
+    const keys: string[] = Object.keys(this.defaultSettings);
+    for (const value of keys) {
+      if (this.userSettings?.[value] !== undefined) {
+        _tempObj[value] = this.userSettings[value];
+      } else if (this.addressConfig?.[value] !== undefined) {
+        _tempObj[value] = this.addressConfig[value];
+      } else {
+        _tempObj[value] = this.defaultSettings[value];
       }
-      return _tempObj;
-    } else {
-      return this.defaultSettings;
     }
+    return _tempObj;
   }
 
   // function to get the autocomplete list based on user input.

--- a/projects/novo-elements/src/elements/places/places.component.ts
+++ b/projects/novo-elements/src/elements/places/places.component.ts
@@ -312,6 +312,12 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
     if (this.settings.showRecentSearch) {
       this.getRecentLocations();
     }
+    if (this.settings.useGoogleGeoApi && !this.settings.googleApiKey) {
+      console.warn(
+        'google-places-list: No googleApiKey configured — Google Places autocomplete is disabled. ' +
+        'Pass address.googleApiKey to NovoElementProviders.forRoot() to enable it.',
+      );
+    }
     if (!this.settings.useGoogleGeoApi) {
       if (!this.settings.geoPredictionServerUrl) {
         this.isSettingsError = true;
@@ -375,10 +381,13 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
       }
       try {
         await this._googlePlacesService.loadGoogleMaps(this.settings);
+        if (!(this._global.nativeGlobal as any)?.google?.maps?.places) {
+          this.updateListItem([]);
+          return;
+        }
         const result = await this._googlePlacesService.getGeoPrediction(_tempParams);
         this.updateListItem(result);
       } catch (err) {
-        // The Maps SDK failed to load; surface an empty list instead of leaving a stale dropdown.
         console.error('Failed to load Google Maps for address predictions', err);
         this.updateListItem([]);
       }

--- a/projects/novo-elements/src/elements/places/places.component.ts
+++ b/projects/novo-elements/src/elements/places/places.component.ts
@@ -43,6 +43,10 @@ export interface PlacesSettings {
   currentLocIconUrl?: string;
   searchIconUrl?: string;
   locationIconUrl?: string;
+  /** Bullhorn-managed key; when set, the library lazy-loads the Maps JS SDK with it instead of relying on a host script tag. */
+  googleApiKey?: string;
+  /** Extra Maps JS loader query params, merged over the defaults (libraries=places, loading=async). */
+  googleMapsLoaderParams?: Record<string, string>;
 }
 
 /** Normalized address prediction; raw provider records are mapped into this via normalizePrediction. */
@@ -118,6 +122,8 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
     currentLocIconUrl: '',
     searchIconUrl: '',
     locationIconUrl: '',
+    googleApiKey: '',
+    googleMapsLoaderParams: {},
   };
 
   model: any;
@@ -348,7 +354,7 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
   }
 
   // function to get the autocomplete list based on user input.
-  private getListQuery(value: string): any {
+  private async getListQuery(value: string): Promise<void> {
     this.recentDropdownOpen = false;
     if (this.settings.useGoogleGeoApi) {
       const _tempParams: any = {
@@ -360,9 +366,15 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
         _tempParams.geoLocation = this.settings.geoLocation;
         _tempParams.radius = this.settings.geoRadius;
       }
-      this._googlePlacesService.getGeoPrediction(_tempParams).then((result) => {
+      try {
+        await this._googlePlacesService.loadGoogleMaps(this.settings);
+        const result = await this._googlePlacesService.getGeoPrediction(_tempParams);
         this.updateListItem(result);
-      });
+      } catch (err) {
+        // The Maps SDK failed to load; surface an empty list instead of leaving a stale dropdown.
+        console.error('Failed to load Google Maps for address predictions', err);
+        this.updateListItem([]);
+      }
     } else {
       this._googlePlacesService.getPredictions(this.settings.geoPredictionServerUrl, value, this.ensureSessionToken()).then((result) => {
         result = this.extractServerList(this.settings.serverResponseListHierarchy, result);
@@ -436,14 +448,20 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
   }
 
   // function to execute to get location detail based on latitude and longitude.
-  private getCurrentLocationInfo(latlng: any): any {
+  private async getCurrentLocationInfo(latlng: any): Promise<void> {
     if (this.settings.useGoogleGeoApi) {
-      this._googlePlacesService.getGeoLatLngDetail(latlng).then((result: any) => {
+      try {
+        await this._googlePlacesService.loadGoogleMaps(this.settings);
+        const result = await this._googlePlacesService.getGeoLatLngDetail(latlng);
         if (result) {
           this.setRecentLocation(result);
         }
+      } catch (err) {
+        console.error('Failed to load Google Maps for current location', err);
+      } finally {
+        // Always clear the spinner, even if the SDK never loaded.
         this.gettingCurrentLocationFlag = false;
-      });
+      }
     } else {
       this._googlePlacesService.getLatLngDetail(this.settings.geoLatLangServiceUrl, latlng.lat, latlng.lng).then((result: any) => {
         if (result) {
@@ -459,9 +477,15 @@ export class PlacesListComponent extends BasePickerResults implements OnInit, On
   private async getPlaceLocationInfo(selectedData: AddressLookupPrediction): Promise<void> {
     const placeId = selectedData.placeId;
     if (this.settings.useGoogleGeoApi) {
-      const data = await this._googlePlacesService.getGeoPlaceDetail(placeId);
-      if (data) {
-        this.setRecentLocation(data);
+      try {
+        // Ensure the SDK is loaded before getGeoPlaceDetail touches window.google.
+        await this._googlePlacesService.loadGoogleMaps(this.settings);
+        const data = await this._googlePlacesService.getGeoPlaceDetail(placeId);
+        if (data) {
+          this.setRecentLocation(data);
+        }
+      } catch (err) {
+        console.error('Failed to load Google Maps for place details', err);
       }
     } else {
       try {

--- a/projects/novo-elements/src/elements/places/places.service.spec.ts
+++ b/projects/novo-elements/src/elements/places/places.service.spec.ts
@@ -1,22 +1,170 @@
 import { of } from 'rxjs';
+import { vi } from 'vitest';
+import type { PlacesSettings } from './places.component';
 import { GooglePlacesService } from './places.service';
 
-describe('Elements: GooglePlacesService', () => {
-  let service: GooglePlacesService;
-  let urls: string[];
+describe('GooglePlacesService', () => {
+  describe('Method: loadGoogleMaps()', () => {
+    let service: GooglePlacesService;
+    let nativeGlobal: any;
 
-  beforeEach(() => {
-    urls = [];
-    const http: any = {
-      get: (url: string) => {
-        urls.push(url);
-        return of({ data: [] });
-      },
+    const build = (platformId: any = 'browser'): GooglePlacesService => {
+      const http: any = {};
+      const global: any = { nativeGlobal };
+      const localStorage: any = {};
+      return new GooglePlacesService(http, platformId, global, localStorage);
     };
-    service = new GooglePlacesService(http, 'browser', {} as any, {} as any);
+
+    beforeEach(() => {
+      nativeGlobal = {};
+      service = build();
+    });
+
+    it('resolves and injects nothing when the SDK is already present', async () => {
+      nativeGlobal.google = { maps: { places: {} } };
+      service = build();
+      const appendSpy = vi.spyOn(document.head, 'appendChild');
+
+      await service.loadGoogleMaps({ googleApiKey: 'abc' } as PlacesSettings);
+
+      expect(appendSpy).not.toHaveBeenCalled();
+      appendSpy.mockRestore();
+    });
+
+    it('resolves without injecting when no key is configured (search-service path)', async () => {
+      const appendSpy = vi.spyOn(document.head, 'appendChild');
+
+      await service.loadGoogleMaps({ googleApiKey: '' } as PlacesSettings);
+
+      expect(appendSpy).not.toHaveBeenCalled();
+      appendSpy.mockRestore();
+    });
+
+    it('resolves without injecting on a non-browser platform', async () => {
+      service = build('server');
+      const appendSpy = vi.spyOn(document.head, 'appendChild');
+
+      await service.loadGoogleMaps({ googleApiKey: 'abc' } as PlacesSettings);
+
+      expect(appendSpy).not.toHaveBeenCalled();
+      appendSpy.mockRestore();
+    });
+
+    it('injects exactly one script for concurrent calls and resolves on load', async () => {
+      const script: any = {};
+      const createSpy = vi.spyOn(document, 'createElement').mockReturnValue(script);
+      const appendSpy = vi.spyOn(document.head, 'appendChild').mockImplementation((node: any) => node);
+      const settings = { googleApiKey: 'abc', googleMapsLoaderParams: { language: 'en-US' } } as PlacesSettings;
+
+      const first = service.loadGoogleMaps(settings);
+      const second = service.loadGoogleMaps(settings);
+
+      expect(appendSpy).toHaveBeenCalledTimes(1);
+      expect(script.src).toContain('key=abc');
+      expect(script.src).toContain('libraries=places');
+      expect(script.src).toContain('loading=async');
+      expect(script.src).toContain('language=en-US');
+
+      script.onload();
+      await Promise.all([first, second]);
+
+      createSpy.mockRestore();
+      appendSpy.mockRestore();
+    });
+
+    it('awaits importLibrary("places") before resolving when loading=async exposes it', async () => {
+      const script: any = {};
+      const createSpy = vi.spyOn(document, 'createElement').mockReturnValue(script);
+      vi.spyOn(document.head, 'appendChild').mockImplementation((node: any) => node);
+      const order: string[] = [];
+      const importLibrary = vi.fn().mockImplementation(() => {
+        order.push('import');
+        return Promise.resolve({});
+      });
+      nativeGlobal.google = { maps: { importLibrary } };
+      service = build();
+
+      const loaded = service.loadGoogleMaps({ googleApiKey: 'abc' } as PlacesSettings);
+      loaded.then(() => order.push('resolve'));
+
+      script.onload();
+      await loaded;
+
+      expect(importLibrary).toHaveBeenCalledWith('places');
+      expect(order).toEqual(['import', 'resolve']);
+      createSpy.mockRestore();
+    });
+
+    it('drops undefined loader params instead of serializing them as "undefined"', () => {
+      const script: any = {};
+      const createSpy = vi.spyOn(document, 'createElement').mockReturnValue(script);
+      vi.spyOn(document.head, 'appendChild').mockImplementation((node: any) => node);
+
+      service.loadGoogleMaps({ googleApiKey: 'abc', googleMapsLoaderParams: { region: undefined } } as any);
+
+      expect(script.src).not.toContain('region');
+      expect(script.src).not.toContain('undefined');
+      createSpy.mockRestore();
+    });
+
+    it('warns and reuses the in-flight loader when a second, different key is requested', async () => {
+      const script: any = {};
+      const createSpy = vi.spyOn(document, 'createElement').mockReturnValue(script);
+      const appendSpy = vi.spyOn(document.head, 'appendChild').mockImplementation((node: any) => node);
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const first = service.loadGoogleMaps({ googleApiKey: 'key-a' } as PlacesSettings);
+      const second = service.loadGoogleMaps({ googleApiKey: 'key-b' } as PlacesSettings);
+
+      expect(second).toBe(first);
+      expect(appendSpy).toHaveBeenCalledTimes(1);
+      expect(script.src).toContain('key=key-a');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      script.onload();
+      await Promise.all([first, second]);
+
+      createSpy.mockRestore();
+      appendSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it('clears the cached loader so a failed load can be retried', async () => {
+      const script: any = {};
+      const createSpy = vi.spyOn(document, 'createElement').mockReturnValue(script);
+      const appendSpy = vi.spyOn(document.head, 'appendChild').mockImplementation((node: any) => node);
+      const settings = { googleApiKey: 'abc' } as PlacesSettings;
+
+      const attempt = service.loadGoogleMaps(settings);
+      script.onerror();
+      await expect(attempt).rejects.toThrow('Failed to load the Google Maps JavaScript API.');
+
+      const retry = service.loadGoogleMaps(settings);
+      expect(retry).not.toBe(attempt);
+      expect(appendSpy).toHaveBeenCalledTimes(2);
+
+      script.onload();
+      await retry;
+      createSpy.mockRestore();
+      appendSpy.mockRestore();
+    });
   });
 
   describe('Method: getPredictions()', () => {
+    let service: GooglePlacesService;
+    let urls: string[];
+
+    beforeEach(() => {
+      urls = [];
+      const http: any = {
+        get: (url: string) => {
+          urls.push(url);
+          return of({ data: [] });
+        },
+      };
+      service = new GooglePlacesService(http, 'browser', {} as any, {} as any);
+    });
+
     it('should append the session token when one is provided', async () => {
       await service.getPredictions('https://api/predict?BhRestToken=t', 'main', 'tok-123');
       expect(urls[0]).toBe('https://api/predict?BhRestToken=t&query=main&sessionToken=tok-123');
@@ -29,6 +177,20 @@ describe('Elements: GooglePlacesService', () => {
   });
 
   describe('Method: getPlaceDetails()', () => {
+    let service: GooglePlacesService;
+    let urls: string[];
+
+    beforeEach(() => {
+      urls = [];
+      const http: any = {
+        get: (url: string) => {
+          urls.push(url);
+          return of({ data: [] });
+        },
+      };
+      service = new GooglePlacesService(http, 'browser', {} as any, {} as any);
+    });
+
     it('should append the session token when one is provided', async () => {
       await service.getPlaceDetails('https://api/detail?BhRestToken=t', 'place-1', 'tok-123');
       expect(urls[0]).toBe('https://api/detail?BhRestToken=t&query=place-1&sessionToken=tok-123');

--- a/projects/novo-elements/src/elements/places/places.service.spec.ts
+++ b/projects/novo-elements/src/elements/places/places.service.spec.ts
@@ -148,6 +148,31 @@ describe('GooglePlacesService', () => {
       createSpy.mockRestore();
       appendSpy.mockRestore();
     });
+
+    it('clears the cached loader when importLibrary rejects so a retry is possible', async () => {
+      const script: any = {};
+      const createSpy = vi.spyOn(document, 'createElement').mockReturnValue(script);
+      const appendSpy = vi.spyOn(document.head, 'appendChild').mockImplementation((node: any) => node);
+      const importLibrary = vi.fn()
+        .mockRejectedValueOnce(new Error('library load failed'))
+        .mockResolvedValueOnce({});
+      nativeGlobal.google = { maps: { importLibrary } };
+      service = build();
+      const settings = { googleApiKey: 'abc' } as PlacesSettings;
+
+      const attempt = service.loadGoogleMaps(settings);
+      script.onload();
+      await expect(attempt).rejects.toThrow('library load failed');
+
+      const retry = service.loadGoogleMaps(settings);
+      expect(retry).not.toBe(attempt);
+      expect(appendSpy).toHaveBeenCalledTimes(2);
+
+      script.onload();
+      await retry;
+      createSpy.mockRestore();
+      appendSpy.mockRestore();
+    });
   });
 
   describe('Method: getPredictions()', () => {

--- a/projects/novo-elements/src/elements/places/places.service.spec.ts
+++ b/projects/novo-elements/src/elements/places/places.service.spec.ts
@@ -62,7 +62,7 @@ describe('GooglePlacesService', () => {
       expect(appendSpy).toHaveBeenCalledTimes(1);
       expect(script.src).toContain('key=abc');
       expect(script.src).toContain('libraries=places');
-      expect(script.src).toContain('loading=async');
+      expect(script.src).not.toContain('loading=async');
       expect(script.src).toContain('language=en-US');
 
       script.onload();
@@ -70,29 +70,6 @@ describe('GooglePlacesService', () => {
 
       createSpy.mockRestore();
       appendSpy.mockRestore();
-    });
-
-    it('awaits importLibrary("places") before resolving when loading=async exposes it', async () => {
-      const script: any = {};
-      const createSpy = vi.spyOn(document, 'createElement').mockReturnValue(script);
-      vi.spyOn(document.head, 'appendChild').mockImplementation((node: any) => node);
-      const order: string[] = [];
-      const importLibrary = vi.fn().mockImplementation(() => {
-        order.push('import');
-        return Promise.resolve({});
-      });
-      nativeGlobal.google = { maps: { importLibrary } };
-      service = build();
-
-      const loaded = service.loadGoogleMaps({ googleApiKey: 'abc' } as PlacesSettings);
-      loaded.then(() => order.push('resolve'));
-
-      script.onload();
-      await loaded;
-
-      expect(importLibrary).toHaveBeenCalledWith('places');
-      expect(order).toEqual(['import', 'resolve']);
-      createSpy.mockRestore();
     });
 
     it('drops undefined loader params instead of serializing them as "undefined"', () => {
@@ -149,30 +126,6 @@ describe('GooglePlacesService', () => {
       appendSpy.mockRestore();
     });
 
-    it('clears the cached loader when importLibrary rejects so a retry is possible', async () => {
-      const script: any = {};
-      const createSpy = vi.spyOn(document, 'createElement').mockReturnValue(script);
-      const appendSpy = vi.spyOn(document.head, 'appendChild').mockImplementation((node: any) => node);
-      const importLibrary = vi.fn()
-        .mockRejectedValueOnce(new Error('library load failed'))
-        .mockResolvedValueOnce({});
-      nativeGlobal.google = { maps: { importLibrary } };
-      service = build();
-      const settings = { googleApiKey: 'abc' } as PlacesSettings;
-
-      const attempt = service.loadGoogleMaps(settings);
-      script.onload();
-      await expect(attempt).rejects.toThrow('library load failed');
-
-      const retry = service.loadGoogleMaps(settings);
-      expect(retry).not.toBe(attempt);
-      expect(appendSpy).toHaveBeenCalledTimes(2);
-
-      script.onload();
-      await retry;
-      createSpy.mockRestore();
-      appendSpy.mockRestore();
-    });
   });
 
   describe('Method: getPredictions()', () => {

--- a/projects/novo-elements/src/elements/places/places.service.ts
+++ b/projects/novo-elements/src/elements/places/places.service.ts
@@ -60,7 +60,10 @@ export class GooglePlacesService {
         // With loading=async, onload fires when the bootstrap loader is ready, not when the
         // places library is. importLibrary resolves only once the library is actually usable.
         if (_window?.google?.maps?.importLibrary) {
-          _window.google.maps.importLibrary('places').then(() => resolve(), reject);
+          _window.google.maps.importLibrary('places').then(
+            () => resolve(),
+            (err) => { this.mapsLoad = undefined; this.mapsLoadKey = undefined; reject(err); },
+          );
         } else {
           resolve();
         }
@@ -215,13 +218,11 @@ export class GooglePlacesService {
         const _window: any = this._global.nativeGlobal;
         const placesService: any = new _window.google.maps.places.PlacesService(document.createElement('div'));
         placesService.getDetails({ placeId }, (result: any) => {
-          if (result === null || result.length === 0) {
+          if (result === null) {
+            resolve(false);
+          } else if (result.length === 0) {
             this.getGeoPaceDetailByReferance(result.referance).then((referanceData: any) => {
-              if (!referanceData) {
-                resolve(false);
-              } else {
-                resolve(referanceData);
-              }
+              resolve(referanceData || false);
             });
           } else {
             resolve(result);

--- a/projects/novo-elements/src/elements/places/places.service.ts
+++ b/projects/novo-elements/src/elements/places/places.service.ts
@@ -69,8 +69,9 @@ export class GooglePlacesService {
         }
       };
       script.onerror = () => {
-        // Clear the cached promise so a later attempt can retry instead of resolving a failed load.
+        // Clear both cached fields so a later attempt can retry with any key.
         this.mapsLoad = undefined;
+        this.mapsLoadKey = undefined;
         reject(new Error('Failed to load the Google Maps JavaScript API.'));
       };
       document.head.appendChild(script);

--- a/projects/novo-elements/src/elements/places/places.service.ts
+++ b/projects/novo-elements/src/elements/places/places.service.ts
@@ -2,15 +2,77 @@ import { isPlatformBrowser } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { GlobalRef, LocalStorageService } from 'novo-elements/services';
+import type { PlacesSettings } from './places.component';
 
 @Injectable()
 export class GooglePlacesService {
+  // Shared across the address fields that use this singleton so the SDK is injected at most once.
+  private mapsLoad?: Promise<void>;
+  // The key the SDK was (or is being) loaded with; the Maps JS API can only be loaded once per page.
+  private mapsLoadKey?: string;
+
   constructor(
     private _http: HttpClient,
     @Inject(PLATFORM_ID) private platformId: Object,
     private _global: GlobalRef,
     private _localStorageService: LocalStorageService,
   ) {}
+
+  // Ensure the Google Maps JS SDK is available before any window.google usage.
+  // No-ops when the SDK is already present (host script tag) or no key is configured (search-service path).
+  loadGoogleMaps(settings: PlacesSettings): Promise<void> {
+    const _window: any = this._global.nativeGlobal;
+    if (_window?.google?.maps?.places) {
+      return Promise.resolve();
+    }
+    if (!isPlatformBrowser(this.platformId) || !settings?.googleApiKey) {
+      return Promise.resolve();
+    }
+    if (!this.mapsLoad) {
+      this.mapsLoadKey = settings.googleApiKey;
+      this.mapsLoad = this.injectGoogleMapsScript(settings);
+    } else if (this.mapsLoadKey && this.mapsLoadKey !== settings.googleApiKey) {
+      // The Maps JS API can only be loaded once per page; a second, different key is ignored.
+      console.warn(
+        'GooglePlacesService: the Google Maps SDK is already loading with a different key; ignoring the new googleApiKey.',
+      );
+    }
+    return this.mapsLoad;
+  }
+
+  private injectGoogleMapsScript(settings: PlacesSettings): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const _window: any = this._global.nativeGlobal;
+      // Build params one at a time so undefined override values are dropped instead of serialized as "undefined".
+      const params = new URLSearchParams();
+      params.set('key', settings.googleApiKey);
+      params.set('libraries', 'places');
+      params.set('loading', 'async');
+      for (const [key, value] of Object.entries(settings.googleMapsLoaderParams ?? {})) {
+        if (value !== undefined && value !== null) {
+          params.set(key, value);
+        }
+      }
+      const script = document.createElement('script');
+      script.src = `https://maps.googleapis.com/maps/api/js?${params.toString()}`;
+      script.async = true;
+      script.onload = () => {
+        // With loading=async, onload fires when the bootstrap loader is ready, not when the
+        // places library is. importLibrary resolves only once the library is actually usable.
+        if (_window?.google?.maps?.importLibrary) {
+          _window.google.maps.importLibrary('places').then(() => resolve(), reject);
+        } else {
+          resolve();
+        }
+      };
+      script.onerror = () => {
+        // Clear the cached promise so a later attempt can retry instead of resolving a failed load.
+        this.mapsLoad = undefined;
+        reject(new Error('Failed to load the Google Maps JavaScript API.'));
+      };
+      document.head.appendChild(script);
+    });
+  }
 
   getPredictions(url: string, query: string, sessionToken?: string): Promise<any> {
     return new Promise((resolve) => {

--- a/projects/novo-elements/src/elements/places/places.service.ts
+++ b/projects/novo-elements/src/elements/places/places.service.ts
@@ -44,10 +44,11 @@ export class GooglePlacesService {
     return new Promise<void>((resolve, reject) => {
       const _window: any = this._global.nativeGlobal;
       // Build params one at a time so undefined override values are dropped instead of serialized as "undefined".
+      // The component uses the legacy Places API (AutocompleteService, PlacesService) which requires the
+      // synchronous library load — google.maps.places is fully populated when onload fires.
       const params = new URLSearchParams();
       params.set('key', settings.googleApiKey);
       params.set('libraries', 'places');
-      params.set('loading', 'async');
       for (const [key, value] of Object.entries(settings.googleMapsLoaderParams ?? {})) {
         if (value !== undefined && value !== null) {
           params.set(key, value);
@@ -56,18 +57,7 @@ export class GooglePlacesService {
       const script = document.createElement('script');
       script.src = `https://maps.googleapis.com/maps/api/js?${params.toString()}`;
       script.async = true;
-      script.onload = () => {
-        // With loading=async, onload fires when the bootstrap loader is ready, not when the
-        // places library is. importLibrary resolves only once the library is actually usable.
-        if (_window?.google?.maps?.importLibrary) {
-          _window.google.maps.importLibrary('places').then(
-            () => resolve(),
-            (err) => { this.mapsLoad = undefined; this.mapsLoadKey = undefined; reject(err); },
-          );
-        } else {
-          resolve();
-        }
-      };
+      script.onload = () => resolve();
       script.onerror = () => {
         // Clear both cached fields so a later attempt can retry with any key.
         this.mapsLoad = undefined;

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.spec.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.spec.ts
@@ -33,6 +33,78 @@ describe('NovoDefaultAddressConditionDef', () => {
       expect(actual).toBeTruthy();
     });
   });
+  describe('Function: addressLabel', () => {
+    const addressLabel = NovoDefaultAddressConditionDef.prototype.addressLabel;
+
+    it('uses formatted_address for the Google client-SDK shape', () => {
+      expect(addressLabel({ formatted_address: 'Boston, MA, USA' } as any)).toBe('Boston, MA, USA');
+    });
+
+    it('falls back to formattedAddress for the address-search-service shape', () => {
+      expect(addressLabel({ formattedAddress: 'Boston, MA, USA' } as any)).toBe('Boston, MA, USA');
+    });
+
+    it('returns empty string when neither field is present', () => {
+      expect(addressLabel({} as any)).toBe('');
+      expect(addressLabel(undefined as any)).toBe('');
+    });
+  });
+
+  describe('Function: selectPlace', () => {
+    const buildContext = (formGroup: FormGroup) => ({
+      getValue: NovoDefaultAddressConditionDef.prototype.getValue,
+      updateRadiusInValues: (_fg: any, values: any[]) => values,
+      inputChildren: { forEach: () => {} },
+      getCurrentInput: () => undefined,
+      closePlacesList: () => {},
+    });
+
+    it('should store the Google client-SDK fields when the result has address_components', () => {
+      const formGroup = new FormGroup({ value: new FormControl(null) });
+      const googleEvent = {
+        address_components: [{ long_name: 'Boston', short_name: 'Boston', types: ['locality'] }],
+        formatted_address: 'Boston, MA, USA',
+        geometry: { location: { lat: 1, lng: 2 } },
+        name: 'Boston',
+        place_id: 'g1',
+        types: ['locality'],
+        extraneous: 'dropped',
+      };
+      NovoDefaultAddressConditionDef.prototype.selectPlace.call(buildContext(formGroup), googleEvent, formGroup, 'v1');
+      expect(formGroup.get('value').value).toEqual([
+        {
+          address_components: googleEvent.address_components,
+          formatted_address: 'Boston, MA, USA',
+          geometry: googleEvent.geometry,
+          name: 'Boston',
+          postal_codes: undefined,
+          place_id: 'g1',
+          types: ['locality'],
+        },
+      ]);
+    });
+
+    it('should store the flat address-search-service shape as-is when there are no address_components', () => {
+      const formGroup = new FormGroup({ value: new FormControl(null) });
+      const flatEvent = {
+        city: 'Boston',
+        state: 'Massachusetts',
+        countryName: 'United States',
+        formattedAddress: 'Boston, MA, USA',
+        referenceId: 'ref-1',
+        viewport: { northeast: { latitude: 1, longitude: 2 }, southwest: { latitude: 3, longitude: 4 } },
+      };
+      NovoDefaultAddressConditionDef.prototype.selectPlace.call(buildContext(formGroup), flatEvent, formGroup, 'v1');
+      expect(formGroup.get('value').value).toEqual([flatEvent]);
+    });
+
+    it('should append to existing values', () => {
+      const formGroup = new FormGroup({ value: new FormControl([{ referenceId: 'existing' }]) });
+      NovoDefaultAddressConditionDef.prototype.selectPlace.call(buildContext(formGroup), { referenceId: 'new' }, formGroup, 'v1');
+      expect(formGroup.get('value').value).toEqual([{ referenceId: 'existing' }, { referenceId: 'new' }]);
+    });
+  });
+
   describe('Function: updateRadiusInValues', () => {
     it('should return values updated with the radius based on form values if radius operator is selected', () => {
       const expected = [

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.spec.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.spec.ts
@@ -98,6 +98,24 @@ describe('NovoDefaultAddressConditionDef', () => {
       expect(formGroup.get('value').value).toEqual([flatEvent]);
     });
 
+    it('does not store UI-state fields (active, description) added by setRecentLocation into the form value', () => {
+      const formGroup = new FormGroup({ value: new FormControl(null) });
+      const flatEventWithUiState = {
+        city: 'Boston',
+        formattedAddress: 'Boston, MA, USA',
+        referenceId: 'ref-1',
+        active: false,
+        description: 'Boston, MA, USA',
+      };
+      NovoDefaultAddressConditionDef.prototype.selectPlace.call(buildContext(formGroup), flatEventWithUiState, formGroup, 'v1');
+      const stored = formGroup.get('value').value[0];
+      expect(stored.active).toBeUndefined();
+      expect(stored.description).toBeUndefined();
+      expect(stored.city).toBe('Boston');
+      expect(stored.formattedAddress).toBe('Boston, MA, USA');
+      expect(stored.referenceId).toBe('ref-1');
+    });
+
     it('should append to existing values', () => {
       const formGroup = new FormGroup({ value: new FormControl([{ referenceId: 'existing' }]) });
       NovoDefaultAddressConditionDef.prototype.selectPlace.call(buildContext(formGroup), { referenceId: 'new' }, formGroup, 'v1');

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.spec.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.spec.ts
@@ -33,23 +33,6 @@ describe('NovoDefaultAddressConditionDef', () => {
       expect(actual).toBeTruthy();
     });
   });
-  describe('Function: addressLabel', () => {
-    const addressLabel = NovoDefaultAddressConditionDef.prototype.addressLabel;
-
-    it('uses formatted_address for the Google client-SDK shape', () => {
-      expect(addressLabel({ formatted_address: 'Boston, MA, USA' } as any)).toBe('Boston, MA, USA');
-    });
-
-    it('falls back to formattedAddress for the address-search-service shape', () => {
-      expect(addressLabel({ formattedAddress: 'Boston, MA, USA' } as any)).toBe('Boston, MA, USA');
-    });
-
-    it('returns empty string when neither field is present', () => {
-      expect(addressLabel({} as any)).toBe('');
-      expect(addressLabel(undefined as any)).toBe('');
-    });
-  });
-
   describe('Function: selectPlace', () => {
     const buildContext = (formGroup: FormGroup) => ({
       getValue: NovoDefaultAddressConditionDef.prototype.getValue,

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
@@ -192,7 +192,23 @@ export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef im
           place_id: event.place_id,
           types: event.types,
         }
-      : { ...event };
+      : {
+          address1: event.address1,
+          address2: event.address2,
+          city: event.city,
+          state: event.state,
+          zip: event.zip,
+          countryName: event.countryName,
+          countryCode: event.countryCode,
+          formattedAddress: event.formattedAddress,
+          location: event.location,
+          viewport: event.viewport,
+          referenceId: event.referenceId,
+          postalCodes: event.postalCodes,
+          postal_codes: event.postal_codes,
+          types: event.types,
+          radius: event.radius,
+        };
     const current: AddressData | AddressData[] = this.getValue(formGroup);
     const updated: AddressData[] = Array.isArray(current) ? [...current, valueToAdd] : [valueToAdd];
     formGroup.get('value').setValue(this.updateRadiusInValues(formGroup, updated));

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
@@ -15,7 +15,7 @@ import {
 } from '@angular/core';
 import { AbstractControl, UntypedFormGroup } from '@angular/forms';
 import { NovoPickerToggleElement } from 'novo-elements/elements/field';
-import { PlacesListComponent } from 'novo-elements/elements/places';
+import { NOVO_ADDRESS_CONFIG, PlacesListComponent, PlacesSettings } from 'novo-elements/elements/places';
 import { NovoLabelService } from 'novo-elements/services';
 import { Key } from 'novo-elements/utils';
 import { Subscription } from 'rxjs';
@@ -64,7 +64,7 @@ import { NovoSelectElement } from 'novo-elements/elements/select';
           <novo-field #novoField class="address-location">
             <novo-chip-list [(ngModel)]="chipListModel" [ngModelOptions]="{ standalone: true }" (click)="openPlacesList(viewIndex)">
               <novo-chip *ngFor="let item of formGroup.get('value').value" (removed)="remove(item, formGroup, viewIndex)">
-                <novo-text ellipsis [tooltip]="item.formatted_address" tooltipOnOverflow>{{ item.formatted_address }}</novo-text>
+                <novo-text ellipsis [tooltip]="addressLabel(item)" tooltipOnOverflow>{{ addressLabel(item) }}</novo-text>
                 <novo-icon novoChipRemove>close</novo-icon>
               </novo-chip>
               <input
@@ -79,6 +79,7 @@ import { NovoSelectElement } from 'novo-elements/elements/select';
             <novo-picker-toggle [overlayId]="viewIndex" icon="location" novoSuffix>
               <google-places-list
                 [term]="term"
+                [userSettings]="addressConfig"
                 (select)="selectPlace($event, formGroup, viewIndex)"
                 formControlName="value"
                 #placesPicker/>
@@ -121,6 +122,9 @@ export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef im
   private _addressChangesSubscription: Subscription = Subscription.EMPTY;
 
   public element = inject(ElementRef);
+  // App-wide address config; when provided with the server path, the picker uses the address-search-service
+  // instead of the Google client SDK. Null leaves the picker on its Google default.
+  protected addressConfig: PlacesSettings = inject(NOVO_ADDRESS_CONFIG, { optional: true });
 
   constructor(labelService: NovoLabelService) {
     super(labelService);
@@ -154,6 +158,11 @@ export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef im
     return formGroup.value.value || [];
   }
 
+  // Google client-SDK results use formatted_address; address-search-service results use formattedAddress.
+  addressLabel(item: AddressData): string {
+    return item?.formatted_address ?? item?.formattedAddress ?? '';
+  }
+
   getCurrentOverlay(viewIndex: string): NovoPickerToggleElement {
     return this.overlayChildren?.find(item => item.overlayId === viewIndex);
   }
@@ -171,15 +180,19 @@ export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef im
   }
 
   selectPlace(event: any, formGroup: AbstractControl, viewIndex: string): void {
-    const valueToAdd: AddressData = {
-      address_components: event.address_components,
-      formatted_address: event.formatted_address,
-      geometry: event.geometry,
-      name: event.name,
-      postal_codes: event.postal_codes,
-      place_id: event.place_id,
-      types: event.types,
-    };
+    // Google client-SDK results expose address_components; address-search-service results are already
+    // a flat, provider-agnostic shape and are stored as-is.
+    const valueToAdd: AddressData = event?.address_components
+      ? {
+          address_components: event.address_components,
+          formatted_address: event.formatted_address,
+          geometry: event.geometry,
+          name: event.name,
+          postal_codes: event.postal_codes,
+          place_id: event.place_id,
+          types: event.types,
+        }
+      : { ...event };
     const current: AddressData | AddressData[] = this.getValue(formGroup);
     const updated: AddressData[] = Array.isArray(current) ? [...current, valueToAdd] : [valueToAdd];
     formGroup.get('value').setValue(this.updateRadiusInValues(formGroup, updated));

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-condition.definition.ts
@@ -64,7 +64,7 @@ import { NovoSelectElement } from 'novo-elements/elements/select';
           <novo-field #novoField class="address-location">
             <novo-chip-list [(ngModel)]="chipListModel" [ngModelOptions]="{ standalone: true }" (click)="openPlacesList(viewIndex)">
               <novo-chip *ngFor="let item of formGroup.get('value').value" (removed)="remove(item, formGroup, viewIndex)">
-                <novo-text ellipsis [tooltip]="addressLabel(item)" tooltipOnOverflow>{{ addressLabel(item) }}</novo-text>
+                <novo-text ellipsis [tooltip]="item | addressLabel" tooltipOnOverflow>{{ item | addressLabel }}</novo-text>
                 <novo-icon novoChipRemove>close</novo-icon>
               </novo-chip>
               <input
@@ -124,7 +124,7 @@ export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef im
   public element = inject(ElementRef);
   // App-wide address config; when provided with the server path, the picker uses the address-search-service
   // instead of the Google client SDK. Null leaves the picker on its Google default.
-  protected addressConfig: PlacesSettings = inject(NOVO_ADDRESS_CONFIG, { optional: true });
+  protected readonly addressConfig: PlacesSettings = inject(NOVO_ADDRESS_CONFIG, { optional: true });
 
   constructor(labelService: NovoLabelService) {
     super(labelService);
@@ -156,11 +156,6 @@ export class NovoDefaultAddressConditionDef extends AbstractConditionFieldDef im
 
   getValue(formGroup: AbstractControl): AddressData[] {
     return formGroup.value.value || [];
-  }
-
-  // Google client-SDK results use formatted_address; address-search-service results use formattedAddress.
-  addressLabel(item: AddressData): string {
-    return item?.formatted_address ?? item?.formattedAddress ?? '';
   }
 
   getCurrentOverlay(viewIndex: string): NovoPickerToggleElement {

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-label.pipe.spec.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-label.pipe.spec.ts
@@ -1,0 +1,22 @@
+import { AddressLabelPipe } from './address-label.pipe';
+
+describe('AddressLabelPipe', () => {
+  let pipe: AddressLabelPipe;
+
+  beforeEach(() => {
+    pipe = new AddressLabelPipe();
+  });
+
+  it('uses formatted_address for the Google client-SDK shape', () => {
+    expect(pipe.transform({ formatted_address: 'Boston, MA, USA' } as any)).toBe('Boston, MA, USA');
+  });
+
+  it('falls back to formattedAddress for the address-search-service shape', () => {
+    expect(pipe.transform({ formattedAddress: 'Boston, MA, USA' } as any)).toBe('Boston, MA, USA');
+  });
+
+  it('returns empty string when neither field is present', () => {
+    expect(pipe.transform({} as any)).toBe('');
+    expect(pipe.transform(undefined as any)).toBe('');
+  });
+});

--- a/projects/novo-elements/src/elements/query-builder/condition-definitions/address-label.pipe.ts
+++ b/projects/novo-elements/src/elements/query-builder/condition-definitions/address-label.pipe.ts
@@ -1,0 +1,16 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { AddressData } from '../query-builder.types';
+
+/**
+ * Resolves a display label from an address value. Google client-SDK results use formatted_address;
+ * address-search-service results use formattedAddress.
+ */
+@Pipe({
+  name: 'addressLabel',
+  standalone: false,
+})
+export class AddressLabelPipe implements PipeTransform {
+  transform(item: AddressData): string {
+    return item?.formatted_address ?? item?.formattedAddress ?? '';
+  }
+}

--- a/projects/novo-elements/src/elements/query-builder/query-builder.module.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.module.ts
@@ -26,6 +26,7 @@ import { NovoSwitchModule } from 'novo-elements/elements/switch';
 import { NovoTabbedGroupPickerModule } from 'novo-elements/elements/tabbed-group-picker';
 import { NovoTabModule } from 'novo-elements/elements/tabs';
 import { ConditionBuilderComponent, ConditionInputOutlet, ConditionOperatorOutlet } from './condition-builder/condition-builder.component';
+import { AddressLabelPipe } from './condition-definitions/address-label.pipe';
 import { NovoDefaultAddressConditionDef } from './condition-definitions/address-condition.definition';
 import { NovoDefaultBooleanConditionDef } from './condition-definitions/boolean-condition.definition';
 import { NovoDefaultDateConditionDef } from './condition-definitions/date-condition.definition';
@@ -75,6 +76,7 @@ import { NovoTooltipModule } from 'novo-elements/elements/tooltip';
     NovoTooltipModule,
   ],
   declarations: [
+    AddressLabelPipe,
     CriteriaBuilderComponent,
     ConditionBuilderComponent,
     ConditionInputOutlet,

--- a/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
+++ b/projects/novo-elements/src/elements/query-builder/query-builder.types.ts
@@ -85,14 +85,39 @@ export interface FieldConfig<T extends BaseFieldDef> {
 }
 
 export interface AddressData {
-  address_components: AddressComponent[];
-  formatted_address: string;
-  geometry: AddressGeometry;
+  // Google Places (client SDK) shape — present when the places picker uses the Google API directly.
+  address_components?: AddressComponent[];
+  formatted_address?: string;
+  geometry?: AddressGeometry;
   name?: string;
-  place_id: string;
+  place_id?: string;
+  // address-search-service (flat) shape — present when an app configures the server path via NOVO_ADDRESS_CONFIG.
+  address1?: string;
+  address2?: string;
+  city?: string;
+  state?: string;
+  zip?: string;
+  countryName?: string;
+  countryCode?: string;
+  formattedAddress?: string;
+  location?: AddressGeoPoint;
+  viewport?: AddressDetailViewport;
+  referenceId?: string;
+  postalCodes?: string[];
+  // common
   radius?: AddressRadius;
   postal_codes?: string[];
   types?: string[];
+}
+
+export interface AddressGeoPoint {
+  latitude: number;
+  longitude: number;
+}
+
+export interface AddressDetailViewport {
+  northeast: AddressGeoPoint;
+  southwest: AddressGeoPoint;
 }
 
 export interface AddressRadius {

--- a/projects/novo-elements/src/novo-elements.providers.spec.ts
+++ b/projects/novo-elements/src/novo-elements.providers.spec.ts
@@ -14,6 +14,14 @@ describe('NovoElementProviders.forRoot', () => {
     expect(provider.useValue).toBe(address);
   });
 
+  it('passes googleApiKey through to NOVO_ADDRESS_CONFIG', () => {
+    const address = { googleApiKey: 'managed-key' };
+    const moduleWithProviders = NovoElementProviders.forRoot({ address });
+
+    const provider = (moduleWithProviders.providers as any[]).find((p) => p.provide === NOVO_ADDRESS_CONFIG);
+    expect(provider.useValue.googleApiKey).toBe('managed-key');
+  });
+
   it('does NOT register NOVO_ADDRESS_CONFIG for a bare forRoot() (avoids shadowing root config)', () => {
     expect(hasAddressProvider(NovoElementProviders.forRoot().providers as any[])).toBe(false);
     expect(hasAddressProvider(NovoElementProviders.forRoot({}).providers as any[])).toBe(false);

--- a/projects/novo-elements/src/novo-elements.providers.ts
+++ b/projects/novo-elements/src/novo-elements.providers.ts
@@ -37,6 +37,20 @@ const NOVO_ELEMENTS_PROVIDERS = [
   imports: [],
 })
 export class NovoElementProviders {
+  /**
+   * Registers Novo Elements root services.
+   *
+   * @param options.address - Optional address-lookup config. Set `googleApiKey` to your
+   *   Google Maps Platform API key (https://developers.google.com/maps/documentation/javascript/get-api-key)
+   *   to enable client-side Places autocomplete. Omit or leave blank to use the
+   *   Bullhorn address-search-service path instead.
+   *
+   * @example
+   * // In AppModule imports:
+   * NovoElementProviders.forRoot({
+   *   address: { googleApiKey: environment.googleMapsApiKey },
+   * })
+   */
   static forRoot(options?: { menu?: IMenuOptions; address?: PlacesSettings }): ModuleWithProviders<NovoElementProviders> {
     return {
       ngModule: NovoElementProviders,


### PR DESCRIPTION
…-88540)

Address code-review findings on the Maps SDK lazy-load / address-search-service work:

- Render flat (address-search-service) chips: add addressLabel() so the chip falls back to formattedAddress when formatted_address is absent, fixing blank chips on the server path.
- Resolve loadGoogleMaps via google.maps.importLibrary('places') on script load so the promise settles only once the places library is usable (loading=async fires onload before it is ready).
- Convert getListQuery/getCurrentLocationInfo/getPlaceLocationInfo to async/await with try/catch: clear the current-location spinner in finally, surface an empty list on prediction-load failure, and add the missing SDK guard before getGeoPlaceDetail.
- Drop undefined Maps loader params instead of serializing them as "undefined", and warn when a second, different googleApiKey is requested (Maps JS can only load once per page).
- Demo: route googlePlacesKey through NOVO_ADDRESS_CONFIG so the address components exercise the real lazy-load path instead of a duplicated bootstrap script.

Adds tests covering importLibrary sequencing, undefined-param filtering, key-conflict warning, async error/finally paths, and addressLabel.

## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**