### PR TITLE
feat(Form): Add Bh2026 styling for dynamic forms to appear card like

### DIFF
--- a/projects/novo-elements/src/addons/ckeditor/CKEditor.scss
+++ b/projects/novo-elements/src/addons/ckeditor/CKEditor.scss
@@ -39,6 +39,14 @@
   }
 }
 
+:host-context(:root[data-theme='bh2026']) {
+  ::ng-deep .cke {
+    border: 1px solid var(--card-color-border-default, #dee0e3);
+    border-radius: var(--field-border-radius-default, 0.4rem);
+    overflow: hidden;
+  }
+}
+
 :host-context(.theme-dark) {
   ::ng-deep .cke_button {
     filter: invert(1);

--- a/projects/novo-elements/src/elements/form/DynamicForm.spec.ts
+++ b/projects/novo-elements/src/elements/form/DynamicForm.spec.ts
@@ -1,0 +1,300 @@
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { vi } from 'vitest';
+import { NovoTheme } from 'novo-elements/elements/common';
+import { NovoTemplateService } from 'novo-elements/services';
+import { NovoDynamicFormElement } from './DynamicForm';
+import { NovoFormModule } from './Form.module';
+
+describe('NovoDynamicFormElement', () => {
+  describe('effectiveCardSections', () => {
+    let fixture: ComponentFixture<NovoDynamicFormElement>;
+    let component: NovoDynamicFormElement;
+    let isBh2026: ReturnType<typeof signal<boolean>>;
+
+    beforeEach(() => {
+      isBh2026 = signal(false);
+
+      TestBed.configureTestingModule({
+        imports: [NovoFormModule, OverlayModule],
+        providers: [
+          NovoTemplateService,
+          { provide: NovoTheme, useValue: { isBh2026 } },
+        ],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(NovoDynamicFormElement);
+      component = fixture.componentInstance;
+      component.form = { fieldsets: [], layout: null, controls: {}, valid: true, getRawValue: () => ({}) } as any;
+    });
+
+    it('returns true when hasCardSections is explicitly true', () => {
+      fixture.componentRef.setInput('hasCardSections', true);
+      expect(component.effectiveCardSections()).toBe(true);
+    });
+
+    it('returns false when hasCardSections is explicitly false, even under bh2026', () => {
+      isBh2026.set(true);
+      fixture.componentRef.setInput('hasCardSections', false);
+      expect(component.effectiveCardSections()).toBe(false);
+    });
+
+    it('returns false when hasCardSections is undefined and theme is not bh2026', () => {
+      isBh2026.set(false);
+      expect(component.effectiveCardSections()).toBe(false);
+    });
+
+    it('returns true when bh2026 and not inside an overlay container', () => {
+      isBh2026.set(true);
+      vi.spyOn(component['element'].nativeElement, 'closest').mockReturnValue(null);
+      expect(component.effectiveCardSections()).toBe(true);
+    });
+
+    it('returns false when bh2026 and inside novo-modal-container', () => {
+      isBh2026.set(true);
+      vi.spyOn(component['element'].nativeElement, 'closest').mockReturnValue(document.createElement('novo-modal-container'));
+      expect(component.effectiveCardSections()).toBe(false);
+    });
+
+    it('returns false when bh2026 and inside slide-out', () => {
+      isBh2026.set(true);
+      vi.spyOn(component['element'].nativeElement, 'closest').mockReturnValue(document.createElement('slide-out'));
+      expect(component.effectiveCardSections()).toBe(false);
+    });
+  });
+
+  describe('showOnlyRequired', () => {
+    let component: NovoDynamicFormElement;
+    let requiredControlDef: any;
+    let optionalControlDef: any;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [NovoFormModule, OverlayModule],
+        providers: [
+          NovoTemplateService,
+          { provide: NovoTheme, useValue: { isBh2026: signal(false) } },
+        ],
+      }).compileComponents();
+
+      const fixture = TestBed.createComponent(NovoDynamicFormElement);
+      component = fixture.componentInstance;
+
+      requiredControlDef = { key: 'name', required: true, hidden: false };
+      optionalControlDef = { key: 'bio', required: false, hidden: false };
+
+      component.form = {
+        fieldsets: [{ controls: [requiredControlDef, optionalControlDef] }],
+        layout: null,
+        controls: {
+          name: { key: 'name', hidden: false, errors: null, required: true, markAsDirty() {}, markAsTouched() {} },
+          bio: { key: 'bio', hidden: false, errors: null, required: false, markAsDirty() {}, markAsTouched() {} },
+        },
+        getRawValue: () => ({ name: '', bio: '' }),
+      } as any;
+    });
+
+    it('hides non-required controls on both formControl and control definition', () => {
+      component.showOnlyRequired(false);
+
+      expect(component.form.controls['bio'].hidden).toBe(true);
+      expect(optionalControlDef.hidden).toBe(true);
+    });
+
+    it('leaves required controls with no value visible', () => {
+      component.showOnlyRequired(false);
+
+      expect(component.form.controls['name'].hidden).toBe(false);
+      expect(requiredControlDef.hidden).toBe(false);
+    });
+
+    it('restores visibility for controls with errors, syncing control definition', () => {
+      component.form.controls['name'].errors = { required: true };
+      component.form.controls['name'].hidden = true;
+      requiredControlDef.hidden = true;
+
+      component.showOnlyRequired(false);
+
+      expect(component.form.controls['name'].hidden).toBe(false);
+      expect(requiredControlDef.hidden).toBe(false);
+    });
+
+    it('hides required controls that already have a value when hideRequiredWithValue is true', () => {
+      (component.form.getRawValue as any) = () => ({ name: 'Alice', bio: '' });
+
+      component.showOnlyRequired(true);
+
+      expect(component.form.controls['name'].hidden).toBe(true);
+      expect(requiredControlDef.hidden).toBe(true);
+    });
+  });
+
+  describe('showAllFields', () => {
+    let component: NovoDynamicFormElement;
+    let optionalControlDef: any;
+    let preHiddenControlDef: any;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [NovoFormModule, OverlayModule],
+        providers: [
+          NovoTemplateService,
+          { provide: NovoTheme, useValue: { isBh2026: signal(false) } },
+        ],
+      }).compileComponents();
+
+      const fixture = TestBed.createComponent(NovoDynamicFormElement);
+      component = fixture.componentInstance;
+
+      optionalControlDef = { key: 'bio', required: false, hidden: false };
+      preHiddenControlDef = { key: 'notes', required: false, hidden: false };
+
+      component.form = {
+        fieldsets: [{ controls: [optionalControlDef, preHiddenControlDef] }],
+        layout: null,
+        controls: {
+          bio: { key: 'bio', hidden: false, errors: null, required: false, markAsDirty() {}, markAsTouched() {} },
+          notes: { key: 'notes', hidden: true, errors: null, required: false, markAsDirty() {}, markAsTouched() {} },
+        },
+        getRawValue: () => ({ bio: '', notes: '' }),
+      } as any;
+    });
+
+    it('restores formControl.hidden and control.hidden for non-pre-hidden controls', () => {
+      component.showOnlyRequired(false);
+      component.showAllFields();
+
+      expect(component.form.controls['bio'].hidden).toBe(false);
+      expect(optionalControlDef.hidden).toBe(false);
+    });
+
+    it('leaves pre-hidden controls hidden', () => {
+      component.showOnlyRequired(false);
+      component.showAllFields();
+
+      expect(component.form.controls['notes'].hidden).toBe(true);
+    });
+  });
+
+  describe('hasVisibleControls', () => {
+    let component: NovoDynamicFormElement;
+    let firstControlDef: any;
+    let secondControlDef: any;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [NovoFormModule, OverlayModule],
+        providers: [
+          NovoTemplateService,
+          { provide: NovoTheme, useValue: { isBh2026: signal(false) } },
+        ],
+      }).compileComponents();
+
+      const fixture = TestBed.createComponent(NovoDynamicFormElement);
+      component = fixture.componentInstance;
+
+      firstControlDef = { key: 'name', required: true };
+      secondControlDef = { key: 'bio', required: false };
+
+      component.form = {
+        fieldsets: [],
+        layout: null,
+        controls: {
+          name: { hidden: false },
+          bio: { hidden: false },
+        },
+        getRawValue: () => ({}),
+      } as any;
+    });
+
+    it('returns true when at least one form control is not hidden', () => {
+      const fieldset = { controls: [firstControlDef, secondControlDef] };
+      component.form.controls['name'].hidden = false;
+      component.form.controls['bio'].hidden = true;
+
+      expect(component.hasVisibleControls(fieldset as any)).toBe(true);
+    });
+
+    it('returns false when all form controls are hidden', () => {
+      const fieldset = { controls: [firstControlDef, secondControlDef] };
+      component.form.controls['name'].hidden = true;
+      component.form.controls['bio'].hidden = true;
+
+      expect(component.hasVisibleControls(fieldset as any)).toBe(false);
+    });
+  });
+
+  describe('visibleFieldsets', () => {
+    let component: NovoDynamicFormElement;
+    let isBh2026: ReturnType<typeof signal<boolean>>;
+
+    beforeEach(() => {
+      isBh2026 = signal(false);
+
+      TestBed.configureTestingModule({
+        imports: [NovoFormModule, OverlayModule],
+        providers: [
+          NovoTemplateService,
+          { provide: NovoTheme, useValue: { isBh2026 } },
+        ],
+      }).compileComponents();
+
+      const fixture = TestBed.createComponent(NovoDynamicFormElement);
+      component = fixture.componentInstance;
+      component.form = {
+        fieldsets: [],
+        layout: null,
+        controls: {},
+        getRawValue: () => ({}),
+      } as any;
+    });
+
+    it('returns only fieldsets with controls when card sections are off', () => {
+      component.form.fieldsets = [
+        { controls: [{ key: 'name' }] },
+        { controls: [] },
+        { controls: [{ key: 'bio' }] },
+      ] as any;
+      component.form.controls = {
+        name: { hidden: false },
+        bio: { hidden: false },
+      } as any;
+
+      expect(component.visibleFieldsets.length).toBe(2);
+    });
+
+    it('excludes fieldsets where all controls are hidden when card sections are on', () => {
+      isBh2026.set(true);
+      vi.spyOn(component['element'].nativeElement, 'closest').mockReturnValue(null);
+
+      component.form.fieldsets = [
+        { controls: [{ key: 'name' }] },
+        { controls: [{ key: 'bio' }] },
+      ] as any;
+      component.form.controls = {
+        name: { hidden: true },
+        bio: { hidden: false },
+      } as any;
+
+      const result = component.visibleFieldsets;
+      expect(result.length).toBe(1);
+      expect((result[0].controls[0] as any).key).toBe('bio');
+    });
+
+    it('includes fieldsets with at least one visible control when card sections are on', () => {
+      isBh2026.set(true);
+      vi.spyOn(component['element'].nativeElement, 'closest').mockReturnValue(null);
+
+      component.form.fieldsets = [
+        { controls: [{ key: 'name' }, { key: 'bio' }] },
+      ] as any;
+      component.form.controls = {
+        name: { hidden: true },
+        bio: { hidden: false },
+      } as any;
+
+      expect(component.visibleFieldsets.length).toBe(1);
+    });
+  });
+});

