### PR TITLE
style(Card): Additions to card styles for 2026 theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "e2e:single": "bash -c 'wdio run projects/novo-e2e/wdio.conf.ts --spec \"projects/novo-e2e/src/e2e/$1.e2e.ts\" --headless=true \"${@:2}\"' --",
     "e2e:single:headed": "bash -c 'wdio run projects/novo-e2e/wdio.conf.ts --spec \"projects/novo-e2e/src/e2e/$1.e2e.ts\" --headless=false \"${@:2}\"' --",
     "e2e:headed": "wdio run projects/novo-e2e/wdio.conf.ts --headless=false",
-    "e2e:headless": "wdio run projects/novo-e2e/wdio.conf.ts --headless=true"
+    "e2e:headless": "wdio run projects/novo-e2e/wdio.conf.ts --headless=true",
+    "e2e:single:headed:debug": "bash -c 'wdio run projects/novo-e2e/wdio.conf.ts --spec \"projects/novo-e2e/src/e2e/$1\" --headless=false \"${@:2}\"' --"
   },
   "dependencies": {
     "@angular/animations": "^20.3.18",

--- a/projects/novo-e2e/src/utils/DatePickerUtil.ts
+++ b/projects/novo-e2e/src/utils/DatePickerUtil.ts
@@ -24,7 +24,7 @@ export const datePicker = {
 };
 
 export function scopedDate(scope: string, dayNumber: number | string): string {
-    return `${scope} .calendar-date${automationId(dayNumber)}`;
+    return `${scope} .calendar-date${automationId(dayNumber)}:not(.notinmonth)`;
 }
 
 export const overlayCalendar = `${datePicker.overlay} ${elements.calendar}`;

--- a/projects/novo-elements/src/elements/card/Card.module.ts
+++ b/projects/novo-elements/src/elements/card/Card.module.ts
@@ -6,10 +6,11 @@ import { NovoButtonModule } from 'novo-elements/elements/button';
 import { NovoIconModule } from 'novo-elements/elements/icon';
 import { NovoLoadingModule } from 'novo-elements/elements/loading';
 import { NovoTooltipModule } from 'novo-elements/elements/tooltip';
+import { NovoCommonModule } from 'novo-elements/elements/common';
 import { CardActionsElement, CardContentElement, CardElement, CardFooterElement, CardHeaderElement } from './Card';
 
 @NgModule({
-  imports: [CommonModule, NovoIconModule, NovoButtonModule, NovoLoadingModule, NovoTooltipModule],
+  imports: [CommonModule, NovoIconModule, NovoButtonModule, NovoLoadingModule, NovoTooltipModule, NovoCommonModule],
   declarations: [CardElement, CardActionsElement, CardContentElement, CardHeaderElement, CardFooterElement],
   exports: [CardElement, CardActionsElement, CardContentElement, CardHeaderElement, CardFooterElement],
 })

--- a/projects/novo-elements/src/elements/card/Card.scss
+++ b/projects/novo-elements/src/elements/card/Card.scss
@@ -8,6 +8,9 @@
   border-radius: var(--border-radius-round);
   position: relative;
   overflow-x: hidden;
+  :root[data-theme=bh2026] & {
+    --spacing-md: var(--spacing-padding-md);
+  }
 
   &.loading {
     min-height: 200px;
@@ -57,10 +60,10 @@
         text-overflow: ellipsis;
         i {
           font-size: 1.2em;
-          &.bhi-info {
-            color: $light;
-          }
         }
+      }
+      :root:not([data-theme='bh2026']) & i.bhi-info {
+        color: $light;
       }
     }
     .actions {
@@ -132,20 +135,27 @@
     border-bottom: 1px solid var(--color-border-default);
 
     .title {
+      padding-inline: var(--spacing-gutter);
       h1,
       h2,
       h3 {
         font-size: var(--typography-card-header-font-size, var(--typography-font-size-18));
         font-weight: var(--typography-card-header-font-weight, var(--typography-font-weight-500));
+        ::ng-deep .card-flag-icon {
+          font-size: var(--font-size-lg);
+          vertical-align: 10%;
+        }
       }
 
-      ::ng-deep i.bhi-move {
-        color: transparent;
+      ::ng-deep i {
+        margin: 0;
       }
     }
 
-    &:hover .title ::ng-deep i.bhi-move {
-      color: var(--color-text-subtle);
+    .card-move-handle {
+      position: absolute;
+      left: var(--spacing-padding-xxsm);
+      color: var(--color-content-icon, #89909A);
     }
 
     .actions {
@@ -156,6 +166,49 @@
 
     novo-button {
       color: var(--color-text-subtle);
+    }
+    ::ng-deep .novo-card-header-text {
+      padding-inline-start: var(--spacing-padding-sm);
+    }
+  }
+  :host {
+    ::ng-deep .card-flag-icon {
+      color: var(--color-content-subtle, #5d7798);
+    }
+    &.icon-color-auto header .title ::ng-deep .card-flag-icon {
+      color: var(--page-entity-color, var(--color-content-subtle, #5d7798));
+      @each $entity, $color in $entity-colors {
+        &.bhi-#{$entity} {
+          @if ($entity == 'person') {
+            color: var(--color-entity-contact);
+          } @else if ($entity == 'notes') {
+            color: var(--color-entity-note);
+          } @else {
+            color: var(--color-entity-#{$entity});
+          }
+        }
+      }
+    }
+    &.icon-color-parent ::ng-deep .card-flag-icon {
+      color: var(--page-entity-color);
+    }
+    .novo-card-header {
+      padding-inline-start: var(--spacing-gutter);
+    }
+    // ng-deep in case this is declared within title bar implementation.
+    ::ng-deep .card-move-handle {
+      position: absolute;
+      left: var(--spacing-padding-xxsm);
+      color: var(--color-content-icon, #89909A);
+      transition: color 0.3s ease-in-out;
+    }
+    header ::ng-deep, ::ng-deep .novo-card-header {
+      &:not(:hover) .card-move-handle {
+        color: transparent;
+      }
+      .novo-icon.card-move-handle i {
+        color: inherit;
+      }
     }
   }
 }

--- a/projects/novo-elements/src/elements/card/Card.ts
+++ b/projects/novo-elements/src/elements/card/Card.ts
@@ -75,13 +75,14 @@ export class CardFooterElement {}
           *ngIf="move || config.move"
           tooltip="{{ labels.move }}"
           tooltipPosition="bottom-right"
+          class="card-move-handle"
           [attr.data-automation-id]="cardAutomationId + '-move'"
           >move</novo-icon
         >
         <!--Card Title-->
         <h3 [attr.data-automation-id]="cardAutomationId + '-title'">
-          <span [tooltip]="iconTooltip" tooltipPosition="right"><i *ngIf="icon" [ngClass]="iconClass"></i></span>
-          {{ title || config.title }}
+          <span [tooltip]="iconTooltip" tooltipPosition="right"><i *ngIf="iconClass" class="card-flag-icon" [ngClass]="iconClass"></i></span><!--
+          --><span class="novo-card-header-text">{{ title || config.title }}</span>
         </h3>
       </div>
       <!--Card Actions-->
@@ -89,7 +90,7 @@ export class CardFooterElement {}
         <ng-content select="novo-card-actions"></ng-content>
         <novo-button
           theme="icon"
-          icon="refresh"
+          [icon]="'refresh-o' | ifBh2026Theme : 'refresh'"
           (click)="toggleRefresh()"
           *ngIf="refresh || config.refresh"
           [attr.data-automation-id]="cardAutomationId + '-refresh'"
@@ -99,7 +100,7 @@ export class CardFooterElement {}
 
         <novo-button
           theme="icon"
-          icon="close-o"
+          [icon]="'x' | ifBh2026Theme : 'close-o'"
           (click)="toggleClose()"
           *ngIf="close || config.close"
           [attr.data-automation-id]="cardAutomationId + '-close'"
@@ -140,6 +141,9 @@ export class CardElement implements OnChanges, OnInit {
   messageIcon: string;
   @Input()
   icon: string;
+  // A feature for the 2026 styles that lets a card icon match either the icon default color (auto) or the --page-entity-color css variable
+  @Input()
+  iconColorClass: 'icon-color-auto' | 'icon-color-parent' | undefined;
   @Input()
   iconTooltip: string;
   @Input()
@@ -158,9 +162,10 @@ export class CardElement implements OnChanges, OnInit {
 
   @Input()
   inset: string = 'none';
+
   @HostBinding('class')
-  get hbInset() {
-    return `novo-card-inset-${this.inset}`;
+  get cardClass() {
+    return `${this.iconColorClass || ''} novo-card-inset-${this.inset}`;
   }
 
   @Output()

--- a/projects/novo-elements/src/elements/card/CardContent.scss
+++ b/projects/novo-elements/src/elements/card/CardContent.scss
@@ -4,5 +4,8 @@
   display: block;
   &:not(.condensed) {
     padding: var(--spacing-md);
+    :root[data-theme=bh2026] & {
+      padding-inline: var(--spacing-gutter);
+    }
   }
 }

--- a/projects/novo-elements/src/elements/card/CardHeader.scss
+++ b/projects/novo-elements/src/elements/card/CardHeader.scss
@@ -7,8 +7,31 @@
   flex-direction: row;
   align-items: center;
   gap: var(--spacing-md);
+  :root[data-theme=bh2026] & {
+    padding: var(--spacing-padding-md) var(--spacing-padding-md) 0 var(--spacing-gutter);
+    gap: 0;
+    .card-move-handle {
+      transition: color 0.3s ease-in-out;
+    }
+    &:not(:hover) {
+      .card-move-handle {
+        color: transparent;
+      }
+    }
+    .novo-card-header-text {
+      font-size: var(--typography-card-header-font-size, 1.8rem);
+      font-weight: var(--typography-card-header-font-weight, 500);
+      ::ng-deep novo-title {
+        font: inherit;
+      }
+    }
+  }
+  
 
   .novo-card-header-text {
     flex: 1 1 0px;
+    :root[data-theme=bh2026] & {
+      padding-inline-start: var(--spacing-padding-sm);
+    }
   }
 }

--- a/projects/novo-elements/src/elements/common/common.module.ts
+++ b/projects/novo-elements/src/elements/common/common.module.ts
@@ -17,6 +17,7 @@ import { NovoLabel } from './typography/label/label.component';
 import { NovoLink } from './typography/link/link.component';
 import { NovoText } from './typography/text/text.component';
 import { NovoTitle } from './typography/title/title.component';
+import { If2026ThemePipe } from './theme/if2026.pipe';
 
 @NgModule({
   imports: [CommonModule, NovoOptionModule],
@@ -39,6 +40,7 @@ import { NovoTitle } from './typography/title/title.component';
     ThemeColorDirective,
     SwitchCasesDirective,
     VisibleDirective,
+    If2026ThemePipe,
   ],
   declarations: [
     NovoTemplate,
@@ -59,6 +61,7 @@ import { NovoTitle } from './typography/title/title.component';
     ThemeColorDirective,
     SwitchCasesDirective,
     VisibleDirective,
+    If2026ThemePipe,
   ],
 })
 export class NovoCommonModule {}

--- a/projects/novo-elements/src/elements/common/index.ts
+++ b/projects/novo-elements/src/elements/common/index.ts
@@ -16,4 +16,5 @@ export * from './option';
 export * from './overlay';
 export * from './selection';
 export * from './theme/theme-options';
+export * from './theme/if2026.pipe';
 export * from './typography';

--- a/projects/novo-elements/src/elements/common/theme/if2026.pipe.ts
+++ b/projects/novo-elements/src/elements/common/theme/if2026.pipe.ts
@@ -1,0 +1,14 @@
+import { inject, Pipe, PipeTransform } from '@angular/core';
+import { NovoTheme } from './theme-options';
+
+@Pipe({
+    name: 'ifBh2026Theme',
+    standalone: false,
+    pure: false,
+})
+export class If2026ThemePipe implements PipeTransform {
+    theme = inject(NovoTheme);
+    public transform(value: any, elseVal: any = undefined): any {
+        return this.theme.isBh2026() ? value : elseVal;
+    }
+}

--- a/projects/novo-elements/src/elements/common/theme/theme-options.spec.ts
+++ b/projects/novo-elements/src/elements/common/theme/theme-options.spec.ts
@@ -1,4 +1,7 @@
-import { DEFAULT_THEME, normalizeThemeName } from './theme-options';
+import { DOCUMENT } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { expect } from 'vitest';
+import { DEFAULT_THEME, normalizeThemeName, NovoTheme, ThemeChangeEvent } from './theme-options';
 
 describe('Theme: normalizeThemeName', () => {
   it('defaults to bh2022-light', () => {
@@ -30,5 +33,65 @@ describe('Theme: normalizeThemeName', () => {
     expect(normalizeThemeName(undefined)).toBe('bh2022-light');
     expect(normalizeThemeName('')).toBe('bh2022-light');
     expect(normalizeThemeName('nonsense')).toBe('bh2022-light');
+  });
+
+  describe('NovoTheme', () => {
+
+    let novoTheme: NovoTheme;
+    let mockDocument: Document;
+
+    beforeEach(() => {
+      mockDocument = new Document();
+      mockDocument.appendChild(mockDocument.createElement('html'));
+      TestBed.configureTestingModule({
+        providers: [NovoTheme, {
+          provide: DOCUMENT,
+          useValue: mockDocument,
+        }],
+      }).compileComponents();
+      novoTheme = TestBed.inject(NovoTheme);
+    });
+
+    it('should store the theme', () => {
+      novoTheme.use({
+        themeName: 'bh2022-dark',
+      });
+      expect(novoTheme.themeName).toBe('bh2022-dark');
+    });
+
+    it('should attach theme-dark to class when theme ends in -dark', () => {
+      novoTheme.use({
+        themeName: 'bh2022-dark',
+      });
+      expect(mockDocument.documentElement.classList.contains('theme-dark')).toBeTruthy();
+      novoTheme.use({
+        themeName: 'bh2022-light',
+      });
+      expect(mockDocument.documentElement.classList.contains('theme-dark')).toBeFalsy();
+    });
+
+    it('should receive an event when the theme changes', () => {
+      let lastEvent: ThemeChangeEvent;
+      novoTheme.onThemeChange.subscribe(theme => {
+        lastEvent = theme;
+      });
+      novoTheme.use({
+        themeName: 'bh2022-dark',
+      });
+      TestBed.tick();
+      expect(lastEvent.options).toEqual({
+        themeName: 'bh2022-dark',
+      });
+      expect(lastEvent.themeName).toBe('bh2022-dark');
+
+      novoTheme.use({
+        themeName: 'bh2022-light',
+      });
+      TestBed.tick();
+      expect(lastEvent.options).toEqual({
+        themeName: 'bh2022-light',
+      });
+      expect(lastEvent.themeName).toBe('bh2022-light');
+    });
   });
 });

--- a/projects/novo-elements/src/elements/common/theme/theme-options.ts
+++ b/projects/novo-elements/src/elements/common/theme/theme-options.ts
@@ -1,5 +1,6 @@
-import { EventEmitter, Injectable } from '@angular/core';
-import { Observable, of } from 'rxjs';
+import { computed, DOCUMENT, inject, Injectable, signal } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { map, Observable, of } from 'rxjs';
 
 /**
  * Novo theme generations named `bh<year>-<mode>`
@@ -41,17 +42,23 @@ export interface ThemeChangeEvent {
 })
 export class NovoTheme {
   private _defaultTheme: NovoThemeOptions = { themeName: DEFAULT_THEME };
-  private _currentTheme: NovoThemeOptions;
+  private _currentTheme = signal<NovoThemeOptions>(undefined);
+  public currentTheme = this._currentTheme.asReadonly();
 
-  onThemeChange: EventEmitter<ThemeChangeEvent> = new EventEmitter<ThemeChangeEvent>();
+  onThemeChange: Observable<ThemeChangeEvent> = toObservable(this._currentTheme).pipe(map(theme => ({
+    themeName: theme?.themeName,
+    options: theme,
+  })));
+
+  document = inject(DOCUMENT);
 
   /** Name of the theme being used. defaults to `bh2022-light`. */
   get themeName() {
-    return this._currentTheme?.themeName || this._defaultTheme.themeName;
+    return this._currentTheme()?.themeName || this._defaultTheme.themeName;
   }
   set themeName(value: string) {
-    this._currentTheme = { themeName: value };
-    this.changeTheme(this._currentTheme);
+    const newTheme = { themeName: value };
+    this.changeTheme(newTheme);
   }
 
   public use(options: NovoThemeOptions): Observable<any> {
@@ -61,20 +68,23 @@ export class NovoTheme {
     return of(options);
   }
 
+  public isBh2026 = computed(() => {
+    return this.currentTheme()?.themeName?.includes('bh2026');
+  });
+
   /**
    * Changes the current theme
    */
   private changeTheme(theme: NovoThemeOptions): void {
-    this._currentTheme = theme;
+    this._currentTheme.set(theme);
     this.applyThemeToDom(theme.themeName);
-    this.onThemeChange.emit({ themeName: theme.themeName, options: theme });
   }
 
   private applyThemeToDom(themeName: string): void {
-    if (typeof document === 'undefined' || !document.documentElement) {
+    if (typeof this.document === 'undefined' || !this.document.documentElement) {
       return;
     }
-    const root = document.documentElement;
+    const root = this.document.documentElement;
     const normalized = normalizeThemeName(themeName);
     const generation = normalized.split('-')[0];
     root.classList.toggle('theme-dark', normalized.endsWith('-dark'));

--- a/projects/novo-elements/src/elements/list/list-item-content.scss
+++ b/projects/novo-elements/src/elements/list/list-item-content.scss
@@ -15,7 +15,7 @@
 :host {
   display: flex;
   margin-left: 0.2em;
-  &.novo-item-content > ::ng-deep * {
+  :root:not([data-theme='bh2026']) &.novo-item-content > ::ng-deep * {
     color: rgba(#434343, 0.85);
   }
   &.novo-item-content ::ng-deep i {

--- a/projects/novo-elements/src/elements/list/list-item-content.scss
+++ b/projects/novo-elements/src/elements/list/list-item-content.scss
@@ -1,10 +1,15 @@
 @import "../../styles/variables.scss";
 
 @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {
-  :host-context([theme="#{$name}"]) {
-    &.novo-item-content > ::ng-deep * {
-      color: rgba(#fff, 0.65);
+  // Wonky deprecation: For 2026, stringently avoid using * selectors to apply font/color changes - prefer inherit functionality
+  // This setup made it very hard to provide overrides.
+  :host-context([theme="#{$name}"]):host-context(:root:not([data-theme='bh2026'])) {
+    &.novo-item-content > ::ng-deep *:not(.xxxx) {
+    color: rgba(#fff, 0.65);
     }
+  }
+  :host-context([theme="#{$name}"]):host-context(:root[data-theme='bh2026']).novo-item-content {
+    color: rgba(#fff, 0.65);
   }
 }
 
@@ -15,7 +20,11 @@
 :host {
   display: flex;
   margin-left: 0.2em;
-  :root:not([data-theme='bh2026']) &.novo-item-content > ::ng-deep * {
+  
+  :root:not([data-theme='bh2026']) &.novo-item-content > ::ng-deep *:not(.yyy) {
+    color: rgba(#434343, 0.85);
+  }
+  :root[data-theme='bh2026'] &.novo-item-content {
     color: rgba(#434343, 0.85);
   }
   &.novo-item-content ::ng-deep i {

--- a/projects/novo-elements/src/styles/themes/bh2026.scss
+++ b/projects/novo-elements/src/styles/themes/bh2026.scss
@@ -118,8 +118,8 @@
   --button-secondary-border-hover:   1px solid var(--color-gray-300);
   --button-dialogue-hover-background: var(--color-background-subtle-hover);
 
-  --color-content-icon: #89909A; // needs extraction to design-tokens
-  --color-text-body: var(--color-dark, #3d464d);
+  --color-content-icon: var(--color-gray-500, #89909A);
+  --color-text-body: var(--color-gray-800, #3d464d);
 }
 
 :root[data-theme='bh2026'] {

--- a/projects/novo-elements/src/styles/themes/bh2026.scss
+++ b/projects/novo-elements/src/styles/themes/bh2026.scss
@@ -117,6 +117,9 @@
   --button-secondary-hover-background: var(--color-background-subtle-hover);
   --button-secondary-border-hover:   1px solid var(--color-gray-300);
   --button-dialogue-hover-background: var(--color-background-subtle-hover);
+
+  --color-content-icon: #89909A; // needs extraction to design-tokens
+  --color-text-body: var(--color-dark, #3d464d);
 }
 
 :root[data-theme='bh2026'] {
@@ -174,4 +177,8 @@
   --color-text-link-hover: var(--text-main);
   --color-text-subtle:     var(--text-muted);
   --color-text-disabled:   var(--text-disabled);
+}
+
+:root:not([data-theme='bh2026']) .showInBh2026Only {
+  display: none !important;
 }

--- a/projects/novo-examples/src/examples.routes.ts
+++ b/projects/novo-examples/src/examples.routes.ts
@@ -1761,7 +1761,7 @@ export class ExpansionPage {
 @Component({
   selector: 'collapsible-nav-page',
   template: `<h1>Collapsible Nav <a href="https://github.com/bullhorn/novo-elements/blob/master/projects/novo-elements/src/elements/layout">(source)</a></h1>
-<p>A slide-out navigation panel that expands to a full-width panel or collapses to a narrow icon rail. Consumers project their own header, body, and footer content into the named slots (<code>novo-collapsible-nav-header</code>, <code>novo-collapsible-nav-body</code>, <code>novo-collapsible-nav-footer</code>). The <code>collapsed</code> state is two-way bindable.</p>
+<p>A navigation panel that animates between an expanded sidebar and a collapsed icon rail. Project content into the <code>novo-collapsible-nav-header</code>, <code>novo-collapsible-nav-body</code>, and <code>novo-collapsible-nav-footer</code> slots. The <code>collapsed</code> state is two-way bindable.</p>
 <h5>Examples</h5>
 <h2>Basic Collapsible Nav</h2>
 <p><code-example example="basic-collapsible-nav"></code-example></p>

--- a/projects/novo-examples/src/layouts/cards/basic-card/basic-card-example.css
+++ b/projects/novo-examples/src/layouts/cards/basic-card/basic-card-example.css
@@ -3,4 +3,5 @@
   display: flex;
   flex-direction: column;
   gap: 2rem;
+  --page-entity-color: var(--color-candidate);
 }

--- a/projects/novo-examples/src/layouts/cards/basic-card/basic-card-example.html
+++ b/projects/novo-examples/src/layouts/cards/basic-card/basic-card-example.html
@@ -1,5 +1,6 @@
 <novo-card [title]="'All Attributes'"
-  icon="activity"
+  [icon]="icon"
+  [iconColorClass]="iconColorClass"
   [loading]="loading"
   [message]="message"
   [messageIcon]="messageIcon"
@@ -10,8 +11,24 @@
   (onClose)="onClose()"
   [padding]="padding"
   data-automation-id="card-all-attributes">
-  This is the ALL attribute card content!
+  This is the ALL attribute card content! (Loading appeared for 2s on page load)
 </novo-card>
+<novo-row align="start" gap="xl" margin="xl">
+  <section>
+    <novo-field>
+      <novo-label>Icon</novo-label>
+      <input novoInput [(ngModel)]="icon"/>
+    </novo-field>
+    <novo-field>
+      <novo-label>Icon Color Class (2026 styles only)</novo-label>
+      <novo-radio-group appearance="vertical" value="single" [(ngModel)]="iconColorClass">
+        <novo-radio name="mode" checked>None (null)</novo-radio>
+        <novo-radio name="mode" value="icon-color-auto">Auto</novo-radio>
+        <novo-radio name="mode" value="icon-color-parent">Parent</novo-radio>
+      </novo-radio-group>
+    </novo-field>
+  </section>
+</novo-row>
 
 
 <novo-row gap="lg" data-automation-id="card-inline-group">

--- a/projects/novo-examples/src/layouts/cards/basic-card/basic-card-example.ts
+++ b/projects/novo-examples/src/layouts/cards/basic-card/basic-card-example.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { AfterViewInit, Component } from '@angular/core';
 import { NovoToastService } from 'novo-elements';
 
 /**
@@ -10,13 +10,15 @@ import { NovoToastService } from 'novo-elements';
     styleUrls: ['basic-card-example.css'],
     standalone: false,
 })
-export class BasicCardExample {
+export class BasicCardExample implements AfterViewInit {
   // Config for demos
   refresh: boolean = true;
   close: boolean = true;
   move: boolean = true;
   padding: boolean = true;
   loading: boolean = true;
+  icon = 'activity';
+  iconColorClass: string = null;
 
   start: number = 2000;
   end: number = 2005;
@@ -33,6 +35,12 @@ export class BasicCardExample {
   donutLabel: string = 'Probability of Win %';
 
   constructor(private toaster: NovoToastService) {}
+
+  ngAfterViewInit(): void {
+    setTimeout(() => {
+      this.loading = false;
+    }, 2000);
+  }
 
   onClose() {
     this.toaster.alert({


### PR DESCRIPTION
## **Description**

Adds styling rules for card elements for the 2026 theme

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**