### PR TITLE
feat(CollapsibleNav): Transition enhancements

### DIFF
--- a/projects/novo-elements/src/elements/layout/collapsible-nav/collapsible-nav.animations.ts
+++ b/projects/novo-elements/src/elements/layout/collapsible-nav/collapsible-nav.animations.ts
@@ -1,5 +1,7 @@
 import { animate, AnimationTriggerMetadata, state, style, transition, trigger } from '@angular/animations';
 
+// WARNING: Angular plans to remove the animations library in v23. When upgrading there, use CSS transition effects
+// to apply similar curves, and change event triggers to fire off of transitionstart/transitionend events.
 /**
  * Animation that grows/shrinks the panel width between its expanded and collapsed (icon-rail) sizes.
  * Width is animated rather than transform because the panel shrinks in place rather than sliding away.

--- a/projects/novo-elements/src/elements/layout/collapsible-nav/collapsible-nav.component.ts
+++ b/projects/novo-elements/src/elements/layout/collapsible-nav/collapsible-nav.component.ts
@@ -16,8 +16,24 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { delay, filter, map, merge, Observable, of, partition, race, switchMap } from 'rxjs';
+import { delay, filter, fromEvent, map, merge, Observable, of, partition, race, switchMap } from 'rxjs';
 import { novoCollapsibleNavAnimations } from './collapsible-nav.animations';
+
+export type NavTransitionState = 'collapsed' | 'expanding' | 'expanded' | 'collapsing';
+
+// Event fired when a user event (click, space) is about to expand navigation early
+export class CollapsibleNavExpansionEvent extends Event {
+  private _expandPrevented = false;
+  public get expandPrevented() {
+    return this._expandPrevented;
+  }
+  constructor(public srcEvent: Event) {
+    super('expansionClick');
+  }
+  preventExpand() {
+    this._expandPrevented = true;
+  }
+}
 
 /**
  * A slide-out navigation panel that expands to a full-width panel or collapses to a narrow icon rail.
@@ -47,12 +63,15 @@ export class NovoCollapsibleNavComponent {
   collapsedWidth = input<string>('4rem');
 
   /** Time in ms to delay between the user entering the nav region, and expanding it */
-  expandDelay = input<number>(0);
+  expandDelay = model<number>(0);
 
   /** When true, hovering a collapsed panel temporarily expands it as an overlay without affecting layout. */
   overlayOnHover = input<boolean>(false);
 
   hoveredChange = output<boolean>();
+  transitionChange = output<NavTransitionState>();
+
+  manualExpand = output<CollapsibleNavExpansionEvent>();
 
   public readonly element = inject(ElementRef);
   private readonly destroyRef = inject(DestroyRef);
