### PR TITLE
fix(Form): revert @for to *ngFor in DynamicForm templates

### DIFF
--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -150,8 +150,9 @@ All user-visible strings must go through `NovoLabelService` — never hardcode d
 ### Template Control Flow
 
 -   Use built-in control flow: `@if`, `@for`, `@switch`
--   Flag `*ngIf`, `*ngFor`, `*ngSwitch` in new code — legacy; should migrate
--   When working in a template that uses `*ngIf`, `*ngFor`, or `*ngSwitch`, migrate the whole template to built-in control flow as part of the same change
+-   Flag `*ngIf`, `*ngSwitch` in new code — legacy; should migrate
+-   When working in a template that uses `*ngIf` or `*ngSwitch`, migrate those to built-in control flow as part of the same change
+-   Keep `*ngFor` unless you have a specific reason to switch — `@for` requires a `track` expression that controls component reuse, which can cause stale state in components that initialize in `ngOnInit`
 -   `@for` blocks must include a `track` expression
 
 ### Dependency Injection

--- a/projects/novo-elements/src/elements/form/DynamicForm.ts
+++ b/projects/novo-elements/src/elements/form/DynamicForm.ts
@@ -71,13 +71,11 @@ export class NovoFieldsetHeaderElement {
           [class.hidden]="hidden"
         ></novo-fieldset-header>
       }
-      @for (control of controls; track control.key; let controlIndex = $index) {
-        @if (control.__type !== 'GroupedControl') {
-          <div class="novo-form-row" [class.disabled]="control.disabled" [class.hidden]="control.hidden">
-            <novo-control [autoFocus]="autoFocus && index === 0 && controlIndex === 0" [control]="control" [form]="form"></novo-control>
-          </div>
-        }
-      }
+      <ng-container *ngFor="let control of controls; let controlIndex = index">
+        <div *ngIf="control.__type !== 'GroupedControl'" class="novo-form-row" [class.disabled]="control.disabled" [class.hidden]="control.hidden">
+          <novo-control [autoFocus]="autoFocus && index === 0 && controlIndex === 0" [control]="control" [form]="form"></novo-control>
+        </div>
+      </ng-container>
     </div>
   `,
     standalone: false,
@@ -115,20 +113,19 @@ export class NovoFieldsetElement {
         <ng-content select="form-subtitle"></ng-content>
       </header>
       <form class="novo-form" [formGroup]="form">
-        @for (fieldset of visibleFieldsets; track fieldset.key; let i = $index) {
-          <novo-fieldset
-            [index]="i"
-            [autoFocus]="autoFocusFirstField"
-            [icon]="fieldset.icon"
-            [controls]="fieldset.controls"
-            [title]="fieldset.title"
-            [form]="form"
-            [isEmbedded]="fieldset.isEmbedded"
-            [isInlineEmbedded]="fieldset.isInlineEmbedded"
-            [hidden]="fieldset.hidden"
-            [cardSection]="effectiveCardSections()"
-          ></novo-fieldset>
-        }
+        <novo-fieldset
+          *ngFor="let fieldset of visibleFieldsets; let i = index"
+          [index]="i"
+          [autoFocus]="autoFocusFirstField"
+          [icon]="fieldset.icon"
+          [controls]="fieldset.controls"
+          [title]="fieldset.title"
+          [form]="form"
+          [isEmbedded]="fieldset.isEmbedded"
+          [isInlineEmbedded]="fieldset.isInlineEmbedded"
+          [hidden]="fieldset.hidden"
+          [cardSection]="effectiveCardSections()"
+        ></novo-fieldset>
       </form>
     </div>
   `,


### PR DESCRIPTION
## **Description**

@for with track-by-key reuses component instances across re-renders,
preventing novo-control from reinitializing when the form group is
replaced. *ngFor without trackBy tracks by identity, ensuring components
are recreated and ngOnInit runs fresh on each form rebuild.

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`

##### **Screenshots**