### PR TITLE
feat(bh2026): Updating bh2026 styles for search lists (BH-102559)

### DIFF
--- a/projects/novo-e2e/src/utils/VerifyUtil.ts
+++ b/projects/novo-e2e/src/utils/VerifyUtil.ts
@@ -41,13 +41,13 @@ export async function verifyNotActive(el: string, friendlyElementName: string = 
     await verifyClassAbsent(el, Classes.active, friendlyElementName, index);
 }
 
-export async function verifyClassPresent(selector: string, expectedClass: string, friendlyElementName: string = null, index: number = 0, totalWaitTime: number = 8000): Promise<void> {
+export async function verifyClassPresent(selector: string, expectedClass: string, friendlyElementName: string = null, index: number = 0, maxRetries: number = 8): Promise<void> {
     const elementName = friendlyElementName || 'element';
-    await expect(await getElement(selector, index)).toHaveElementClass(expectedClass, {
-        message: `${elementName} is missing the expected class: ${expectedClass}.`,
-        interval: 1000,
-        wait: totalWaitTime,
-    });
+    await retry(async () => {
+        if (!(await hasClass(selector, expectedClass, index))) {
+            throw new Error(`${elementName} is missing the expected class: ${expectedClass}.`);
+        }
+    }, null, maxRetries);
 }
 
 export async function verifyClassAbsent(el: string, unexpectedClass: string, friendlyElementName: string = null, index: number = 0): Promise<void> {

--- a/projects/novo-elements/src/elements/checkbox/CheckList.scss
+++ b/projects/novo-elements/src/elements/checkbox/CheckList.scss
@@ -88,3 +88,72 @@
     }
   }
 }
+
+// bh2026: CSS-based checkbox rendering — replaces icon font glyphs
+:host-context([data-theme='bh2026']) {
+  .novo-checkbox-group {
+    label i.bhi-checkbox-empty,
+    label i.bhi-checkbox-filled {
+      font-size: 0;
+      display: inline-flex;
+      align-self: center;
+      width: 16px;
+      height: 16px;
+      position: relative;
+      flex-shrink: 0;
+    }
+
+    label i.bhi-checkbox-empty {
+      &::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        border: 1px solid var(--color-border-control);
+        border-radius: 2px;
+        background: white;
+      }
+    }
+
+    label i.bhi-checkbox-filled {
+      &::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: var(--color-background-utility-positive);
+        border: 1px solid var(--color-utility-blue-600);
+        border-radius: 2px;
+      }
+      &::after {
+        content: '';
+        position: absolute;
+        left: 3px;
+        top: 4px;
+        width: 9px;
+        height: 5px;
+        border-left: 2px solid var(--color-utility-blue-600);
+        border-bottom: 2px solid var(--color-utility-blue-600);
+        transform: rotate(-45deg);
+      }
+    }
+
+    &.disabled {
+      label {
+        opacity: 1;
+      }
+      label i.bhi-checkbox-empty {
+        &::before {
+          background: var(--color-background-utility-positive);
+          border-color: var(--color-border-input-disabled);
+        }
+      }
+      label i.bhi-checkbox-filled {
+        &::before {
+          border-color: var(--color-border-input-disabled);
+        }
+        &::after {
+          border-color: var(--color-border-input-disabled);
+        }
+      }
+    }
+  }
+}

--- a/projects/novo-elements/src/elements/checkbox/Checkbox.scss
+++ b/projects/novo-elements/src/elements/checkbox/Checkbox.scss
@@ -91,3 +91,107 @@
     }
   }
 }
