### PR TITLE
fix(DataTableCheckboxHeaderCell): Bug with selecting all new page rows when paginating

### DIFF
--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-checkbox-header-cell.component.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-checkbox-header-cell.component.ts
@@ -65,6 +65,7 @@ export class NovoDataTableCheckboxHeaderCell<T> extends CdkHeaderCell implements
             this.dataTable.state.selectedRows.has(`${row[this.dataTable.rowIdentifier]}`),
           );
           if (!allCurrentPageSelected) {
+            this.dataTable.state.selectedRows.clear();
             this.dataTable.selectRows(true);
             this.ref.markForCheck();
             return;

--- a/projects/novo-elements/src/elements/data-table/cell-headers/data-table-checkbox-header-cell.component.ts
+++ b/projects/novo-elements/src/elements/data-table/cell-headers/data-table-checkbox-header-cell.component.ts
@@ -60,6 +60,16 @@ export class NovoDataTableCheckboxHeaderCell<T> extends CdkHeaderCell implements
     this.selectionSubscription = this.dataTable.state.selectionSource.subscribe(() => {
       this.checked = this.dataTable.allCurrentRowsSelected() || (this.dataTable?.canSelectAll && this.dataTable?.allMatchingSelected);
       if (this.dataTable?.canSelectAll) {
+        if (this.dataTable.allMatchingSelected) {
+          const allCurrentPageSelected = (this.dataTable.dataSource.data || []).every((row) =>
+            this.dataTable.state.selectedRows.has(`${row[this.dataTable.rowIdentifier]}`),
+          );
+          if (!allCurrentPageSelected) {
+            this.dataTable.selectRows(true);
+            this.ref.markForCheck();
+            return;
+          }
+        }
         this.selectAllChanged();
       }
       this.ref.markForCheck();

--- a/projects/novo-elements/src/elements/data-table/data-table.token.ts
+++ b/projects/novo-elements/src/elements/data-table/data-table.token.ts
@@ -19,6 +19,7 @@ export interface NovoDataTableRef<T = any> {
   allSelected: EventEmitter<any>;
   canSelectAll: boolean;
   allMatchingSelected: boolean;
+  rowIdentifier: string;
   state: DataTableState<T>;
   dataSource: DataTableSource<T>;
 }


### PR DESCRIPTION
## **Description**

Fix a bug with selecting all new page rows when paginating to a new page and 'all match records' is selected

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**