### PR TITLE
fix(Chip): Limit transition effects to border/color

### DIFF
--- a/projects/novo-elements/src/elements/chips/Chip.scss
+++ b/projects/novo-elements/src/elements/chips/Chip.scss
@@ -46,7 +46,9 @@ $chip-spacing: (
   @include novo-body-text();
   background: var(--background-main);
   border: 1px solid transparent;
-  transition: all 200ms ease-in-out;
+  transition-duration: 0.2s;
+  transition-timing-function: ease-in-out;
+  transition-property: color, opacity, border-color, border-width, background-color;
   display: inline-flex;
   align-items: center;
   cursor: default;


### PR DESCRIPTION
## **Description**

This chip was using transition: all, which will affect width, height, font-size, and many other things that generally aren't changed at runtime. This reduces performance, and was difficult for our e2e tests.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**