### PR TITLE
feat(styles): BH-102237 - update bh2026 component styling

### DIFF
--- a/projects/novo-elements/src/elements/button/styles/button-secondary.scss
+++ b/projects/novo-elements/src/elements/button/styles/button-secondary.scss
@@ -11,7 +11,6 @@
     background: var(--color-white);
     color: var(--button-secondary-text, var(--color-positive));
     border: var(--button-secondary-border, 1px solid $positive);
-    padding: 0 calc(#{var(--spacing-md)} - 1px);
 
     i.loading {
       margin-left: 0.8rem;

--- a/projects/novo-elements/src/elements/card/Card.scss
+++ b/projects/novo-elements/src/elements/card/Card.scss
@@ -117,7 +117,7 @@
   }
 }
 
-// bh2026: roomier, rounder card, larger title
+// bh2026: rounder card, grippy on hover
 :host-context([data-theme='bh2026']) {
   border-radius: var(--border-radius-md, 1.6rem);
   border: 1px solid var(--color-border-default, #f0f5f9);
@@ -128,26 +128,34 @@
   }
 
   header {
-    padding: var(--spacing-md, 1.6rem);
-    margin-left: var(--spacing-md);
+    padding: var(--spacing-16, 1.6rem) var(--spacing-24, 2.4rem) var(--spacing-16, 1.6rem) 0;
+    border-bottom: 1px solid var(--color-border-default, #f0f5f9);
 
     .title {
-      ::ng-deep i.bhi-move {
-        display: none;
-      }
-
       h1,
       h2,
       h3 {
-        font-size: 1.8rem;
-        font-weight: 500;
+        font-size: var(--typography-card-header-font-size, 1.8rem);
+        font-weight: var(--typography-card-header-font-weight, 500);
+      }
+
+      ::ng-deep i.bhi-move {
+        color: transparent;
       }
     }
 
+    &:hover .title ::ng-deep i.bhi-move {
+      color: var(--color-content-subtle, #5d7798);
+    }
+
+    .actions {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-8, 0.8rem);
+    }
+
     novo-button {
-      color: rgba(var(--text-secondary), 0.7);
-      margin-left: var(--spacing-sm);
-      margin-right: var(--spacing-sm);
+      color: var(--color-content-subtle, #5d7798);
     }
   }
 }

--- a/projects/novo-elements/src/elements/category-dropdown/CategoryDropdown.scss
+++ b/projects/novo-elements/src/elements/category-dropdown/CategoryDropdown.scss
@@ -15,7 +15,7 @@
       min-width: 400px;
       display: block;
       z-index: z("max");
-      border-radius: var(--border-radius-xsm, 2px);
+      border-radius: var(--border-radius-sm, 2px);
       top: 100%;
       margin-top: 5px;
     }

--- a/projects/novo-elements/src/elements/common/directives/accent.directive.ts
+++ b/projects/novo-elements/src/elements/common/directives/accent.directive.ts
@@ -18,7 +18,7 @@ export class AccentColorDirective implements OnDestroy {
       return `novo-theme-${this.accent}`;
     }
     const normalized = normalizeThemeName(this.theme.themeName);
-    if (normalized.includes('bh2022')) {
+    if (normalized.includes('bh2022') || normalized.includes('bh2026')) {
       return `novo-accent-${this.accent}`;
     }
     return '';

--- a/projects/novo-elements/src/elements/date-picker/DatePicker.scss
+++ b/projects/novo-elements/src/elements/date-picker/DatePicker.scss
@@ -3,7 +3,7 @@
 :host {
   display: block;
   .date-picker-container {
-    border-radius: var(--border-radius-default, 4px);
+    border-radius: var(--border-radius-sm, 4px);
     width: min-content;
     text-align: center;
     background: var(--background-main);
@@ -218,9 +218,4 @@
   .calendar.popup.open {
     display: block;
   }
-}
-
-// bh2026: rounder calendar
-:host-context([data-theme='bh2026']) .date-picker-container {
-  border-radius: var(--calendar-radius, 0.8rem);
 }

--- a/projects/novo-elements/src/elements/date-time-picker/_DateTimePicker.scss
+++ b/projects/novo-elements/src/elements/date-time-picker/_DateTimePicker.scss
@@ -6,7 +6,7 @@ $time-select-height: 45px;
   display: block;
   width: min-content;
   overflow: hidden;
-  border-radius: var(--border-radius-default, 4px);
+  border-radius: var(--border-radius-sm, 4px);
   background-color: var(--background-bright);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15), 0 2px 7px rgba(0, 0, 0, 0.1);
   z-index: z(max);

--- a/projects/novo-elements/src/elements/dropdown/Dropdown.scss
+++ b/projects/novo-elements/src/elements/dropdown/Dropdown.scss
@@ -16,13 +16,15 @@
       font-size: 0.8em !important;
       width: 1em !important;
       height: 1em !important;
-      margin: 0 0.5em;
+      margin: 0 var(--button-icon-margin, 0.5em);
     }
   }
 }
 
 .dropdown-container {
   background-color: var(--background-bright, $color-bright);
+  border-radius: var(--border-radius-sm);
+  overflow: hidden;
   list-style: none;
   margin: 0;
   padding: 0;

--- a/projects/novo-elements/src/elements/header/Header.scss
+++ b/projects/novo-elements/src/elements/header/Header.scss
@@ -152,9 +152,37 @@
   }
 }
 