--- a/projects/novo-elements/src/elements/form/DynamicForm.ts
+++ b/projects/novo-elements/src/elements/form/DynamicForm.ts
@@ -10,9 +10,12 @@ import {
   QueryList,
   SimpleChanges,
   ViewEncapsulation,
+  computed,
+  inject,
+  input,
 } from '@angular/core';
 import { NovoTemplateService } from 'novo-elements/services';
-import { NovoTemplate } from 'novo-elements/elements/common';
+import { NovoTemplate, NovoTheme } from 'novo-elements/elements/common';
 // App
 import { Helpers } from 'novo-elements/utils';
 import { NovoFieldset } from './FormInterfaces';
@@ -21,10 +24,17 @@ import { NovoFormGroup } from './NovoFormGroup';
 @Component({
     selector: 'novo-fieldset-header',
     template: `
-    <novo-title smaller>
-      <novo-icon>{{ icon?.replace('bhi-', '') }}</novo-icon
-      >{{ title }}
-    </novo-title>
+    @if (cardSection) {
+      @if (icon) {
+        <novo-icon>{{ cardIcon }}</novo-icon>
+      }
+      <span>{{ title }}</span>
+    } @else {
+      <novo-title smaller>
+        <novo-icon>{{ icon?.replace('bhi-', '') }}</novo-icon
+        >{{ title }}
+      </novo-title>
+    }
     <ng-content />
   `,
     styleUrls: ['./fieldset-header.scss'],
@@ -38,26 +48,36 @@ export class NovoFieldsetHeaderElement {
   title: string;
   @Input()
   icon: string = 'section';
+  @Input()
+  cardSection = false;
+
+  get cardIcon(): string {
+    const stripped = this.icon?.replace('bhi-', '') || '';
+    return stripped === 'section' ? 'edit-circle' : stripped;
+  }
 }
 
 @Component({
     selector: 'novo-fieldset',
     template: `
-    <div class="novo-fieldset-container">
-      <novo-fieldset-header
-        [icon]="icon"
-        [title]="title"
-        *ngIf="title"
-        [class.embedded]="isEmbedded"
-        [class.inline-embedded]="isInlineEmbedded"
-        [class.hidden]="hidden"
-      ></novo-fieldset-header>
-      <ng-container *ngFor="let control of controls; let controlIndex = index">
-        <div class="novo-form-row" [class.disabled]="control.disabled" *ngIf="control.__type !== 'GroupedControl'">
-          <novo-control [autoFocus]="autoFocus && index === 0 && controlIndex === 0" [control]="control" [form]="form"></novo-control>
-        </div>
-        <div *ngIf="control.__type === 'GroupedControl'">TODO - GroupedControl</div>
-      </ng-container>
+    <div class="novo-fieldset-container" [class.card-section]="cardSection">
+      @if (title) {
+        <novo-fieldset-header
+          [icon]="icon"
+          [title]="title"
+          [cardSection]="cardSection"
+          [class.embedded]="isEmbedded"
+          [class.inline-embedded]="isInlineEmbedded"
+          [class.hidden]="hidden"
+        ></novo-fieldset-header>
+      }
+      @for (control of controls; track control.key; let controlIndex = $index) {
+        @if (control.__type !== 'GroupedControl') {
+          <div class="novo-form-row" [class.disabled]="control.disabled" [class.hidden]="control.hidden">
+            <novo-control [autoFocus]="autoFocus && index === 0 && controlIndex === 0" [control]="control" [form]="form"></novo-control>
+          </div>
+        }
+      }
     </div>
   `,
     standalone: false,
@@ -81,6 +101,8 @@ export class NovoFieldsetElement {
   isInlineEmbedded = false;
   @Input()
   hidden = false;
+  @Input()
+  cardSection = false;
 }
 
 @Component({
@@ -93,9 +115,8 @@ export class NovoFieldsetElement {
         <ng-content select="form-subtitle"></ng-content>
       </header>
       <form class="novo-form" [formGroup]="form">
-        <ng-container *ngFor="let fieldset of form.fieldsets; let i = index">
+        @for (fieldset of visibleFieldsets; track fieldset.key; let i = $index) {
           <novo-fieldset
-            *ngIf="fieldset.controls.length"
             [index]="i"
             [autoFocus]="autoFocusFirstField"
             [icon]="fieldset.icon"
@@ -105,8 +126,9 @@ export class NovoFieldsetElement {
             [isEmbedded]="fieldset.isEmbedded"
             [isInlineEmbedded]="fieldset.isInlineEmbedded"
             [hidden]="fieldset.hidden"
+            [cardSection]="effectiveCardSections()"
           ></novo-fieldset>
-        </ng-container>
+        }
       </form>
     </div>
   `,
@@ -128,6 +150,7 @@ export class NovoDynamicFormElement implements OnChanges, OnInit, AfterContentIn
   hideNonRequiredFields: boolean = true;
   @Input()
   autoFocusFirstField: boolean = false;
+  readonly hasCardSections = input<boolean | undefined>(undefined);
   @ContentChildren(NovoTemplate)
   customTemplates: QueryList<NovoTemplate>;
   private fieldsAlreadyHidden: string[];
@@ -137,6 +160,26 @@ export class NovoDynamicFormElement implements OnChanges, OnInit, AfterContentIn
   showingAllFields = false;
   showingRequiredFields = true;
   numControls = 0;
+
+  private readonly theme = inject(NovoTheme);
+
+  readonly effectiveCardSections = computed(() => {
+    const override = this.hasCardSections();
+    if (override !== undefined) {
+      return override;
+    }
+    if (!this.theme.isBh2026()) {
+      return false;
+    }
+    return !this.element.nativeElement.closest('novo-modal-container, slide-out');
+  });
+
+  get visibleFieldsets(): NovoFieldset[] {
+    if (!this.effectiveCardSections()) {
+      return this.form?.fieldsets?.filter((fieldset) => fieldset.controls.length) ?? [];
+    }
+    return this.form?.fieldsets?.filter((fieldset) => fieldset.controls.length && this.hasVisibleControls(fieldset)) ?? [];
+  }
 
   constructor(private element: ElementRef, private templates: NovoTemplateService) {}
 
@@ -191,12 +234,20 @@ export class NovoDynamicFormElement implements OnChanges, OnInit, AfterContentIn
     }
   }
 
+  public hasVisibleControls(fieldset: NovoFieldset): boolean {
+    return fieldset.controls.some((control) => {
+      const formControl = this.form.controls[control.key];
+      return formControl && !formControl.hidden;
+    });
+  }
+
   public showAllFields(): void {
     this.form.fieldsets.forEach((fieldset) => {
       fieldset.controls.forEach((control) => {
-        const ctl = this.form.controls[control.key];
+        const formControl = this.form.controls[control.key];
         if (!this.fieldsAlreadyHidden?.includes(control.key)) {
-          ctl.hidden = false;
+          formControl.hidden = false;
+          control.hidden = false;
         }
       });
     });
@@ -208,29 +259,29 @@ export class NovoDynamicFormElement implements OnChanges, OnInit, AfterContentIn
     this.fieldsAlreadyHidden = [];
     this.form.fieldsets.forEach((fieldset) => {
       fieldset.controls.forEach((control) => {
-        const ctl = this.form.controls[control.key];
+        const formControl = this.form.controls[control.key];
 
-        if (ctl.hidden) {
+        if (formControl.hidden) {
           this.fieldsAlreadyHidden.push(control.key);
         }
 
-        // Hide any non-required fields
         if (!control.required) {
-          ctl.hidden = true;
+          formControl.hidden = true;
+          control.hidden = true;
         }
 
-        // Hide required fields that have been successfully filled out
         if (
           hideRequiredWithValue &&
           !Helpers.isBlank(this.form.getRawValue()[control.key]) &&
-          (!control.isEmpty || (control.isEmpty && control.isEmpty(ctl)))
+          (!control.isEmpty || (control.isEmpty && control.isEmpty(formControl)))
         ) {
-          ctl.hidden = true;
+          formControl.hidden = true;
+          control.hidden = true;
         }
 
-        // Don't hide fields with errors
-        if (ctl.errors) {
-          ctl.hidden = false;
+        if (formControl.errors) {
+          formControl.hidden = false;
+          control.hidden = false;
         }
       });
     });

--- a/projects/novo-elements/src/elements/form/Form.scss
+++ b/projects/novo-elements/src/elements/form/Form.scss
@@ -840,6 +840,9 @@ control-prompt-modal {
     letter-spacing: var(--typography-input-label-sm-letter-spacing);
     text-transform: var(--typography-input-label-sm-text-transform);
     color: var(--color-text-body) !important;
+    margin-right: var(--spacing-gap-lg);
+    max-width: 128px;
+    min-width: 128px;
   }
   .novo-control-outer-container input:not([type='checkbox']):not([type='radio']) {
     font-size: var(--typography-input-value-default-font-size) !important;
@@ -863,5 +866,66 @@ control-prompt-modal {
       font-size: var(--typography-input-value-sm-font-size);
       color: var(--color-text-subtle);
     }
+  }
+
+  .novo-fieldset-container.card-section,
+  novo-form .novo-form-container.card-section {
+    border-radius: var(--border-radius-md);
+    border: 1px solid var(--color-border-default);
+    box-shadow: 0 4px 8px 0 var(--color-transparency-charcoal-charcoal-08);
+    background: var(--color-background-default);
+    padding-bottom: var(--spacing-padding-md);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-gap-md);
+
+    .novo-form-row {
+      padding-left: var(--spacing-padding-lg);
+      padding-right: var(--spacing-padding-lg);
+    }
+
+    novo-control,
+    novo-custom-control-container {
+      margin-top: 0 !important;
+    }
+  }
+
+  .novo-fieldset-container.card-section {
+    padding-top: 0;
+    padding-left: 0;
+    padding-right: 0;
+    margin-bottom: 0;
+
+    &:not(:has(> novo-fieldset-header)) {
+      padding-top: var(--spacing-padding-md);
+    }
+  }
+
+  novo-form .novo-form-container.card-section {
+    padding-top: var(--spacing-padding-md);
+  }
+
+  novo-form,
+  novo-dynamic-form {
+    max-width: 720px;
+    width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  // Gap between fieldset cards
+  .novo-form-container form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-gutter);
+
+    novo-fieldset {
+      margin-top: 0;
+    }
+  }
+
+  .novo-form-row.hidden {
+    display: none;
   }
 }

--- a/projects/novo-elements/src/elements/form/Form.scss
+++ b/projects/novo-elements/src/elements/form/Form.scss
@@ -914,7 +914,6 @@ control-prompt-modal {
     margin-right: auto;
   }
 
-  // Gap between fieldset cards
   .novo-form-container form {
     display: flex;
     flex-direction: column;

--- a/projects/novo-elements/src/elements/form/Form.ts
+++ b/projects/novo-elements/src/elements/form/Form.ts
@@ -1,5 +1,5 @@
 // NG
-import { AfterContentInit, Component, ContentChildren, Input, OnInit, QueryList, ViewEncapsulation } from '@angular/core';
+import { AfterContentInit, Component, ContentChildren, Input, OnInit, QueryList, ViewEncapsulation, computed, input } from '@angular/core';
 // App
 import { NovoTemplateService } from 'novo-elements/services';
 import { Helpers } from 'novo-elements/utils';
@@ -10,7 +10,7 @@ import { NovoFormGroup } from './NovoFormGroup';
     selector: 'novo-form',
     template: `
     <novo-control-templates></novo-control-templates>
-    <div class="novo-form-container">
+    <div class="novo-form-container" [class.card-section]="effectiveCardSections()">
       <header *ngIf="!hideHeader">
         <ng-content select="form-title"></ng-content>
         <ng-content select="form-subtitle"></ng-content>
@@ -32,6 +32,9 @@ export class NovoFormElement implements AfterContentInit, OnInit {
   layout: string;
   @Input()
   hideHeader: boolean = false;
+
+  readonly hasCardSections = input<boolean | undefined>(undefined);
+  readonly effectiveCardSections = computed(() => this.hasCardSections() ?? false);
 
   @ContentChildren(NovoTemplate)
   customTemplates: QueryList<NovoTemplate>;

--- a/projects/novo-elements/src/elements/form/fieldset-header.scss
+++ b/projects/novo-elements/src/elements/form/fieldset-header.scss
@@ -15,3 +15,38 @@
     display: none;
   }
 }
+
+:host-context([data-theme='bh2026'] .card-section) {
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  margin-right: 0;
+  padding: var(--spacing-padding-md) var(--spacing-padding-lg);
+  background: var(--background-bright);
+  border-bottom: 1px solid var(--color-border-default);
+  align-items: center;
+  gap: var(--spacing-gap-sm);
+  font-size: var(--typography-title-small-font-size, 1.8rem);
+  font-weight: 600;
+  line-height: var(--typography-title-small-line-height, 2.4rem);
+  letter-spacing: var(--typography-title-small-letter-spacing, 0);
+  text-transform: capitalize;
+  color: var(--color-text-body);
+  > span {
+    flex: 1 0 0;
+    min-width: 0;
+  }
+  ::ng-deep novo-icon {
+    font-size: 1.6rem;
+    width: 1.6rem;
+    height: 1.6rem;
+    flex-shrink: 0;
+    color: var(--color-content-icon);
+    margin: 0;
+    i {
+      font-size: 1.6rem;
+      width: 1.6rem;
+      height: 1.6rem;
+    }
+  }
+}

--- a/projects/novo-elements/src/styles/themes/bh2026.scss
+++ b/projects/novo-elements/src/styles/themes/bh2026.scss
@@ -76,7 +76,7 @@
   --font-size-label:   var(--typography-label-lg-font-size);
   --font-size-text:    var(--typography-body-default-font-size);
   --font-size-button:  var(--typography-body-default-font-size);
-  --font-size-title:   var(--typography-title-font-size);
+  --font-size-title:   var(--typography-title-default-font-size);
   --font-size-tab:     var(--typography-tabs-default-font-size);
 
   // --- Button ---

--- a/projects/novo-elements/src/styles/variables.scss
+++ b/projects/novo-elements/src/styles/variables.scss
@@ -119,6 +119,7 @@ $entity-colors: (
   "credential": $color-neutral,
   "user": $color-neutral,
   "corporateuser": $color-neutral,
+  "neutral": $color-neutral,
   "contract": $color-contract,
   "jobCode": $color-job-code,
   "earnCode": $color-earn-code,

--- a/projects/novo-elements/src/styles/variables.scss
+++ b/projects/novo-elements/src/styles/variables.scss
@@ -98,6 +98,7 @@ $analytics-colors: (
 );
 // Entity Color Map
 $entity-colors: (
+  "appointment": $color-neutral,
   "star": $color-placement,
   "person": $color-contact,
   "company": $color-company,

--- a/projects/novo-examples/src/form-controls/dynamic-form/dynamic-form/dynamic-form-example.html
+++ b/projects/novo-examples/src/form-controls/dynamic-form/dynamic-form/dynamic-form-example.html
@@ -1,5 +1,9 @@
-<button theme="secondary" *ngIf="!myform.showingAllFields && !(myform.allFieldsRequired || myform.allFieldsNotRequired)" (click)="myform.showAllFields()" data-automation-id="dynamic-form-show-all">Show All Fields</button>
-<button theme="secondary" *ngIf="!myform.showingRequiredFields && !(myform.allFieldsRequired || myform.allFieldsNotRequired)" (click)="myform.showOnlyRequired(false)" data-automation-id="dynamic-form-show-required">Show Required Fields</button>
+@if (!myform.showingAllFields && !(myform.allFieldsRequired || myform.allFieldsNotRequired)) {
+    <button theme="secondary" (click)="myform.showAllFields()" data-automation-id="dynamic-form-show-all">Show All Fields</button>
+}
+@if (!myform.showingRequiredFields && !(myform.allFieldsRequired || myform.allFieldsNotRequired)) {
+    <button theme="secondary" (click)="myform.showOnlyRequired(false)" data-automation-id="dynamic-form-show-required">Show Required Fields</button>
+}
 <novo-dynamic-form [autoFocusFirstField]="true" class="dynamic" [fieldsets]="dynamic" [(form)]="dynamicForm" #myform data-automation-id="dynamic-form"></novo-dynamic-form>
 <footer class="dynamic-demo-footer" data-automation-id="dynamic-form-footer">
     <button (click)="save(myform)" theme="primary" icon="check" data-automation-id="dynamic-form-save">Save</button>


### PR DESCRIPTION
## **Description**

Adds bh2026 card-style layout for dynamic forms, where each fieldset renders as a visually distinct card with a bordered, shadowed container and a styled header.

- Card section styling: In the bh2026 theme, novo-dynamic-form and novo-form automatically render fieldsets as cards (bordered, rounded, shadowed) unless inside a modal or slide-out, where the flat layout is preserved. The behavior can be overridden via a new hasCardSections input on both components.
- Fieldset header: When in card mode, the header renders with a horizontal icon + label layout, tighter typography, and a bottom border separating it from the form fields.
- Visible fieldset filtering: Fieldsets with no visible controls (e.g. when required-only mode is active) are now hidden entirely rather than rendering an empty card.
- Hidden field sync: When toggling between "show all" and "show required only" modes, control.hidden is now kept in sync with formControl.hidden so that the card-section visibility logic (which reads from the control) works correctly.
- CKEditor border: Adds a border around the CKEditor input for bh2026.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**