### PR TITLE
style(bh2026): update checkbox and switch styling

### DIFF
--- a/projects/novo-elements/src/elements/checkbox/CheckList.scss
+++ b/projects/novo-elements/src/elements/checkbox/CheckList.scss
@@ -88,3 +88,72 @@
     }
   }
 }
+
+// bh2026: CSS-based checkbox rendering — replaces icon font glyphs
+:host-context([data-theme='bh2026']) {
+  .novo-checkbox-group {
+    label i.bhi-checkbox-empty,
+    label i.bhi-checkbox-filled {
+      font-size: 0;
+      display: inline-flex;
+      align-self: center;
+      width: 16px;
+      height: 16px;
+      position: relative;
+      flex-shrink: 0;
+    }
+
+    label i.bhi-checkbox-empty {
+      &::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        border: 1px solid var(--color-border-control);
+        border-radius: 2px;
+        background: white;
+      }
+    }
+
+    label i.bhi-checkbox-filled {
+      &::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: var(--color-background-utility-positive);
+        border: 1px solid var(--color-utility-blue-600);
+        border-radius: 2px;
+      }
+      &::after {
+        content: '';
+        position: absolute;
+        left: 3px;
+        top: 4px;
+        width: 9px;
+        height: 5px;
+        border-left: 2px solid var(--color-utility-blue-600);
+        border-bottom: 2px solid var(--color-utility-blue-600);
+        transform: rotate(-45deg);
+      }
+    }
+
+    &.disabled {
+      label {
+        opacity: 1;
+      }
+      label i.bhi-checkbox-empty {
+        &::before {
+          background: var(--color-background-utility-positive);
+          border-color: var(--color-border-input-disabled);
+        }
+      }
+      label i.bhi-checkbox-filled {
+        &::before {
+          border-color: var(--color-border-input-disabled);
+        }
+        &::after {
+          border-color: var(--color-border-input-disabled);
+        }
+      }
+    }
+  }
+}

--- a/projects/novo-elements/src/elements/checkbox/Checkbox.scss
+++ b/projects/novo-elements/src/elements/checkbox/Checkbox.scss
@@ -91,3 +91,107 @@
     }
   }
 }
+
+// bh2026: CSS-based checkbox rendering — replaces icon font glyphs
+:host-context([data-theme='bh2026']) {
+  .novo-checkbox-group {
+    // Suppress glyph and establish box dimensions for all box-style states
+    label i.bhi-checkbox-empty,
+    label i.bhi-checkbox-filled,
+    label i.bhi-checkbox-indeterminate {
+      font-size: 0;
+      display: inline-flex;
+      align-self: center;
+      width: 16px;
+      height: 16px;
+      position: relative;
+      flex-shrink: 0;
+    }
+
+    // Unchecked: white box with gray border
+    label i.bhi-checkbox-empty {
+      &::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        border: 1px solid var(--color-border-control);
+        border-radius: 2px;
+        background: white;
+      }
+    }
+
+    // Checked: light-blue box with brand-blue border and checkmark
+    label i.bhi-checkbox-filled {
+      &::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: var(--color-background-utility-positive);
+        border: 1px solid var(--color-utility-blue-600);
+        border-radius: 2px;
+      }
+      &::after {
+        content: '';
+        position: absolute;
+        left: 3px;
+        top: 4px;
+        width: 9px;
+        height: 5px;
+        border-left: 2px solid var(--color-utility-blue-600);
+        border-bottom: 2px solid var(--color-utility-blue-600);
+        transform: rotate(-45deg);
+      }
+    }
+
+    // Indeterminate: light-blue box with brand-blue border and dash
+    label i.bhi-checkbox-indeterminate {
+      &::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: var(--color-background-utility-positive);
+        border: 1px solid var(--color-utility-blue-600);
+        border-radius: 2px;
+      }
+      &::after {
+        content: '';
+        position: absolute;
+        left: 4px;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 8px;
+        height: 2px;
+        background: var(--color-utility-blue-600);
+      }
+    }
+
+    // Disabled: override the base opacity:0.4 and use explicit muted colors
+    &.disabled {
+      label {
+        opacity: 1;
+      }
+      label i.bhi-checkbox-empty {
+        &::before {
+          background: var(--color-background-utility-positive);
+          border-color: var(--color-border-input-disabled);
+        }
+      }
+      label i.bhi-checkbox-filled {
+        &::before {
+          border-color: var(--color-border-input-disabled);
+        }
+        &::after {
+          border-color: var(--color-border-input-disabled);
+        }
+      }
+      label i.bhi-checkbox-indeterminate {
+        &::before {
+          border-color: var(--color-border-input-disabled);
+        }
+        &::after {
+          background: var(--color-border-input-disabled);
+        }
+      }
+    }
+  }
+}

--- a/projects/novo-elements/src/elements/switch/Switch.scss
+++ b/projects/novo-elements/src/elements/switch/Switch.scss
@@ -142,10 +142,46 @@ $switch-thumb-size: 20px !default;
   }
 }
 
-// bh2026: outlined toggle — white track + 1px neutral border in the off state
+// bh2026: 32×20 pill track, 16×16 thumb, always white — per Figma spec
 :host-context([data-theme='bh2026']) {
+  .novo-switch-container {
+    width: 32px;
+    height: 20px;
+  }
   .novo-switch-bar {
-    background-color: var(--toggle-color-background, #ffffff);
-    border: 1px solid var(--toggle-color-border, var(--color-border-default, #f0f5f9));
+    top: 0;
+    left: 0;
+    width: 32px;
+    height: 20px;
+    border-radius: 10px;
+    background-color: white;
+    border: 1px solid var(--color-border-input);
+  }
+  .novo-switch-thumb-container {
+    top: 2px;
+    left: 2px;
+    width: 12px; // travel: 32 - 16 - 4px padding = 12px
+  }
+  .novo-switch-thumb {
+    height: 16px;
+    width: 16px;
+    background-color: white;
+    border: 1px solid var(--color-border-input);
+    box-shadow: 0px 2px 4px 0px var(--color-transparency-charcoal-04);
+
+    novo-icon {
+      display: none;
+    }
+  }
+
+  &[aria-checked="true"] {
+    .novo-switch-bar {
+      background-color: var(--color-utility-blue-600);
+      border: none;
+    }
+    .novo-switch-thumb {
+      background-color: white;
+      border: none;
+    }
   }
 }


### PR DESCRIPTION
## **Description**

Updates the styling for checkbox and switch to match the bh2026 restyling effort: 



#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**
<img width="106" height="127" alt="Screenshot 2026-08-04 at 10 43 32 AM" src="https://github.com/user-attachments/assets/0cd702d7-02bf-46b6-8035-3e605ae8b937" />
<img width="286" height="471" alt="Screenshot 2026-08-04 at 10 43 43 AM" src="https://github.com/user-attachments/assets/4ba36b83-a080-445d-9735-0f6a71cf7643" />