-// bh2026: soften the entity-accent underline
+// bh2026: frosted translucent header + entity squircle icon
 :host-context([data-theme='bh2026']) {
-  &[class*='novo-accent-'] > section:first-of-type {
-    border-bottom: 1px solid var(--color-border-default, #f0f5f9);
+  &[class*='novo-accent-'] {
+    background: var(--color-transparency-white-90, rgba(255, 255, 255, 0.9));
+    backdrop-filter: blur(12px);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+    padding-top: var(--spacing-md);
+    padding-left: var(--spacing-lg);
+    padding-right: var(--spacing-lg);
+
+    & > section:first-of-type {
+      border-bottom: none;
+    }
+
+    utils {
+      color: var(--color-transparency-black-60);
+    }
+  }
+
+  @each $entity, $color in $entity-colors {
+    &.novo-accent-#{$entity} {
+      ::ng-deep .header-icon i {
+        color: var(--color-white);
+        background: $color;
+        border-radius: var(--border-radius-sm);
+        width: var(--typography-font-size-40);
+        height: var(--typography-font-size-40);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+    }
   }
 }

--- a/projects/novo-elements/src/elements/menu/menu-content.component.scss
+++ b/projects/novo-elements/src/elements/menu/menu-content.component.scss
@@ -16,6 +16,7 @@
       cursor: default;
       list-style: none;
       background-color: var(--background-bright);
+      border-radius: var(--border-radius-sm);
       padding-inline-start: 0px !important;
       box-shadow: $shadow-multi;
       :hover {

--- a/projects/novo-elements/src/elements/modal/modal.component.scss
+++ b/projects/novo-elements/src/elements/modal/modal.component.scss
@@ -3,7 +3,7 @@
 :host {
   display: block;
   background-color: var(--background-bright);
-  border-radius: var(--border-radius-default, 4px);
+  border-radius: var(--border-radius-md, 4px);
   box-shadow: 0 1px 7px rgba(0, 0, 0, 0.09), 0 1px 3px rgba(0, 0, 0, 0.2);
   z-index: z(modal);
   position: relative;
@@ -17,8 +17,8 @@
   }
 
   > ::ng-deep header {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-top-left-radius: var(--border-radius-md, 4px);
+    border-top-right-radius: var(--border-radius-md, 4px);
     overflow: hidden;
 
     h1,
@@ -42,15 +42,5 @@
     ::ng-deep button {
       min-width: 10rem;
     }
-  }
-}
-
-// bh2026: rounded modal and header top corners.
-:host-context([data-theme='bh2026']) {
-  border-radius: var(--border-radius-md, 1.6rem);
-
-  > ::ng-deep header {
-    border-top-left-radius: var(--border-radius-md, 1.6rem);
-    border-top-right-radius: var(--border-radius-md, 1.6rem);
   }
 }

--- a/projects/novo-elements/src/elements/modal/notification.component.scss
+++ b/projects/novo-elements/src/elements/modal/notification.component.scss
@@ -4,7 +4,7 @@
   text-align: center;
   display: block;
   background-color: var(--background-bright);
-  border-radius: var(--border-radius-default, 4px);
+  border-radius: var(--border-radius-md, 4px);
   box-shadow: 0 1px 7px rgba(0, 0, 0, 0.09), 0 1px 3px rgba(0, 0, 0, 0.2);
   z-index: z(modal);
   position: relative;
@@ -105,9 +105,4 @@
       min-width: 10rem;
     }
   }
-}
-
-// bh2026: rounded notifications
-:host-context([data-theme='bh2026']) {
-  border-radius: var(--border-radius-md, 1.6rem);
 }

--- a/projects/novo-elements/src/elements/select/Select.scss
+++ b/projects/novo-elements/src/elements/select/Select.scss
@@ -91,6 +91,7 @@
     opacity: 1;
   }
   background-color: var(--background-bright);
+  border-radius: var(--border-radius-sm);
   cursor: default;
   list-style: none;
   overflow: auto;

