### PR TITLE
feat(CollapsibleNav): Add an expandDelay input to collapsible nav

### DIFF
--- a/projects/novo-elements/src/elements/layout/collapsible-nav/collapsible-nav.component.spec.ts
+++ b/projects/novo-elements/src/elements/layout/collapsible-nav/collapsible-nav.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { NovoCollapsibleNavComponent } from './collapsible-nav.component';
+import { tick } from 'novo-testing';
 
 describe('Elements: NovoCollapsibleNavComponent', () => {
   let fixture: ComponentFixture<NovoCollapsibleNavComponent>;
@@ -13,6 +14,8 @@ describe('Elements: NovoCollapsibleNavComponent', () => {
     }).compileComponents();
     fixture = TestBed.createComponent(NovoCollapsibleNavComponent);
     component = fixture.componentInstance;
+    const element = component.element;
+    vi.spyOn(element.nativeElement, 'matches').mockReturnValue(true);
     fixture.detectChanges();
   });
 
@@ -73,9 +76,10 @@ describe('Elements: NovoCollapsibleNavComponent', () => {
       fixture.detectChanges();
     });
 
-    it('mouseenter while collapsed should expand the animation state and remove collapsed class', () => {
+    it('mouseenter while collapsed should expand the animation state and remove collapsed class', async () => {
       component.onMouseEnter();
       fixture.detectChanges();
+      await tick(400);
       expect(component.expandCollapseState.value).toBe('expanded');
       expect(component.isCollapsed).toBe(false);
     });
@@ -96,12 +100,24 @@ describe('Elements: NovoCollapsibleNavComponent', () => {
       expect(component.isCollapsed).toBe(true);
     });
 
-    it('setting collapsed to true while hovered should collapse immediately', () => {
+    it('setting collapsed to true while hovered should collapse immediately', async () => {
       component.onMouseEnter();
       fixture.detectChanges();
+      await tick(400);
       expect(component.expandCollapseState.value).toBe('expanded');
       component.collapse();
       fixture.detectChanges();
+      expect(component.expandCollapseState.value).toBe('collapsed');
+    });
+
+    it('should not expand if the user\'s mouse exits before the debounce finishes', async () => {
+      fixture.componentRef.setInput('expandDelay', 300);
+      component.onMouseEnter();
+      fixture.detectChanges();
+      await tick(200);
+      component.onMouseLeave();
+      fixture.detectChanges();
+      await tick(200);
       expect(component.expandCollapseState.value).toBe('collapsed');
     });
 

--- a/projects/novo-elements/src/elements/layout/collapsible-nav/collapsible-nav.component.ts
+++ b/projects/novo-elements/src/elements/layout/collapsible-nav/collapsible-nav.component.ts
@@ -1,15 +1,22 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
+  DestroyRef,
+  effect,
+  ElementRef,
   HostBinding,
   HostListener,
-  ViewEncapsulation,
-  computed,
-  effect,
+  inject,
   input,
   model,
+  output,
+  Signal,
   signal,
+  ViewEncapsulation,
 } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { delay, filter, map, merge, Observable, of, partition, race, switchMap } from 'rxjs';
 import { novoCollapsibleNavAnimations } from './collapsible-nav.animations';
 
 /**
@@ -39,17 +46,29 @@ export class NovoCollapsibleNavComponent {
   /** Width of the panel when collapsed to the icon rail. */
   collapsedWidth = input<string>('4rem');
 
+  /** Time in ms to delay between the user entering the nav region, and expanding it */
+  expandDelay = input<number>(0);
+
   /** When true, hovering a collapsed panel temporarily expands it as an overlay without affecting layout. */
   overlayOnHover = input<boolean>(false);
 
+  hoveredChange = output<boolean>();
+
+  public readonly element = inject(ElementRef);
+  private readonly destroyRef = inject(DestroyRef);
   private readonly isHovered = signal(false);
-  private readonly effectiveCollapsed = computed(() => this.collapsed() && !(this.overlayOnHover() && this.isHovered()));
+  private readonly isHoveredDebounced$ = this.debounceHover(this.isHovered);
+  private readonly isEffectiveHovered = toSignal(this.isHoveredDebounced$);
+  private readonly effectiveCollapsed = computed(() => this.collapsed() && !(this.overlayOnHover() && this.isEffectiveHovered()));
 
   constructor() {
     effect(() => {
       if (this.collapsed()) {
         this.isHovered.set(false);
       }
+    });
+    this.isHoveredDebounced$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(hovered => {
+      this.hoveredChange.emit(hovered);
     });
   }
 
@@ -69,6 +88,17 @@ export class NovoCollapsibleNavComponent {
       value: this.effectiveCollapsed() ? 'collapsed' : 'expanded',
       params: { expandedWidth: this.expandedWidth(), collapsedWidth: this.collapsedWidth() },
     };
+  }
+
+  private debounceHover(hoverSignal: Signal<boolean>): Observable<boolean> {
+      const hoverObs = toObservable(hoverSignal);
+      const [enters, exits] = partition(hoverObs, hovered => hovered);
+      const waitedEnters = enters.pipe(switchMap(
+        enter => race(of(enter).pipe(delay(this.expandDelay())), exits),
+      ), filter(result => result), map(
+        () => this.element.nativeElement.matches(':hover'),
+      ));
+      return merge(waitedEnters, exits);
   }
 
   @HostBinding('class.novo-collapsible-nav-collapsed')

--- a/projects/novo-examples/src/layouts/collapsible-nav/basic-collapsible-nav/basic-collapsible-nav-example.html
+++ b/projects/novo-examples/src/layouts/collapsible-nav/basic-collapsible-nav/basic-collapsible-nav-example.html
@@ -1,5 +1,5 @@
 <div class="collapsible-nav-example" data-automation-id="collapsible-nav-example">
-  <novo-collapsible-nav [(collapsed)]="collapsed" [overlayOnHover]="true" data-automation-id="collapsible-nav">
+  <novo-collapsible-nav [(collapsed)]="collapsed" [overlayOnHover]="true" [expandDelay]="600" data-automation-id="collapsible-nav">
     <div novo-collapsible-nav-header>
       <novo-option (click)="collapsed = !collapsed" data-automation-id="collapsible-nav-toggle">
         <novo-icon>{{ collapsed ? 'arrow-right' : 'arrow-left' }}</novo-icon>


### PR DESCRIPTION
## **Description**

Add an expandDelay option to the nav component, which holds off on expanding until time has passed.
Added an event to the component so others can track this action.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**