@@ -60,6 +79,10 @@ export class NovoCollapsibleNavComponent {
   private readonly isHoveredDebounced$ = this.debounceHover(this.isHovered);
   private readonly isEffectiveHovered = toSignal(this.isHoveredDebounced$);
   private readonly effectiveCollapsed = computed(() => this.collapsed() && !(this.overlayOnHover() && this.isEffectiveHovered()));
+  private readonly clicked$ = fromEvent<MouseEvent>(this.element.nativeElement, 'click');
+  private readonly activationKeyPressed$ = fromEvent<KeyboardEvent>(this.element.nativeElement, 'keydown').pipe(
+    filter(kevt => kevt.key === ' ' || kevt.key === 'Enter'));
+  private readonly manualExpandUnprevented$: Observable<CollapsibleNavExpansionEvent>;
 
   constructor() {
     effect(() => {
@@ -70,6 +93,8 @@ export class NovoCollapsibleNavComponent {
     this.isHoveredDebounced$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(hovered => {
       this.hoveredChange.emit(hovered);
     });
+
+    this.manualExpandUnprevented$ = this.setupExpandFromActivation();
   }
 
   @HostListener('mouseenter')
@@ -82,6 +107,14 @@ export class NovoCollapsibleNavComponent {
     this.isHovered.set(false);
   }
 
+  @HostListener('keypress', ['$event'])
+  wPressed(event: KeyboardEvent) {
+    if (event.key === 'w') {
+      const newDelay = (this.expandDelay() === 0 ? 6000 : 0);
+      this.expandDelay.set(newDelay);
+    }
+  }
+
   @HostBinding('@expandCollapse')
   get expandCollapseState(): { value: string; params: { expandedWidth: string; collapsedWidth: string } } {
     return {
@@ -90,15 +123,40 @@ export class NovoCollapsibleNavComponent {
     };
   }
 
+  @HostListener('@expandCollapse.start', ['$event'])
+  transitionStart(event: any) {
+    this.transitionChange.emit(event.toState === 'expanded' ? 'expanding' : 'collapsing');
+  }
+
+  @HostListener('@expandCollapse.done', ['$event'])
+  transitionEnd(event) {
+    this.transitionChange.emit(event.toState === 'expanded' ? 'expanded' : 'collapsed');
+  }
+
   private debounceHover(hoverSignal: Signal<boolean>): Observable<boolean> {
       const hoverObs = toObservable(hoverSignal);
       const [enters, exits] = partition(hoverObs, hovered => hovered);
       const waitedEnters = enters.pipe(switchMap(
-        enter => race(of(enter).pipe(delay(this.expandDelay())), exits),
-      ), filter(result => result), map(
+        enter => race(of(enter).pipe(delay(this.expandDelay())), exits, this.manualExpandUnprevented$),
+      ), filter(result => Boolean(result)), map(
         () => this.element.nativeElement.matches(':hover'),
       ));
       return merge(waitedEnters, exits);
+  }
+
+  private setupExpandFromActivation() {
+    const userEvents = merge(this.clicked$, this.activationKeyPressed$);
+    // Emit anytime that the user clicks, or presses space/enter inside the nav,
+    // AND the ensuing event is not prevented when emitted to parent components.
+    return userEvents.pipe(
+      takeUntilDestroyed(this.destroyRef),
+      map(event => {
+        const expandEvent = new CollapsibleNavExpansionEvent(event);
+        this.manualExpand.emit(expandEvent);
+        return expandEvent;
+      }),
+      filter(expandEvent => !expandEvent.expandPrevented),
+    );
   }
 
   @HostBinding('class.novo-collapsible-nav-collapsed')

--- a/projects/novo-elements/src/elements/layout/collapsible-nav/collapsible-nav.component.ts
+++ b/projects/novo-elements/src/elements/layout/collapsible-nav/collapsible-nav.component.ts
@@ -107,14 +107,6 @@ export class NovoCollapsibleNavComponent {
     this.isHovered.set(false);
   }
 
-  @HostListener('keypress', ['$event'])
-  wPressed(event: KeyboardEvent) {
-    if (event.key === 'w') {
-      const newDelay = (this.expandDelay() === 0 ? 6000 : 0);
-      this.expandDelay.set(newDelay);
-    }
-  }
-
   @HostBinding('@expandCollapse')
   get expandCollapseState(): { value: string; params: { expandedWidth: string; collapsedWidth: string } } {
     return {

--- a/projects/novo-examples/src/layouts/collapsible-nav/basic-collapsible-nav/basic-collapsible-nav-example.html
+++ b/projects/novo-examples/src/layouts/collapsible-nav/basic-collapsible-nav/basic-collapsible-nav-example.html
@@ -1,5 +1,5 @@
 <div class="collapsible-nav-example" data-automation-id="collapsible-nav-example">
-  <novo-collapsible-nav [(collapsed)]="collapsed" [overlayOnHover]="true" [expandDelay]="600" data-automation-id="collapsible-nav">
+  <novo-collapsible-nav [(collapsed)]="collapsed" [overlayOnHover]="true" [expandDelay]="600" data-automation-id="collapsible-nav" (manualExpand)="onManualExpansion($event)">
     <div novo-collapsible-nav-header>
       <novo-option (click)="collapsed = !collapsed" data-automation-id="collapsible-nav-toggle">
         <novo-icon>{{ collapsed ? 'arrow-right' : 'arrow-left' }}</novo-icon>

--- a/projects/novo-examples/src/layouts/collapsible-nav/basic-collapsible-nav/basic-collapsible-nav-example.ts
+++ b/projects/novo-examples/src/layouts/collapsible-nav/basic-collapsible-nav/basic-collapsible-nav-example.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { CollapsibleNavExpansionEvent } from 'novo-elements';
 
 /**
  * @title Basic Collapsible Nav
@@ -25,4 +26,11 @@ export class BasicCollapsibleNavExample {
       label: 'Companies',
     },
   ];
+
+  onManualExpansion(event: CollapsibleNavExpansionEvent) {
+    // Do not expand early if a user clicked on a collapsed option (demo of modifying early-expansion rules)
+    if ((event.srcEvent.target as HTMLElement).matches('novo-option, novo-option *')) {
+      event.preventExpand();
+    }
+  }
 }


### PR DESCRIPTION
## **Description**

Add transition-state events to collapsible nav
Clicks will expand the menu early. A menuExpand event lets you cancel this behavior by inspecting the mouse click event.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**