### PR TITLE
chore(Workflows): Correct publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
   workflow_dispatch:
     inputs:
       dry-run:
@@ -29,30 +30,14 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Update npm
         run: npm install -g npm@10.9.7
-      - name: Verify tag matches package.json version
-        if: github.event_name == 'push'
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          TAG="${{ github.ref_name }}"
-          echo "Tag: $TAG"
-          echo "package.json version: $VERSION"
-          if [ "$TAG" != "$VERSION" ]; then
-            echo "::error::Tag '$TAG' does not match package.json version '$VERSION'"
-            exit 1
-          fi
       - name: Install Dependencies
         run: |
           npm ci
       - name: Building Projects
         run: |
           npm run build:ci
-      - name: Sync dist version with root package.json
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          echo "Setting dist/novo-elements version to $VERSION"
-          (cd dist/novo-elements && npm version "$VERSION" --no-git-tag-version --allow-same-version)
       - name: Publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          npm publish dist/novo-elements${{ github.event.inputs.dry-run == 'true' && ' --dry-run' || '' }}
+          npm publish ./dist/novo-elements


### PR DESCRIPTION
Removed version verification and syncing steps from the publish workflow.
Correct path to novo-elements in `npm publish`

## **Description**
Our release automation will update the `package.json` files in the repository to the correct version. The action's job should be only to publish (DRY)

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [x] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [x] Run `Novo Automation`

##### **Screenshots**