### PR TITLE
test(Datepicker): Corrections to datepicker.e2e test

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "e2e:single": "bash -c 'wdio run projects/novo-e2e/wdio.conf.ts --spec \"projects/novo-e2e/src/e2e/$1.e2e.ts\" --headless=true \"${@:2}\"' --",
     "e2e:single:headed": "bash -c 'wdio run projects/novo-e2e/wdio.conf.ts --spec \"projects/novo-e2e/src/e2e/$1.e2e.ts\" --headless=false \"${@:2}\"' --",
     "e2e:headed": "wdio run projects/novo-e2e/wdio.conf.ts --headless=false",
-    "e2e:headless": "wdio run projects/novo-e2e/wdio.conf.ts --headless=true"
+    "e2e:headless": "wdio run projects/novo-e2e/wdio.conf.ts --headless=true",
+    "e2e:single:headed:debug": "bash -c 'wdio run projects/novo-e2e/wdio.conf.ts --spec \"projects/novo-e2e/src/e2e/$1\" --headless=false \"${@:2}\"' --"
   },
   "dependencies": {
     "@angular/animations": "^20.3.18",

--- a/projects/novo-e2e/src/utils/DatePickerUtil.ts
+++ b/projects/novo-e2e/src/utils/DatePickerUtil.ts
@@ -24,7 +24,7 @@ export const datePicker = {
 };
 
 export function scopedDate(scope: string, dayNumber: number | string): string {
-    return `${scope} .calendar-date${automationId(dayNumber)}`;
+    return `${scope} .calendar-date${automationId(dayNumber)}:not(.notinmonth)`;
 }
 
 export const overlayCalendar = `${datePicker.overlay} ${elements.calendar}`;


### PR DESCRIPTION
## **Description**

Correct a selector that breaks if the calendar shows two of one day (eg, the 28th once in the pre-month view)

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**