--- a/projects/novo-elements/src/elements/tabs/tab.scss
+++ b/projects/novo-elements/src/elements/tabs/tab.scss
@@ -157,7 +157,7 @@
   }
 }
 
-// bh2026: charcoal tabs, near-black active text + rounded neutral indicator
+// bh2026: charcoal tabs, navy active text, rounded indicator
 :host-context([data-theme='bh2026']) {
   margin-right: var(--spacing-gap-lg);
 
@@ -165,31 +165,28 @@
     color: var(--color-content-link, #282828);
     // Tabs are Title Case, not uppercase.
     text-transform: none;
-    font-weight: 400;
+    font-weight: var(--typography-font-weight-400, 400);
   }
 
   &.active,
   &.router-link-active {
-    color: var(--color-content-link-hover, #221f1f);
+    color: #1450a0;
     .novo-tab-link {
-      color: var(--color-content-link-hover, #221f1f);
-      font-weight: 500;
+      color: #1450a0;
+      font-weight: var(--typography-font-weight-600, 600);
     }
     .indicator {
-      background: var(--color-content-link-hover, #221f1f);
-      border-radius: 999px;
-      // Quarter round from the top, flat on bottom
-      border-radius: 3px 3px 0 0 / 100% 100% 0 0;
+      background: #1450a0;
+      border-radius: 999px 999px 0 0;
     }
   }
 
   &:hover {
     .novo-tab-link {
-      font-weight: 500;
+      color: #1450a0;
     }
   }
 }
-
 
 :host-context(novo-nav[theme="color"]),
 :host-context(novo-nav[theme="neutral"]) {

--- a/projects/novo-elements/src/elements/tiles/Tiles.scss
+++ b/projects/novo-elements/src/elements/tiles/Tiles.scss
@@ -46,7 +46,21 @@
   }
 }
 
-// bh2026: neutral border
+// bh2026: pill container, muted bg, navy selected state
 :host-context([data-theme='bh2026']) > .tile-container {
-  border-color: var(--color-border-default, #f0f5f9);
+  border-color: #8ca1b9;
+  border-radius: 999px;
+
+  .tile {
+    border-radius: 999px;
+  }
+
+  .tile.defaultColor.active {
+    background: var(--button-primary-background, #1f57a1);
+  }
+
+  .tile:not(.active) {
+    color: var(--text-muted, #8ca1b9);
+    i { color: var(--text-muted, #8ca1b9); }
+  }
 }

--- a/projects/novo-elements/src/elements/time-picker/TimePicker.scss
+++ b/projects/novo-elements/src/elements/time-picker/TimePicker.scss
@@ -364,7 +364,7 @@
   }
 
   &.hasButtons {
-    border-radius: 4px 4px 0 0;
+    border-radius: var(--border-radius-sm) var(--border-radius-sm) 0 0;
 
     &.military {
       .increments--hour,
@@ -379,7 +379,7 @@
       justify-content: flex-end;
       padding: 1rem;
       gap: .5rem;
-      border-radius: 0 0 4px 4px;
+      border-radius: 0 0 var(--border-radius-sm) var(--border-radius-sm);
       box-shadow: 0 1px 3px #00000026, 0 2px 7px #0000001a;
     }
   }

--- a/projects/novo-elements/src/elements/toolbar/toolbar.component.scss
+++ b/projects/novo-elements/src/elements/toolbar/toolbar.component.scss
@@ -62,4 +62,19 @@
     flex-direction: column;
     width: 100%;
   }
+
+  // bh2026: frosted translucent toolbar, no entity accent border
+  :root[data-theme='bh2026'] & {
+    background: var(--color-transparency-white-90, rgba(255, 255, 255, 0.9));
+    backdrop-filter: blur(12px);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+
+    .novo-toolbar-row {
+      background: transparent;
+
+      &[class*='novo-accent-'] {
+        border-bottom: none;
+      }
+    }
+  }
 }

--- a/projects/novo-elements/src/elements/tooltip/Tooltip.scss
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.scss
@@ -27,7 +27,7 @@ $tooltip-success-color: var(--color-shade-success, #458746);
   div {
     background: $tooltip-background;
     color: var(--color-white, #fff);
-    border-radius: var(--tooltip-border-radius, 4px);
+    border-radius: var(--border-radius-sm, 4px);
     padding: 8px 10px;
     font-size: var(--font-size-sm);
     line-height: 12px;
@@ -159,9 +159,4 @@ $tooltip-success-color: var(--color-shade-success, #458746);
       }
     }
   }
-}
-
-// bh2026: rounder tooltip
-:host-context([data-theme='bh2026']) div {
-  border-radius: var(--tooltip-radius, 0.8rem);
 }

--- a/projects/novo-elements/src/styles/themes/bh2026.scss
+++ b/projects/novo-elements/src/styles/themes/bh2026.scss
@@ -1,4 +1,4 @@
-// Maps design tokens (Figma "subatomic") onto the semantic CSS-variable contract for novo-elements components.
+// Maps design tokens onto the semantic CSS-variable contract for novo-elements components.
 @mixin bh2026-variables {
   // Live color-math direction (light): elevate() brightens, recede() darkens.
   --bg-fade-multiplier: 1;
@@ -35,6 +35,8 @@
   --border:              var(--color-border-default, #f0f5f9);
   --border-2:            var(--color-border-subtle, #f0f5f9);
   --border-hard:         var(--color-border-emphasized, #282828);
+  --border-radius-sm:    0.8rem;
+  --border-radius-md:    1.6rem;
   --border-radius-round: var(--border-radius-sm);
 
   // --- Interactive ---
@@ -51,24 +53,26 @@
   --font-size-tab:     var(--typography-tabs-default-font-size, 1.4rem);
 
   // --- Button ---
-  --button-background:     var(--color-grayscale-white, #ffffff);
-  --button-color:          var(--color-content-link, #282828);
+  --button-background:     #e2e2e2;
+  --button-color:          var(--color-content-subtle, #5d7798);
+  --button-focus-ring:     0 0 0 2px #4a89dc;
   --button-font-weight:    var(--typography-font-weight-400, 400);
   --button-gap:            var(--spacing-8, 0.8rem);
   --button-height:         3.5rem;
-  --button-letter-spacing: var(--typography-letter-spacing-half, 0.05rem);
+  --button-icon-margin:    0;
+  --button-letter-spacing: var(--typography-button-letter-spacing, 0);
   --button-padding-x:      var(--spacing-16, 1.6rem);
   --button-padding-y:      var(--spacing-8, 0.8rem);
   --button-radius:         999px;
   --button-text-transform: none;
-  --button-text:           var(--color-content-link, #282828);
+  --button-text:           var(--color-content-subtle, #5d7798);
 
   // Button variants
-  --button-primary-background: var(--button-background);
-  --button-primary-color:      var(--button-color);
-  --button-primary-border:     1px solid var(--border);
-  --button-secondary-text:     var(--button-text);
-  --button-secondary-border:   1px solid var(--border);
+  --button-primary-background: #1450a0;
+  --button-primary-color:      #ffffff;
+  --button-primary-border:     none;
+  --button-secondary-text:     var(--color-content-subtle, #5d7798);
+  --button-secondary-border:   1px solid var(--color-border-subtle, #8ca1b9);
 
   // Best guess currently at the refresh accent color
   --color-positive: #0095da;
@@ -77,6 +81,30 @@
 :root[data-theme='bh2026'],
 :root.theme-bh2026 {
   @include bh2026-variables();
+}
+
+// bh2026: primary icon defaults to left. row-reverse moves the default right-side icon
+// visually before the text. Explicit side="left" reverts to row (icon already first in DOM).
+:root[data-theme='bh2026'] [theme="primary"],
+:root.theme-bh2026 [theme="primary"] {
+  flex-direction: row-reverse;
+
+  &[side="left"] {
+    flex-direction: row;
+  }
+}
+
+// Dropdown trigger buttons keep the collapse icon on the right.
+// This override wins over the base rule (0,3,1 > 0,3,0).
+:root[data-theme='bh2026'] novo-dropdown [theme="primary"],
+:root.theme-bh2026 novo-dropdown [theme="primary"] {
+  flex-direction: row;
+}
+
+// bh2026: dialogue does not share pill format on hover
+:root[data-theme='bh2026'] [theme="dialogue"],
+:root.theme-bh2026 [theme="dialogue"] {
+  border-radius: var(--border-radius-sm, 0.8rem);
 }
 
 // bh2026 dark


### PR DESCRIPTION
## **Description**

feat(bh2026): modern theme styling pass
- Buttons: restyled primary/secondary, icon margin, icon default position
- Tiles: restyled to match mockups
- Cards: restyled to match mockups
- Headers & Toolbar: spacing, hierarchy, and bh2026 alignment
- Tabs: restyled to match mockups
- Overlays: rounded modals, dropdowns, select, menu, tooltip, date/time pickers
- Category Dropdown: icon exception for overlay context
- Accent directive: removed legacy accent styling

#### **Verify that...**

- [x] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [x] `npm run lint` passes
- [x] `npm test` passes and code coverage is increased
- [x] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**

<img width="678" height="801" alt="image" src="https://github.com/user-attachments/assets/af8239d5-de8b-49e4-8baf-2945a724ec0a" />
