### PR TITLE
style(Tab): Update active styling on tabs for bh2026

### DIFF
--- a/projects/novo-elements/src/elements/tabs/tab.scss
+++ b/projects/novo-elements/src/elements/tabs/tab.scss
@@ -194,6 +194,33 @@
   margin-right: 0;
 }
 
+:host-context([data-theme='bh2026'] novo-nav[theme="color"]) {
+  .novo-tab-link {
+    color: var(--color-text-subtle) !important;
+    text-transform: none;
+    font-weight: var(--typography-tabs-default-font-weight);
+  }
+
+  &.active,
+  &.router-link-active {
+    .novo-tab-link {
+      color: var(--color-text-body) !important;
+      font-weight: var(--typography-tabs-active-font-weight);
+    }
+
+    .indicator {
+      background: var(--tab-indicator-color, var(--color-border-utility-positive));
+      border-radius: 999px 999px 0 0;
+    }
+  }
+
+  &:hover:not(.active):not(.router-link-active):not(.disabled) {
+    .novo-tab-link {
+      color: var(--color-text-body) !important;
+    }
+  }
+}
+
 :host-context(novo-nav[theme="color"]),
 :host-context(novo-nav[theme="neutral"]) {
   .novo-tab-link {

--- a/projects/novo-elements/src/elements/tabs/tab.scss
+++ b/projects/novo-elements/src/elements/tabs/tab.scss
@@ -179,6 +179,7 @@
     .indicator {
       background: var(--tab-indicator-color, var(--color-border-utility-positive));
       border-radius: 999px 999px 0 0;
+      height: 2px;
     }
   }
 
@@ -192,6 +193,13 @@
 
 :host-context([data-theme='bh2026'] novo-nav[direction=vertical]) {
   margin-right: 0;
+
+  &.active,
+  &.router-link-active {
+    .indicator {
+      border-radius: 0 999px 999px 0;
+    }
+  }
 }
 
 :host-context([data-theme='bh2026'] novo-nav[theme="color"]) {
@@ -211,6 +219,7 @@
     .indicator {
       background: var(--tab-indicator-color, var(--color-border-utility-positive));
       border-radius: 999px 999px 0 0;
+      height: 2px;
     }
   }
 


### PR DESCRIPTION
## **Description**

Updating tab styling particularly the underline when active to match UI refresh styling

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**