### PR TITLE
fix(bh2026): Update disabled primary button color

### DIFF
--- a/projects/novo-elements/src/styles/themes/bh2026.scss
+++ b/projects/novo-elements/src/styles/themes/bh2026.scss
@@ -150,7 +150,7 @@
 // bh2026: primary disabled uses a lighter blue at full opacity instead of the default 0.5 opacity dimming
 :root[data-theme='bh2026'] [theme="primary"][disabled],
 :root[data-theme='bh2026'] [theme="primary"].novo-button-disabled {
-  background: var(--color-utility-blue-400);
+  background: var(--color-utility-blue-300);
   opacity: 1;
 }
 


### PR DESCRIPTION
## **Description**

Minor change of button color

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**