### PR TITLE
feat(tooltip): Add preline tooltip component

### DIFF
--- a/projects/novo-elements/src/elements/tooltip/Tooltip.component.ts
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.component.ts
@@ -1,6 +1,6 @@
 // NG2
 import { animate, state, style, transition, trigger } from '@angular/animations';
-import { Component } from '@angular/core';
+import { Component, computed, signal } from '@angular/core';
 
 @Component({
     selector: 'novo-tooltip',
@@ -27,7 +27,8 @@ import { Component } from '@angular/core';
     standalone: false,
 })
 export class NovoTooltip {
-  public message: string;
+  public readonly message = signal<string>('');
+  public readonly messageLines = computed(() => this.message().split('\n'));
   public hidden: boolean;
   public tooltipType: string;
   public rounded: boolean;

--- a/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.directive.ts
@@ -135,7 +135,7 @@ export class TooltipDirective implements OnDestroy, OnInit, AfterViewInit {
     this.portal = this.portal || new ComponentPortal(NovoTooltip, this.viewContainerRef);
 
     const tooltipInstance = this.overlayRef.attach(this.portal).instance;
-    tooltipInstance.message = this.tooltip;
+    tooltipInstance.message.set(this.tooltip);
     tooltipInstance.tooltipType = this.type;
     tooltipInstance.rounded = this.rounded;
     tooltipInstance.size = this.size;

--- a/projects/novo-elements/src/elements/tooltip/Tooltip.html
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.html
@@ -1,5 +1,15 @@
-<div *ngIf="this.isHTML" [@state]="noAnimate ? 'no-animation' : 'visible'"
-     [ngClass]="[tooltipType, rounded ? 'rounded' : '', size ? size : '', preline? 'preline' : '', bounce ? 'bounce' : '', position]"
-     [innerHTML]="message"></div>
-<div *ngIf="!this.isHTML" [@state]="noAnimate ? 'no-animation' : 'visible'"
-     [ngClass]="[tooltipType, rounded ? 'rounded' : '', size ? size : '', preline? 'preline' : '', bounce ? 'bounce' : '', position]">{{message}}</div>
+@if (isHTML) {
+  <div [@state]="noAnimate ? 'no-animation' : 'visible'"
+       [ngClass]="[tooltipType, rounded ? 'rounded' : '', size ? size : '', preline ? 'preline' : '', bounce ? 'bounce' : '', position]"
+       [innerHTML]="message()"></div>
+} @else if (preline) {
+  <div [@state]="noAnimate ? 'no-animation' : 'visible'"
+       [ngClass]="[tooltipType, rounded ? 'rounded' : '', size ? size : '', 'preline', bounce ? 'bounce' : '', position]">
+    @for (line of messageLines(); track $index) {
+      <span>{{line}}</span>
+    }
+  </div>
+} @else {
+  <div [@state]="noAnimate ? 'no-animation' : 'visible'"
+       [ngClass]="[tooltipType, rounded ? 'rounded' : '', size ? size : '', bounce ? 'bounce' : '', position]">{{message()}}</div>
+}

--- a/projects/novo-elements/src/elements/tooltip/Tooltip.html
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.html
@@ -6,10 +6,10 @@
   <div [@state]="noAnimate ? 'no-animation' : 'visible'"
        [ngClass]="[tooltipType, rounded ? 'rounded' : '', size ? size : '', 'preline', bounce ? 'bounce' : '', position]">
     @for (line of messageLines(); track $index) {
-      <span>{{line}}</span>
+      <span>{{ line }}</span>
     }
   </div>
 } @else {
   <div [@state]="noAnimate ? 'no-animation' : 'visible'"
-       [ngClass]="[tooltipType, rounded ? 'rounded' : '', size ? size : '', bounce ? 'bounce' : '', position]">{{message()}}</div>
+       [ngClass]="[tooltipType, rounded ? 'rounded' : '', size ? size : '', bounce ? 'bounce' : '', position]">{{ message() }}</div>
 }

--- a/projects/novo-elements/src/elements/tooltip/Tooltip.scss
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.scss
@@ -1,4 +1,4 @@
-$tooltip-background: var(--tooltip-background-color, #383838);
+$tooltip-background: var(--tooltip-color-background-default, #3D464D);
 $tooltip-error-color: var(--color-shade-error, #b34e4d);
 $tooltip-info-color: var(--color-shade-info, #3986ac);
 $tooltip-warning-color: var(--color-shade-warning, #c09854);
@@ -25,14 +25,23 @@ $tooltip-success-color: var(--color-shade-success, #458746);
 
 :host {
   div {
+    display: flex;
+    max-width: 300px;
+    padding: var(--tooltip-spacing-container-medium-padding-vertical, 16px) var(--tooltip-spacing-container-medium-padding-horizontal, 16px);
+    justify-content: center;
+    align-items: flex-start;
+    gap: 10px;
+    border-radius: var(--tooltip-border-radius-medium, 8px);
     background: $tooltip-background;
-    color: var(--color-white, #fff);
-    border-radius: var(--border-radius-sm, 4px);
-    padding: 8px 10px;
-    font-size: var(--font-size-sm);
-    line-height: 12px;
-    white-space: nowrap;
-    box-shadow: var(--shadow-2);
+    box-shadow: 0 1px 2px -1px rgba(40, 40, 40, 0.10), 0 1px 2px 0 rgba(40, 40, 40, 0.08), 0 2px 2px -1px rgba(40, 40, 40, 0.08);
+    color: var(--tooltip-color-content-default, #fff);
+    font-family: var(--typography-body-sm-font-family, Inter);
+    font-size: var(--typography-body-sm-font-size, 12px);
+    font-weight: var(--typography-body-sm-font-weight-default, 400);
+    line-height: var(--typography-body-sm-line-height, 16px);
+    letter-spacing: var(--typography-body-sm-letter-spacing, 0);
+    white-space: normal;
+    word-wrap: break-word;
 
     &.error {
       background-color: $tooltip-error-color;
@@ -117,16 +126,9 @@ $tooltip-success-color: var(--color-shade-success, #458746);
     }
 
     // Sizing
-    &.extra-large,
-    &.large,
-    &.small,
-    &.medium {
-      white-space: normal;
-      line-height: 1.4em;
-      word-wrap: break-word;
-    }
     &.extra-large {
       width: 400px;
+      max-width: unset;
       font-size: 1.2vh;
     }
     &.large {
@@ -139,7 +141,7 @@ $tooltip-success-color: var(--color-shade-success, #458746);
       width: 80px;
     }
     &.preline {
-      white-space: pre-line;
+      flex-direction: column;
     }
 
     // Bounce

--- a/projects/novo-elements/src/elements/tooltip/Tooltip.spec.ts
+++ b/projects/novo-elements/src/elements/tooltip/Tooltip.spec.ts
@@ -1,9 +1,11 @@
 import { OverlayModule } from '@angular/cdk/overlay';
-import { Component } from '@angular/core';
+import { Component, ComponentFixture } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { NovoTooltip } from './Tooltip.component';
 import { TooltipDirective } from './Tooltip.directive';
+import { NovoTooltipModule } from './Tooltip.module';
 
 @Component({
   selector: 'test-component',
@@ -12,6 +14,46 @@ import { TooltipDirective } from './Tooltip.directive';
   standalone: false,
 })
 class TestComponent {}
+
+describe('Component: NovoTooltip', () => {
+  describe('preline rendering', () => {
+    let fixture: ComponentFixture<NovoTooltip>;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [NovoTooltipModule, OverlayModule],
+        providers: [provideNoopAnimations()],
+      }).compileComponents();
+      fixture = TestBed.createComponent(NovoTooltip);
+    });
+
+    it('should render a span per newline-delimited segment when preline is true', () => {
+      const instance = fixture.componentInstance;
+      instance.message.set('line1\nline2\nline3');
+      instance.preline = true;
+      instance.tooltipType = 'normal';
+      instance.position = 'top';
+      instance.noAnimate = true;
+      fixture.detectChanges();
+      const spans = fixture.debugElement.queryAll(By.css('span'));
+      expect(spans.length).toBe(3);
+      expect(spans[0].nativeElement.textContent).toBe('line1');
+      expect(spans[1].nativeElement.textContent).toBe('line2');
+      expect(spans[2].nativeElement.textContent).toBe('line3');
+    });
+
+    it('should not render spans when preline is false', () => {
+      const instance = fixture.componentInstance;
+      instance.message.set('single line');
+      instance.preline = false;
+      instance.tooltipType = 'normal';
+      instance.position = 'top';
+      instance.noAnimate = true;
+      fixture.detectChanges();
+      expect(fixture.debugElement.queryAll(By.css('span')).length).toBe(0);
+    });
+  });
+});
 
 describe('Elements: TooltipDirective', () => {
   let fixture;

--- a/projects/novo-examples/src/components/tooltip/index.ts
+++ b/projects/novo-examples/src/components/tooltip/index.ts
@@ -1,6 +1,7 @@
 export * from './tooltip-align';
 export * from './tooltip-options';
 export * from './tooltip-placement';
+export * from './tooltip-preline';
 export * from './tooltip-sizes';
 export * from './tooltip-toggle';
 export * from './tooltip-types';

--- a/projects/novo-examples/src/components/tooltip/tooltip-examples.md
+++ b/projects/novo-examples/src/components/tooltip/tooltip-examples.md
@@ -25,6 +25,10 @@ order: 4
 
 <code-example example="tooltip-options"></code-example>
 
+## Preline Multi-line
+
+<code-example example="tooltip-preline"></code-example>
+
 ## Toggle Trigger
 
 <code-example example="tooltip-toggle"></code-example>

--- a/projects/novo-examples/src/components/tooltip/tooltip-preline/index.ts
+++ b/projects/novo-examples/src/components/tooltip/tooltip-preline/index.ts
@@ -1,0 +1,1 @@
+export * from './tooltip-preline-example';

--- a/projects/novo-examples/src/components/tooltip/tooltip-preline/tooltip-preline-example.html
+++ b/projects/novo-examples/src/components/tooltip/tooltip-preline/tooltip-preline-example.html
@@ -1,0 +1,1 @@
+<span [tooltip]="multiLineTooltip" tooltipPreline="true" tooltipPosition="top" data-automation-id="tooltip-preline-multiline">Multi-line tooltip</span>

--- a/projects/novo-examples/src/components/tooltip/tooltip-preline/tooltip-preline-example.ts
+++ b/projects/novo-examples/src/components/tooltip/tooltip-preline/tooltip-preline-example.ts
@@ -1,0 +1,15 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+/**
+ * @title Tooltip Preline Multi-line Example
+ */
+@Component({
+    selector: 'tooltip-preline-example',
+    templateUrl: 'tooltip-preline-example.html',
+    styleUrls: ['tooltip-preline-example.css'],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    standalone: false,
+})
+export class TooltipPrelineExample {
+  public multiLineTooltip: string = 'Date Added: 09/07/2026, 11:46am\nDate Last Modified: 09/09/2026, 2:32pm';
+}

--- a/projects/novo-examples/src/examples.routes.ts
+++ b/projects/novo-examples/src/examples.routes.ts
@@ -3432,6 +3432,8 @@ export class ComponentsPage {
 <p><code-example example="tooltip-sizes"></code-example></p>
 <h2>Options</h2>
 <p><code-example example="tooltip-options"></code-example></p>
+<h2>Preline Multi-line</h2>
+<p><code-example example="tooltip-preline"></code-example></p>
 <h2>Toggle Trigger</h2>
 <p><code-example example="tooltip-toggle"></code-example></p>
 <h2>Overflow</h2>


### PR DESCRIPTION
## **Description**

Added preline tooltip component.

#### **Verify that...**

- [X] Any related demos were added and `npm start` and `npm run build` still works
- [X] New demos work in `Safari`, `Chrome` and `Firefox`
- [X] `npm run lint` passes
- [X] `npm test` passes and code coverage is increased
- [X] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**

<img width="399" height="181" alt="preline_tooltip" src="https://github.com/user-attachments/assets/3ba72483-7e03-48dd-889b-a407777eb1ff" />
