### PR TITLE
fix(bh2026): Remove banded list look

### DIFF
--- a/projects/novo-elements/src/elements/data-table/data-table.component.scss
+++ b/projects/novo-elements/src/elements/data-table/data-table.component.scss
@@ -661,10 +661,12 @@ novo-data-table {
       .novo-data-table-dropdown-cell,
       .novo-data-table-expand-cell,
       .novo-data-table-checkbox-cell {
-        background-color: var(--color-background-muted);
+        // To enable every-other "banded" styling change to --color-background-muted
+        background-color: var(--background-body);
       }
       + .novo-data-table-detail-row {
-        background-color: var(--color-background-muted);
+        // To enable every-other "banded" styling change to --color-background-muted
+        background-color: var(--background-body);
       }
     }
     > .novo-data-table-row:nth-of-type(even) {

--- a/projects/novo-elements/src/styles/themes/bh2026.scss
+++ b/projects/novo-elements/src/styles/themes/bh2026.scss
@@ -150,7 +150,7 @@
 // bh2026: primary disabled uses a lighter blue at full opacity instead of the default 0.5 opacity dimming
 :root[data-theme='bh2026'] [theme="primary"][disabled],
 :root[data-theme='bh2026'] [theme="primary"].novo-button-disabled {
-  background: var(--color-utility-blue-400);
+  background: var(--color-utility-blue-300);
   opacity: 1;
 }
 


### PR DESCRIPTION
## **Description**

Remove the banded list look in bh2026, but leave it in place we wish to go back.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**