+
+// bh2026: CSS-based checkbox rendering — replaces icon font glyphs
+:host-context([data-theme='bh2026']) {
+  .novo-checkbox-group {
+    // Suppress glyph and establish box dimensions for all box-style states
+    label i.bhi-checkbox-empty,
+    label i.bhi-checkbox-filled,
+    label i.bhi-checkbox-indeterminate {
+      font-size: 0;
+      display: inline-flex;
+      align-self: center;
+      width: 16px;
+      height: 16px;
+      position: relative;
+      flex-shrink: 0;
+    }
+
+    // Unchecked: white box with gray border
+    label i.bhi-checkbox-empty {
+      &::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        border: 1px solid var(--color-border-control);
+        border-radius: 2px;
+        background: white;
+      }
+    }
+
+    // Checked: light-blue box with brand-blue border and checkmark
+    label i.bhi-checkbox-filled {
+      &::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: var(--color-background-utility-positive);
+        border: 1px solid var(--color-utility-blue-600);
+        border-radius: 2px;
+      }
+      &::after {
+        content: '';
+        position: absolute;
+        left: 3px;
+        top: 4px;
+        width: 9px;
+        height: 5px;
+        border-left: 2px solid var(--color-utility-blue-600);
+        border-bottom: 2px solid var(--color-utility-blue-600);
+        transform: rotate(-45deg);
+      }
+    }
+
+    // Indeterminate: light-blue box with brand-blue border and dash
+    label i.bhi-checkbox-indeterminate {
+      &::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: var(--color-background-utility-positive);
+        border: 1px solid var(--color-utility-blue-600);
+        border-radius: 2px;
+      }
+      &::after {
+        content: '';
+        position: absolute;
+        left: 4px;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 8px;
+        height: 2px;
+        background: var(--color-utility-blue-600);
+      }
+    }
+
+    // Disabled: override the base opacity:0.4 and use explicit muted colors
+    &.disabled {
+      label {
+        opacity: 1;
+      }
+      label i.bhi-checkbox-empty {
+        &::before {
+          background: var(--color-background-utility-positive);
+          border-color: var(--color-border-input-disabled);
+        }
+      }
+      label i.bhi-checkbox-filled {
+        &::before {
+          border-color: var(--color-border-input-disabled);
+        }
+        &::after {
+          border-color: var(--color-border-input-disabled);
+        }
+      }
+      label i.bhi-checkbox-indeterminate {
+        &::before {
+          border-color: var(--color-border-input-disabled);
+        }
+        &::after {
+          background: var(--color-border-input-disabled);
+        }
+      }
+    }
+  }
+}

--- a/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.scss
+++ b/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.scss
@@ -107,7 +107,7 @@ $breakpoint: 1000px;
         font-size: var(--font-size-text);
         border-radius: var(--border-radius-xsm, 2px);
         list-style-type: none;
-        margin: 0;
+        margin-top: 3px;
         cursor: pointer;
         color: var(--color-company);
         &.disabled {
@@ -158,9 +158,12 @@ $breakpoint: 1000px;
       margin-right: var(--spacing-gap-sm);
 
       ::ng-deep .novo-select-trigger {
-        border-bottom-color: var(--button-color-select-color-border-default, var(--border-hard));
         height: var(--spacing-padding-xlg);
         width: 5rem;
+
+        i.bhi-collapse::before {
+          content: "\f226"; // bhi-sort-desc - all code points are fixed in bullhorn-icons
+        }
 
         span.text-ellipsis {
           color: var(--button-color-select-color-content-value, var(--text-secondary));

--- a/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.scss
+++ b/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.scss
@@ -132,7 +132,7 @@ $breakpoint: 1000px;
   &.standard {
     align-items: center;
     border-top: 1px solid var(--pagination-color-border-default, var(--border));
-    padding: var(--pagination-spacing-padding-vertical, var(--spacing-padding-sm)) var(--pagination-spacing-padding-horizontal, var(--spacing-padding-md));
+    padding: var(--spacing-padding-sm) var(--spacing-padding-sm) 0 var(--spacing-padding-md);
 
     > * {
       margin: 0;

--- a/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.scss
+++ b/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.scss
@@ -153,8 +153,8 @@ $breakpoint: 1000px;
 
     novo-select {
       color: var(--text-muted);
-      max-width: unset;
-      min-width: unset;
+      max-width: 60px;
+      min-width: 60px;
       margin-right: var(--spacing-gap-sm);
 
       ::ng-deep .novo-select-trigger {

--- a/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.scss
+++ b/projects/novo-elements/src/elements/data-table/pagination/data-table-pagination.component.scss
@@ -107,6 +107,7 @@ $breakpoint: 1000px;
         font-size: var(--font-size-text);
         border-radius: var(--border-radius-xsm, 2px);
         list-style-type: none;
+        margin: 0;
         cursor: pointer;
         color: var(--color-company);
         &.disabled {
@@ -123,6 +124,75 @@ $breakpoint: 1000px;
     .novo-data-table-of-total-amount {
       color: var(--color-slate);
       font-size: var(--font-size-sm);
+    }
+  }
+}
+
+:host-context([data-theme='bh2026']) {
+  &.standard {
+    align-items: center;
+    border-top: 1px solid var(--pagination-color-border-default, var(--border));
+    padding: var(--pagination-spacing-padding-vertical, var(--spacing-padding-sm)) var(--pagination-spacing-padding-horizontal, var(--spacing-padding-md));
+
+    > * {
+      margin: 0;
+    }
+
+    h5.rows {
+      color: var(--pagination-color-content-label, var(--text-muted));
+      font-size: var(--typography-font-size-12);
+      font-weight: var(--typography-meta-sm-font-weight);
+      letter-spacing: var(--typography-meta-sm-letter-spacing);
+      line-height: var(--typography-meta-sm-line-height);
+      margin-right: var(--spacing-gap-sm);
+      opacity: 1;
+      padding: 0;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+
+    novo-select {
+      color: var(--text-muted);
+      max-width: unset;
+      min-width: unset;
+      margin-right: var(--spacing-gap-sm);
+
+      ::ng-deep .novo-select-trigger {
+        border-bottom-color: var(--button-color-select-color-border-default, var(--border-hard));
+        height: var(--spacing-padding-xlg);
+        width: 5rem;
+
+        span.text-ellipsis {
+          color: var(--button-color-select-color-content-value, var(--text-secondary));
+          font-size: var(--typography-button-default-font-size, var(--font-size-body));
+          font-weight: var(--typography-button-default-font-weight, var(--typography-body-default-font-weight));
+          letter-spacing: var(--typography-button-default-letter-spacing, var(--typography-body-default-letter-spacing));
+          line-height: var(--typography-button-default-line-height, var(--typography-line-height-20));
+        }
+      }
+    }
+
+    .novo-data-table-of-total-amount {
+      color: var(--pagination-color-content-label, var(--text-muted));
+      font-size: var(--typography-font-size-12);
+      font-weight: var(--typography-meta-sm-font-weight);
+    }
+
+    .pager {
+      gap: var(--data-table-spacing-gap, 0);
+
+      .page {
+        border-radius: var(--border-radius-xsm);
+        color: var(--pagination-color-content-label, var(--text-muted));
+        font-size: var(--typography-font-size-12);
+        font-weight: var(--typography-meta-sm-font-weight);
+
+        &.active {
+          background: var(--color-background-subtle, var(--background-muted));
+          border: 1px solid var(--pagination-color-border-default, var(--border));
+          opacity: 1;
+        }
+      }
     }
   }
 }

--- a/projects/novo-elements/src/elements/header/Header.scss
+++ b/projects/novo-elements/src/elements/header/Header.scss
@@ -168,7 +168,7 @@
   }
 
   &[class*='novo-accent-'] {
-    background: var(--color-transparency-white-90);
+    background: var(--header-background, var(--color-transparency-white-90));
     backdrop-filter: blur(12px);
     box-shadow: 0 1px 2px var(--color-transparency-black-10);
     padding-top: var(--spacing-md);

--- a/projects/novo-elements/src/elements/list/list-item-content.scss
+++ b/projects/novo-elements/src/elements/list/list-item-content.scss
@@ -3,12 +3,7 @@
 @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {
   // Wonky deprecation: For 2026, stringently avoid using * selectors to apply font/color changes - prefer inherit functionality
   // This setup made it very hard to provide overrides.
-  :host-context([theme="#{$name}"]):host-context(:root:not([data-theme='bh2026'])) {
-    &.novo-item-content > ::ng-deep *:not(.xxxx) {
-    color: rgba(#fff, 0.65);
-    }
-  }
-  :host-context([theme="#{$name}"]):host-context(:root[data-theme='bh2026']).novo-item-content {
+  :host-context([theme="#{$name}"]).novo-item-content {
     color: rgba(#fff, 0.65);
   }
 }
@@ -21,16 +16,13 @@
   display: flex;
   margin-left: 0.2em;
   
-  :root:not([data-theme='bh2026']) &.novo-item-content > ::ng-deep *:not(.yyy) {
+  &.novo-item-content {
     color: rgba(#434343, 0.85);
-  }
-  :root[data-theme='bh2026'] &.novo-item-content {
-    color: rgba(#434343, 0.85);
-  }
-  &.novo-item-content ::ng-deep i {
-    @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {
-      &.#{$name} {
-        color: getCssVarname($name);
+    ::ng-deep i {
+      @include theme-colors() using ($name, $color, $contrast, $tint, $shade, $pale) {
+        &.#{$name} {
+          color: getCssVarname($name);
+        }
       }
     }
   }

--- a/projects/novo-elements/src/elements/search/SearchBox.module.ts
+++ b/projects/novo-elements/src/elements/search/SearchBox.module.ts
@@ -6,10 +6,10 @@ import { NovoOverlayModule } from 'novo-elements/elements/common';
 import { NovoIconModule } from 'novo-elements/elements/icon';
 import { NovoPickerModule } from 'novo-elements/elements/picker';
 import { NovoTooltipModule } from 'novo-elements/elements/tooltip';
-import { NovoSearchBoxElement } from './SearchBox';
+import { NovoSearchBoxElement, NovoSearchLeadingContentDirective } from './SearchBox';
 @NgModule({
   imports: [CommonModule, NovoIconModule, NovoPickerModule, NovoTooltipModule, NovoOverlayModule],
-  declarations: [NovoSearchBoxElement],
-  exports: [NovoSearchBoxElement],
+  declarations: [NovoSearchBoxElement, NovoSearchLeadingContentDirective],
+  exports: [NovoSearchBoxElement, NovoSearchLeadingContentDirective],
 })
 export class NovoSearchBoxModule {}

--- a/projects/novo-elements/src/elements/search/SearchBox.module.ts
+++ b/projects/novo-elements/src/elements/search/SearchBox.module.ts
@@ -2,14 +2,13 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 // APP
-import { NovoButtonModule } from 'novo-elements/elements/button';
 import { NovoOverlayModule } from 'novo-elements/elements/common';
 import { NovoIconModule } from 'novo-elements/elements/icon';
 import { NovoPickerModule } from 'novo-elements/elements/picker';
 import { NovoTooltipModule } from 'novo-elements/elements/tooltip';
 import { NovoSearchBoxElement } from './SearchBox';
 @NgModule({
-  imports: [CommonModule, NovoButtonModule, NovoIconModule, NovoPickerModule, NovoTooltipModule, NovoOverlayModule],
+  imports: [CommonModule, NovoIconModule, NovoPickerModule, NovoTooltipModule, NovoOverlayModule],
   declarations: [NovoSearchBoxElement],
   exports: [NovoSearchBoxElement],
 })

--- a/projects/novo-elements/src/elements/search/SearchBox.scss
+++ b/projects/novo-elements/src/elements/search/SearchBox.scss
@@ -70,7 +70,7 @@
   }
 }
 
-:host(.has-search-button) {
+:host(.has-border) {
   display: flex;
   align-items: center;
   gap: var(--spacing-8, 0.8rem);
@@ -98,7 +98,7 @@
 }
 
 :host-context([data-theme='bh2026']) {
-  &.has-search-button {
+  &.has-border {
     border: 1px solid var(--color-border-default);
     border-radius: var(--button-radius);
   }

--- a/projects/novo-elements/src/elements/search/SearchBox.scss
+++ b/projects/novo-elements/src/elements/search/SearchBox.scss
@@ -75,7 +75,7 @@
   align-items: center;
   gap: var(--spacing-8, 0.8rem);
   height: auto;
-  padding: var(--spacing-md) var(--spacing-lg) var(--spacing-md) var(--spacing-xl);
+  padding: var(--spacing-4, 0.4rem) 0 var(--spacing-4, 0.4rem) var(--spacing-16, 1.6rem);
   border-radius: var(--border-radius-sm, 3px);
   max-width: none;
   box-shadow: 0 0.2rem 0.2rem var(--color-transparency-charcoal-04, transparent);

--- a/projects/novo-elements/src/elements/search/SearchBox.scss
+++ b/projects/novo-elements/src/elements/search/SearchBox.scss
@@ -92,6 +92,13 @@
     color: var(--color-text-subtle, var(--text-muted));
   }
 
+  ::ng-deep [novo-search-leading-content] {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+  }
+
   > input {
     flex: 1 1 0;
     min-width: 0;
@@ -100,6 +107,12 @@
     &::placeholder {
       color: var(--color-text-subtle, var(--text-muted));
     }
+  }
+}
+
+:host(.has-border.has-leading-content) {
+  > input {
+    display: none;
   }
 }
 

--- a/projects/novo-elements/src/elements/search/SearchBox.scss
+++ b/projects/novo-elements/src/elements/search/SearchBox.scss
@@ -75,7 +75,7 @@
   align-items: center;
   gap: var(--spacing-8, 0.8rem);
   height: auto;
-  padding: var(--spacing-4, 0.4rem) 0 var(--spacing-4, 0.4rem) var(--spacing-16, 1.6rem);
+  padding: var(--spacing-md) var(--spacing-lg) var(--spacing-md) var(--spacing-xl);
   border-radius: var(--border-radius-sm, 3px);
   max-width: none;
   box-shadow: 0 0.2rem 0.2rem var(--color-transparency-charcoal-04, transparent);
@@ -83,6 +83,12 @@
   novo-icon:first-child {
     flex-shrink: 0;
     font-size: 1.6rem;
+    color: var(--color-text-subtle, var(--text-muted));
+  }
+
+  [novo-search-trailing-action] {
+    flex-shrink: 0;
+    cursor: pointer;
     color: var(--color-text-subtle, var(--text-muted));
   }
 

--- a/projects/novo-elements/src/elements/search/SearchBox.ts
+++ b/projects/novo-elements/src/elements/search/SearchBox.ts
@@ -47,10 +47,8 @@ const SEARCH_VALUE_ACCESSOR = {
       #input
       data-automation-id="novo-search-input"
     />
-    <!-- SEARCH SUBMIT BUTTON -->
-    @if (submitButton) {
-      <novo-button theme="primary" icon="search" side="left" [attr.data-automation-id]="submitButtonAutomationId || null" (click)="onSubmitClick($event)">{{ submitLabel }}</novo-button>
-    }
+    <!-- TRAILING ACTION SLOT -->
+    <ng-content select="[novo-search-trailing-action]"></ng-content>
     <!-- SEARCH OVERLAY -->
     <novo-overlay-template
       [parent]="element"
@@ -79,18 +77,12 @@ export class NovoSearchBoxElement implements ControlValueAccessor, OnInit {
   @HostBinding('class.always-open')
   public alwaysOpen: boolean = false;
   @Input()
-  public submitButton: boolean = false;
-  @Input()
   public bordered: boolean = false;
-  @Input()
-  public submitLabel: string = 'Search';
 
   @HostBinding('class.has-border')
-  get hasSearchButton(): boolean {
-    return this.submitButton || this.bordered;
+  get hasBorder(): boolean {
+    return this.bordered;
   }
-  @Input()
-  public submitButtonAutomationId: string;
   @Input()
   public theme: string;
   @Input()
@@ -191,13 +183,6 @@ export class NovoSearchBoxElement implements ControlValueAccessor, OnInit {
     return this.panelOpen || this.alwaysOpen;
   }
   /** END: Convenient Panel Methods. */
-
-  onSubmitClick(event: MouseEvent): void {
-    this.applySearch.emit(event as unknown as KeyboardEvent);
-    if (this.panelOpen) {
-      this.closePanel();
-    }
-  }
 
   _handleKeydown(event: KeyboardEvent): void {
     if ((event.key === Key.Escape || event.key === Key.Enter || event.key === Key.Tab) && this.panelOpen) {

--- a/projects/novo-elements/src/elements/search/SearchBox.ts
+++ b/projects/novo-elements/src/elements/search/SearchBox.ts
@@ -79,10 +79,16 @@ export class NovoSearchBoxElement implements ControlValueAccessor, OnInit {
   @HostBinding('class.always-open')
   public alwaysOpen: boolean = false;
   @Input()
-  @HostBinding('class.has-search-button')
   public submitButton: boolean = false;
   @Input()
+  public bordered: boolean = false;
+  @Input()
   public submitLabel: string = 'Search';
+
+  @HostBinding('class.has-border')
+  get hasSearchButton(): boolean {
+    return this.submitButton || this.bordered;
+  }
   @Input()
   public submitButtonAutomationId: string;
   @Input()
@@ -139,10 +145,6 @@ export class NovoSearchBoxElement implements ControlValueAccessor, OnInit {
     }
   }
 
-  /**
-   * @name showFasterFind
-   * @description This function shows the picker and adds the active class (for animation)
-   */
   showSearch(event?: any, forceClose: boolean = false) {
     if (!this.panelOpen) {
       // Reset search

--- a/projects/novo-elements/src/elements/search/SearchBox.ts
+++ b/projects/novo-elements/src/elements/search/SearchBox.ts
@@ -43,7 +43,6 @@ const SEARCH_VALUE_ACCESSOR = {
 @Component({
     selector: 'novo-search',
     providers: [SEARCH_VALUE_ACCESSOR],
-    changeDetection: ChangeDetectionStrategy.OnPush,
     template: `
     <!-- SEARCH ICON -->
     <novo-icon (click)="showSearch($event)" [tooltip]="hint" tooltipPosition="bottom">{{ icon }}</novo-icon>

--- a/projects/novo-elements/src/elements/search/SearchBox.ts
+++ b/projects/novo-elements/src/elements/search/SearchBox.ts
@@ -43,6 +43,7 @@ const SEARCH_VALUE_ACCESSOR = {
 @Component({
     selector: 'novo-search',
     providers: [SEARCH_VALUE_ACCESSOR],
+    changeDetection: ChangeDetectionStrategy.OnPush,
     template: `
     <!-- SEARCH ICON -->
     <novo-icon (click)="showSearch($event)" [tooltip]="hint" tooltipPosition="bottom">{{ icon }}</novo-icon>

--- a/projects/novo-elements/src/elements/search/SearchBox.ts
+++ b/projects/novo-elements/src/elements/search/SearchBox.ts
@@ -1,9 +1,12 @@
 // NG2
 import { ENTER } from '@angular/cdk/keycodes';
 import {
+  AfterContentChecked,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  ContentChild,
+  Directive,
   ElementRef,
   EventEmitter,
   forwardRef,
@@ -20,6 +23,16 @@ import { NovoLabelService } from 'novo-elements/services';
 import { Key } from 'novo-elements/utils';
 import { NovoOverlayTemplateComponent } from 'novo-elements/elements/common';
 
+/**
+ * Marker directive for content projected into the leading (left) area of `novo-search`.
+ * When present, the text input is hidden and the projected content fills its space.
+ */
+@Directive({
+  selector: '[novo-search-leading-content]',
+  standalone: false,
+})
+export class NovoSearchLeadingContentDirective {}
+
 // Value accessor for the component (supports ngModel)
 const SEARCH_VALUE_ACCESSOR = {
   provide: NG_VALUE_ACCESSOR,
@@ -34,6 +47,8 @@ const SEARCH_VALUE_ACCESSOR = {
     template: `
     <!-- SEARCH ICON -->
     <novo-icon (click)="showSearch($event)" [tooltip]="hint" tooltipPosition="bottom">{{ icon }}</novo-icon>
+    <!-- LEADING CONTENT SLOT (chips, tags, etc. that visually replace the input when present) -->
+    <ng-content select="[novo-search-leading-content]"></ng-content>
     <!-- SEARCH INPUT -->
     <input
       type="text"
@@ -64,7 +79,7 @@ const SEARCH_VALUE_ACCESSOR = {
     styleUrls: ['./SearchBox.scss'],
     standalone: false,
 })
-export class NovoSearchBoxElement implements ControlValueAccessor, OnInit {
+export class NovoSearchBoxElement implements ControlValueAccessor, OnInit, AfterContentChecked {
   @Input()
   public name: string;
   @Input()
@@ -111,6 +126,14 @@ export class NovoSearchBoxElement implements ControlValueAccessor, OnInit {
   focused: boolean = false;
   public value: any;
 
+  @ContentChild(NovoSearchLeadingContentDirective)
+  leadingContent: NovoSearchLeadingContentDirective;
+
+  @HostBinding('class.has-leading-content')
+  get hasLeadingContent(): boolean {
+    return !!this.leadingContent;
+  }
+
   /** View -> model callback called when value changes */
   _onChange: (value: any) => void = () => {};
   /** View -> model callback called when autocomplete has been touched */
@@ -123,6 +146,7 @@ export class NovoSearchBoxElement implements ControlValueAccessor, OnInit {
   input: any;
 
   private debounceSearchChange: any;
+  private _hasLeadingContent = false;
 
   constructor(
     public element: ElementRef,
@@ -137,14 +161,22 @@ export class NovoSearchBoxElement implements ControlValueAccessor, OnInit {
     }
   }
 
+  ngAfterContentChecked() {
+    const hasLeading = !!this.leadingContent;
+    if (hasLeading !== this._hasLeadingContent) {
+      this._hasLeadingContent = hasLeading;
+      this._changeDetectorRef.markForCheck();
+    }
+  }
+
   showSearch(event?: any, forceClose: boolean = false) {
     if (!this.panelOpen) {
-      // Reset search
-      // Set focus on search
       setTimeout(() => {
-        const element = this.input.nativeElement;
-        if (element) {
-          element.focus();
+        const inputElement = this.input.nativeElement;
+        if (inputElement?.offsetParent) {
+          inputElement.focus();
+        } else {
+          this.openPanel();
         }
       }, 10);
     } else {

--- a/projects/novo-elements/src/elements/switch/Switch.scss
+++ b/projects/novo-elements/src/elements/switch/Switch.scss
@@ -142,10 +142,46 @@ $switch-thumb-size: 20px !default;
   }
 }
 
-// bh2026: outlined toggle — white track + 1px neutral border in the off state
+// bh2026: 32×20 pill track, 16×16 thumb, always white — per Figma spec
 :host-context([data-theme='bh2026']) {
+  .novo-switch-container {
+    width: 32px;
+    height: 20px;
+  }
   .novo-switch-bar {
-    background-color: var(--toggle-color-background, #ffffff);
-    border: 1px solid var(--toggle-color-border, var(--color-border-default, #f0f5f9));
+    top: 0;
+    left: 0;
+    width: 32px;
+    height: 20px;
+    border-radius: 10px;
+    background-color: white;
+    border: 1px solid var(--color-border-input);
+  }
+  .novo-switch-thumb-container {
+    top: 2px;
+    left: 2px;
+    width: 12px; // travel: 32 - 16 - 4px padding = 12px
+  }
+  .novo-switch-thumb {
+    height: 16px;
+    width: 16px;
+    background-color: white;
+    border: 1px solid var(--color-border-input);
+    box-shadow: 0px 2px 4px 0px var(--color-transparency-charcoal-04);
+
+    novo-icon {
+      display: none;
+    }
+  }
+
+  &[aria-checked="true"] {
+    .novo-switch-bar {
+      background-color: var(--color-utility-blue-600);
+      border: none;
+    }
+    .novo-switch-thumb {
+      background-color: white;
+      border: none;
+    }
   }
 }

--- a/projects/novo-elements/src/utils/outside-click/OutsideClick.ts
+++ b/projects/novo-elements/src/utils/outside-click/OutsideClick.ts
@@ -1,17 +1,19 @@
 // NG2
-import { ElementRef, EventEmitter, Injectable, OnDestroy } from '@angular/core';
+import { Directive, ElementRef, EventEmitter, OnDestroy, Output } from '@angular/core';
 // APP
 import { Helpers } from '../Helpers';
 
 /**
  * Outside click helper, makes to set the element as inactive when clicking outside of it
  */
-@Injectable()
+@Directive()
 export class OutsideClick implements OnDestroy {
   element: ElementRef;
   otherElement: ElementRef;
   active: boolean = false;
+  @Output()
   onOutsideClick: EventListenerOrEventListenerObject;
+  @Output()
   onActiveChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   constructor(element: ElementRef) {

--- a/projects/novo-examples/src/components/search/search-usage/search-usage-example.css
+++ b/projects/novo-examples/src/components/search/search-usage/search-usage-example.css
@@ -4,3 +4,7 @@
   flex-flow: column;
   gap: 2rem;
 }
+
+novo-search[data-automation-id="search-bordered-with-button"] {
+  padding: var(--spacing-4, 0.4rem) 0 var(--spacing-4, 0.4rem) var(--spacing-16, 1.6rem);
+}

--- a/projects/novo-examples/src/components/search/search-usage/search-usage-example.css
+++ b/projects/novo-examples/src/components/search/search-usage/search-usage-example.css
@@ -4,7 +4,3 @@
   flex-flow: column;
   gap: 2rem;
 }
-
-novo-search[data-automation-id="search-bordered-with-button"] {
-  padding: var(--spacing-4, 0.4rem) 0 var(--spacing-4, 0.4rem) var(--spacing-16, 1.6rem);
-}

--- a/projects/novo-examples/src/components/search/search-usage/search-usage-example.html
+++ b/projects/novo-examples/src/components/search/search-usage/search-usage-example.html
@@ -37,3 +37,12 @@
 <novo-search data-automation-id="search-bordered-with-close" [bordered]="true" placeholder="Search...">
   <novo-action novo-search-trailing-action icon="x" tooltip="Close" tooltipPosition="bottom" size="medium"></novo-action>
 </novo-search>
+
+<novo-search data-automation-id="search-bordered-with-chip" [bordered]="true" placeholder="Search...">
+  <div novo-search-leading-content>
+    <novo-chip-list>
+      <novo-chip size="sm">My Saved Search<novo-icon novoChipRemove>x</novo-icon></novo-chip>
+    </novo-chip-list>
+  </div>
+  <novo-button novo-search-trailing-action theme="dialogue" icon="edit" side="left">Edit Search</novo-button>
+</novo-search>

--- a/projects/novo-examples/src/components/search/search-usage/search-usage-example.html
+++ b/projects/novo-examples/src/components/search/search-usage/search-usage-example.html
@@ -26,10 +26,14 @@
 
 <novo-search data-automation-id="search-bordered" [bordered]="true" placeholder="Search..."></novo-search>
 
-<novo-search data-automation-id="search-bordered-with-icon" [bordered]="true" placeholder="Search...">
-  <novo-icon novo-search-trailing-action>settings</novo-icon>
+<novo-search data-automation-id="search-bordered-with-settings" [bordered]="true" placeholder="Search...">
+  <novo-action novo-search-trailing-action icon="settings" tooltip="Settings" tooltipPosition="bottom" size="medium"></novo-action>
 </novo-search>
 
-<novo-search data-automation-id="search-bordered-with-button" [bordered]="true" placeholder="Search...">
+<novo-search data-automation-id="search-bordered-with-submit" [bordered]="true" placeholder="Search...">
   <novo-button novo-search-trailing-action theme="primary" icon="search" side="left">Search</novo-button>
+</novo-search>
+
+<novo-search data-automation-id="search-bordered-with-close" [bordered]="true" placeholder="Search...">
+  <novo-action novo-search-trailing-action icon="x" tooltip="Close" tooltipPosition="bottom" size="medium"></novo-action>
 </novo-search>

--- a/projects/novo-examples/src/components/search/search-usage/search-usage-example.html
+++ b/projects/novo-examples/src/components/search/search-usage/search-usage-example.html
@@ -26,4 +26,10 @@
 
 <novo-search data-automation-id="search-bordered" [bordered]="true" placeholder="Search..."></novo-search>
 
-<novo-search data-automation-id="search-submit-button" [submitButton]="true" placeholder="Search..."></novo-search>
+<novo-search data-automation-id="search-bordered-with-icon" [bordered]="true" placeholder="Search...">
+  <novo-icon novo-search-trailing-action>settings</novo-icon>
+</novo-search>
+
+<novo-search data-automation-id="search-bordered-with-button" [bordered]="true" placeholder="Search...">
+  <novo-button novo-search-trailing-action theme="primary" icon="search" side="left">Search</novo-button>
+</novo-search>

--- a/projects/novo-examples/src/components/search/search-usage/search-usage-example.html
+++ b/projects/novo-examples/src/components/search/search-usage/search-usage-example.html
@@ -24,4 +24,6 @@
   <entity-picker-results [matches]="searchData" (select)="onSelectEntity($event)"></entity-picker-results>
 </novo-search>
 
+<novo-search data-automation-id="search-bordered" [bordered]="true" placeholder="Search..."></novo-search>
+
 <novo-search data-automation-id="search-submit-button" [submitButton]="true" placeholder="Search..."></novo-search>


### PR DESCRIPTION
## **Description**

More configurability of the search bar:

<img width="858" height="1036" alt="image" src="https://github.com/user-attachments/assets/7e5004d2-e376-4e1f-bac9-587c2cff12c0" />

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**